### PR TITLE
fix: resolve race conditions in singleton patterns and improve VS Code integration

### DIFF
--- a/plugins/vscode/src/diff-manager.ts
+++ b/plugins/vscode/src/diff-manager.ts
@@ -133,8 +133,7 @@ export class DiffManager {
 			await vscode.window.showTextDocument(doc, {
 				preview: true,
 				preserveFocus: true,
-				viewColumn: vscode.ViewColumn.Beside,
-			});
+				});
 
 			// Restore terminal focus
 			if (activeTerminal) {

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -125,7 +125,7 @@ export default function App({
 		[logger],
 	);
 
-	useVSCodeServer({
+	const vscodeServer = useVSCodeServer({
 		enabled: vscodeMode,
 		port: vscodePort,
 		currentModel: appState.currentModel,
@@ -394,6 +394,9 @@ export default function App({
 				lspServersStatus: appState.lspServersStatus,
 				preferencesLoaded: appState.preferencesLoaded,
 				customCommandsCount: appState.customCommandsCount,
+				vscodeMode,
+				vscodePort: vscodeServer.actualPort,
+				vscodeRequestedPort: vscodeServer.requestedPort,
 			}),
 		[
 			shouldShowWelcome,
@@ -405,6 +408,9 @@ export default function App({
 			appState.lspServersStatus,
 			appState.preferencesLoaded,
 			appState.customCommandsCount,
+			vscodeMode,
+			vscodeServer.actualPort,
+			vscodeServer.requestedPort,
 		],
 	);
 

--- a/source/app/components/app-container.tsx
+++ b/source/app/components/app-container.tsx
@@ -15,6 +15,9 @@ export interface AppContainerProps {
 	lspServersStatus: LSPConnectionStatus[];
 	preferencesLoaded: boolean;
 	customCommandsCount: number;
+	vscodeMode?: boolean;
+	vscodePort?: number | null;
+	vscodeRequestedPort?: number;
 }
 
 /**
@@ -31,6 +34,9 @@ export function createStaticComponents({
 	lspServersStatus,
 	preferencesLoaded,
 	customCommandsCount,
+	vscodeMode,
+	vscodePort,
+	vscodeRequestedPort,
 }: AppContainerProps): React.ReactNode[] {
 	const components: React.ReactNode[] = [];
 
@@ -49,6 +55,9 @@ export function createStaticComponents({
 			lspServersStatus={lspServersStatus}
 			preferencesLoaded={preferencesLoaded}
 			customCommandsCount={customCommandsCount}
+			vscodeMode={vscodeMode}
+			vscodePort={vscodePort}
+			vscodeRequestedPort={vscodeRequestedPort}
 		/>,
 	);
 

--- a/source/commands/lsp.tsx
+++ b/source/commands/lsp.tsx
@@ -104,17 +104,15 @@ export function LSP({status}: LSPProps) {
 export const lspCommand: Command = {
 	name: 'lsp',
 	description: 'Show connected LSP servers and their status',
-	handler: (_args: string[], _messages, _metadata) => {
-		const lspManager = getLSPManager();
+	handler: async (_args: string[], _messages, _metadata) => {
+		const lspManager = await getLSPManager();
 
 		// Get the current status of LSP servers
 		const status = lspManager.getStatus();
 
-		return Promise.resolve(
-			React.createElement(LSP, {
-				key: `lsp-${Date.now()}`,
-				status: status,
-			}),
-		);
+		return React.createElement(LSP, {
+			key: `lsp-${Date.now()}`,
+			status: status,
+		});
 	},
 };

--- a/source/components/status.tsx
+++ b/source/components/status.tsx
@@ -29,6 +29,9 @@ export default memo(function Status({
 	lspServersStatus,
 	customCommandsCount,
 	preferencesLoaded,
+	vscodeMode,
+	vscodePort,
+	vscodeRequestedPort,
 }: {
 	provider: string;
 	model: string;
@@ -39,6 +42,9 @@ export default memo(function Status({
 	lspServersStatus?: LSPConnectionStatus[];
 	customCommandsCount?: number;
 	preferencesLoaded?: boolean;
+	vscodeMode?: boolean;
+	vscodePort?: number | null;
+	vscodeRequestedPort?: number;
 }) {
 	const {boxWidth, isNarrow, truncatePath} = useResponsiveTerminal();
 	const colors = getThemeColors(theme);
@@ -61,6 +67,13 @@ export default memo(function Status({
 		if (connected > 0) return colors.warning;
 		return colors.error;
 	};
+
+	// VS Code port status
+	const showPortWarning =
+		vscodeMode &&
+		vscodePort &&
+		vscodeRequestedPort &&
+		vscodePort !== vscodeRequestedPort;
 
 	// Calculate max path length based on terminal size
 	const maxPathLength = isNarrow
@@ -106,6 +119,13 @@ export default memo(function Status({
 					{customCommandsCount !== undefined && customCommandsCount > 0 && (
 						<Text color={colors.secondary}>
 							✓ {customCommandsCount} custom commands
+						</Text>
+					)}
+					{vscodeMode && vscodePort && (
+						<Text color={showPortWarning ? colors.warning : colors.secondary}>
+							{showPortWarning
+								? `⚠ VS Code: port ${vscodeRequestedPort}→${vscodePort}`
+								: `✓ VS Code: port ${vscodePort}`}
 						</Text>
 					)}
 					{mcpTotal > 0 && (
@@ -191,6 +211,13 @@ export default memo(function Status({
 					{customCommandsCount !== undefined && customCommandsCount > 0 && (
 						<Text color={colors.secondary}>
 							✓ {customCommandsCount} custom commands loaded
+						</Text>
+					)}
+					{vscodeMode && vscodePort && (
+						<Text color={showPortWarning ? colors.warning : colors.secondary}>
+							{showPortWarning
+								? `⚠ VS Code server on port ${vscodePort} (requested ${vscodeRequestedPort} was in use)`
+								: `✓ VS Code server listening on port ${vscodePort}`}
 						</Text>
 					)}
 					{mcpTotal > 0 && (

--- a/source/hooks/useAppInitialization.tsx
+++ b/source/hooks/useAppInitialization.tsx
@@ -191,7 +191,7 @@ export function useAppInitialization({
 
 	// Initialize LSP servers with auto-discovery
 	const initializeLSPServers = async () => {
-		const lspManager = getLSPManager({
+		const lspManager = await getLSPManager({
 			rootUri: `file://${process.cwd()}`,
 			autoDiscover: true,
 			// Use custom servers from config if provided

--- a/source/hooks/useToolHandler.tsx
+++ b/source/hooks/useToolHandler.tsx
@@ -14,7 +14,7 @@ import {MessageBuilder} from '@/utils/message-builder';
 import {parseToolArguments} from '@/utils/tool-args-parser';
 import {createCancellationResults} from '@/utils/tool-cancellation';
 import {displayToolResult} from '@/utils/tool-result-display';
-import {getVSCodeServer} from '@/vscode/index';
+import {getVSCodeServerSync} from '@/vscode/index';
 
 interface UseToolHandlerProps {
 	pendingToolCalls: ToolCall[];
@@ -92,7 +92,7 @@ export function useToolHandler({
 	const handleToolConfirmation = (confirmed: boolean) => {
 		if (!confirmed) {
 			// User cancelled - close all VS Code diffs
-			const vscodeServer = getVSCodeServer();
+			const vscodeServer = getVSCodeServerSync();
 			if (vscodeServer?.hasConnections()) {
 				vscodeServer.closeAllDiffs();
 			}
@@ -298,7 +298,7 @@ export function useToolHandler({
 	// Handle tool confirmation cancel
 	const handleToolConfirmationCancel = () => {
 		// Close all VS Code diffs when user cancels
-		const vscodeServer = getVSCodeServer();
+		const vscodeServer = getVSCodeServerSync();
 		if (vscodeServer?.hasConnections()) {
 			vscodeServer.closeAllDiffs();
 		}

--- a/source/hooks/useVSCodeServer.tsx
+++ b/source/hooks/useVSCodeServer.tsx
@@ -22,6 +22,8 @@ interface UseVSCodeServerProps {
 interface UseVSCodeServerReturn {
 	isConnected: boolean;
 	connectionCount: number;
+	actualPort: number | null;
+	requestedPort: number;
 	sendAssistantMessage: (content: string, isGenerating?: boolean) => void;
 	notifyFileChange: (
 		filePath: string,
@@ -48,6 +50,7 @@ export function useVSCodeServer({
 	const serverRef = useRef<VSCodeServer | null>(null);
 	const [isConnected, setIsConnected] = useState(false);
 	const [connectionCount, setConnectionCount] = useState(0);
+	const [actualPort, setActualPort] = useState<number | null>(null);
 
 	// Store callbacks in refs to avoid re-creating server on callback changes
 	const onPromptRef = useRef(onPrompt);
@@ -79,7 +82,7 @@ export function useVSCodeServer({
 		}
 
 		const initServer = async () => {
-			const server = getVSCodeServer(port);
+			const server = await getVSCodeServer(port);
 			serverRef.current = server;
 
 			// Set up callbacks using refs
@@ -110,6 +113,7 @@ export function useVSCodeServer({
 
 			// Start the server
 			await server.start();
+			setActualPort(server.getPort());
 		};
 
 		void initServer();
@@ -179,6 +183,8 @@ export function useVSCodeServer({
 	return {
 		isConnected,
 		connectionCount,
+		actualPort,
+		requestedPort: port,
 		sendAssistantMessage,
 		notifyFileChange,
 		requestDiagnostics,

--- a/source/lsp/lsp-manager.spec.ts
+++ b/source/lsp/lsp-manager.spec.ts
@@ -223,28 +223,41 @@ test('LSPManager - can remove listeners', t => {
 });
 
 // Singleton tests
-test('getLSPManager - returns an LSPManager instance', t => {
-	const manager = getLSPManager();
+test('getLSPManager - returns an LSPManager instance', async t => {
+	const manager = await getLSPManager();
 	t.truthy(manager);
 	t.true(manager instanceof LSPManager);
 });
 
-test('getLSPManager - returns same instance on multiple calls', t => {
-	const manager1 = getLSPManager();
-	const manager2 = getLSPManager();
+test('getLSPManager - returns same instance on multiple calls', async t => {
+	const manager1 = await getLSPManager();
+	const manager2 = await getLSPManager();
 	t.is(manager1, manager2);
 });
 
-test('getLSPManager - accepts config on first call', t => {
-	const manager = getLSPManager({rootUri: 'file:///test'});
+test('getLSPManager - accepts config on first call', async t => {
+	const manager = await getLSPManager({rootUri: 'file:///test'});
 	t.truthy(manager);
+});
+
+test('getLSPManager - prevents race conditions with concurrent calls', async t => {
+	await resetLSPManager();
+	// Call getLSPManager multiple times concurrently
+	const [manager1, manager2, manager3] = await Promise.all([
+		getLSPManager(),
+		getLSPManager(),
+		getLSPManager(),
+	]);
+	// All should return the same instance
+	t.is(manager1, manager2);
+	t.is(manager2, manager3);
 });
 
 // resetLSPManager tests
 test('resetLSPManager - creates fresh instance after reset', async t => {
-	const manager1 = getLSPManager();
+	const manager1 = await getLSPManager();
 	await resetLSPManager();
-	const manager2 = getLSPManager();
+	const manager2 = await getLSPManager();
 
 	t.not(manager1, manager2);
 });

--- a/source/tools/lsp-get-diagnostics.tsx
+++ b/source/tools/lsp-get-diagnostics.tsx
@@ -17,7 +17,7 @@ interface GetDiagnosticsArgs {
 async function getVSCodeDiagnostics(
 	filePath?: string,
 ): Promise<DiagnosticInfo[] | null> {
-	const server = getVSCodeServer();
+	const server = await getVSCodeServer();
 
 	// Convert to absolute path for VS Code
 	const absPath = filePath ? resolvePath(filePath) : undefined;
@@ -99,7 +99,7 @@ const executeGetDiagnostics = async (
 	args: GetDiagnosticsArgs,
 ): Promise<string> => {
 	// Prefer VS Code diagnostics when connected
-	const server = getVSCodeServer();
+	const server = await getVSCodeServer();
 	const hasConnections = server.hasConnections();
 
 	if (hasConnections) {
@@ -111,7 +111,7 @@ const executeGetDiagnostics = async (
 	}
 
 	// Fall back to local LSP
-	const lspManager = getLSPManager();
+	const lspManager = await getLSPManager();
 
 	if (!lspManager.isInitialized()) {
 		return 'No diagnostics source available. Either connect VS Code with --vscode flag, or install a language server.';

--- a/source/vscode/index.ts
+++ b/source/vscode/index.ts
@@ -40,6 +40,7 @@ export {
 	closeAllDiffsInVSCode,
 	closeDiffInVSCode,
 	getVSCodeServer,
+	getVSCodeServerSync,
 	isVSCodeConnected,
 	type MessageHandler,
 	type PromptHandler,


### PR DESCRIPTION
## Summary

Fixes #237 - Resolves race conditions in `getLSPManager()` and `getVSCodeServer()` singleton patterns that could cause multiple instances to be created during concurrent initialization.

Additionally includes VS Code server improvements for better reliability and user experience.

## Changes

### Race Condition Fixes

**LSPManager Singleton** (`source/lsp/lsp-manager.ts`)
- Fixed race condition where concurrent calls could create multiple instances
- Implemented promise-based initialization to ensure single instance
- Updated `resetLSPManager()` to clear both instance and promise

**VSCodeServer Singleton** (`source/vscode/vscode-server.ts`)
- Fixed race condition with same promise-based pattern
- Added `getVSCodeServerSync()` for synchronous access when needed

### VS Code Server Improvements

**Automatic Port Fallback**
- Tries up to 10 alternative ports if requested port is taken
- Prevents `EADDRINUSE` errors blocking server startup
- Added `getPort()` method to retrieve actual port being used

**UI Display Enhancements**
- Added VS Code port status to Status and WelcomeMessage components
- Shows warning when fallback port is used vs requested port
- Port info properly threaded through component hierarchy

**Extension Layout Fix**
- Fixed `write_file` tool opening in dual-column layout
- Now opens in single pane like `string_replace` (better UX)

### Updated Callers

All singleton callers updated to use async pattern:
- `source/commands/lsp.tsx`
- `source/hooks/useAppInitialization.tsx`
- `source/tools/lsp-get-diagnostics.tsx`
- `source/hooks/useToolHandler.tsx` (uses sync version)

## Test Coverage

### New Tests Added
- LSP Manager: Race condition test with concurrent calls
- VS Code Server: Race condition test with concurrent calls
- VS Code Server: Port fallback tests (3 new tests)
  - `getPort()` returns actual port
  - Falls back to next port when requested port is busy
  - Exhausts all 10 alternatives and fails appropriately

**All tests pass:** 51 LSP tests, 30 VS Code server tests

## Test Plan

- [x] Run full test suite (`pnpm run test:all`)
- [x] Test concurrent initialization scenarios
- [x] Test port fallback with occupied ports
- [x] Verify VS Code extension behavior (single pane layout)
- [x] Verify UI displays port information correctly