### PR TITLE
fix: sets test locale to en-US to prevent broken tests for foreign lo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,9 @@
 		"workerThreads": false,
 		"serial": true,
 		"environmentVariables": {
-			"NODE_ENV": "test"
+			"NODE_ENV": "test",
+			"LC_ALL": "en-US.UTF-8",
+			"LANG": "en-US.UTF-8"
 		}
 	},
 	"prettier": "@vdemedes/prettier-config"


### PR DESCRIPTION
## Description

Number Formatting Tests (11 tests) are broken on systems with non-US systems:
  - Added locale environment variables to AVA configuration:
    - LC_ALL: "en-US.UTF-8"
    - LANG: "en-US.UTF-8"
  - This ensures tests run with consistent number formatting (commas as thousand separators) regardless of the developer's system locale
  - Production code unchanged - still respects user's locale for best UX
  - Fixed tests in:
    - calculator.spec.ts (5 tests)
    - usage-display.spec.tsx (6 tests)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
