### PR TITLE
fix: parse JSON tool fallbacks for local models

### DIFF
--- a/source/tool-calling/tool-parser.spec.ts
+++ b/source/tool-calling/tool-parser.spec.ts
@@ -141,6 +141,81 @@ test('parseToolCalls: preserves identical XML tool calls (no deduplication)', t 
 	}
 });
 
+test('parseToolCalls: parses JSON tool calls from tool_calls arrays', t => {
+	const content = JSON.stringify({
+		tool_calls: [
+			{
+				function: {
+					name: 'read_file',
+					arguments: {path: '/tmp/test.txt'},
+				},
+			},
+		],
+	});
+
+	const result = parseToolCalls(content);
+
+	t.true(result.success);
+	if (result.success) {
+		t.is(result.toolCalls.length, 1);
+		t.is(result.toolCalls[0].function.name, 'read_file');
+		t.deepEqual(result.toolCalls[0].function.arguments, {
+			path: '/tmp/test.txt',
+		});
+		t.is(result.cleanedContent, '');
+	}
+});
+
+test('parseToolCalls: parses JSON tool calls from fenced code blocks', t => {
+	const content = `I'll create that now.\n\n\
+\`\`\`json
+{
+  "name": "write_file",
+  "arguments": {
+    "path": "/tmp/test.txt",
+    "content": "hello"
+  }
+}
+\`\`\`
+\nDone.`;
+
+	const result = parseToolCalls(content);
+
+	t.true(result.success);
+	if (result.success) {
+		t.is(result.toolCalls.length, 1);
+		t.is(result.toolCalls[0].function.name, 'write_file');
+		t.deepEqual(result.toolCalls[0].function.arguments, {
+			path: '/tmp/test.txt',
+			content: 'hello',
+		});
+		t.regex(result.cleanedContent, /I'll create that now\./);
+		t.regex(result.cleanedContent, /Done\./);
+	}
+});
+
+test('parseToolCalls: normalizes create_file aliases from JSON fallback', t => {
+	const content = JSON.stringify({
+		name: 'create_file',
+		arguments: {
+			file_path: '/tmp/test.txt',
+			contents: 'hello',
+		},
+	});
+
+	const result = parseToolCalls(content);
+
+	t.true(result.success);
+	if (result.success) {
+		t.is(result.toolCalls.length, 1);
+		t.is(result.toolCalls[0].function.name, 'write_file');
+		t.deepEqual(result.toolCalls[0].function.arguments, {
+			path: '/tmp/test.txt',
+			content: 'hello',
+		});
+	}
+});
+
 // Think Tag Tests (models like GLM-4 emit these for chain-of-thought)
 
 test('parseToolCalls: strips complete <think>...</think> tags', t => {

--- a/source/tool-calling/tool-parser.ts
+++ b/source/tool-calling/tool-parser.ts
@@ -2,13 +2,21 @@ import {XMLToolCallParser} from '@/tool-calling/xml-parser';
 import type {ToolCall} from '@/types/index';
 import {ensureString} from '@/utils/type-helpers';
 
+type JSONValue =
+	| string
+	| number
+	| boolean
+	| null
+	| JSONValue[]
+	| {[key: string]: JSONValue};
+
 /**
- * Strip  tags from content (some models output thinking that shouldn't be shown)
+ * Strip <think> tags from content (some models output thinking that shouldn't be shown)
  */
 function stripThinkTags(content: string): string {
 	return (
 		content
-			// Strip complete  blocks
+			// Strip complete <think> blocks
 			.replace(/<think>[\s\S]*?<\/think>/gi, '')
 			// Strip orphaned/incomplete think tags
 			.replace(/<think>[\s\S]*$/gi, '')
@@ -32,6 +40,202 @@ function normalizeWhitespace(content: string): string {
 			.replace(/\n{3,}/g, '\n\n')
 			.trim()
 	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeToolName(name: string): string {
+	switch (name) {
+		case 'create_file':
+		case 'write':
+		case 'write_tool':
+		case 'write_file_text':
+		case 'write_to_file_text':
+			return 'write_file';
+		default:
+			return name;
+	}
+}
+
+function normalizeArguments(
+	args: Record<string, unknown>,
+): Record<string, unknown> {
+	const normalized = {...args};
+
+	if (!('path' in normalized) && typeof normalized.file_path === 'string') {
+		normalized.path = normalized.file_path;
+	}
+
+	if (!('content' in normalized) && typeof normalized.contents === 'string') {
+		normalized.content = normalized.contents;
+	}
+
+	delete normalized.file_path;
+	delete normalized.contents;
+
+	return normalized;
+}
+
+function convertJSONToolCall(
+	name: string,
+	args: Record<string, unknown>,
+	index: number,
+): ToolCall {
+	return {
+		id: `json_call_${index}`,
+		function: {
+			name: normalizeToolName(name),
+			arguments: normalizeArguments(args),
+		},
+	};
+}
+
+function extractToolCallsFromJSONObject(
+	value: unknown,
+	toolCalls: ToolCall[],
+): void {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			extractToolCallsFromJSONObject(item, toolCalls);
+		}
+		return;
+	}
+
+	if (!isRecord(value)) {
+		return;
+	}
+
+	if (Array.isArray(value.tool_calls)) {
+		extractToolCallsFromJSONObject(value.tool_calls, toolCalls);
+		return;
+	}
+
+	if (Array.isArray(value.functions)) {
+		extractToolCallsFromJSONObject(value.functions, toolCalls);
+		return;
+	}
+
+	if (isRecord(value.function)) {
+		const functionName =
+			typeof value.function.name === 'string' ? value.function.name : null;
+		const functionArgs = isRecord(value.function.arguments)
+			? value.function.arguments
+			: null;
+
+		if (functionName && functionArgs) {
+			toolCalls.push(
+				convertJSONToolCall(functionName, functionArgs, toolCalls.length),
+			);
+			return;
+		}
+	}
+
+	if (typeof value.name === 'string') {
+		if (isRecord(value.arguments)) {
+			toolCalls.push(
+				convertJSONToolCall(value.name, value.arguments, toolCalls.length),
+			);
+			return;
+		}
+
+		if (isRecord(value.parameters)) {
+			if (
+				typeof value.parameters.function === 'string' &&
+				isRecord(value.parameters.parameters)
+			) {
+				toolCalls.push(
+					convertJSONToolCall(
+						value.parameters.function,
+						value.parameters.parameters,
+						toolCalls.length,
+					),
+				);
+				return;
+			}
+
+			toolCalls.push(
+				convertJSONToolCall(value.name, value.parameters, toolCalls.length),
+			);
+			return;
+		}
+	}
+
+	if (typeof value.function === 'string' && isRecord(value.parameters)) {
+		toolCalls.push(
+			convertJSONToolCall(value.function, value.parameters, toolCalls.length),
+		);
+		return;
+	}
+
+	if (typeof value.tool === 'string') {
+		const {tool, ...args} = value;
+		toolCalls.push(convertJSONToolCall(tool, args, toolCalls.length));
+	}
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractJSONToolCalls(content: string): {
+	toolCalls: ToolCall[];
+	cleanedContent: string;
+} | null {
+	const toolCalls: ToolCall[] = [];
+	const trimmed = content.trim();
+	const candidates: Array<{raw: string; inCodeBlock: boolean}> = [];
+	const seen = new Set<string>();
+
+	const addCandidate = (raw: string, inCodeBlock: boolean) => {
+		const normalized = raw.trim();
+		if (!normalized || seen.has(normalized)) {
+			return;
+		}
+		seen.add(normalized);
+		candidates.push({raw: normalized, inCodeBlock});
+	};
+
+	for (const match of content.matchAll(
+		/```(?:json|javascript|js)?\s*\n?([\s\S]*?)\n?```/g,
+	)) {
+		if (match[1]) {
+			addCandidate(match[1], true);
+		}
+	}
+
+	if (
+		(trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+		(trimmed.startsWith('[') && trimmed.endsWith(']'))
+	) {
+		addCandidate(trimmed, false);
+	}
+
+	for (const candidate of candidates) {
+		try {
+			const parsed = JSON.parse(candidate.raw) as JSONValue;
+			extractToolCallsFromJSONObject(parsed, toolCalls);
+			if (toolCalls.length > 0) {
+				const cleanedContent = candidate.inCodeBlock
+					? normalizeWhitespace(
+							content.replace(
+								new RegExp(
+									`\`\`\`(?:json|javascript|js)?\\s*\\n?${escapeRegExp(candidate.raw)}\\n?\`\`\``,
+								),
+								'',
+							),
+						)
+					: '';
+
+				return {toolCalls, cleanedContent};
+			}
+		} catch {
+			// Ignore invalid JSON candidates and continue trying others.
+		}
+	}
+
+	return null;
 }
 
 /**
@@ -58,7 +262,7 @@ export function parseToolCalls(content: unknown): ParseResult {
 	// 1. Safety Coercion
 	const contentStr = ensureString(content);
 
-	// Strip tags first - some models (like GLM-4) emit these for chain-of-thought
+	// Strip think tags first - some models (like GLM-4) emit these for chain-of-thought
 	const strippedContent = stripThinkTags(contentStr);
 
 	// 2. Try XML parser for valid tool calls (OPTIMISTIC: Success first!)
@@ -76,6 +280,16 @@ export function parseToolCalls(content: unknown): ParseResult {
 				cleanedContent,
 			};
 		}
+	}
+
+	// 2.5 Try structured JSON fallback for local models that ignore the XML-only prompt.
+	const jsonResult = extractJSONToolCalls(strippedContent);
+	if (jsonResult && jsonResult.toolCalls.length > 0) {
+		return {
+			success: true,
+			toolCalls: jsonResult.toolCalls,
+			cleanedContent: jsonResult.cleanedContent,
+		};
 	}
 
 	// 3. Check for malformed XML patterns (DEFENSIVE: Error second!)

--- a/source/utils/response-formatter.spec.ts
+++ b/source/utils/response-formatter.spec.ts
@@ -31,8 +31,8 @@ test('normalizeLLMResponse - handles JSON object with tool_calls', async t => {
 
 	t.is(normalized.metadata.detectedFormat, 'json');
 	t.true(normalized.metadata.hasJSONBlocks);
-	// JSON tool call extraction was removed - only XML extraction remains
-	t.is(normalized.toolCalls.length, 0);
+	t.is(normalized.toolCalls.length, 1);
+	t.is(normalized.toolCalls[0].function.name, 'write_file');
 });
 
 test('normalizeLLMResponse - handles plain JSON object', async t => {


### PR DESCRIPTION
## Description

Fixes #489 by teaching the XML fallback path to also accept structured JSON tool calls from local models like Ollama.

When native tool calling gets disabled after a provider error, some local models still emit JSON such as `tool_calls`, fenced `{ "name": ..., "arguments": ... }` blocks, or `create_file`-style aliases instead of the documented XML format. Before this change, those responses were treated as plain assistant text, so no tool execution happened.

This PR adds a JSON fallback parser that:
- extracts tool calls from `tool_calls` arrays and single JSON call objects
- strips fenced JSON tool blocks from assistant content once parsed
- normalizes common local-model aliases like `create_file` + `file_path`/`contents` to Nanocoder's `write_file` shape
- updates regression tests for both `parseToolCalls()` and `normalizeLLMResponse()`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
