### PR TITLE
Fix: React Context Error - useTitleShape must be used within a TitleShapeProvider

### DIFF
--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -460,11 +460,13 @@ export default function App({
 		logger.debug('Directory trust check in progress');
 
 		return (
-			<Box flexDirection="column" padding={1}>
-				<Text color={themeContextValue.colors.secondary}>
-					<Spinner type="dots" /> Checking directory trust...
-				</Text>
-			</Box>
+			<ThemeContext.Provider value={themeContextValue}>
+				<Box flexDirection="column" padding={1}>
+					<Text color={themeContextValue.colors.secondary}>
+						<Spinner type="dots" /> Checking directory trust...
+					</Text>
+				</Box>
+			</ThemeContext.Provider>
 		);
 	}
 
@@ -476,14 +478,16 @@ export default function App({
 		});
 
 		return (
-			<Box flexDirection="column" padding={1}>
-				<Text color={themeContextValue.colors.error}>
-					⚠️ Error checking directory trust: {isTrustedError}
-				</Text>
-				<Text color={themeContextValue.colors.secondary}>
-					Please restart the application or check your permissions.
-				</Text>
-			</Box>
+			<ThemeContext.Provider value={themeContextValue}>
+				<Box flexDirection="column" padding={1}>
+					<Text color={themeContextValue.colors.error}>
+						⚠️ Error checking directory trust: {isTrustedError}
+					</Text>
+					<Text color={themeContextValue.colors.secondary}>
+						Please restart the application or check your permissions.
+					</Text>
+				</Box>
+			</ThemeContext.Provider>
 		);
 	}
 
@@ -492,7 +496,14 @@ export default function App({
 		logger.info('Directory not trusted, showing security disclaimer');
 
 		return (
-			<SecurityDisclaimer onConfirm={handleConfirmTrust} onExit={handleExit} />
+			<ThemeContext.Provider value={themeContextValue}>
+				<TitleShapeContext.Provider value={titleShapeContextValue}>
+					<SecurityDisclaimer
+						onConfirm={handleConfirmTrust}
+						onExit={handleExit}
+					/>
+				</TitleShapeContext.Provider>
+			</ThemeContext.Provider>
 		);
 	}
 


### PR DESCRIPTION
## Description

This PR fixes a critical production startup issue where Nanocoder would fail to launch with the error:
```
ERROR: useTitleShape must be used within a TitleShapeProvider
```

The issue occurred because several rendering paths in the App component were missing the required React context providers (`TitleShapeContext.Provider` and `ThemeContext.Provider`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Root Cause

The `SecurityDisclaimer` component uses `TitledBoxWithPreferences`, which calls the `useTitleShape()` hook. However, the component was being rendered in a path that didn't have the required `TitleShapeContext.Provider` in the component tree.

## Solution

Added the missing context providers to three rendering paths in `source/app/App.tsx`:

1. **Directory Trust Loading State** - Added `ThemeContext.Provider`
2. **Directory Trust Error State** - Added `ThemeContext.Provider`
3. **Security Disclaimer** - Added both `ThemeContext.Provider` and `TitleShapeContext.Provider`

## Changes Made

**File**: `source/app/App.tsx`

```typescript
// Security Disclaimer rendering path (the main fix)
return (
    <ThemeContext.Provider value={themeContextValue}>
        <TitleShapeContext.Provider value={titleShapeContextValue}>
            <SecurityDisclaimer onConfirm={handleConfirmTrust} onExit={handleExit} />
        </TitleShapeContext.Provider>
    </ThemeContext.Provider>
);
```

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [x] Tested with production mode: `NODE_ENV=production nanocoder` ✅ No React context error
- [x] Tested with normal mode: `nanocoder` ✅ No React context error
- [x] Tested with run mode: `nanocoder run help` ✅ No React context error
- [x] Verified build success: `npm run build` ✅ Successful compilation

## Impact

- **Severity**: High - This was preventing Nanocoder from starting in production mode
- **Frequency**: Occurred on first run or when running in new directories
- **User Experience**: Complete failure to launch with confusing error message

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes
- [x] Appropriate logging already exists
- [x] Changes are minimal and focused on the specific issue

## Related Issue

Fixes #269 - React Context Error: useTitleShape must be used within a TitleShapeProvider

## Additional Notes

This fix ensures that all early rendering paths have access to the required React contexts, allowing Nanocoder to start successfully in all scenarios. The fix is minimal, focused, and maintains backward compatibility while resolving the critical startup issue.