### PR TITLE
WIP: fixes the split issue when args.content is not a string

### DIFF
--- a/source/tools/create-file.tsx
+++ b/source/tools/create-file.tsx
@@ -22,7 +22,7 @@ const handler: ToolHandler = async (args: {
 const CreateFileFormatter = React.memo(({args}: {args: any}) => {
 	const {colors} = React.useContext(ThemeContext)!;
 	const path = args.path || args.file_path || 'unknown';
-	const newContent = args.content || '';
+	const newContent = typeof args.content === 'string' ? args.content : '';
 	const lineCount = newContent.split('\n').length;
 	const charCount = newContent.length;
 


### PR DESCRIPTION
## Description

This fixes an issue when args.content in the file create tool receives a non-null value other than a string (e.g. an object).
Reproduced when using qwen/qwen3-coder-30b to create a file.

`newContent.split is not a function`

in 

`node_modules/@nanocollective/nanocoder/dist/tools/create-file.js:21:34`




## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [x] Tested with LM Studio
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
