### PR TITLE
fix: type MCPTool inputSchema as JSONSchema7 instead of any

### DIFF
--- a/source/mcp/mcp-client.ts
+++ b/source/mcp/mcp-client.ts
@@ -16,6 +16,7 @@ import type {
 	MCPInitResult,
 	MCPServer,
 	MCPTool,
+	MCPToolInputSchema,
 	Tool,
 	ToolParameterSchema,
 } from '@/types/index';
@@ -140,7 +141,8 @@ export class MCPClient {
 				const tools: MCPTool[] = toolsResult.tools.map(tool => ({
 					name: tool.name,
 					description: tool.description || undefined,
-					inputSchema: tool.inputSchema,
+					// MCP SDK types properties as Record<string, object>; cast to JSONSchema7 at protocol boundary
+					inputSchema: tool.inputSchema as MCPToolInputSchema | undefined,
 					serverName: normalizedServer.name,
 				}));
 
@@ -275,13 +277,7 @@ export class MCPClient {
 			for (const mcpTool of serverTools) {
 				// Convert MCP tool to nanocoder Tool format
 				// Use the original tool name for better model compatibility
-				const schema = mcpTool.inputSchema as
-					| {
-							type?: string;
-							properties?: Record<string, unknown>;
-							required?: string[];
-					  }
-					| undefined;
+				const schema = mcpTool.inputSchema;
 
 				const tool: Tool = {
 					type: 'function',
@@ -325,7 +321,7 @@ export class MCPClient {
 						? `[MCP:${serverName}] ${mcpTool.description}`
 						: `MCP tool from ${serverName}`,
 					inputSchema: jsonSchema<Record<string, unknown>>(
-						(mcpTool.inputSchema as unknown) || {type: 'object'},
+						mcpTool.inputSchema || {type: 'object'},
 					),
 					// Medium risk: MCP tools require approval unless explicitly configured in the server's alwaysAllow list or in auto-accept mode
 					needsApproval: () => {
@@ -452,14 +448,13 @@ export class MCPClient {
 		const sanitizedArgs = {...args};
 
 		if (toolDef?.inputSchema) {
-			const schema = toolDef.inputSchema as {
-				properties?: Record<string, {type?: string}>;
-			};
+			const schema = toolDef.inputSchema;
 			if (schema.properties) {
 				for (const [key, value] of Object.entries(args)) {
 					const propSchema = schema.properties[key];
 					// Only coerce if the schema explicitly demands a string and we have an object
 					if (
+						typeof propSchema === 'object' &&
 						propSchema?.type === 'string' &&
 						typeof value === 'object' &&
 						value !== null

--- a/source/mcp/mcp-client.ts
+++ b/source/mcp/mcp-client.ts
@@ -32,7 +32,7 @@ import {
 	startMetrics,
 } from '@/utils/logging/performance.js';
 import {getSafeMemory} from '@/utils/logging/safe-process.js';
-import {ensureString} from '@/utils/type-helpers';
+import {ensureString, isPlainObject} from '@/utils/type-helpers';
 import {TransportFactory} from './transport-factory.js';
 
 export class MCPClient {
@@ -141,8 +141,11 @@ export class MCPClient {
 				const tools: MCPTool[] = toolsResult.tools.map(tool => ({
 					name: tool.name,
 					description: tool.description || undefined,
-					// MCP SDK types properties as Record<string, object>; cast to JSONSchema7 at protocol boundary
-					inputSchema: tool.inputSchema as MCPToolInputSchema | undefined,
+					// MCP SDK types inputSchema as Record<string, object>; validate at protocol boundary
+					// before trusting the shape as JSONSchema7
+					inputSchema: isPlainObject(tool.inputSchema)
+						? (tool.inputSchema as MCPToolInputSchema)
+						: undefined,
 					serverName: normalizedServer.name,
 				}));
 

--- a/source/types/mcp.ts
+++ b/source/types/mcp.ts
@@ -1,3 +1,4 @@
+import type {JSONSchema7} from 'ai';
 import type {MCPServerConfig} from '@/types/config';
 
 export type MCPTransportType = 'stdio' | 'websocket' | 'http';
@@ -5,12 +6,12 @@ export type MCPTransportType = 'stdio' | 'websocket' | 'http';
 // MCPServer is MCPServerConfig without the source tracking field
 export type MCPServer = Omit<MCPServerConfig, 'source'>;
 
+export type MCPToolInputSchema = JSONSchema7;
+
 export interface MCPTool {
 	name: string;
 	description?: string;
-	// JSON Schema for tool input - intentionally flexible
-	// biome-ignore lint/suspicious/noExplicitAny: Dynamic typing required
-	inputSchema?: any;
+	inputSchema?: MCPToolInputSchema;
 	serverName: string;
 }
 


### PR DESCRIPTION
## Description

Type `MCPTool.inputSchema` as `JSONSchema7` instead of `any`. Fixes #467.

Introduces a `MCPToolInputSchema` alias for `JSONSchema7` (already available via the `ai` package) in `source/types/mcp.ts`, and updates `source/mcp/mcp-client.ts` to use it — removing all ad-hoc inline type assertions that were previously needed to work around the `any` type.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [x] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
