### PR TITLE
fix: show all commands when pressing / + tab

### DIFF
--- a/source/commands.spec.ts
+++ b/source/commands.spec.ts
@@ -119,13 +119,13 @@ test('CommandRegistry.getAll - returns all registered commands', t => {
 // Tests for getCompletions()
 // ============================================================================
 
-test('CommandRegistry.getCompletions - returns empty array for empty prefix', t => {
+test('CommandRegistry.getCompletions - returns all commands alphabetically for empty prefix', t => {
 	const registry = new CommandRegistry();
 	registry.register([createTestCommand('help'), createTestCommand('test')]);
 
 	const completions = registry.getCompletions('');
 
-	t.deepEqual(completions, []);
+	t.deepEqual(completions, ['help', 'test']);
 });
 
 test('CommandRegistry.getCompletions - returns exact match', t => {

--- a/source/commands.ts
+++ b/source/commands.ts
@@ -23,8 +23,15 @@ class CommandRegistry {
 	}
 
 	getCompletions(prefix: string): string[] {
+		const commandNames = Array.from(this.commands.keys());
+
+		// No prefix: return all commands alphabetically
+		if (!prefix) {
+			return commandNames.sort((a, b) => a.localeCompare(b));
+		}
+
 		// Use fuzzy matching with scoring
-		const scoredCommands = Array.from(this.commands.keys())
+		const scoredCommands = commandNames
 			.map(name => ({
 				name,
 				score: fuzzyScore(name, prefix),

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -126,14 +126,15 @@ export default function UserInput({
 		}
 
 		const commandPrefix = input.slice(1).split(' ')[0];
-		if (commandPrefix.length === 0) {
-			return [];
-		}
 
 		const builtInCompletions = commandRegistry.getCompletions(commandPrefix);
 		const customCompletions = customCommands
 			.filter(cmd => {
-				return cmd.toLowerCase().includes(commandPrefix.toLowerCase());
+				// Include all when no prefix, otherwise filter by prefix
+				return (
+					!commandPrefix ||
+					cmd.toLowerCase().includes(commandPrefix.toLowerCase())
+				);
 			})
 			.sort((a, b) => a.localeCompare(b));
 


### PR DESCRIPTION
## Description

Shows all available commands alphabetically when user types `/` and presses Tab, enabling easy command discovery without requiring at least one character after the slash.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)

Fixes #207