### PR TITLE
fix: avoid stale lastProvider after config wizard completion

### DIFF
--- a/source/hooks/useModeHandlers.tsx
+++ b/source/hooks/useModeHandlers.tsx
@@ -141,10 +141,7 @@ export function useModeHandlers({
 			reloadAppConfig();
 
 			try {
-				const preferences = loadPreferences();
-				const {client: newClient, actualProvider} = await createLLMClient(
-					preferences.lastProvider,
-				);
+				const {client: newClient, actualProvider} = await createLLMClient();
 				setClient(newClient);
 				setCurrentProvider(actualProvider);
 				setCurrentProviderConfig(newClient.getProviderConfig());


### PR DESCRIPTION
## Description

Fixes post-config-wizard initialization failure caused by passing a stale `preferences.lastProvider` into `createLLMClient`.

After saving a new config, the previous provider may no longer exist in `agents.config.json`, resulting in a `ConfigurationError`.

This change removes the explicit stale provider and allows `createLLMClient()` to resolve against the freshly loaded config.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

## Testing

### Automated Tests

* [ ] New features include passing tests in `.spec.ts/tsx` files
* [x] All existing tests pass (`pnpm test:all` completes successfully)
* [ ] Tests cover both success and error scenarios

### Manual Testing

* [ ] Tested with Ollama
* [ ] Tested with OpenRouter
* [ ] Tested with OpenAI-compatible API
* [ ] Tested MCP integration (if applicable)

## Checklist

* [x] Code follows project style guidelines
* [x] Self-review completed
* [ ] Documentation updated (if needed)
* [x] No breaking changes (or clearly documented)
* [ ] Appropriate logging added using structured logging (see [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md#logging)](../CONTRIBUTING.md#logging))

---

Fixes #460.

This prevents post-config-wizard initialization from passing a stale `preferences.lastProvider` into `createLLMClient`.

After the wizard saves a new config, the previous `lastProvider` may no longer exist in `agents.config.json`, causing:

`ConfigurationError: Provider 'GitHub Models' not found in agents.config.json`

Calling `createLLMClient()` without the stale explicit provider lets the client resolve against the freshly loaded config and initialize correctly.

Confirmed locally:

* GitHub Copilot config saved successfully
* post-wizard initialization no longer throws the stale provider mismatch
* next prompt is Copilot auth, which is expected