### PR TITLE
refactor(logging): replace console calls with structured pino logger

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -23,6 +23,7 @@ import {getThemeColors} from '@/config/themes';
 import {setCurrentMode as setCurrentModeContext} from '@/context/mode-context';
 import {ThemeContext} from '@/hooks/useTheme';
 import {CheckpointManager} from '@/services/checkpoint-manager';
+import {getLogger} from '@/utils/logging';
 import {
 	generateCorrelationId,
 	withNewCorrelationContext,
@@ -647,10 +648,11 @@ export default function App({
 			);
 
 			if (shouldExit) {
+				const logger = getLogger();
 				if (reason === 'timeout') {
-					console.error('Non-interactive mode timed out');
+					logger.error('Non-interactive mode timed out');
 				} else if (reason === 'error') {
-					console.error('Non-interactive mode encountered errors');
+					logger.error('Non-interactive mode encountered errors');
 				} else if (reason === 'tool-approval') {
 					// Exit with error code when tool approval is required
 					// Error message already printed by useChatHandler

--- a/source/components/tool-confirmation.tsx
+++ b/source/components/tool-confirmation.tsx
@@ -4,6 +4,7 @@ import {getToolManager} from '@/message-handler';
 import {toolFormatters} from '@/tools/index';
 import type {ToolCall} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
+import {getLogger} from '@/utils/logging';
 import {parseToolArguments} from '@/utils/tool-args-parser';
 import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
@@ -64,7 +65,11 @@ export default function ToolConfirmation({
 							return;
 						}
 					} catch (error) {
-						console.error('Error running validator:', error);
+						const logger = getLogger();
+						logger.error(
+							{error: formatError(error)},
+							'Error running validator',
+						);
 						const errorMsg = `Validation error: ${formatError(error)}`;
 						setValidationError(errorMsg);
 						setHasValidationError(true);
@@ -83,7 +88,11 @@ export default function ToolConfirmation({
 					const preview = await formatter(parsedArgs);
 					setFormatterPreview(preview);
 				} catch (error) {
-					console.error('Error loading formatter preview:', error);
+					const logger = getLogger();
+					logger.error(
+						{error: formatError(error)},
+						'Error loading formatter preview',
+					);
 					setHasFormatterError(true);
 					setFormatterPreview(
 						<Text color={colors.error}>Error: {String(error)}</Text>,

--- a/source/models/models-cache.ts
+++ b/source/models/models-cache.ts
@@ -5,6 +5,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {formatError} from '@/utils/error-formatter';
+import {getLogger} from '@/utils/logging';
 import {xdgCache} from 'xdg-basedir';
 import type {CachedModelsData, ModelsDevDatabase} from './models-types.js';
 
@@ -53,7 +55,8 @@ export function readCache(): CachedModelsData | null {
 		return cached;
 	} catch (error) {
 		// If there's any error reading cache, return null to trigger fresh fetch
-		console.warn('Failed to read models cache:', error);
+		const logger = getLogger();
+		logger.warn({error: formatError(error)}, 'Failed to read models cache');
 		return null;
 	}
 }
@@ -71,6 +74,7 @@ export function writeCache(data: ModelsDevDatabase): void {
 		const cachePath = getCacheFilePath();
 		fs.writeFileSync(cachePath, JSON.stringify(cached, null, 2), 'utf-8');
 	} catch (error) {
-		console.warn('Failed to write models cache:', error);
+		const logger = getLogger();
+		logger.warn({error: formatError(error)}, 'Failed to write models cache');
 	}
 }

--- a/source/models/models-dev-client.ts
+++ b/source/models/models-dev-client.ts
@@ -3,6 +3,8 @@
  * Fetches and caches model metadata
  */
 
+import {formatError} from '@/utils/error-formatter';
+import {getLogger} from '@/utils/logging';
 import {request} from 'undici';
 import {readCache, writeCache} from './models-cache.js';
 import type {ModelInfo, ModelsDevDatabase} from './models-types.js';
@@ -184,12 +186,13 @@ async function fetchModelsData(): Promise<ModelsDevDatabase | null> {
 
 		return data;
 	} catch (error) {
-		console.warn('Failed to fetch from models.dev:', error);
+		const logger = getLogger();
+		logger.warn({error: formatError(error)}, 'Failed to fetch from models.dev');
 
 		// Try to use cached data as fallback
 		const cached = readCache();
 		if (cached) {
-			console.log('Using cached models data');
+			logger.info('Using cached models data');
 			return cached.data;
 		}
 

--- a/source/utils/file-autocomplete.ts
+++ b/source/utils/file-autocomplete.ts
@@ -3,7 +3,9 @@ import {existsSync, readFileSync} from 'node:fs';
 import {join} from 'node:path';
 import {promisify} from 'node:util';
 import ignore from 'ignore';
+import {formatError} from './error-formatter';
 import {fuzzyScoreFilePath} from './fuzzy-matching';
+import {getLogger} from './logging';
 
 const execAsync = promisify(exec);
 
@@ -92,7 +94,8 @@ async function getAllFiles(cwd: string): Promise<string[]> {
 		return allFiles;
 	} catch (error) {
 		// If find fails, return empty array
-		console.error('Failed to list files:', error);
+		const logger = getLogger();
+		logger.error({error: formatError(error)}, 'Failed to list files');
 		return [];
 	}
 }

--- a/source/utils/prompt-processor.ts
+++ b/source/utils/prompt-processor.ts
@@ -4,6 +4,7 @@ import {join} from 'path';
 import {promptPath} from '../config/index';
 import type {InputState} from '../types/hooks';
 import {PlaceholderType} from '../types/hooks';
+import {getLogger} from './logging';
 
 /**
  * Get the default shell for the current platform
@@ -83,7 +84,8 @@ export function processPromptTemplate(): string {
 		} catch (error) {
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
-			console.warn(
+			const logger = getLogger();
+			logger.warn(
 				`Failed to load system prompt from ${promptPath}: ${errorMessage}`,
 			);
 		}
@@ -101,7 +103,8 @@ export function processPromptTemplate(): string {
 		} catch (error) {
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
-			console.warn(
+			const logger = getLogger();
+			logger.warn(
 				`Failed to load AGENTS.md from ${agentsPath}: ${errorMessage}`,
 			);
 		}

--- a/source/vscode/vscode-server.ts
+++ b/source/vscode/vscode-server.ts
@@ -4,6 +4,8 @@
 
 import {randomUUID} from 'crypto';
 import * as fs from 'fs';
+import {formatError} from '@/utils/error-formatter';
+import {getLogger} from '@/utils/logging';
 import {WebSocket, WebSocketServer} from 'ws';
 import {
 	AssistantMessage,
@@ -277,7 +279,11 @@ export class VSCodeServer {
 				const message = JSON.parse(data.toString()) as ClientMessage;
 				this.handleMessage(message);
 			} catch (error) {
-				console.error('Failed to parse message from VS Code:', error);
+				const logger = getLogger();
+				logger.error(
+					{error: formatError(error)},
+					'Failed to parse message from VS Code',
+				);
 			}
 		});
 


### PR DESCRIPTION
## Description

Fix #166 
Replace all `console.warn/error/log` calls with the structured pino logger across production source files to ensure consistent logging behavior, proper error formatting, sensitive data redaction, and improved log aggregation.

This change enforces the project’s logging guidelines and avoids bypassing structured logging via direct console usage.

### Changes

| File | Change |
|------|--------|
| `source/models/models-cache.ts` | `console.warn` → `logger.warn` for cache read/write errors |
| `source/models/models-dev-client.ts` | `console.warn` / `console.log` → `logger.warn` / `logger.info` |
| `source/components/tool-confirmation.tsx` | `console.error` → `logger.error` for validator errors |
| `source/app.tsx` | `console.error` → `logger.error` for non-interactive mode errors |
| `source/vscode/vscode-server.ts` | `console.error` → `logger.error` for message parsing errors |
| `source/utils/prompt-processor.ts` | `console.warn` → `logger.warn` for template processing errors |
| `source/utils/file-autocomplete.ts` | `console.error` → `logger.error` for file search errors |

### Excluded (intentional)

- Test files (`.spec.ts`) — not production code
- Logging infrastructure (`utils/logging/*`) — requires `console` as a fallback

---

## Type of Change

- [x] Bug fix (logging consistency & correctness)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all`)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

---

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (not required)
- [x] No breaking changes
- [x] Appropriate logging added using structured logging (see `CONTRIBUTING.md#logging`)
