### PR TITLE
feat(lsp): add Deno project detection for context-aware LSP selection

### DIFF
--- a/source/lsp/lsp-manager.ts
+++ b/source/lsp/lsp-manager.ts
@@ -5,6 +5,7 @@
 
 import {EventEmitter} from 'events';
 import {extname} from 'path';
+import {fileURLToPath} from 'url';
 import {readFile} from 'fs/promises';
 import {LSPClient, LSPServerConfig} from './lsp-client';
 import {
@@ -72,7 +73,11 @@ export class LSPManager extends EventEmitter {
 
 		// Auto-discover additional servers if enabled (default: true)
 		if (config.autoDiscover !== false) {
-			const discovered = await discoverLanguageServers();
+			// Extract file path from rootUri for context-aware server discovery
+			const projectRoot = this.rootUri.startsWith('file://')
+				? fileURLToPath(this.rootUri)
+				: this.rootUri;
+			const discovered = await discoverLanguageServers(projectRoot);
 
 			// Only add discovered servers for languages not already covered
 			const coveredLanguages = new Set<string>();


### PR DESCRIPTION
## Description

Add context-aware LSP server selection that prioritizes Deno LSP over TypeScript LSP when working in a Deno project. This enables proper language server support for Deno projects by detecting `deno.json` or `deno.jsonc` configuration files.

**Changes:**
- Add `isDenoProject()` function to detect Deno projects via config files
- Add `getOrderedServers()` to prioritize Deno LSP in Deno project contexts
- Modify `discoverLanguageServers()` to accept optional `projectRoot` parameter
- Update `LSPManager` to pass `projectRoot` for context-aware discovery

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)
- [x] Unit tests added (11 new tests)

**Test Coverage:**
- 6 tests for `isDenoProject()` - positive and negative cases
- 5 tests for `getOrderedServers()` - ordering, immutability, defaults

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed) - JSDoc added
- [x] No breaking changes (or clearly documented)
- [x] Tests pass (`npm run test:ava -- --match='*Deno*' --match='*getOrderedServers*'`)

Closes #116