### PR TITLE
fix(errors): surface context-size failures instead of retrying empty responses

### DIFF
--- a/source/ai-sdk-client/error-handling/error-extractor.spec.ts
+++ b/source/ai-sdk-client/error-handling/error-extractor.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {RetryError} from 'ai';
+import {NoOutputGeneratedError, RetryError} from 'ai';
 import {extractRootError} from './error-extractor.js';
 
 test('extractRootError returns error unchanged if not a RetryError', t => {
@@ -46,6 +46,36 @@ test('extractRootError handles RetryError with no lastError', t => {
 
 	const result = extractRootError(retryError);
 	t.is(result, retryError);
+});
+
+test('extractRootError unwraps Error.cause chains', t => {
+	const rootError = new Error('Root cause');
+	const wrappedError = new Error('Wrapper', {cause: rootError});
+
+	const result = extractRootError(wrappedError);
+	t.is(result, rootError);
+});
+
+test('extractRootError unwraps AI_NoOutputGeneratedError cause', t => {
+	const rootError = new Error(
+		'request (5360 tokens) exceeds the available context size (4096 tokens), try increasing it',
+	);
+	const wrappedError = new NoOutputGeneratedError({cause: rootError});
+
+	const result = extractRootError(wrappedError);
+	t.is(result, rootError);
+});
+
+test('extractRootError unwraps RetryError -> AI_NoOutputGeneratedError -> cause', t => {
+	const rootError = new Error('request exceeds the available context size');
+	const wrappedError = new RetryError({
+		message: 'Retry failed',
+		reason: 'maxRetriesExceeded',
+		errors: [new NoOutputGeneratedError({cause: rootError})],
+	});
+
+	const result = extractRootError(wrappedError);
+	t.is(result, rootError);
 });
 
 test('extractRootError handles non-Error values', t => {

--- a/source/ai-sdk-client/error-handling/error-extractor.ts
+++ b/source/ai-sdk-client/error-handling/error-extractor.ts
@@ -1,15 +1,38 @@
 import {RetryError} from 'ai';
 
+function unwrapError(error: unknown, seen: Set<unknown>): unknown {
+	if (error === null || error === undefined) {
+		return error;
+	}
+
+	if (typeof error !== 'object' && typeof error !== 'function') {
+		return error;
+	}
+
+	if (seen.has(error)) {
+		return error;
+	}
+	seen.add(error);
+
+	// Handle AI SDK RetryError - extract the last error
+	if (RetryError.isInstance(error) && error.lastError) {
+		return unwrapError(error.lastError, seen);
+	}
+
+	// AI SDK v6 often wraps transport/API failures in Error.cause
+	// (for example AI_NoOutputGeneratedError -> APICallError). Unwrap
+	// that chain so callers can surface the real provider error instead
+	// of treating it like a blank model response.
+	if (error instanceof Error && error.cause) {
+		return unwrapError(error.cause, seen);
+	}
+
+	return error;
+}
+
 /**
  * Extracts the root cause error from AI SDK error wrappers.
- * AI SDK wraps errors in RetryError which contains lastError.
  */
 export function extractRootError(error: unknown): unknown {
-	// Handle AI SDK RetryError - extract the last error
-	if (RetryError.isInstance(error)) {
-		if (error.lastError) {
-			return extractRootError(error.lastError);
-		}
-	}
-	return error;
+	return unwrapError(error, new Set());
 }

--- a/source/ai-sdk-client/error-handling/error-parser.spec.ts
+++ b/source/ai-sdk-client/error-handling/error-parser.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {APICallError} from 'ai';
+import {APICallError, NoOutputGeneratedError} from 'ai';
 import {parseAPIError} from './error-parser.js';
 
 test('parseAPIError handles non-Error values', t => {
@@ -160,6 +160,30 @@ test('parseAPIError handles connection errors', t => {
 
 test('parseAPIError handles context length errors', t => {
 	const error = new Error('context length exceeded');
+	const result = parseAPIError(error);
+	t.is(
+		result,
+		'Context too large: Please reduce the conversation length or message size',
+	);
+});
+
+test('parseAPIError handles LM Studio available context size errors', t => {
+	const error = new Error(
+		'request (5360 tokens) exceeds the available context size (4096 tokens), try increasing it',
+	);
+	const result = parseAPIError(error);
+	t.is(
+		result,
+		'Context too large: Please reduce the conversation length or message size',
+	);
+});
+
+test('parseAPIError unwraps AI_NoOutputGeneratedError causes before classifying', t => {
+	const error = new NoOutputGeneratedError({
+		cause: new Error(
+			'request (5360 tokens) exceeds the available context size (4096 tokens), try increasing it',
+		),
+	});
 	const result = parseAPIError(error);
 	t.is(
 		result,

--- a/source/ai-sdk-client/error-handling/error-parser.ts
+++ b/source/ai-sdk-client/error-handling/error-parser.ts
@@ -171,8 +171,11 @@ export function parseAPIError(error: unknown): string {
 
 	// Handle context length errors
 	if (
-		errorMessage.includes('context length') ||
-		errorMessage.includes('too many tokens')
+		lowerMessage.includes('context length') ||
+		lowerMessage.includes('too many tokens') ||
+		lowerMessage.includes('available context size') ||
+		lowerMessage.includes('context window') ||
+		(lowerMessage.includes('exceeds') && lowerMessage.includes('context size'))
 	) {
 		return 'Context too large: Please reduce the conversation length or message size';
 	}


### PR DESCRIPTION
## Description

Unwrap AI SDK `Error.cause` chains before classifying chat failures so LM Studio/OpenAI-compatible context-window errors surface as provider errors instead of being mistaken for blank model output. This stops the conversation loop from auto-appending `Please continue with the task.` on issue #501 and adds LM Studio-specific context-size detection for a clearer user-facing message.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
