### PR TITLE
fix(tool-calling): restore JSON fallback on native path

### DIFF
--- a/source/hooks/chat-handler/conversation/conversation-loop.tsx
+++ b/source/hooks/chat-handler/conversation/conversation-loop.tsx
@@ -5,7 +5,11 @@ import AssistantReasoning from '@/components/assistant-reasoning';
 import {ErrorMessage, InfoMessage} from '@/components/message-box';
 import {getAppConfig} from '@/config/index';
 import {MAX_EMPTY_TURNS, MAX_MALFORMED_RETRIES} from '@/constants';
-import {parseToolCalls, stripThinkTags} from '@/tool-calling/index';
+import {
+	dedupeToolCalls,
+	parseToolCalls,
+	stripThinkTags,
+} from '@/tool-calling/index';
 import {loadTasks} from '@/tools/tasks/storage';
 import type {Task} from '@/tools/tasks/types';
 import type {ToolManager} from '@/tools/tool-manager';
@@ -251,11 +255,10 @@ export const processAssistantResponse = async (
 	const fullContent = stripThinkTags(message.content || '');
 	const fullReasoning = message.reasoning;
 
-	// Only parse text for XML tool calls on the fallback path (non-tool-calling models).
-	// On the native path, response text is just text - no tool calls are embedded in it.
-	const parseResult = result.toolsDisabled
-		? parseToolCalls(fullContent)
-		: {success: true as const, toolCalls: [], cleanedContent: fullContent};
+	// Always run the defensive parser over the text stream. Native-tool models can
+	// still echo raw JSON/XML into content, and non-native models still need the
+	// XML/JSON fallback path.
+	const parseResult = parseToolCalls(fullContent);
 
 	// Notify the user once per session when the XML fallback path is active
 	if (result.toolsDisabled && !hasShownFallbackNotice) {
@@ -269,8 +272,7 @@ export const processAssistantResponse = async (
 		);
 	}
 
-	// Check for malformed tool calls and send error back to model for self-correction
-	// (only happens on the XML fallback path)
+	// Check for malformed tool calls and send error back to model for self-correction.
 	if (!parseResult.success) {
 		// Cap malformed-retry recursion. Without this, a model stuck producing
 		// bad XML loops forever, appending two messages per iteration, until
@@ -340,10 +342,12 @@ export const processAssistantResponse = async (
 	const parsedToolCalls = parseResult.toolCalls;
 	const cleanedContent = parseResult.cleanedContent;
 
-	// Combine native tool calls with any parsed from content (XML fallback path)
-	// Native and parsed are mutually exclusive: native comes from tool-calling models,
-	// parsed comes from non-tool-calling models using XML in text
-	let allToolCalls = [...(toolCalls || []), ...parsedToolCalls];
+	// Combine native tool calls with any parsed from content, but keep only the
+	// first exact match so a model that double-emits doesn't execute the same tool twice.
+	let allToolCalls = dedupeToolCalls([
+		...(toolCalls || []),
+		...parsedToolCalls,
+	]);
 
 	// Single-tool enforcement: truncate to first tool call
 	// Active when tune profile implies single-tool (e.g. minimal profile)

--- a/source/plain/conversation.spec.ts
+++ b/source/plain/conversation.spec.ts
@@ -172,6 +172,57 @@ test('executes a tool call that does not need approval and recurses to success',
 	t.is(handlerCalls, 1);
 });
 
+
+test('deduplicates ghost-echo JSON on the native path', async t => {
+	const toolCall: ToolCall = {
+		id: 'call-1',
+		function: {name: 'safe_tool', arguments: {path: '/tmp/test.txt'}},
+	};
+	const client = makeFakeClient({
+		responses: [
+			{
+				choices: [
+					{
+						message: {
+							role: 'assistant',
+							content:
+								'```json\n{"name":"safe_tool","arguments":{"path":"/tmp/test.txt"}}\n```',
+							tool_calls: [toolCall],
+						},
+					},
+				],
+			},
+			{
+				choices: [{message: {role: 'assistant', content: 'all done'}}],
+			},
+		],
+	});
+	const toolManager = makeFakeToolManager({
+		knownTools: new Set(['safe_tool']),
+		needsApprovalByName: {safe_tool: false},
+	});
+	let handlerCalls = 0;
+	setToolRegistryGetter(() => ({
+		safe_tool: (async () => {
+			handlerCalls++;
+			return 'tool-output';
+		}) as ToolHandler,
+	}));
+
+	const outcome = await runPlainConversation({
+		client,
+		toolManager,
+		systemMessage: SYSTEM,
+		initialMessages: [USER],
+		developmentMode: 'auto-accept',
+		nonInteractiveAlwaysAllow: [],
+		abortSignal: new AbortController().signal,
+	});
+
+	t.is(outcome.kind, 'success');
+	t.is(handlerCalls, 1);
+});
+
 test('returns tool-approval-required when a tool needs approval and mode is not yolo', async t => {
 	const toolCall: ToolCall = {
 		id: 'call-1',

--- a/source/plain/conversation.ts
+++ b/source/plain/conversation.ts
@@ -1,6 +1,6 @@
 import {processToolUse} from '@/message-handler';
 import {color, write, writeError, writeLine, writeStatus} from '@/plain/writer';
-import {parseToolCalls} from '@/tool-calling/index';
+import {dedupeToolCalls, parseToolCalls} from '@/tool-calling/index';
 import type {ToolManager} from '@/tools/tool-manager';
 import type {
 	DevelopmentMode,
@@ -110,19 +110,17 @@ export async function runPlainConversation(
 		const nativeToolCalls = message.tool_calls || [];
 		const fullContent = message.content || '';
 
-		const xmlParse = result.toolsDisabled
-			? parseToolCalls(fullContent)
-			: {success: true as const, toolCalls: [], cleanedContent: fullContent};
+		const xmlParse = parseToolCalls(fullContent);
 
 		if (!xmlParse.success) {
 			writeError(`Malformed tool call: ${xmlParse.error}`);
 			return {kind: 'error', message: xmlParse.error};
 		}
 
-		const allToolCalls: ToolCall[] = [
+		const allToolCalls: ToolCall[] = dedupeToolCalls([
 			...nativeToolCalls,
 			...xmlParse.toolCalls,
-		];
+		]);
 		const cleanedContent = xmlParse.cleanedContent;
 
 		const validToolCalls: ToolCall[] = [];

--- a/source/tool-calling/index.ts
+++ b/source/tool-calling/index.ts
@@ -2,4 +2,8 @@
  * Tool calling utilities - main exports
  */
 
-export {parseToolCalls, stripThinkTags} from '@/tool-calling/tool-parser';
+export {
+	dedupeToolCalls,
+	parseToolCalls,
+	stripThinkTags,
+} from '@/tool-calling/tool-parser';

--- a/source/tool-calling/json-parser.spec.ts
+++ b/source/tool-calling/json-parser.spec.ts
@@ -1,0 +1,54 @@
+import test from 'ava';
+import {
+	cleanJSONToolCalls,
+	detectMalformedJSONToolCall,
+	parseJSONToolCalls,
+} from './json-parser';
+
+test('parseJSONToolCalls: parses fenced JSON tool call', t => {
+	const content = `
+\`\`\`json
+{
+  "name": "read_file",
+  "arguments": {
+    "path": "/tmp/test.txt"
+  }
+}
+\`\`\`
+	`;
+
+	const calls = parseJSONToolCalls(content);
+
+	t.is(calls.length, 1);
+	t.is(calls[0].function.name, 'read_file');
+	t.deepEqual(calls[0].function.arguments, {path: '/tmp/test.txt'});
+});
+
+test('cleanJSONToolCalls: removes fenced JSON tool call but keeps surrounding text', t => {
+	const content = `Before
+
+\`\`\`json
+{
+  "name": "read_file",
+  "arguments": {
+    "path": "/tmp/test.txt"
+  }
+}
+\`\`\`
+
+After`;
+
+	const calls = parseJSONToolCalls(content);
+	const cleaned = cleanJSONToolCalls(content, calls);
+
+	t.is(cleaned, `Before
+
+After`);
+});
+
+test('detectMalformedJSONToolCall: detects missing arguments field', t => {
+	const result = detectMalformedJSONToolCall('{"name": "read_file"}');
+
+	t.truthy(result);
+	t.regex(result?.error || '', /missing "arguments" field/i);
+});

--- a/source/tool-calling/json-parser.ts
+++ b/source/tool-calling/json-parser.ts
@@ -1,0 +1,144 @@
+import type {ToolCall} from '@/types/index';
+import {ensureString} from '@/utils/type-helpers';
+
+type ToolCallShape = {
+	name?: string;
+	arguments?: Record<string, unknown>;
+};
+
+function isToolCallShape(value: unknown): value is ToolCallShape {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return false;
+	}
+
+	const parsed = value as ToolCallShape;
+	return (
+		typeof parsed.name === 'string' &&
+		parsed.arguments !== undefined &&
+		parsed.arguments !== null &&
+		typeof parsed.arguments === 'object' &&
+		!Array.isArray(parsed.arguments)
+	);
+}
+
+function toToolCall(parsed: ToolCallShape, index = 0): ToolCall {
+	return {
+		id: `call_${Date.now()}_${index}`,
+		function: {
+			name: parsed.name || '',
+			arguments: parsed.arguments || {},
+		},
+	};
+}
+
+export function detectMalformedJSONToolCall(
+	content: unknown,
+): {error: string; examples: string} | null {
+	const contentStr = ensureString(content);
+	const patterns = [
+		{
+			regex: /(?:^|\n)\s*\{\s*"name"\s*:\s*"[^"]+"\s*,?\s*\}/,
+			error: 'Incomplete tool call: missing "arguments" field',
+		},
+		{
+			regex: /(?:^|\n)\s*\{\s*"arguments"\s*:\s*\{[^}]*\}\s*\}/,
+			error: 'Incomplete tool call: missing "name" field',
+		},
+		{
+			regex:
+				/(?:^|\n)\s*\{\s*"name"\s*:\s*"[^"]+"\s*,\s*"arguments"\s*:\s*"[^"]*"\s*\}/,
+			error: 'Invalid tool call: "arguments" must be an object, not a string',
+		},
+	];
+
+	for (const pattern of patterns) {
+		if (pattern.regex.test(contentStr)) {
+			return {
+				error: pattern.error,
+				examples:
+					'Please use the native tool calling format provided by the system. The tools are already available to you - call them directly using the function calling interface.',
+			};
+		}
+	}
+
+	return null;
+}
+
+export function parseJSONToolCalls(content: unknown): ToolCall[] {
+	const contentStr = ensureString(content);
+	let trimmedContent = contentStr.trim();
+
+	const codeBlockMatch = trimmedContent.match(
+		/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/,
+	);
+	if (codeBlockMatch?.[1]) {
+		trimmedContent = codeBlockMatch[1].trim();
+	}
+
+	if (trimmedContent.startsWith('{') && trimmedContent.endsWith('}')) {
+		if (trimmedContent.replace(/\s/g, '') === '{}') {
+			return [];
+		}
+
+		try {
+			const parsed = JSON.parse(trimmedContent);
+			if (isToolCallShape(parsed)) {
+				return [toToolCall(parsed)];
+			}
+		} catch {
+			// Fall through to regex-based scanning.
+		}
+	}
+
+	const extractedCalls: ToolCall[] = [];
+	const patterns = [
+		/\{\s*\n\s*"name":\s*"([^"]+)",\s*\n\s*"arguments":\s*\{[\s\S]*?\}\s*\n\s*\}/g,
+		/\{"name":\s*"([^"]+)",\s*"arguments":\s*(\{[\s\S]*?\})\}/g,
+	];
+
+	for (const pattern of patterns) {
+		let match: RegExpExecArray | null;
+		while ((match = pattern.exec(contentStr)) !== null) {
+			try {
+				const parsed = JSON.parse(match[0]);
+				if (isToolCallShape(parsed)) {
+					extractedCalls.push(toToolCall(parsed, extractedCalls.length));
+				}
+			} catch {
+				// Ignore malformed JSON here; malformed detection runs separately.
+			}
+		}
+	}
+
+	return extractedCalls;
+}
+
+export function cleanJSONToolCalls(
+	content: unknown,
+	toolCalls: ToolCall[],
+): string {
+	const contentStr = ensureString(content);
+	if (toolCalls.length === 0) return contentStr;
+
+	return contentStr
+		.replace(
+			/```(?:json)?\s*\n?([\s\S]*?)\n?```/g,
+			(match, blockContent: string) => {
+				try {
+					const parsed = JSON.parse(blockContent.trim());
+					return isToolCallShape(parsed) ? '' : match;
+				} catch {
+					return match;
+				}
+			},
+		)
+		.replace(
+			/\{\s*\n\s*"name":\s*"([^"]+)",\s*\n\s*"arguments":\s*\{[\s\S]*?\}\s*\n\s*\}/g,
+			'',
+		)
+		.replace(/\{"name":\s*"([^"]+)",\s*"arguments":\s*(\{[\s\S]*?\})\}/g, '')
+		.replace(/[ \t]+$/gm, '')
+		.replace(/^[ \t]+$/gm, '')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim();
+}

--- a/source/tool-calling/tool-parser.spec.ts
+++ b/source/tool-calling/tool-parser.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {parseToolCalls} from './tool-parser';
+import {dedupeToolCalls, parseToolCalls} from './tool-parser';
 
 console.log(`\ntool-parser.spec.ts`);
 
@@ -119,6 +119,54 @@ test('parseToolCalls: handles empty JSON object', t => {
 	if (result.success) {
 		t.is(result.toolCalls.length, 0);
 	}
+});
+
+
+test('parseToolCalls: parses fenced JSON tool call and strips it from content', t => {
+	const content = `Before
+
+\`\`\`json
+{
+  "name": "read_file",
+  "arguments": {
+    "path": "/tmp/test.txt"
+  }
+}
+\`\`\`
+
+After`;
+
+	const result = parseToolCalls(content);
+
+	t.true(result.success);
+	if (result.success) {
+		t.is(result.toolCalls.length, 1);
+		t.is(result.toolCalls[0].function.name, 'read_file');
+		t.deepEqual(result.toolCalls[0].function.arguments, {path: '/tmp/test.txt'});
+		t.is(result.cleanedContent, 'Before\n\nAfter');
+	}
+});
+
+test('parseToolCalls: surfaces malformed JSON tool calls for self-correction', t => {
+	const result = parseToolCalls('{"name": "read_file"}');
+
+	t.false(result.success);
+	if (!result.success) {
+		t.regex(result.error, /missing "arguments" field/i);
+	}
+});
+
+test('dedupeToolCalls: removes parsed duplicates after native tool calls', t => {
+	const deduped = dedupeToolCalls([
+		{id: 'native', function: {name: 'read_file', arguments: {path: '/tmp/test.txt'}}},
+		{id: 'parsed', function: {name: 'read_file', arguments: {path: '/tmp/test.txt'}}},
+		{id: 'other', function: {name: 'list_directory', arguments: {path: '/tmp'}}},
+	]);
+
+	t.deepEqual(
+		deduped.map(call => call.id),
+		['native', 'other'],
+	);
 });
 
 test('parseToolCalls: preserves identical XML tool calls (no deduplication)', t => {

--- a/source/tool-calling/tool-parser.ts
+++ b/source/tool-calling/tool-parser.ts
@@ -1,6 +1,11 @@
 import {XMLToolCallParser} from '@/tool-calling/xml-parser';
 import type {ToolCall} from '@/types/index';
 import {ensureString} from '@/utils/type-helpers';
+import {
+	cleanJSONToolCalls,
+	detectMalformedJSONToolCall,
+	parseJSONToolCalls,
+} from './json-parser';
 
 /**
  * Strip  tags from content (some models output thinking that shouldn't be shown)
@@ -78,7 +83,26 @@ export function parseToolCalls(content: unknown): ParseResult {
 		}
 	}
 
-	// 3. Check for malformed XML patterns (DEFENSIVE: Error second!)
+	// 3. Try targeted JSON fallback for panicked native-tool models
+	const jsonToolCalls = parseJSONToolCalls(strippedContent);
+	if (jsonToolCalls.length > 0) {
+		return {
+			success: true,
+			toolCalls: jsonToolCalls,
+			cleanedContent: cleanJSONToolCalls(strippedContent, jsonToolCalls),
+		};
+	}
+
+	// 4. Check for malformed JSON or XML patterns (DEFENSIVE: Error second!)
+	const jsonMalformed = detectMalformedJSONToolCall(strippedContent);
+	if (jsonMalformed) {
+		return {
+			success: false,
+			error: jsonMalformed.error,
+			examples: jsonMalformed.examples,
+		};
+	}
+
 	const xmlMalformed =
 		XMLToolCallParser.detectMalformedToolCall(strippedContent);
 	if (xmlMalformed) {
@@ -89,10 +113,26 @@ export function parseToolCalls(content: unknown): ParseResult {
 		};
 	}
 
-	// 4. No tool calls found - normalize whitespace in content
+	// 5. No tool calls found - normalize whitespace in content
 	return {
 		success: true,
 		toolCalls: [],
 		cleanedContent: normalizeWhitespace(strippedContent),
 	};
+}
+
+function getToolCallKey(toolCall: ToolCall): string {
+	return `${toolCall.function.name}:${JSON.stringify(toolCall.function.arguments)}`;
+}
+
+export function dedupeToolCalls(toolCalls: ToolCall[]): ToolCall[] {
+	const seen = new Set<string>();
+	return toolCalls.filter(toolCall => {
+		const key = getToolCallKey(toolCall);
+		if (seen.has(key)) {
+			return false;
+		}
+		seen.add(key);
+		return true;
+	});
 }


### PR DESCRIPTION
## Description

Restores the defensive JSON fallback path from issue #500 so native-tool models can still recover from raw JSON/XML text-stream hallucinations. The response loop now always parses the assistant text stream, removes echoed tool payloads from user-visible content, and deduplicates parsed tool calls against native SDK tool calls so ghost echoes do not execute twice.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
