### PR TITLE
fix: safe memory operations to prevent process polyfill crash

### DIFF
--- a/source/ai-sdk-client/chat/chat-handler.ts
+++ b/source/ai-sdk-client/chat/chat-handler.ts
@@ -24,6 +24,7 @@ import {
 	startMetrics,
 	withNewCorrelationContext,
 } from '@/utils/logging';
+import {getSafeMemory} from '@/utils/logging/safe-process.js';
 import {convertToModelMessages} from '../converters/message-converter.js';
 import {
 	convertAISDKToolCalls,
@@ -257,7 +258,7 @@ export async function handleChat(
 				responseLength: content.length,
 				toolCallsFound: toolCalls.length,
 				memoryDelta: formatMemoryUsage(
-					finalMetrics.memoryUsage || process.memoryUsage(),
+					finalMetrics.memoryUsage || getSafeMemory(),
 				),
 				correlationId,
 				provider: providerConfig.name,
@@ -368,7 +369,7 @@ export async function handleChat(
 				correlationId,
 				provider: providerConfig.name,
 				memoryDelta: formatMemoryUsage(
-					finalMetrics.memoryUsage || process.memoryUsage(),
+					finalMetrics.memoryUsage || getSafeMemory(),
 				),
 			});
 

--- a/source/mcp/mcp-client.ts
+++ b/source/mcp/mcp-client.ts
@@ -28,6 +28,7 @@ import {
 	startMetrics,
 	withNewCorrelationContext,
 } from '@/utils/logging';
+import {getSafeMemory} from '@/utils/logging/safe-process.js';
 import {ensureString} from '@/utils/type-helpers';
 import {TransportFactory} from './transport-factory.js';
 
@@ -150,7 +151,7 @@ export class MCPClient {
 					toolCount: tools.length,
 					duration: `${finalMetrics.duration.toFixed(2)}ms`,
 					memoryDelta: formatMemoryUsage(
-						finalMetrics.memoryUsage || process.memoryUsage(),
+						finalMetrics.memoryUsage || getSafeMemory(),
 					),
 					correlationId,
 				});
@@ -163,7 +164,7 @@ export class MCPClient {
 					errorName: error instanceof Error ? error.name : 'Unknown',
 					duration: `${finalMetrics.duration.toFixed(2)}ms`,
 					memoryDelta: formatMemoryUsage(
-						finalMetrics.memoryUsage || process.memoryUsage(),
+						finalMetrics.memoryUsage || getSafeMemory(),
 					),
 					correlationId,
 				});

--- a/source/utils/logging/health-monitor/checks/memory-check.ts
+++ b/source/utils/logging/health-monitor/checks/memory-check.ts
@@ -2,6 +2,7 @@
  * Memory health check
  */
 
+import {getSafeMemory} from '../../safe-process.js';
 import type {HealthCheck, HealthCheckConfig} from '../types.js';
 
 /**
@@ -9,7 +10,7 @@ import type {HealthCheck, HealthCheckConfig} from '../types.js';
  */
 export function checkMemory(config: HealthCheckConfig): HealthCheck {
 	const startTime = performance.now();
-	const memory = process.memoryUsage();
+	const memory = getSafeMemory();
 	const heapUsagePercent = memory.heapUsed / memory.heapTotal;
 	const externalMB = memory.external / 1024 / 1024;
 

--- a/source/utils/logging/health-monitor/core/health-monitor.ts
+++ b/source/utils/logging/health-monitor/core/health-monitor.ts
@@ -19,6 +19,7 @@ import {globalLogStorage} from '../../log-query/index.js';
 import {loggerProvider} from '../../logger-provider.js';
 import {globalPerformanceMonitor} from '../../performance.js';
 import {globalRequestTracker} from '../../request-tracker.js';
+import {getSafeCpuUsage, getSafeMemory} from '../../safe-process.js';
 
 const getLogger = () => loggerProvider.getLogger();
 
@@ -238,8 +239,8 @@ export class HealthMonitor {
 	 */
 	getSystemMetrics(): SystemMetrics {
 		const _now = Date.now();
-		const memory = process.memoryUsage();
-		const cpuUsage = process.cpuUsage();
+		const memory = getSafeMemory();
+		const cpuUsage = getSafeCpuUsage();
 		const requestStats = globalRequestTracker.getStats();
 		const logStats = globalLogStorage.getEntryCount();
 		const perfStats = globalPerformanceMonitor.getAllStats();

--- a/source/utils/logging/request-tracker.ts
+++ b/source/utils/logging/request-tracker.ts
@@ -12,6 +12,7 @@ import {
 	formatBytes,
 	trackPerformance,
 } from './performance.js';
+import {getSafeMemory} from './safe-process.js';
 
 // Get logger instance directly to avoid circular dependencies
 const logger = getLogger();
@@ -102,7 +103,7 @@ export class RequestTracker {
 			startTime: Date.now(),
 			status: 'pending',
 			correlationId: generateCorrelationId(),
-			memoryStart: process.memoryUsage(),
+			memoryStart: getSafeMemory(),
 		};
 
 		this.activeRequests.set(id, request);
@@ -140,7 +141,7 @@ export class RequestTracker {
 		}
 
 		const endTime = Date.now();
-		const memoryEnd = process.memoryUsage();
+		const memoryEnd = getSafeMemory();
 		const duration = endTime - request.startTime;
 		let memoryDelta: Record<string, number> | undefined;
 		if (request.memoryStart) {
@@ -210,7 +211,7 @@ export class RequestTracker {
 		}
 
 		const endTime = Date.now();
-		const memoryEnd = process.memoryUsage();
+		const memoryEnd = getSafeMemory();
 		const duration = endTime - request.startTime;
 		let memoryDelta: Record<string, number> | undefined;
 		if (request.memoryStart) {
@@ -282,7 +283,7 @@ export class RequestTracker {
 		}
 
 		const endTime = Date.now();
-		const memoryEnd = process.memoryUsage();
+		const memoryEnd = getSafeMemory();
 		const duration = endTime - request.startTime;
 		let memoryDelta: Record<string, number> | undefined;
 		if (request.memoryStart) {
@@ -344,7 +345,7 @@ export class RequestTracker {
 		}
 
 		const endTime = Date.now();
-		const memoryEnd = process.memoryUsage();
+		const memoryEnd = getSafeMemory();
 		const duration = endTime - request.startTime;
 		let memoryDelta: Record<string, number> | undefined;
 		if (request.memoryStart) {

--- a/source/utils/logging/safe-process.ts
+++ b/source/utils/logging/safe-process.ts
@@ -1,0 +1,37 @@
+/**
+ * Safe process metrics utilities
+ * Provides defensive wrappers around process.memoryUsage() and process.cpuUsage()
+ * to handle environments where process is polyfilled to null
+ */
+
+import nodeProcess from 'node:process';
+
+/**
+ * Safe memory usage getter with runtime checks
+ * Returns fallback values if process.memoryUsage() is unavailable or throws
+ */
+export function getSafeMemory(): NodeJS.MemoryUsage {
+	try {
+		if (nodeProcess && typeof nodeProcess.memoryUsage === 'function') {
+			return nodeProcess.memoryUsage();
+		}
+	} catch {
+		// Ignore any errors during process.memoryUsage()
+	}
+	return {rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0};
+}
+
+/**
+ * Safe CPU usage getter with runtime checks
+ * Returns fallback values if process.cpuUsage() is unavailable or throws
+ */
+export function getSafeCpuUsage(): NodeJS.CpuUsage {
+	try {
+		if (nodeProcess && typeof nodeProcess.cpuUsage === 'function') {
+			return nodeProcess.cpuUsage();
+		}
+	} catch {
+		// Ignore any errors during process.cpuUsage()
+	}
+	return {user: 0, system: 0};
+}


### PR DESCRIPTION
Fixes a runtime crash when `process.memoryUsage()` is called in environments where `process` is polyfilled to null.

### Problem
The application crashed with:
```text
ERROR  Cannot read properties of null (reading 'memoryUsage')
dist/utils/logging/performance.js:89:30
```

This happened because:
* Code called `process.memoryUsage()` and `process.cpuUsage()` without runtime checks
* In certain environments, `process` is polyfilled to null, causing direct calls to fail
* The crash occurred during startup in `startMetrics()` → `addTypedMessage()` → `logError()` → `loadPreferences()` → `useAppState()`

### Solution
Implemented defensive helper functions with runtime checks:
* `getSafeMemory()` - Safe memory usage getter with fallback values
* `getSafeCpuUsage()` - Safe CPU usage getter with fallback values

### Files Modified
* `source/utils/logging/performance.ts`
* `source/utils/logging/request-tracker.ts`
* `source/utils/logging/health-monitor/checks/memory-check.ts`
* `source/utils/logging/health-monitor/core/health-monitor.ts`

### Testing
Added tests in `performance.spec.ts` and `request-tracker.spec.ts` to verify:
* Fallback behavior when `process.memoryUsage()` throws
* Correct fallback values are returned