### PR TITLE
Fix #430: Epilepsy/seizure inducing README GH front!

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A local-first CLI coding agent built by the [Nano Collective](https://github.com
 
 Nanocoder brings the power of agentic coding tools like Claude Code and Gemini CLI to local models or controlled APIs like OpenRouter. Built with privacy and control in mind, it supports multiple AI providers with tool support for file operations and command execution.
 
-![Example](./.github/assets/example.gif)
-
 ---
 ![Build Status](https://github.com/Nano-Collective/nanocoder/raw/main/badges/build.svg)
 ![Coverage](https://github.com/Nano-Collective/nanocoder/raw/main/badges/coverage.svg)


### PR DESCRIPTION
Closes #430

## Description

Removes the animated GIF (`example.gif`) from `README.md` that was reported as potentially triggering for users with photosensitive epilepsy. The two lines embedding `./.github/assets/example.gif` via a Markdown image tag have been deleted entirely.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Verified `README.md` renders correctly on GitHub without the GIF — badges, description, and remaining content display as expected.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*