### PR TITLE
fix(security): use crypto.randomBytes for secure ID generation

### DIFF
--- a/source/ai-sdk-client.ts
+++ b/source/ai-sdk-client.ts
@@ -1,3 +1,5 @@
+import {randomBytes} from 'node:crypto';
+
 import {getModelContextLimit} from '@/models/index.js';
 import {XMLToolCallParser} from '@/tool-calling/xml-parser';
 import type {
@@ -528,9 +530,7 @@ export class AISDKClient implements LLMClient {
 								const tc: ToolCall = {
 									id:
 										toolCall.toolCallId ||
-										`tool_${Date.now()}_${Math.random()
-											.toString(36)
-											.substring(7)}`,
+										`tool_${Date.now()}_${randomBytes(8).toString('hex')}`,
 									function: {
 										name: toolCall.toolName,
 										arguments: toolCall.input as Record<string, unknown>,
@@ -634,7 +634,7 @@ export class AISDKClient implements LLMClient {
 						const stepToolCalls: ToolCall[] = step.toolCalls.map(toolCall => ({
 							id:
 								toolCall.toolCallId ||
-								`tool_${Date.now()}_${Math.random().toString(36).substring(7)}`,
+								`tool_${Date.now()}_${randomBytes(8).toString('hex')}`,
 							function: {
 								name: toolCall.toolName,
 								arguments: toolCall.input as Record<string, unknown>,
@@ -660,7 +660,7 @@ export class AISDKClient implements LLMClient {
 								content: resultStr,
 								tool_call_id:
 									toolCall.toolCallId ||
-									`tool_${Date.now()}_${Math.random().toString(36).substring(7)}`,
+									`tool_${Date.now()}_${randomBytes(8).toString('hex')}`,
 								name: toolCall.toolName,
 							});
 						});
@@ -679,7 +679,7 @@ export class AISDKClient implements LLMClient {
 							// Some providers (like Ollama) don't provide toolCallId, so generate one
 							id:
 								toolCall.toolCallId ||
-								`tool_${Date.now()}_${Math.random().toString(36).substring(7)}`,
+								`tool_${Date.now()}_${randomBytes(8).toString('hex')}`,
 							function: {
 								name: toolCall.toolName,
 								// AI SDK v5 uses 'input' for tool arguments

--- a/source/usage/tracker.ts
+++ b/source/usage/tracker.ts
@@ -3,6 +3,8 @@
  * Tracks current session usage
  */
 
+import {randomBytes} from 'node:crypto';
+
 import {getModelContextLimit} from '@/models/index';
 import type {Message} from '@/types/core';
 import type {Tokenizer} from '@/types/tokenization';
@@ -24,7 +26,7 @@ export class SessionTracker {
 	}
 
 	private generateSessionId(): string {
-		return `${Date.now()}-${Math.random().toString(36).substring(7)}`;
+		return `${Date.now()}-${randomBytes(8).toString('hex')}`;
 	}
 
 	async getCurrentStats(

--- a/source/utils/logging/performance.ts
+++ b/source/utils/logging/performance.ts
@@ -3,7 +3,9 @@
  * Provides comprehensive monitoring and analysis capabilities
  */
 
-import {loadavg} from 'os';
+import {randomBytes} from 'node:crypto';
+import {loadavg} from 'node:os';
+
 import {generateCorrelationId} from './index.js';
 import type {Logger, PerformanceMetrics} from './types.js';
 
@@ -643,7 +645,7 @@ class PerformanceMonitor {
 	 * Start measuring an operation
 	 */
 	start(operation: string): string {
-		const id = `${operation}_${Date.now()}_${Math.random()}`;
+		const id = `${operation}_${Date.now()}_${randomBytes(8).toString('hex')}`;
 		const metrics = startMetrics();
 
 		if (!this.measurements.has(operation)) {

--- a/source/utils/logging/request-tracker.ts
+++ b/source/utils/logging/request-tracker.ts
@@ -3,6 +3,8 @@
  * Provides comprehensive monitoring for HTTP requests, AI calls, and MCP operations
  */
 
+import {randomBytes} from 'node:crypto';
+
 import {generateCorrelationId, getLogger} from './index.js';
 import {
 	calculateMemoryDelta,
@@ -554,7 +556,7 @@ export class RequestTracker {
 	}
 
 	private generateRequestId(): string {
-		return `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+		return `req_${Date.now()}_${randomBytes(8).toString('hex')}`;
 	}
 
 	private addToCompleted(request: RequestMetadata): void {


### PR DESCRIPTION
## Description

Fix #163 
Replace insecure `Math.random()` usage with cryptographically secure `crypto.randomBytes()` for all ID generation across the codebase. This improves security and unpredictability of session IDs, tool IDs, request IDs, and performance measurement IDs while maintaining backward compatibility with external APIs.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios
<img width="520" height="568" alt="Screenshot 2025-12-21 at 12 38 03 AM" src="https://github.com/user-attachments/assets/ede747a8-a1f9-4cd0-9e5a-4321a05f18e3" />
<img width="445" height="552" alt="Screenshot 2025-12-21 at 12 40 10 AM" src="https://github.com/user-attachments/assets/16190681-861a-4627-beb5-2760ffbd2917" />



### Manual Testing

- [ ] Tested with Ollama
- [x] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

## Notes

**ID Format Change:**
- **Before:** `${Date.now()}-${Math.random().toString(36).substring(7)}` (base36, ~5-6 chars)
- **After:** `${Date.now()}-${randomBytes(8).toString('hex')}` (hex, 16 chars)

>
> Tool ID fallbacks are generated **only** when providers do not supply IDs themselves.  
> This change does **not** affect or break any external API contracts.
