### PR TITLE
feat: Add MCP & LSP connection status display to Status component

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -180,6 +180,8 @@ export default function App({vscodeMode = false, vscodePort}: AppProps) {
 		setStartChat: appState.setStartChat,
 		setMcpInitialized: appState.setMcpInitialized,
 		setUpdateInfo: appState.setUpdateInfo,
+		setMcpServersStatus: appState.setMcpServersStatus,
+		setLspServersStatus: appState.setLspServersStatus,
 		addToChatQueue: appState.addToChatQueue,
 		componentKeyCounter: appState.componentKeyCounter,
 		customCommandCache: appState.customCommandCache,
@@ -246,6 +248,8 @@ export default function App({vscodeMode = false, vscodePort}: AppProps) {
 				model={appState.currentModel}
 				theme={appState.currentTheme}
 				updateInfo={appState.updateInfo}
+				mcpServersStatus={appState.mcpServersStatus}
+				lspServersStatus={appState.lspServersStatus}
 			/>,
 		);
 	}, [appState]);
@@ -313,6 +317,8 @@ export default function App({vscodeMode = false, vscodePort}: AppProps) {
 				model={appState.currentModel}
 				theme={appState.currentTheme}
 				updateInfo={appState.updateInfo}
+				mcpServersStatus={appState.mcpServersStatus}
+				lspServersStatus={appState.lspServersStatus}
 			/>,
 		],
 		[
@@ -320,6 +326,8 @@ export default function App({vscodeMode = false, vscodePort}: AppProps) {
 			appState.currentModel,
 			appState.currentTheme,
 			appState.updateInfo,
+			appState.mcpServersStatus,
+			appState.lspServersStatus,
 		],
 	);
 

--- a/source/components/status-connection-display.spec.tsx
+++ b/source/components/status-connection-display.spec.tsx
@@ -1,0 +1,87 @@
+import test from 'ava';
+import React from 'react';
+import {render} from 'ink-testing-library';
+import Status from '@/components/status';
+import type {MCPConnectionStatus, LSPConnectionStatus} from '@/types/core';
+
+test('Status component with MCP status renders', async t => {
+	const mcpStatus: MCPConnectionStatus[] = [
+		{name: 'server1', status: 'connected'},
+	];
+
+	const {lastFrame} = render(
+		<Status
+			provider="test-provider"
+			model="test-model"
+			theme="tokyo-night"
+			mcpServersStatus={mcpStatus}
+		/>,
+	);
+
+	const output = lastFrame();
+	t.true(output.includes('Status'));
+	t.true(output.includes('MCP:'));
+	t.true(output.includes('1/1 connected'));
+});
+
+test('Status component with LSP status renders', async t => {
+	const lspStatus: LSPConnectionStatus[] = [
+		{name: 'ts-language-server', status: 'connected'},
+	];
+
+	const {lastFrame} = render(
+		<Status
+			provider="test-provider"
+			model="test-model"
+			theme="tokyo-night"
+			lspServersStatus={lspStatus}
+		/>,
+	);
+
+	const output = lastFrame();
+	t.true(output.includes('Status'));
+	t.true(output.includes('LSP:'));
+	t.true(output.includes('1/1 connected'));
+});
+
+test('Status component without MCP/LSP still renders', async t => {
+	const {lastFrame} = render(
+		<Status provider="test-provider" model="test-model" theme="tokyo-night" />,
+	);
+
+	const output = lastFrame();
+	t.true(output.includes('Status'));
+	// Should not contain MCP or LSP sections when no status provided
+	t.false(output.includes('MCP:'));
+	t.false(output.includes('LSP:'));
+});
+
+test('Status component renders with connection status props', async t => {
+	const mcpStatus: MCPConnectionStatus[] = [
+		{name: 'server1', status: 'connected'},
+		{name: 'server2', status: 'failed', errorMessage: 'Connection timeout'},
+	];
+
+	const lspStatus: LSPConnectionStatus[] = [
+		{name: 'ts-language-server', status: 'connected'},
+		{name: 'pyright', status: 'connected'},
+	];
+
+	const {lastFrame} = render(
+		<Status
+			provider="test-provider"
+			model="test-model"
+			theme="tokyo-night"
+			mcpServersStatus={mcpStatus}
+			lspServersStatus={lspStatus}
+		/>,
+	);
+
+	const output = lastFrame();
+	t.true(output.includes('Status'));
+	t.true(output.includes('MCP:'));
+	t.true(output.includes('1/2 connected')); // 1 of 2 MCP servers connected
+	t.true(output.includes('LSP:'));
+	t.true(output.includes('2/2 connected')); // 2 of 2 LSP servers connected
+	t.true(output.includes('Connection timeout')); // Error message should be shown
+});

--- a/source/hooks/useAppState.tsx
+++ b/source/hooks/useAppState.tsx
@@ -1,5 +1,12 @@
 import {useState, useCallback, useMemo, useEffect} from 'react';
-import {LLMClient, Message, DevelopmentMode, ToolCall} from '@/types/core';
+import {
+	LLMClient,
+	Message,
+	DevelopmentMode,
+	ToolCall,
+	MCPConnectionStatus,
+	LSPConnectionStatus,
+} from '@/types/core';
 import {ToolManager} from '@/tools/tool-manager';
 import {CustomCommandLoader} from '@/custom-commands/loader';
 import {CustomCommandExecutor} from '@/custom-commands/executor';
@@ -44,6 +51,14 @@ export function useAppState() {
 	const [startChat, setStartChat] = useState<boolean>(false);
 	const [mcpInitialized, setMcpInitialized] = useState<boolean>(false);
 	const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+
+	// Connection status states
+	const [mcpServersStatus, setMcpServersStatus] = useState<
+		MCPConnectionStatus[]
+	>([]);
+	const [lspServersStatus, setLspServersStatus] = useState<
+		LSPConnectionStatus[]
+	>([]);
 
 	// Cancelling indicator state
 	const [isCancelling, setIsCancelling] = useState<boolean>(false);
@@ -178,6 +193,8 @@ export function useAppState() {
 		startChat,
 		mcpInitialized,
 		updateInfo,
+		mcpServersStatus,
+		lspServersStatus,
 		isCancelling,
 		abortController,
 		isModelSelectionMode,
@@ -213,6 +230,8 @@ export function useAppState() {
 		setStartChat,
 		setMcpInitialized,
 		setUpdateInfo,
+		setMcpServersStatus,
+		setLspServersStatus,
 		setIsCancelling,
 		setAbortController,
 		setIsModelSelectionMode,

--- a/source/tool-calling/tool-parser.ts
+++ b/source/tool-calling/tool-parser.ts
@@ -10,16 +10,18 @@ import {
  * Normalize whitespace in content to remove excessive blank lines and spacing
  */
 function normalizeWhitespace(content: string): string {
-	return content
-		// Remove trailing whitespace from each line
-		.replace(/[ \t]+$/gm, '')
-		// Collapse multiple spaces (but not at start of line for indentation)
-		.replace(/([^ \t\n]) {2,}/g, '$1 ')
-		// Remove lines that are only whitespace
-		.replace(/^[ \t]+$/gm, '')
-		// Collapse 3+ consecutive newlines to exactly 2 (one blank line)
-		.replace(/\n{3,}/g, '\n\n')
-		.trim();
+	return (
+		content
+			// Remove trailing whitespace from each line
+			.replace(/[ \t]+$/gm, '')
+			// Collapse multiple spaces (but not at start of line for indentation)
+			.replace(/([^ \t\n]) {2,}/g, '$1 ')
+			// Remove lines that are only whitespace
+			.replace(/^[ \t]+$/gm, '')
+			// Collapse 3+ consecutive newlines to exactly 2 (one blank line)
+			.replace(/\n{3,}/g, '\n\n')
+			.trim()
+	);
 }
 
 /**

--- a/source/tool-calling/xml-parser.ts
+++ b/source/tool-calling/xml-parser.ts
@@ -243,9 +243,7 @@ export class XMLToolCallParser {
 				error:
 					'Invalid syntax: [tool_use: name] or [Tool: name] format is not supported',
 				hint: (match: string) => {
-					const toolName = match.match(
-						/\[(?:tool_use|Tool):\s*(\w+)\]/i,
-					)?.[1];
+					const toolName = match.match(/\[(?:tool_use|Tool):\s*(\w+)\]/i)?.[1];
 					return `Use XML tags: <${toolName}><param>value</param></${toolName}> instead of [Tool: ${toolName}]`;
 				},
 			},

--- a/source/types/core-connection-status.spec.ts
+++ b/source/types/core-connection-status.spec.ts
@@ -1,0 +1,67 @@
+import test from 'ava';
+import type {
+	MCPConnectionStatus,
+	LSPConnectionStatus,
+	ConnectionStatus,
+} from '@/types/core';
+
+test('MCPConnectionStatus type structure', t => {
+	const status: MCPConnectionStatus = {
+		name: 'test-server',
+		status: 'connected',
+	};
+
+	t.is(status.name, 'test-server');
+	t.is(status.status, 'connected');
+	t.is(status.errorMessage, undefined);
+});
+
+test('MCPConnectionStatus with error', t => {
+	const status: MCPConnectionStatus = {
+		name: 'failed-server',
+		status: 'failed',
+		errorMessage: 'Connection timeout',
+	};
+
+	t.is(status.name, 'failed-server');
+	t.is(status.status, 'failed');
+	t.is(status.errorMessage, 'Connection timeout');
+});
+
+test('LSPConnectionStatus type structure', t => {
+	const status: LSPConnectionStatus = {
+		name: 'ts-language-server',
+		status: 'connected',
+	};
+
+	t.is(status.name, 'ts-language-server');
+	t.is(status.status, 'connected');
+	t.is(status.errorMessage, undefined);
+});
+
+test('ConnectionStatus union type', t => {
+	const validStatuses: ConnectionStatus[] = ['connected', 'failed', 'pending'];
+
+	validStatuses.forEach(status => {
+		t.true(['connected', 'failed', 'pending'].includes(status));
+	});
+});
+
+test('Connection status filtering', t => {
+	const mcpStatuses: MCPConnectionStatus[] = [
+		{name: 'server1', status: 'connected'},
+		{name: 'server2', status: 'failed', errorMessage: 'Timeout'},
+		{name: 'server3', status: 'pending'},
+	];
+
+	const connected = mcpStatuses.filter(s => s.status === 'connected');
+	const failed = mcpStatuses.filter(s => s.status === 'failed');
+	const pending = mcpStatuses.filter(s => s.status === 'pending');
+
+	t.is(connected.length, 1);
+	t.is(failed.length, 1);
+	t.is(pending.length, 1);
+	t.is(connected[0].name, 'server1');
+	t.is(failed[0].errorMessage, 'Timeout');
+	t.is(pending[0].name, 'server3');
+});

--- a/source/types/core.ts
+++ b/source/types/core.ts
@@ -161,3 +161,18 @@ export const DEVELOPMENT_MODE_LABELS: Record<DevelopmentMode, string> = {
 	'auto-accept': '⏵⏵ auto-accept mode on',
 	plan: '⏸ plan mode on',
 };
+
+// Connection status types for MCP and LSP servers
+export type ConnectionStatus = 'connected' | 'failed' | 'pending';
+
+export interface MCPConnectionStatus {
+	name: string;
+	status: ConnectionStatus;
+	errorMessage?: string;
+}
+
+export interface LSPConnectionStatus {
+	name: string;
+	status: ConnectionStatus;
+	errorMessage?: string;
+}


### PR DESCRIPTION
## Summary
Implements GitHub issue #120 by moving verbose MCP and LSP server connection messages from the main chat area to a clean, summarized status display in the Status component.

## Changes Made

### 1. Type Definitions (`source/types/core.ts`)
- Added `ConnectionStatus` type for server states ('connected', 'failed', 'pending')
- Added `MCPConnectionStatus` and `LSPConnectionStatus` interfaces
- Included error message support for failed connections

### 2. State Management (`source/hooks/useAppState.tsx`)
- Added `mcpServersStatus` and `lspServersStatus` state arrays
- Added corresponding setter functions to track connection status

### 3. Background Initialization (`source/hooks/useAppInitialization.tsx`)
- Modified MCP and LSP initialization to track status silently
- Removed verbose success messages from chat during initialization
- Added progress callbacks to update status arrays in real-time
- Preserved error information for failed connections

### 4. Status Component Enhancement (`source/components/status.tsx`)
- Added MCP and LSP status sections after Theme display
- Shows connected/total count with color-coded status indicators
- Displays error details for failed connections in an indented list
- Maintains all existing functionality without breaking changes

### 5. App Integration (`source/app.tsx`)
- Updated Status component calls to pass connection status props
- Provided status props to both static and dynamic Status instances

## Test Plan
- Created comprehensive tests for new Status component functionality
- Tests cover MCP/LSP status display, error handling, and edge cases
- All tests pass successfully

## Benefits
- **Cleaner startup experience**: No more verbose server connection messages flooding chat
- **At-a-glance status**: Users can quickly see connection health (e.g., "MCP: 3/4 connected")
- **Error visibility**: Failed connections show error messages for debugging
- **Non-intrusive**: Status displayed in dedicated section, separate from conversation

Closes #120