### PR TITLE
fix: resolve provider names case-insensitively

### DIFF
--- a/source/client-factory.spec.ts
+++ b/source/client-factory.spec.ts
@@ -1017,6 +1017,40 @@ test.serial(
 );
 
 test.serial(
+	'createLLMClient: resolves explicit provider names case-insensitively',
+	async t => {
+		globalThis.fetch = createMockFetch(true, 200);
+
+		const configDir = join(testDir, 'case-insensitive-provider-test');
+		mkdirSync(configDir, {recursive: true});
+
+		createTestConfig(
+			{
+				nanocoder: {
+					providers: [
+						{
+							name: 'Ollama',
+							baseUrl: 'http://localhost:8000/v1',
+							models: ['llama3.1:latest'],
+						},
+					],
+				},
+			},
+			configDir,
+		);
+
+		process.cwd = () => configDir;
+		clearAppConfig();
+		reloadAppConfig();
+
+		const result = await createLLMClient('ollama');
+
+		t.truthy(result);
+		t.is(result.actualProvider, 'Ollama');
+	},
+);
+
+test.serial(
 	'createLLMClient: throws ConfigurationError when provider not found',
 	async t => {
 		globalThis.fetch = createMockFetch(true, 200);
@@ -1219,6 +1253,46 @@ test.serial(
 		t.truthy(result);
 		t.truthy(result.client);
 		t.is(result.actualProvider, 'NewProvider');
+	},
+);
+
+test.serial(
+	'createLLMClient: matches preferences.lastProvider case-insensitively',
+	async t => {
+		globalThis.fetch = createMockFetch(true, 200);
+
+		const configDir = join(testDir, 'case-insensitive-last-provider-test');
+		mkdirSync(configDir, {recursive: true});
+
+		createTestConfig(
+			{
+				nanocoder: {
+					providers: [
+						{
+							name: 'Ollama',
+							baseUrl: 'http://localhost:8000/v1',
+							models: ['llama3.1:latest'],
+						},
+					],
+				},
+			},
+			configDir,
+		);
+
+		writeFileSync(
+			join(configDir, 'nanocoder-preferences.json'),
+			JSON.stringify({lastProvider: 'ollama'}, null, 2),
+		);
+
+		process.cwd = () => configDir;
+		clearAppConfig();
+		reloadAppConfig();
+		resetPreferencesCache();
+
+		const result = await createLLMClient();
+
+		t.truthy(result);
+		t.is(result.actualProvider, 'Ollama');
 	},
 );
 

--- a/source/client-factory.ts
+++ b/source/client-factory.ts
@@ -71,20 +71,21 @@ async function createAISDKClient(
 		}
 	}
 
+	const resolveProviderName = (providerName?: string): string | undefined => {
+		if (!providerName) {
+			return undefined;
+		}
+
+		return providers.find(
+			provider => provider.name.toLowerCase() === providerName.toLowerCase(),
+		)?.name;
+	};
+
 	// Determine which provider to try first
 	let targetProvider: string;
 	if (requestedProvider) {
-		targetProvider = requestedProvider;
-	} else {
-		// Use preferences or default to first available provider
-		const preferences = loadPreferences();
-		targetProvider = preferences.lastProvider || providers[0].name;
-	}
-
-	// Validate provider exists if specified
-	if (requestedProvider) {
-		const providerConfig = providers.find(p => p.name === requestedProvider);
-		if (!providerConfig) {
+		const resolvedRequestedProvider = resolveProviderName(requestedProvider);
+		if (!resolvedRequestedProvider) {
 			const availableProviders = providers.map(p => p.name).join(', ');
 			throw new ConfigurationError(
 				`Provider '${requestedProvider}' not found in agents.config.json. Available providers: ${availableProviders}`,
@@ -93,6 +94,12 @@ async function createAISDKClient(
 				false,
 			);
 		}
+		targetProvider = resolvedRequestedProvider;
+	} else {
+		// Use preferences or default to first available provider
+		const preferences = loadPreferences();
+		targetProvider =
+			resolveProviderName(preferences.lastProvider) || providers[0].name;
 	}
 
 	// Validate model exists in the target provider's model list if specified


### PR DESCRIPTION
## Description

Fixes the provider lookup mismatch from #488 when the config stores a provider as `Ollama` but the CLI flag or saved preference uses `ollama`.

### Changes

- resolve explicit `--provider` values case-insensitively while preserving the configured provider name internally
- apply the same normalization to `preferences.lastProvider` so older lowercase preferences still work
- add regression tests for both explicit CLI selection and saved preferences

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Passed:
- `corepack pnpm test:ava source/client-factory.spec.ts`

Note: `corepack pnpm test:types` currently fails on upstream `main` with `source/subagents/markdown-parser.ts(21,34): error TS2307: Cannot find module 'yaml' or its corresponding type declarations.`

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

Fixes #488
