### PR TITLE
Switch the Homebrew formula dependency from `node@20` to `node@22`

### DIFF
--- a/Formula/nanocoder.rb
+++ b/Formula/nanocoder.rb
@@ -5,7 +5,7 @@ class Nanocoder < Formula
   sha256 "3bea46e646cb006e835ca571effcc0ae4264f984cccee3ab963e7dd198e63b59"
   license "MIT"
 
-  depends_on "node@20"
+  depends_on "node@22"
 
   def install
     system "npm", "install", *std_npm_args


### PR DESCRIPTION
Prevent the current startup crash seen when the formula pins `node@20`

With the published formula, `nanocoder --help` works, but an actual app boot fails immediately on `node@20` with:

`webidl.util.markAsUncloneable is not a function`

Using Node 22 it runs.

## Description

Brief description of what this PR does

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- `brew reinstall --build-from-source nanocoder`
- `brew test nanocoder`
- `nanocoder --version`
- `nanocoder run "hello"`
- 
### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
