### PR TITLE
fix: add Bun runtime detection to LoggerProvider

### DIFF
--- a/source/utils/logging/logger-provider.spec.ts
+++ b/source/utils/logging/logger-provider.spec.ts
@@ -300,34 +300,54 @@ test('multiple initializeLogger calls do not cause duplicate async loads', async
 	}, 'All logger instances should work after async load');
 });
 
-test('Bun runtime detection - uses fallback logger when Bun detected', t => {
-	const provider = LoggerProvider.getInstance();
+test.serial(
+	'Bun runtime detection - uses fallback logger when Bun detected',
+	async t => {
+		const provider = LoggerProvider.getInstance();
 
-	// Simulate Bun runtime by setting globalThis.Bun
-	const originalBun = (globalThis as Record<string, unknown>).Bun;
-	(globalThis as Record<string, unknown>).Bun = {version: '1.0.0'};
+		// Simulate Bun runtime by setting globalThis.Bun
+		const originalBun = (globalThis as Record<string, unknown>).Bun;
+		(globalThis as Record<string, unknown>).Bun = {version: '1.0.0'};
 
-	try {
-		provider.reset();
-		const logger = provider.initializeLogger();
+		try {
+			provider.reset();
+			const logger = provider.initializeLogger();
 
-		// Logger should still work (using fallback)
-		t.truthy(logger, 'Should create logger even with Bun runtime');
-		t.truthy(typeof logger.info === 'function', 'Should have info method');
-		t.truthy(typeof logger.error === 'function', 'Should have error method');
+			// Logger should still work (using fallback)
+			t.truthy(logger, 'Should create logger even with Bun runtime');
+			t.truthy(typeof logger.info === 'function', 'Should have info method');
+			t.truthy(typeof logger.error === 'function', 'Should have error method');
 
-		// Should be able to call logging methods without crashing
-		t.notThrows(() => {
-			logger.info('Test message');
-			logger.error('Error message');
-		}, 'Should be able to log without Pino transport crash');
-	} finally {
-		// Restore original state
-		if (originalBun === undefined) {
-			delete (globalThis as Record<string, unknown>).Bun;
-		} else {
-			(globalThis as Record<string, unknown>).Bun = originalBun;
+			// Should be able to call logging methods without crashing
+			t.notThrows(() => {
+				logger.info('Test message');
+				logger.error('Error message');
+			}, 'Should be able to log without Pino transport crash');
+
+			// Wait for async loading period to pass - under Bun, loadRealDependencies
+			// should NOT be called, so the logger should remain a fallback logger
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			// Verify the logger is still functional after the async period
+			// (in Bun, we skip Pino loading entirely, so no upgrade should occur)
+			t.notThrows(() => {
+				logger.info('Post-async test message');
+			}, 'Logger should remain functional (fallback) after async period');
+
+			// The fallback logger's flush is a no-op that resolves immediately
+			// Pino's flush would interact with file streams - this verifies we're using fallback
+			await t.notThrowsAsync(
+				async () => provider.flush(),
+				'Flush should complete without errors (fallback logger)',
+			);
+		} finally {
+			// Restore original state
+			if (originalBun === undefined) {
+				delete (globalThis as Record<string, unknown>).Bun;
+			} else {
+				(globalThis as Record<string, unknown>).Bun = originalBun;
+			}
+			provider.reset();
 		}
-		provider.reset();
-	}
-});
+	},
+);

--- a/source/utils/logging/logger-provider.ts
+++ b/source/utils/logging/logger-provider.ts
@@ -69,13 +69,10 @@ export class LoggerProvider {
 		// which uses thread-stream and real-require packages
 		if (LoggerProvider.isBunRuntime()) {
 			if (process.env.NODE_ENV === 'development') {
-				this.createFallbackLogger().info(
-					'Bun runtime detected - using fallback logger (Pino transport incompatible)',
-					{
-						source: 'logger-provider',
-						runtime: 'bun',
-						status: 'fallback-only',
-					},
+				// Use console directly since this._config is not yet set,
+				// so createFallbackLogger() would default to 'silent' level
+				console.info(
+					'[LOGGER_PROVIDER] Bun runtime detected - using fallback logger (Pino transport incompatible)',
 				);
 			}
 			return;
@@ -344,7 +341,6 @@ export class LoggerProvider {
 
 	/**
 	 * Flush any pending logs
-	 * Includes defensive error handling for shutdown edge cases
 	 */
 	public async flush(): Promise<void> {
 		if (this._logger) {


### PR DESCRIPTION
## Description

Add Bun runtime detection to LoggerProvider to fix crash on startup when running nanocoder under Bun. When Bun is detected, the LoggerProvider skips loading Pino's file transport (which is incompatible with Bun's worker thread implementation) and uses a console-based fallback logger instead.

This PR builds on top of @will-lamerton's work in #245 (LoggerProvider async loading fix), which split the dependency tracking flags and provided the foundation for this Bun compatibility fix.

### Changes:
- Add `isBunRuntime()` helper to detect Bun runtime via `globalThis.Bun` check
- Skip loading Pino file transport when running under Bun
- Gracefully fall back to console logger on Bun runtime
- Add test for Bun runtime detection behavior

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)
- [x] Tested nanocoder startup under Bun runtime - no longer crashes
- [x] Verified Node.js behavior unchanged - normal Pino loading continues
- [x] `pnpm test:all` passes (logger-provider tests: 19/19)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed) - N/A, internal implementation detail
- [x] No breaking changes (or clearly documented)

Fixes #128