### PR TITLE
Avoid env var pickup as a fallback on tracker test

### DIFF
--- a/source/usage/tracker.spec.ts
+++ b/source/usage/tracker.spec.ts
@@ -430,17 +430,27 @@ test('session tracking across provider/model changes', async t => {
 });
 
 test('getCurrentStats handles unknown model with no context limit', async t => {
-	const tracker = new SessionTracker('unknown-provider', 'unknown-model-that-does-not-exist');
-	const tokenizer = new MockTokenizer();
-	const messages = createMockMessages();
+	// Unset NANOCODER_CONTEXT_LIMIT so it doesn't act as a fallback
+	const originalEnv = process.env.NANOCODER_CONTEXT_LIMIT;
+	delete process.env.NANOCODER_CONTEXT_LIMIT;
 
-	const stats = await tracker.getCurrentStats(messages, tokenizer);
+	try {
+		const tracker = new SessionTracker('unknown-provider', 'unknown-model-that-does-not-exist');
+		const tokenizer = new MockTokenizer();
+		const messages = createMockMessages();
 
-	// When context limit is not found, percentUsed should be 0
-	t.is(stats.percentUsed, 0);
-	t.is(stats.provider, 'unknown-provider');
-	t.is(stats.model, 'unknown-model-that-does-not-exist');
-	t.is(stats.messageCount, 3);
+		const stats = await tracker.getCurrentStats(messages, tokenizer);
+
+		// When context limit is not found, percentUsed should be 0
+		t.is(stats.percentUsed, 0);
+		t.is(stats.provider, 'unknown-provider');
+		t.is(stats.model, 'unknown-model-that-does-not-exist');
+		t.is(stats.messageCount, 3);
+	} finally {
+		if (originalEnv !== undefined) {
+			process.env.NANOCODER_CONTEXT_LIMIT = originalEnv;
+		}
+	}
 });
 
 test('getCurrentStats uses provider-configured context limit for percentage', async t => {


### PR DESCRIPTION
## Description

 Fix flaky `getCurrentStats handles unknown model with no
 context limit` test by unsetting NANOCODER_CONTEXT_LIMIT
 before assertions. When set in the developer's environment,
 the variable acted as an unexpected fallback context limit,
 causing percentUsed to be non-zero when the test expected 0.

 Changes

 • source/usage/tracker.spec.ts — Wrapped the test body in
 try/finally that saves, deletes, and restores
 process.env.NANOCODER_CONTEXT_LIMIT so the assertion is
 isolated from the caller's shell environment.

⚠️ WARNING: Apparently **main** is broken. The CI/CD pipeline errors are not related to this PR (in fact they are being resolved in this PR #481). Wait to merge the mentioned PR before continue the merge of this one. 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
