### PR TITLE
fix: throw last streaming error if finishReason is error

### DIFF
--- a/source/ai-sdk-client/chat/chat-handler.ts
+++ b/source/ai-sdk-client/chat/chat-handler.ts
@@ -156,6 +156,7 @@ export async function handleChat(
 				};
 			}
 
+			const streamingErrors: Error[] = [];
 			const result = streamText({
 				model,
 				messages: modelMessages,
@@ -166,11 +167,11 @@ export async function handleChat(
 				onStepFinish: createOnStepFinishHandler(callbacks),
 				prepareStep: createPrepareStepHandler(),
 				onError: ({error}) => {
-					// Catch streaming errors so raw SSE events don't leak to stdout.
-					// The error will still be thrown by the stream and caught by
-					// the outer try-catch for proper formatting.
+					// Collect streaming errors so raw SSE events don't leak to stdout.
+					const e = error instanceof Error ? error : new Error(String(error));
+					streamingErrors.push(e);
 					logger.warn('Streaming error received', {
-						error: error instanceof Error ? error.message : String(error),
+						error: e,
 						model: currentModel,
 						correlationId,
 						provider: providerConfig.name,
@@ -257,13 +258,19 @@ export async function handleChat(
 			flushBuffer();
 
 			// After streaming completes, collect final results
-			const [fullText, resolvedToolCalls, resolvedSteps, reasoning] =
-				await Promise.all([
-					result.text,
-					result.toolCalls,
-					result.steps,
-					result.reasoningText,
-				]);
+			const [
+				fullText,
+				resolvedToolCalls,
+				resolvedSteps,
+				reasoning,
+				finishReason,
+			] = await Promise.all([
+				result.text,
+				result.toolCalls,
+				result.steps,
+				result.reasoningText,
+				result.finishReason,
+			]);
 
 			logger.debug('AI SDK response received', {
 				responseLength: fullText.length,
@@ -271,7 +278,12 @@ export async function handleChat(
 				hasToolCalls: resolvedToolCalls.length > 0,
 				toolCallCount: resolvedToolCalls.length,
 				stepCount: resolvedSteps.length,
+				finishReason: result.finishReason,
 			});
+
+			if (finishReason === 'error' && streamingErrors.length > 0) {
+				throw streamingErrors[streamingErrors.length - 1];
+			}
 
 			// Without execute functions on tools, the SDK doesn't auto-execute anything.
 			// All tool calls are returned for us to handle (parallel execution, confirmation, etc.).


### PR DESCRIPTION
## Description

While streaming a response, a chunk with type `error` is swallowed and never reaches the console (`result.fullStream` only throws [network errors](https://github.com/vercel/ai/blob/main/packages/ai/src/generate-object/stream-object-result.ts#L76)). This can cause an infinite loop of continues because the chat loop never receives the error but does receive the empty message. This code change collects streaming errors and throws the last one once the stream has closed.

Here's the before and after of calling an inference server with a 2k token context window (left is 1.25.2, right is this branch):

<img width="1490" height="734" alt="Screenshot 2026-04-28 at 3 41 45 PM" src="https://github.com/user-attachments/assets/a981c714-4dc9-465f-841a-9e6b5a2c6230" />

Notes:

* In most cases, an error in a stream will also end the stream. So the vast majority of the time I expect that `streamingErrors` will be a single error. If for some reason a chunk in the middle of a stream has an error and then later an error stops the stream, this approach surfaces the last error, because it was more likely to be the one that stopped the stream. The chunk with an error in the middle of the stream still emits a debug log (this is unchanged).
* This change also adds logging of the `finishReason`, which is useful for debugging.
* See #483 for some more info.
* There are no streaming tests, so this PR comes with risk of regression. 

> (From [chat-handler.spec.ts](https://github.com/Nano-Collective/nanocoder/blob/60a3f3952afef474725906000bda6a32677c6644/source/ai-sdk-client/chat/chat-handler.spec.ts#L11))
> // Note: This file contains basic structure tests
> // Full integration tests would require mocking the AI SDK's streamText function
> // which is complex and better tested through the full AISDKClient

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
   - streaming change. can't mock the streaming call so no spec change
- [ ] All existing tests pass (`pnpm test:all` completes successfully)

```
  5194 tests passed
  96 tests remained pending after a timeout
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
```

- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

<details><summary>Screenshot of testing with OpenAI-compatible API with debug logs</summary>
<p>

### test with small context

<img width="1047" height="941" alt="Screenshot 2026-04-28 at 6 01 10 PM" src="https://github.com/user-attachments/assets/48d7070e-428c-43c7-af47-dbcc2df9bedb" />

### test with big context

<img width="975" height="1001" alt="Screenshot 2026-04-28 at 7 03 47 PM" src="https://github.com/user-attachments/assets/d759a6a1-14b5-4567-8157-ec4c051d8913" />

</p>
</details> 

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

Closes #483