### PR TITLE
feat: add subagent context window overrides

### DIFF
--- a/docs/features/subagents.md
+++ b/docs/features/subagents.md
@@ -73,6 +73,7 @@ Create a markdown file in `.nanocoder/agents/` (project-level) or `~/.config/nan
 name: code-reviewer
 description: Reviews code for bugs, security issues, and style problems
 model: inherit
+contextWindow: 16384
 tools:
   - read_file
   - search_file_contents
@@ -96,6 +97,7 @@ You are a code review specialist. When given a file or directory to review:
 | `description` | Yes | — | When to use this agent (shown to the LLM) |
 | `provider` | No | parent's | Provider name from `agents.config.json`. Set this to use a different API endpoint (e.g. `ollama` for local models) |
 | `model` | No | `inherit` | Model ID available on the provider. Use `inherit` to use the parent's current model |
+| `contextWindow` | No | provider/model default | Override the subagent's context window in tokens (e.g. `16384`) |
 | `tools` | No | all | Array of tool names to allow. If set, only these tools are available |
 | `disallowedTools` | No | none | Array of tool names to block |
 
@@ -123,6 +125,8 @@ Always use your tools — never guess.
 ```
 
 The `provider` must match a provider name configured in your `agents.config.json`.
+
+If you set `contextWindow`, Nanocoder creates that subagent with its own context limit override. This is useful when a lightweight research agent should run with a smaller local-model context than your main coding agent.
 
 ## Priority and Overrides
 

--- a/source/client-factory.spec.ts
+++ b/source/client-factory.spec.ts
@@ -1415,3 +1415,44 @@ test.serial(
 		t.deepEqual(providerConfig?.contextWindows, {model1: 65536});
 	},
 );
+
+test.serial(
+	'createLLMClient: applies context window overrides on provider config',
+	async t => {
+		globalThis.fetch = createMockFetch(true, 200);
+
+		const configDir = join(testDir, 'provider-context-override-config-test');
+		mkdirSync(configDir, {recursive: true});
+
+		createTestConfig(
+			{
+				nanocoder: {
+					providers: [
+						{
+							name: 'TestProvider',
+							baseUrl: 'http://localhost:8000/v1',
+							models: ['model1'],
+							contextWindow: 32768,
+						},
+					],
+				},
+			},
+			configDir,
+		);
+
+		process.cwd = () => configDir;
+		clearAppConfig();
+		reloadAppConfig();
+
+		const result = await createLLMClient('TestProvider', 'model1', {
+			contextWindow: 16384,
+		});
+		const providerConfig = getClientProviderConfig(
+			result.client as unknown as {providerConfig?: AIProviderConfig},
+		);
+
+		t.truthy(result);
+		t.truthy(providerConfig);
+		t.is(providerConfig?.contextWindow, 16384);
+	},
+);

--- a/source/client-factory.ts
+++ b/source/client-factory.ts
@@ -31,19 +31,25 @@ export class ConfigurationError extends Error {
 export async function createLLMClient(
 	provider?: string,
 	model?: string,
+	overrides?: Partial<
+		Pick<AIProviderConfig, 'contextWindow' | 'contextWindows'>
+	>,
 ): Promise<{client: LLMClient; actualProvider: string}> {
 	// Check if agents.config.json exists
 	const agentsJsonPath = getClosestConfigFile('agents.config.json');
 	const hasConfigFile = existsSync(agentsJsonPath);
 
 	// Use AI SDK - it handles both tool-calling and non-tool-calling models
-	return createAISDKClient(provider, model, hasConfigFile);
+	return createAISDKClient(provider, model, hasConfigFile, overrides);
 }
 
 async function createAISDKClient(
 	requestedProvider?: string,
 	requestedModel?: string,
 	hasConfigFile = true,
+	overrides?: Partial<
+		Pick<AIProviderConfig, 'contextWindow' | 'contextWindows'>
+	>,
 ): Promise<{client: LLMClient; actualProvider: string}> {
 	// Load provider configs
 	const providers = loadProviderConfigs();
@@ -149,10 +155,14 @@ async function createAISDKClient(
 				continue;
 			}
 
-			// Validate credentials (sync, no network calls)
-			validateProviderCredentials(providerConfig);
+			const effectiveProviderConfig = overrides
+				? {...providerConfig, ...overrides}
+				: providerConfig;
 
-			const client = await AISDKClient.create(providerConfig);
+			// Validate credentials (sync, no network calls)
+			validateProviderCredentials(effectiveProviderConfig);
+
+			const client = await AISDKClient.create(effectiveProviderConfig);
 
 			// Set model if specified
 			if (requestedModel) {

--- a/source/subagents/markdown-parser.spec.ts
+++ b/source/subagents/markdown-parser.spec.ts
@@ -63,6 +63,7 @@ test.serial('validateFrontmatter - accepts valid frontmatter', t => {
 		name: 'test',
 		description: 'A test agent',
 		model: 'haiku',
+		contextWindow: 16384,
 		tools: ['Read'],
 	};
 
@@ -94,6 +95,21 @@ test.serial('validateFrontmatter - rejects missing description', t => {
 	t.false(result.valid);
 	if (!result.valid) {
 		t.regex(result.error, /description is required/);
+	}
+});
+
+test.serial('validateFrontmatter - rejects invalid contextWindow', t => {
+	const frontmatter = {
+		name: 'test',
+		description: 'A test agent',
+		contextWindow: 0,
+	};
+
+	const result = validateFrontmatter(frontmatter);
+
+	t.false(result.valid);
+	if (!result.valid) {
+		t.regex(result.error, /contextWindow must be a positive number/);
 	}
 });
 
@@ -159,6 +175,7 @@ test.serial('parseSubagentMarkdown - parses complete agent file', async t => {
 name: test-agent
 description: A test agent for parsing
 model: sonnet
+contextWindow: 16384
 tools: [Read]
 disallowedTools: [Write]
 ---
@@ -172,6 +189,7 @@ You are a test agent. Do your best!`;
 		t.is(result.config.name, 'test-agent');
 		t.is(result.config.description, 'A test agent for parsing');
 		t.is(result.config.model, 'sonnet');
+		t.is(result.config.contextWindow, 16384);
 		t.deepEqual(result.config.tools, ['Read']);
 		t.deepEqual(result.config.disallowedTools, ['Write']);
 		t.is(result.config.systemPrompt, 'You are a test agent. Do your best!');

--- a/source/subagents/markdown-parser.ts
+++ b/source/subagents/markdown-parser.ts
@@ -42,6 +42,7 @@ export async function parseSubagentMarkdown(
 		description: frontmatter.description,
 		provider: frontmatter.provider,
 		model: frontmatter.model || 'inherit',
+		contextWindow: frontmatter.contextWindow,
 		tools: frontmatter.tools,
 		disallowedTools: frontmatter.disallowedTools,
 		systemPrompt,
@@ -82,6 +83,19 @@ export function validateFrontmatter(
 			return {
 				valid: false,
 				error: 'model must be a non-empty string (a model ID or "inherit")',
+			};
+		}
+	}
+
+	if (frontmatter.contextWindow !== undefined) {
+		if (
+			typeof frontmatter.contextWindow !== 'number' ||
+			!Number.isFinite(frontmatter.contextWindow) ||
+			frontmatter.contextWindow <= 0
+		) {
+			return {
+				valid: false,
+				error: 'contextWindow must be a positive number',
 			};
 		}
 	}

--- a/source/subagents/subagent-executor.spec.ts
+++ b/source/subagents/subagent-executor.spec.ts
@@ -65,6 +65,12 @@ function createMockClient(
 		},
 		getAvailableModels: async () => ['test-model-sonnet-v1'],
 		getContextSize: () => 128000,
+		getProviderConfig: () => ({
+			name: 'TestProvider',
+			type: 'openai',
+			models: ['test-model-sonnet-v1'],
+			config: {},
+		}),
 		clearContext: async () => {},
 		getTimeout: () => undefined,
 	} as unknown as LLMClient;

--- a/source/subagents/subagent-executor.ts
+++ b/source/subagents/subagent-executor.ts
@@ -266,6 +266,26 @@ export class SubagentExecutor {
 		client: LLMClient;
 		restoreParent: () => void;
 	}> {
+		const requestedContextWindow =
+			typeof config.contextWindow === 'number'
+				? config.contextWindow
+				: undefined;
+		const parentProviderConfig = this.parentClient.getProviderConfig();
+		const targetProvider = config.provider ?? parentProviderConfig.name;
+		const targetModel =
+			config.model && config.model !== 'inherit'
+				? config.model
+				: targetProvider === parentProviderConfig.name
+					? this.parentClient.getCurrentModel()
+					: undefined;
+
+		if (requestedContextWindow) {
+			const {client} = await createLLMClient(targetProvider, targetModel, {
+				contextWindow: requestedContextWindow,
+			});
+			return {client, restoreParent: () => {}};
+		}
+
 		// Different provider — create a new client entirely
 		if (config.provider) {
 			const model =
@@ -280,7 +300,10 @@ export class SubagentExecutor {
 			// In concurrent mode, create a new client to avoid mutating the
 			// shared parent client (which would race with other agents)
 			if (concurrent) {
-				const {client} = await createLLMClient(undefined, config.model);
+				const {client} = await createLLMClient(
+					parentProviderConfig.name,
+					config.model,
+				);
 				return {client, restoreParent: () => {}};
 			}
 

--- a/source/subagents/types.ts
+++ b/source/subagents/types.ts
@@ -18,6 +18,8 @@ export interface SubagentConfig {
 	provider?: string;
 	/** Model ID to use, or 'inherit' to use the parent's current model */
 	model?: string;
+	/** Optional context window override for this subagent, in tokens */
+	contextWindow?: number;
 	/** List of allowed tool names (empty = all tools allowed) */
 	tools?: string[];
 	/** List of disallowed tool names */
@@ -121,6 +123,8 @@ export interface SubagentFrontmatter {
 	provider?: string;
 	/** Model ID to use, or 'inherit' */
 	model?: string;
+	/** Context window override in tokens */
+	contextWindow?: number;
 	/** Allowed tools */
 	tools?: string[];
 	/** Disallowed tools */


### PR DESCRIPTION
## Description

Adds a `contextWindow` frontmatter option for subagents so they can run with their own context limit override, even when reusing the same provider/model as the parent agent. This covers the missing subagent-specific half of #485.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

### Ran

- `corepack pnpm exec ava source/subagents/markdown-parser.spec.ts source/subagents/subagent-executor.spec.ts source/client-factory.spec.ts`
- `corepack pnpm run test:types`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
