### PR TITLE
Fix incorrect 'Interrupted by user' error on empty model responses

### DIFF
--- a/source/ai-sdk-client/chat/chat-handler.ts
+++ b/source/ai-sdk-client/chat/chat-handler.ts
@@ -259,8 +259,14 @@ export async function handleChat(
 				// Check if there's an underlying RetryError with the real cause
 				const rootError = extractRootError(error);
 				if (rootError === error) {
-					// No underlying error - this is just a cancellation
-					throw new Error('Operation was cancelled');
+					// No underlying error - check if user actually cancelled
+					if (signal?.aborted) {
+						throw new Error('Operation was cancelled');
+					}
+					// Model returned empty response without cancellation
+					throw new Error(
+						'Model returned empty response. This may indicate the model is not responding correctly or the prompt was unclear.',
+					);
 				}
 				// There's a real error underneath, parse it
 				const userMessage = parseAPIError(rootError);


### PR DESCRIPTION
Fixes #110 - Resolves false "Interrupted by user" errors when models return empty responses.

## Problem
When models return empty responses, the AI SDK throws AI_NoOutputGeneratedError. The code incorrectly assumed this always meant user cancellation, displaying "Interrupted by user" error even when the user didn't cancel anything.

## Root Cause
Bug in chat-handler.ts:261-263 - When AI_NoOutputGeneratedError occurred without an underlying error, the code immediately threw "Operation was cancelled" without checking if the user actually cancelled via the abort signal.

## Solution
Added signal?.aborted check before treating empty responses as cancellations. This properly distinguishes between actual user cancellations and models returning empty responses.

## Testing
All existing tests pass with no regressions.

## Credit
Thanks to @JimStenstrom for the excellent root cause analysis.