### PR TITLE
feat: add GitHub Models as a provider

### DIFF
--- a/agents.config.example.json
+++ b/agents.config.example.json
@@ -8,6 +8,12 @@
 				"models": ["openai/gpt-4o-mini", "anthropic/claude-3-haiku"]
 			},
 			{
+				"name": "GitHub Models",
+				"baseUrl": "https://models.github.ai/inference",
+				"apiKey": "your-github-token-here",
+				"models": ["openai/gpt-4o-mini", "openai/gpt-4o"]
+			},
+			{
 				"name": "Local Ollama",
 				"baseUrl": "http://localhost:11434/v1",
 				"models": ["llama3.2", "qwen2.5-coder"]

--- a/source/wizard/templates/provider-templates.ts
+++ b/source/wizard/templates/provider-templates.ts
@@ -297,6 +297,38 @@ export const PROVIDER_TEMPLATES: ProviderTemplate[] = [
 		}),
 	},
 	{
+		id: 'github-models',
+		name: 'GitHub Models',
+		fields: [
+			{
+				name: 'apiKey',
+				prompt: 'GitHub Token (PAT with models:read scope)',
+				required: true,
+				sensitive: true,
+			},
+			{
+				name: 'model',
+				prompt: 'Model name(s) (comma-separated)',
+				default: 'openai/gpt-4o-mini',
+				required: true,
+			},
+			{
+				name: 'providerName',
+				prompt: 'Provider name',
+				default: 'GitHub Models',
+			},
+		],
+		buildConfig: answers => ({
+			name: answers.providerName || 'GitHub Models',
+			baseUrl: 'https://models.github.ai/inference',
+			apiKey: answers.apiKey,
+			models: answers.model
+				.split(',')
+				.map(m => m.trim())
+				.filter(Boolean),
+		}),
+	},
+	{
 		id: 'custom',
 		name: 'Custom Provider',
 		fields: [


### PR DESCRIPTION
Adds GitHub Models (models.github.ai) as a native provider option, addressing feature request #67 with minimal code change.

GitHub Models is GitHub's official OpenAI-compatible inference API. Users can authenticate with a GitHub Personal Access Token (PAT) that has the models scope.

Changes:
- Added github-models provider template to /setup-config wizard
- Added GitHub Models example to agents.config.example.json
