### PR TITLE
fix: prioritize prefix matches over suffix matches in command completion

### DIFF
--- a/source/utils/fuzzy-matching.spec.ts
+++ b/source/utils/fuzzy-matching.spec.ts
@@ -122,6 +122,18 @@ test('command matching - fuzzy matching for /pvd matches provider', t => {
 	t.true(score > 0);
 });
 
+test('command matching - /l should prioritize /lsp over /model', t => {
+	const lspScore = fuzzyScore('lsp', 'l');
+	const modelScore = fuzzyScore('model', 'l');
+
+	// /lsp starts with 'l' (prefix match: 850)
+	// /model ends with 'l' (suffix match: 800)
+	// Therefore, /lsp should score higher
+	t.true(lspScore > modelScore);
+	t.is(lspScore, 850); // prefix match
+	t.is(modelScore, 800); // suffix match
+});
+
 test('command matching - /init matches init higher than initialization', t => {
 	const initScore = fuzzyScore('init', 'init');
 	const initializationScore = fuzzyScore('initialization', 'init');

--- a/source/utils/fuzzy-matching.ts
+++ b/source/utils/fuzzy-matching.ts
@@ -17,13 +17,13 @@ export function fuzzyScore(text: string, query: string): number {
 		return 1000;
 	}
 
-	// Text ends with query
-	if (lowerText.endsWith(lowerQuery)) {
+	// Text starts with query (prefix match - prioritized for command completion)
+	if (lowerText.startsWith(lowerQuery)) {
 		return 850;
 	}
 
-	// Text starts with query
-	if (lowerText.startsWith(lowerQuery)) {
+	// Text ends with query (suffix match)
+	if (lowerText.endsWith(lowerQuery)) {
 		return 800;
 	}
 


### PR DESCRIPTION
## Summary

Fixes #219 - Command completion now correctly prioritizes prefix matches over suffix matches.

## Changes

- Swapped scoring priority in `fuzzyScore()`: prefix matches now score 850 (up from 800), suffix matches now score 800 (down from 850)
- Added test case to verify `/l` correctly prioritizes `/lsp` over `/model`

## Problem

When typing `/l` and pressing Tab for command completion, `/model` appeared before `/lsp` because:
- `/lsp` matched as a prefix (scored 800)
- `/model` matched as a suffix with "l" (scored 850)

This was counterintuitive since prefix matches are more relevant for command completion.

## Solution

Prefix matches are now prioritized over suffix matches, making command completion behavior more intuitive and user-friendly.

## Test Results

All tests pass including the new test case:
```
✔ command matching - /l should prioritize /lsp over /model
```

Verified fix:
```
/lsp score: 850 (prefix match)
/model score: 800 (suffix match)
```