### PR TITLE
fix: add helpful error messages for missing MCP server commands

### DIFF
--- a/source/mcp/transport-factory.spec.ts
+++ b/source/mcp/transport-factory.spec.ts
@@ -369,20 +369,21 @@ test('TransportFactory.validateServerConfig: detects missing command', t => {
 	);
 });
 
-test('TransportFactory.validateServerConfig: returns error for missing command', t => {
+test('TransportFactory.validateServerConfig: returns uvx-specific installation hint', t => {
 	const server: MCPServer = {
-		name: 'test-stdio-missing-command',
+		name: 'test-stdio-uvx-hint',
 		transport: 'stdio',
-		command: 'nonexistent-command-for-testing',
+		command: 'uvx',
 	};
 
 	const result = TransportFactory.validateServerConfig(server);
 
-	// Should fail since command doesn't exist
+	// Should fail since uvx is likely not installed in test environment
 	t.false(result.valid);
-	// Should have an error message with generic hint
+	// Should include uvx-specific installation instructions
 	t.true(result.errors.length > 0);
-	t.true(result.errors[0]!.includes("not found"));
+	t.true(result.errors[0]!.includes("'uv' Python package manager"));
+	t.true(result.errors[0]!.includes('astral.sh/uv/install.sh'));
 });
 
 test('TransportFactory.validateServerConfig: validates existing command (node)', t => {


### PR DESCRIPTION
## Description

When an MCP server requires a command that isn't installed (like `uvx`, `npx`, etc.), users now get clear error messages with installation instructions instead of confusing ENOENT spawn errors.

**Supersedes #150** (rebased to remove unrelated file-cache changes)

Fixes #148

## Type of Change

- [x] Bug fix (UX improvement for configuration errors)

## Changes

**Modified:**
- `source/mcp/transport-factory.ts`
  - Add `commandExists()` function to check if command is in PATH (cross-platform)
  - Add `COMMAND_INSTALL_HINTS` with installation instructions for common commands (uvx, npx, node, python, python3)
  - Validate command existence in `validateServerConfig()` before spawning
  
- `source/mcp/transport-factory.spec.ts`
  - Add 3 tests for command existence validation

## Example Error Message

Before:
```
Error: spawn uvx ENOENT
```

After:
```
Command 'uvx' not found.

'uvx' is part of the 'uv' Python package manager.

Install uv:
  • macOS/Linux: curl -LsSf https://astral.sh/uv/install.sh | sh
  • Windows: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
  • pip: pip install uv
  • Homebrew: brew install uv

After installation, restart your terminal and try again.
```

## Testing

- [x] Added 3 automated tests for command existence validation
- [x] All tests pass: `pnpm test:ava source/mcp/transport-factory.spec.ts` (26 tests)
- [x] Type checks pass

## Checklist

- [x] Code follows project style guidelines (Biome formatting passed)
- [x] Self-review completed
- [x] Tests added for new functionality
- [x] No breaking changes