### PR TITLE
Fixes Nix Flake + PNPM Building Issue

### DIFF
--- a/nix/packages/default/default.nix
+++ b/nix/packages/default/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Vn7DsIczYX9quYUfF7UMEWZWB69Ce+JRvsL5AzHpeHM=";
+    hash = "sha256-o2KDZMbXhoXy66We6oy3LA7BGRnBkM4Tbjv4iE8DxFI=";
     fetcherVersion = 2;
 
     # Fix pnpm workspace error - add packages field to workspace file


### PR DESCRIPTION
## Description

NixOS flake was failing to build, long story short it requiured me to add: `fetcherVersion = "1";` to nancoder's flake to get everything to work building locally and figured I would pass it upstream since its an easy fix and makes the instructions for installing on nix work as describe requiring such a minor tweak. 

Anyways, awesome project thanks for your hard work and have a great weekend!
-TLH

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
