### PR TITLE
Fix: Remove deprecated functions

### DIFF
--- a/source/tools/tool-manager.ts
+++ b/source/tools/tool-manager.ts
@@ -103,14 +103,6 @@ export class ToolManager {
 	}
 
 	/**
-	 * Get native AI SDK tools registry
-	 * @deprecated Use getAllTools() instead - they now return the same thing
-	 */
-	getNativeToolsRegistry(): Record<string, AISDKCoreTool> {
-		return this.registry.getNativeTools();
-	}
-
-	/**
 	 * Check if a tool exists
 	 */
 	hasTool(toolName: string): boolean {

--- a/source/utils/file-autocomplete.spec.ts
+++ b/source/utils/file-autocomplete.spec.ts
@@ -1,75 +1,75 @@
 import test from 'ava';
 import {
 	clearFileListCache,
-	fuzzyScore,
 	getCurrentFileMention,
 } from './file-autocomplete.js';
+import {fuzzyScoreFilePath} from './fuzzy-matching.js';
 
 console.log(`\nfile-autocomplete.spec.ts`);
 
-// Test fuzzyScore()
+// Test fuzzyScoreFilePath()
 test('fuzzy score: exact match gets highest score', t => {
-	const score = fuzzyScore('app.tsx', 'app.tsx');
+	const score = fuzzyScoreFilePath('app.tsx', 'app.tsx');
 	t.is(score, 1000);
 });
 
 test('fuzzy score: exact filename match', t => {
-	const score = fuzzyScore('src/components/app.tsx', 'app.tsx');
+	const score = fuzzyScoreFilePath('src/components/app.tsx', 'app.tsx');
 	t.is(score, 900);
 });
 
 test('fuzzy score: path ends with query', t => {
-	const score = fuzzyScore('src/components/Button.tsx', 'Button.tsx');
+	const score = fuzzyScoreFilePath('src/components/Button.tsx', 'Button.tsx');
 	// This matches exact filename, so it gets 900 not 850
 	t.is(score, 900);
 });
 
 test('fuzzy score: filename starts with query', t => {
-	const score = fuzzyScore('src/components/Button.tsx', 'butt');
+	const score = fuzzyScoreFilePath('src/components/Button.tsx', 'butt');
 	t.is(score, 800);
 });
 
 test('fuzzy score: path starts with query', t => {
-	const score = fuzzyScore('src/components/Button.tsx', 'src/comp');
+	const score = fuzzyScoreFilePath('src/components/Button.tsx', 'src/comp');
 	t.is(score, 750);
 });
 
 test('fuzzy score: filename contains query', t => {
-	const score = fuzzyScore('src/components/Button.tsx', 'ton');
+	const score = fuzzyScoreFilePath('src/components/Button.tsx', 'ton');
 	t.is(score, 700);
 });
 
 test('fuzzy score: path contains query', t => {
-	const score = fuzzyScore('src/components/Button.tsx', 'compo');
+	const score = fuzzyScoreFilePath('src/components/Button.tsx', 'compo');
 	// "compo" is a substring in path but doesn't start the path
 	t.is(score, 600);
 });
 
 test('fuzzy score: sequential character match', t => {
-	const score = fuzzyScore('src/components/Button.tsx', 'btn');
+	const score = fuzzyScoreFilePath('src/components/Button.tsx', 'btn');
 	t.true(score > 0 && score < 600);
 });
 
 test('fuzzy score: no match returns 0', t => {
-	const score = fuzzyScore('app.tsx', 'xyz');
+	const score = fuzzyScoreFilePath('app.tsx', 'xyz');
 	t.is(score, 0);
 });
 
 test('fuzzy score: empty query returns 0', t => {
-	const score = fuzzyScore('app.tsx', '');
+	const score = fuzzyScoreFilePath('app.tsx', '');
 	t.is(score, 0);
 });
 
 test('fuzzy score: case insensitive', t => {
-	const score1 = fuzzyScore('App.tsx', 'app');
-	const score2 = fuzzyScore('app.tsx', 'APP');
+	const score1 = fuzzyScoreFilePath('App.tsx', 'app');
+	const score2 = fuzzyScoreFilePath('app.tsx', 'APP');
 	t.true(score1 > 0);
 	t.true(score2 > 0);
 });
 
 test('fuzzy score: prefers shorter paths', t => {
-	const shortPath = fuzzyScore('app.tsx', 'app');
-	const longPath = fuzzyScore('src/components/nested/app.tsx', 'app');
+	const shortPath = fuzzyScoreFilePath('app.tsx', 'app');
+	const longPath = fuzzyScoreFilePath('src/components/nested/app.tsx', 'app');
 	// Both match filename "app.tsx" starting with "app", so they get same score
 	// The scoring doesn't currently prefer shorter paths
 	t.is(shortPath, longPath);
@@ -77,9 +77,9 @@ test('fuzzy score: prefers shorter paths', t => {
 
 test('fuzzy score: consecutive matches get bonus', t => {
 	// "but" matches consecutively in "Button"
-	const consecutive = fuzzyScore('Button.tsx', 'but');
+	const consecutive = fuzzyScoreFilePath('Button.tsx', 'but');
 	// "btn" requires skipping characters
-	const nonConsecutive = fuzzyScore('Button.tsx', 'btn');
+	const nonConsecutive = fuzzyScoreFilePath('Button.tsx', 'btn');
 	t.true(consecutive > nonConsecutive);
 });
 

--- a/source/utils/file-autocomplete.ts
+++ b/source/utils/file-autocomplete.ts
@@ -98,15 +98,6 @@ async function getAllFiles(cwd: string): Promise<string[]> {
 }
 
 /**
- * Fuzzy match scoring algorithm for file paths
- * Returns a score from 0 to 1000 (higher = better match)
- * @deprecated Use fuzzyScoreFilePath from fuzzy-matching.ts instead
- */
-export function fuzzyScore(filePath: string, query: string): number {
-	return fuzzyScoreFilePath(filePath, query);
-}
-
-/**
  * Extract the current @mention being typed at cursor position
  * Returns the mention text and its position in the input
  */

--- a/source/utils/logging/correlation.spec.ts
+++ b/source/utils/logging/correlation.spec.ts
@@ -7,9 +7,7 @@ console.log(`\nlogging/correlation.spec.ts`);
 
 // Import correlation functions
 import {
-	addCorrelationMetadata,
 	checkCorrelationHealth,
-	clearCorrelationContext,
 	correlationMiddleware,
 	createCorrelationContext,
 	createCorrelationContextWithId,
@@ -25,7 +23,6 @@ import {
 	getCurrentCorrelationContext,
 	isCorrelationEnabled,
 	resetCorrelationMonitoring,
-	setCorrelationContext,
 	withCorrelation,
 	withCorrelationContext,
 	withNewCorrelationContext,
@@ -46,9 +43,6 @@ test.after.always(() => {
 	if (existsSync(testDir)) {
 		rmSync(testDir, {recursive: true, force: true});
 	}
-
-	// Clear correlation context
-	clearCorrelationContext();
 });
 
 test('generateCorrelationId creates valid correlation ID', t => {
@@ -84,7 +78,7 @@ test('correlation context management works', t => {
 		},
 	};
 
-	// Use withCorrelationContext instead of deprecated setCorrelationContext
+	// Use withCorrelationContext for proper async context management
 	withCorrelationContext(context, () => {
 		// Get current context
 		const current = getCurrentCorrelationContext();
@@ -371,12 +365,6 @@ test('context isolation between concurrent operations', async t => {
 });
 
 test('error handling in correlation functions', t => {
-	// Test with invalid context
-	t.notThrows(() => {
-		setCorrelationContext(null as any);
-		getCurrentCorrelationContext();
-	}, 'Should handle invalid context gracefully');
-
 	// Test with malformed headers
 	const malformedHeaders = {
 		'x-correlation-id': null,

--- a/source/utils/logging/correlation.ts
+++ b/source/utils/logging/correlation.ts
@@ -212,33 +212,6 @@ export function getCurrentCorrelationContext(): CorrelationContext | null {
 }
 
 /**
- * Set the current correlation context (runs function with context)
- * Note: AsyncLocalStorage doesn't support direct setting, use withCorrelationContext instead
- * @deprecated Use withCorrelationContext or withNewCorrelationContext
- */
-export function setCorrelationContext(_context: CorrelationContext): void {
-	// This function is deprecated - AsyncLocalStorage requires running within a context
-	console.warn(
-		'⚠️  setCorrelationContext is DEPRECATED and will be removed in future versions.' +
-			'\nUse withCorrelationContext() or withNewCorrelationContext() instead.' +
-			'\nExample: withNewCorrelationContext(async (context) => { ... })',
-	);
-}
-
-/**
- * Clear the current correlation context
- * Note: AsyncLocalStorage handles cleanup automatically
- * @deprecated Context is automatically cleared when async operation completes
- */
-export function clearCorrelationContext(): void {
-	// This function is deprecated - Context cleanup is automatic with AsyncLocalStorage
-	console.warn(
-		'⚠️  clearCorrelationContext is DEPRECATED. ' +
-			'Context cleanup is automatic with AsyncLocalStorage.',
-	);
-}
-
-/**
  * Run a function with a specific correlation context
  */
 export function withCorrelationContext<T>(
@@ -393,19 +366,6 @@ export function createCorrelationFromHeaders(
 	}
 
 	return createCorrelationContext(undefined, metadata);
-}
-
-/**
- * Add correlation metadata
- * Note: Creates a new context with updated metadata since AsyncLocalStorage is immutable
- * @deprecated Use withNewCorrelationContext with metadata parameter
- */
-export function addCorrelationMetadata(_key: string, _value: unknown): void {
-	// This function is deprecated - use withNewCorrelationContext with metadata instead
-	console.warn(
-		'⚠️  addCorrelationMetadata is DEPRECATED. ' +
-			'Use withNewCorrelationContext with metadata parameter instead.',
-	);
 }
 
 /**


### PR DESCRIPTION
## Description

This PR removes 5 deprecated functions that had better alternatives available, eliminating deprecation warnings and cleaning up the codebase. The changes follow OpenSpec change proposal `remove-deprecated-functions` which addresses GitHub issue #167.

### Deprecated Functions Removed:
1. **Correlation functions** (`source/utils/logging/correlation.ts`):
   - `setCorrelationContext()` → Use `withCorrelationContext()` or `withNewCorrelationContext()`
   - `clearCorrelationContext()` → Automatic cleanup with AsyncLocalStorage
   - `addCorrelationMetadata()` → Use `withNewCorrelationContext()` with metadata parameter

2. **Tool Manager** (`source/tools/tool-manager.ts`):
   - `getNativeToolsRegistry()` → Use `getAllTools()`

3. **File Autocomplete** (`source/utils/file-autocomplete.ts`):
   - `fuzzyScore()` wrapper → Use `fuzzyScoreFilePath()` directly

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [X] New features include passing tests in `.spec.ts/tsx` files
- [X] All existing tests pass (`pnpm test:all` completes successfully)
- [X] Tests cover both success and error scenarios

### Manual Testing

- [x] Tested with Ollama
- [x] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [x] Tested MCP integration (if applicable)

## Checklist

- [X] Code follows project style guidelines
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] No breaking changes (or clearly documented)
- [X] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))