### PR TITLE
fix: prevent process hang when exiting security disclaimer

### DIFF
--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -85,6 +85,9 @@ export default function App({
 
 	const handleExit = () => {
 		exit();
+		// Force exit - at security disclaimer stage, no services need cleanup
+		// TODO: Replace with ShutdownManager.gracefulShutdown() once #239 is implemented
+		process.exit(0);
 	};
 
 	// VS Code server integration


### PR DESCRIPTION
## Description

Fix process hanging when user selects "No, exit" on the security disclaimer banner.

ink's `exit()` only unmounts the React tree but doesn't terminate the process if there are active event listeners. Added `process.exit(0)` as a workaround since no services requiring cleanup have been initialized at this stage.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Verified process exits cleanly when selecting "No, exit"
- [x] Build passes

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes

## Notes

Refs #239 - This workaround will be replaced with proper ShutdownManager integration once that enhancement is implemented.