### PR TITLE
fix: don't pass stale lastProvider to createLLMClient after config wizard

### DIFF
--- a/source/client-factory.spec.ts
+++ b/source/client-factory.spec.ts
@@ -1273,33 +1273,48 @@ test.serial(
 		globalThis.fetch = createMockFetch(true, 200);
 
 		const configDir = join(testDir, 'issue-460-no-provider-test');
+		const preferencesDir = join(configDir, 'preferences');
+		const originalConfigDir = process.env.NANOCODER_CONFIG_DIR;
 		mkdirSync(configDir, {recursive: true});
+		mkdirSync(preferencesDir, {recursive: true});
 
-		// Config only has "GitHub Copilot"; lastProvider preference is irrelevant
-		// because we are not passing a provider argument.
-		createTestConfig(
-			{
-				nanocoder: {
-					providers: [
-						{
-							name: 'GitHub Copilot',
-							baseUrl: 'https://api.githubcopilot.com',
-							apiKey: 'dummy-key',
-							models: ['claude-sonnet-4-5'],
-						},
-					],
+		try {
+			// Scope NANOCODER_CONFIG_DIR to a temp dir so loadPreferences() never
+			// reads from or writes to the real user config directory.
+			process.env.NANOCODER_CONFIG_DIR = preferencesDir;
+
+			// Config only has "GitHub Copilot"; lastProvider preference is irrelevant
+			// because we are not passing a provider argument.
+			createTestConfig(
+				{
+					nanocoder: {
+						providers: [
+							{
+								name: 'GitHub Copilot',
+								baseUrl: 'https://api.githubcopilot.com',
+								apiKey: 'dummy-key',
+								models: ['claude-sonnet-4-5'],
+							},
+						],
+					},
 				},
-			},
-			configDir,
-		);
+				configDir,
+			);
 
-		process.cwd = () => configDir;
-		clearAppConfig();
-		reloadAppConfig();
+			process.cwd = () => configDir;
+			clearAppConfig();
+			reloadAppConfig();
 
-		// Must NOT throw - falls back to the first (and only) configured provider.
-		const result = await createLLMClient();
-		t.truthy(result.client);
-		t.is(result.actualProvider, 'GitHub Copilot');
+			// Must NOT throw - falls back to the first (and only) configured provider.
+			const result = await createLLMClient();
+			t.truthy(result.client);
+			t.is(result.actualProvider, 'GitHub Copilot');
+		} finally {
+			if (originalConfigDir === undefined) {
+				delete process.env.NANOCODER_CONFIG_DIR;
+			} else {
+				process.env.NANOCODER_CONFIG_DIR = originalConfigDir;
+			}
+		}
 	},
 );

--- a/source/client-factory.spec.ts
+++ b/source/client-factory.spec.ts
@@ -1219,3 +1219,87 @@ test.serial(
 		t.deepEqual(providerConfig?.contextWindows, {model1: 65536});
 	},
 );
+
+// ============================================================================
+// Regression: issue #460 - stale lastProvider causes ConfigurationError
+// ============================================================================
+
+// Passing a stale explicit provider name must throw ConfigurationError so the
+// caller knows it asked for something that does not exist.
+test.serial(
+	'createLLMClient: throws ConfigurationError when explicit provider not in config (issue #460)',
+	async t => {
+		globalThis.fetch = createMockFetch(true, 200);
+
+		const configDir = join(testDir, 'issue-460-explicit-test');
+		mkdirSync(configDir, {recursive: true});
+
+		// Config only has "GitHub Copilot"; simulate a fresh wizard save.
+		createTestConfig(
+			{
+				nanocoder: {
+					providers: [
+						{
+							name: 'GitHub Copilot',
+							baseUrl: 'https://api.githubcopilot.com',
+							apiKey: 'dummy-key',
+							models: ['claude-sonnet-4-5'],
+						},
+					],
+				},
+			},
+			configDir,
+		);
+
+		process.cwd = () => configDir;
+		clearAppConfig();
+		reloadAppConfig();
+
+		// "GitHub Models" is a stale name that is not present in the config.
+		const error = await t.throwsAsync(
+			createLLMClient('GitHub Models'),
+			{instanceOf: ConfigurationError},
+		);
+		t.regex(error.message, /GitHub Models/);
+		t.regex(error.message, /Available providers: GitHub Copilot/);
+	},
+);
+
+// Calling without a provider (the post-wizard path after the fix) must fall
+// through to the first available provider instead of throwing.
+test.serial(
+	'createLLMClient: succeeds without explicit provider even when config changed (issue #460)',
+	async t => {
+		globalThis.fetch = createMockFetch(true, 200);
+
+		const configDir = join(testDir, 'issue-460-no-provider-test');
+		mkdirSync(configDir, {recursive: true});
+
+		// Config only has "GitHub Copilot"; lastProvider preference is irrelevant
+		// because we are not passing a provider argument.
+		createTestConfig(
+			{
+				nanocoder: {
+					providers: [
+						{
+							name: 'GitHub Copilot',
+							baseUrl: 'https://api.githubcopilot.com',
+							apiKey: 'dummy-key',
+							models: ['claude-sonnet-4-5'],
+						},
+					],
+				},
+			},
+			configDir,
+		);
+
+		process.cwd = () => configDir;
+		clearAppConfig();
+		reloadAppConfig();
+
+		// Must NOT throw - falls back to the first (and only) configured provider.
+		const result = await createLLMClient();
+		t.truthy(result.client);
+		t.is(result.actualProvider, 'GitHub Copilot');
+	},
+);

--- a/source/hooks/useModeHandlers.tsx
+++ b/source/hooks/useModeHandlers.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {createLLMClient} from '@/client-factory';
 import {ErrorMessage, SuccessMessage} from '@/components/message-box';
 import {reloadAppConfig} from '@/config/index';
-import {loadPreferences, saveTune, updateLastUsed} from '@/config/preferences';
+import {saveTune, updateLastUsed} from '@/config/preferences';
 import type {ActiveMode} from '@/hooks/useAppState';
 import {getToolManager} from '@/message-handler';
 import type {AIProviderConfig, TuneConfig} from '@/types/config';
@@ -141,10 +141,12 @@ export function useModeHandlers({
 			reloadAppConfig();
 
 			try {
-				const preferences = loadPreferences();
-				const {client: newClient, actualProvider} = await createLLMClient(
-					preferences.lastProvider,
-				);
+				// Do not pass a stale lastProvider here: if the wizard just wrote a
+				// new config with different provider names, passing the old name
+				// explicitly would trigger a ConfigurationError.  Call without an
+				// argument so createLLMClient falls back to the first available
+				// provider in the freshly-loaded config.
+				const {client: newClient, actualProvider} = await createLLMClient();
 				setClient(newClient);
 				setCurrentProvider(actualProvider);
 				setCurrentProviderConfig(newClient.getProviderConfig());


### PR DESCRIPTION
## Description

After the provider wizard saves a new `agents.config.json`, the app immediately calls `createLLMClient(preferences.lastProvider)` in `handleConfigWizardComplete`. If the old `lastProvider` preference (e.g. `"GitHub Models"`) is not present in the freshly-written config (which only has `"GitHub Copilot"`), `createLLMClient` throws:

```
ConfigurationError: Provider 'GitHub Models' not found in agents.config.json. Available providers: GitHub Copilot
```

…which surfaces in the UI as the `Failed to initialize with new configuration: ConfigurationError` message reported in #460.

**Root cause:** `handleConfigWizardComplete` passed the stale `preferences.lastProvider` string explicitly. The validation block in `createLLMClient` treats an explicit provider name as a hard requirement and throws when it is absent from the new config.

**Fix:** Call `createLLMClient()` without an explicit provider argument in the post-wizard reinitialisation path. Without that argument the validation block is skipped; the function's internal fallback loop uses `preferences.lastProvider` as a preference hint (not a hard requirement) and gracefully falls through to the first available provider in the freshly-loaded config.

## Type of Change

- [x] Bug fix

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Two new serial tests added to `source/client-factory.spec.ts`:

1. **`createLLMClient: throws ConfigurationError when explicit provider not in config (issue #460)`** — confirms that passing a stale explicit provider name still throws `ConfigurationError` (the existing contract is preserved for other callers).
2. **`createLLMClient: succeeds without explicit provider even when config changed (issue #460)`** — confirms the no-argument path succeeds, using the first available provider in the new config (`"GitHub Copilot"`).

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))