### PR TITLE
fix: revert config file location; prepare for config/data separation

### DIFF
--- a/source/config/paths.ts
+++ b/source/config/paths.ts
@@ -1,5 +1,28 @@
-import {xdgData} from 'xdg-basedir';
+import {homedir} from 'os';
+import {join} from 'path';
 
 export function getAppDataPath(): string {
-	return `${xdgData}/nanocoder`;
+	return getConfigPath();
+}
+
+function getConfigPath(): string {
+	// Allow explicit override via environment variable
+	if (process.env.NANOCODER_CONFIG_DIR) {
+		return process.env.NANOCODER_CONFIG_DIR;
+	}
+
+	// Platform-specific defaults
+	let baseConfigPath: string;
+	switch (process.platform) {
+		case 'win32':
+			baseConfigPath = process.env.APPDATA ?? join(homedir(), '.config');
+			break;
+		case 'darwin':
+			baseConfigPath = join(homedir(), 'Library', 'Preferences');
+			break;
+		default:
+			baseConfigPath =
+				process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config');
+	}
+	return join(baseConfigPath, 'nanocoder');
 }


### PR DESCRIPTION
## Description

Commit aa57027 introduced breaking changes to where configuration files were found; this reverts that, while also preparing the way for separate config/data file handling in the future (currently, both `getAppDataPath` and `getConfigPath` return the same path.) I also added support for a NANOCODER_CONFIG_DIR variable that, if set, supercedes other logic.

While this is a dramatic change from aa57027, this PR introduces no breaking changes from the documented functionality and from the functionality prior to aa57027. In other words, this restores the expected functionality.

Resolves #82 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
