### PR TITLE
fix(test): handle line wrap in read-file metadata test

### DIFF
--- a/source/tools/read-file.spec.tsx
+++ b/source/tools/read-file.spec.tsx
@@ -86,7 +86,7 @@ test('ReadFileFormatter shows metadata only indicator', async t => {
 
 		const output = lastFrame();
 		t.truthy(output);
-		t.regex(output!, /metadata only/);
+		t.regex(output!, /metadata\s+only/);
 	} finally {
 		rmSync(testDir, {recursive: true, force: true});
 	}


### PR DESCRIPTION
## Description

Fix flaky test in `read-file.spec.tsx` that fails when terminal width causes line wrap.

Changed regex from `/metadata only/` to `/metadata\s+only/` to match any whitespace (including newlines) between words.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)