### PR TITLE
fix(nix): copy themes.json to fix nix run crash

### DIFF
--- a/nix/packages/default/default.nix
+++ b/nix/packages/default/default.nix
@@ -55,9 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
         cp package.json $out/lib/nanocoder/
         cp -r plugins $out/lib/nanocoder/
 
-        # Copy static assets not bundled by tsc
-        mkdir -p $out/lib/nanocoder/source/config
-        cp -r source/config $out/lib/nanocoder/source/
+        # Copy static themes.json not bundled by tsc
+        install -D source/config/themes.json $out/lib/nanocoder/source/config/themes.json
 
         # Create wrapper script
         cat > $out/bin/nanocoder <<EOF

--- a/nix/packages/default/default.nix
+++ b/nix/packages/default/default.nix
@@ -54,7 +54,10 @@ stdenv.mkDerivation (finalAttrs: {
         cp -r node_modules $out/lib/nanocoder/
         cp package.json $out/lib/nanocoder/
         cp -r plugins $out/lib/nanocoder/
-        cp -r source $out/lib/nanocoder/
+
+        # Copy static assets not bundled by tsc
+        mkdir -p $out/lib/nanocoder/source/config
+        cp -r source/config $out/lib/nanocoder/source/
 
         # Create wrapper script
         cat > $out/bin/nanocoder <<EOF

--- a/nix/packages/default/default.nix
+++ b/nix/packages/default/default.nix
@@ -44,26 +44,27 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
-    runHook preInstall
+        runHook preInstall
 
-    mkdir -p $out/bin
-    mkdir -p $out/lib/nanocoder
+        mkdir -p $out/bin
+        mkdir -p $out/lib/nanocoder
 
-    # Copy built files
-    cp -r dist $out/lib/nanocoder/
-    cp -r node_modules $out/lib/nanocoder/
-    cp package.json $out/lib/nanocoder/
-    cp -r plugins $out/lib/nanocoder/
+        # Copy built files
+        cp -r dist $out/lib/nanocoder/
+        cp -r node_modules $out/lib/nanocoder/
+        cp package.json $out/lib/nanocoder/
+        cp -r plugins $out/lib/nanocoder/
+        cp -r source $out/lib/nanocoder/
 
-    # Create wrapper script
-    cat > $out/bin/nanocoder <<EOF
-#!/usr/bin/env bash
-NODE_PATH="$out/lib/nanocoder/node_modules" exec ${nodejs}/bin/node "$out/lib/nanocoder/dist/cli.js" "\$@"
-EOF
+        # Create wrapper script
+        cat > $out/bin/nanocoder <<EOF
+    #!/usr/bin/env bash
+    NODE_PATH="$out/lib/nanocoder/node_modules" exec ${nodejs}/bin/node "$out/lib/nanocoder/dist/cli.js" "\$@"
+    EOF
 
-    chmod +x $out/bin/nanocoder
+        chmod +x $out/bin/nanocoder
 
-    runHook postInstall
+        runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description

Add `install -D source/config/themes.json $out/lib/nanocoder/source/config/themes.json` to the `installPhase` in the Nix package derivation. The `source/config/themes.json` file was not being copied into the Nix store which caused `nix run` to crash immediately. I could run nanocoder by building it locally, so I figured it was probably a nix flake issue, which it was. the `source/config/themes.json` wasn't being copied and it isn't bundled by the tsc so we need to manually copy it.

## Type of Change

- [x] Bug fix

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging