### PR TITLE
fix: improve Ollama timeout handling for slow local models

### DIFF
--- a/source/ai-sdk-client/ai-sdk-client.ts
+++ b/source/ai-sdk-client/ai-sdk-client.ts
@@ -1,7 +1,10 @@
 import type {OpenAIProvider} from '@ai-sdk/openai';
 import type {LanguageModel} from 'ai';
 import {Agent} from 'undici';
-import {TIMEOUT_SOCKET_DEFAULT_MS} from '@/constants';
+import {
+	TIMEOUT_SOCKET_DEFAULT_MS,
+	TIMEOUT_SOCKET_LOCAL_DEFAULT_MS,
+} from '@/constants';
 import {getModelContextLimit} from '@/models/index.js';
 import type {
 	AIProviderConfig,
@@ -13,6 +16,7 @@ import type {
 	StreamCallbacks,
 } from '@/types/index';
 import {getLogger} from '@/utils/logging';
+import {isLocalURL} from '@/utils/url-utils';
 import {handleChat} from './chat/chat-handler.js';
 import {type AIProvider, createProvider} from './providers/provider-factory.js';
 
@@ -46,10 +50,16 @@ export class AISDKClient implements LLMClient {
 		const {connectionPool} = this.providerConfig;
 		const {requestTimeout, socketTimeout} = this.providerConfig;
 		const effectiveSocketTimeout = socketTimeout ?? requestTimeout;
+		const isLocal =
+			providerConfig.config.baseURL &&
+			isLocalURL(providerConfig.config.baseURL);
+		const defaultTimeout = isLocal
+			? TIMEOUT_SOCKET_LOCAL_DEFAULT_MS
+			: TIMEOUT_SOCKET_DEFAULT_MS;
 		const resolvedSocketTimeout =
 			effectiveSocketTimeout === -1
 				? 0
-				: (effectiveSocketTimeout ?? TIMEOUT_SOCKET_DEFAULT_MS);
+				: (effectiveSocketTimeout ?? defaultTimeout);
 
 		this.undiciAgent = new Agent({
 			connect: {

--- a/source/ai-sdk-client/error-handling/error-parser.spec.ts
+++ b/source/ai-sdk-client/error-handling/error-parser.spec.ts
@@ -144,6 +144,14 @@ test('parseAPIError handles UND_ERR_HEADERS_TIMEOUT with actionable guidance', t
 	t.true(result.includes('requestTimeout/socketTimeout'));
 });
 
+test('parseAPIError handles variant-case headers timeout errors', t => {
+	const error = new Error('und_err_headers_timeout: headers timeout error');
+	const result = parseAPIError(error);
+	t.true(result.includes('waiting for model response headers'));
+	t.true(result.includes('requestTimeout/socketTimeout'));
+	t.true(result.includes('set both to -1'));
+});
+
 test('parseAPIError handles connection errors', t => {
 	const error = new Error('ECONNREFUSED: connection refused');
 	const result = parseAPIError(error);

--- a/source/ai-sdk-client/error-handling/error-parser.spec.ts
+++ b/source/ai-sdk-client/error-handling/error-parser.spec.ts
@@ -129,6 +129,21 @@ test('parseAPIError handles timeout errors', t => {
 	t.is(result, 'Request timed out: The model took too long to respond');
 });
 
+test('parseAPIError handles Headers Timeout Error with actionable guidance', t => {
+	const error = new Error('Cannot connect to API: Headers Timeout Error');
+	const result = parseAPIError(error);
+	t.true(result.includes('waiting for model response headers'));
+	t.true(result.includes('requestTimeout/socketTimeout'));
+	t.true(result.includes('set both to -1'));
+});
+
+test('parseAPIError handles UND_ERR_HEADERS_TIMEOUT with actionable guidance', t => {
+	const error = new Error('UND_ERR_HEADERS_TIMEOUT: Headers Timeout Error');
+	const result = parseAPIError(error);
+	t.true(result.includes('waiting for model response headers'));
+	t.true(result.includes('requestTimeout/socketTimeout'));
+});
+
 test('parseAPIError handles connection errors', t => {
 	const error = new Error('ECONNREFUSED: connection refused');
 	const result = parseAPIError(error);

--- a/source/ai-sdk-client/error-handling/error-parser.ts
+++ b/source/ai-sdk-client/error-handling/error-parser.ts
@@ -141,12 +141,12 @@ export function parseAPIError(error: unknown): string {
 	if (
 		lowerMessage.includes('timeout') ||
 		errorMessage.includes('ETIMEDOUT') ||
-		errorMessage.includes('UND_ERR_HEADERS_TIMEOUT') ||
-		errorMessage.includes('Headers Timeout Error')
+		lowerMessage.includes('und_err_headers_timeout') ||
+		lowerMessage.includes('headers timeout error')
 	) {
 		if (
-			errorMessage.includes('UND_ERR_HEADERS_TIMEOUT') ||
-			errorMessage.includes('Headers Timeout Error')
+			lowerMessage.includes('und_err_headers_timeout') ||
+			lowerMessage.includes('headers timeout error')
 		) {
 			return (
 				'Request timed out while waiting for model response headers. ' +

--- a/source/ai-sdk-client/error-handling/error-parser.ts
+++ b/source/ai-sdk-client/error-handling/error-parser.ts
@@ -78,6 +78,7 @@ export function parseAPIError(error: unknown): string {
 	}
 
 	const errorMessage = rootError.message;
+	const lowerMessage = errorMessage.toLowerCase();
 
 	// Extract status code and clean message from common error patterns FIRST
 	// This ensures HTTP status codes are properly parsed before falling through
@@ -137,7 +138,23 @@ export function parseAPIError(error: unknown): string {
 	}
 
 	// Handle timeout errors
-	if (errorMessage.includes('timeout') || errorMessage.includes('ETIMEDOUT')) {
+	if (
+		lowerMessage.includes('timeout') ||
+		errorMessage.includes('ETIMEDOUT') ||
+		errorMessage.includes('UND_ERR_HEADERS_TIMEOUT') ||
+		errorMessage.includes('Headers Timeout Error')
+	) {
+		if (
+			errorMessage.includes('UND_ERR_HEADERS_TIMEOUT') ||
+			errorMessage.includes('Headers Timeout Error')
+		) {
+			return (
+				'Request timed out while waiting for model response headers. ' +
+				'For slow local models, increase requestTimeout/socketTimeout in your provider config, ' +
+				'or set both to -1 to disable timeouts.'
+			);
+		}
+
 		return 'Request timed out: The model took too long to respond';
 	}
 

--- a/source/constants.ts
+++ b/source/constants.ts
@@ -17,6 +17,7 @@ export const TIMEOUT_HTTP_HEADERS_MS = 10_000;
 export const TIMEOUT_HTTP_BODY_MS = 30_000;
 export const TIMEOUT_UPDATE_CHECK_MS = 10_000;
 export const TIMEOUT_SOCKET_DEFAULT_MS = 120_000;
+export const TIMEOUT_SOCKET_LOCAL_DEFAULT_MS = 600_000; // 10 minutes for local models (Ollama, etc.)
 export const TIMEOUT_LSP_DIAGNOSTICS_MS = 5000;
 
 // === PASTE DETECTION ===

--- a/source/utils/url-utils.ts
+++ b/source/utils/url-utils.ts
@@ -1,4 +1,10 @@
-const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]']);
+const LOCAL_HOSTNAMES = new Set([
+	'localhost',
+	'127.0.0.1',
+	'0.0.0.0',
+	'[::1]',
+	'::1',
+]);
 
 /**
  * Check if a URL points to a local server.


### PR DESCRIPTION
## Description

Fixes #448 by improving timeout behavior and timeout error messaging for slow local Ollama models.

- Use a longer default socket timeout for local endpoints (10 minutes) while keeping hosted-provider default unchanged.
- Detect undici header-timeout failures (`UND_ERR_HEADERS_TIMEOUT` / `Headers Timeout Error`) and return actionable guidance.
- Keep timeout parsing case-insensitive to catch more variants.
- Add regression tests for header-timeout parsing paths.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [x] Tested with Ollama
- [x] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

## Notes

