### PR TITLE
fix: read_file returns empty marker instead of throwing on empty files

### DIFF
--- a/source/constants.ts
+++ b/source/constants.ts
@@ -56,6 +56,7 @@ export const FILE_READ_CHUNKING_HINT_THRESHOLD_LINES = 500;
 export const FILE_READ_CHUNK_SIZE_LINES = 250;
 export const CHARS_PER_TOKEN_ESTIMATE = 4;
 export const MAX_LINE_LENGTH_CHARS = 10_000; // Lines longer than this are likely minified/binary
+export const EMPTY_FILE_MARKER = '[file is empty]';
 
 // === TERMINAL AND UI ===
 export const PATH_LENGTH_NARROW_TERMINAL = 30;

--- a/source/tools/read-file.spec.tsx
+++ b/source/tools/read-file.spec.tsx
@@ -643,7 +643,7 @@ test.serial('read_file throws error for nonexistent file', async t => {
 	);
 });
 
-test.serial('read_file throws error for empty files', async t => {
+test.serial('read_file returns empty marker for empty files', async t => {
 	t.timeout(10000);
 	const testDir = join(process.cwd(), 'test-read-empty-temp');
 
@@ -651,17 +651,14 @@ test.serial('read_file throws error for empty files', async t => {
 		mkdirSync(testDir, {recursive: true});
 		writeFileSync(join(testDir, 'empty.ts'), '');
 
-		await t.throwsAsync(
-			async () => {
-				await readFileTool.tool.execute!(
-					{
-						path: join(testDir, 'empty.ts'),
-					},
-					{toolCallId: 'test', messages: []},
-				);
+		const result = await readFileTool.tool.execute!(
+			{
+				path: join(testDir, 'empty.ts'),
 			},
-			{message: /exists but is empty/},
+			{toolCallId: 'test', messages: []},
 		);
+
+		t.is(result, '[file is empty]');
 	} finally {
 		rmSync(testDir, {recursive: true, force: true});
 	}

--- a/source/tools/read-file.spec.tsx
+++ b/source/tools/read-file.spec.tsx
@@ -4,6 +4,7 @@ import test from 'ava';
 import {render} from 'ink-testing-library';
 import React from 'react';
 import {themes} from '../config/themes';
+import {EMPTY_FILE_MARKER} from '../constants';
 import {ThemeContext} from '../hooks/useTheme';
 import {readFileTool} from './read-file';
 
@@ -658,11 +659,64 @@ test.serial('read_file returns empty marker for empty files', async t => {
 			{toolCallId: 'test', messages: []},
 		);
 
-		t.is(result, '[file is empty]');
+		t.is(result, EMPTY_FILE_MARKER);
 	} finally {
 		rmSync(testDir, {recursive: true, force: true});
 	}
 });
+
+test.serial(
+	'read_file returns empty marker for empty files with line ranges',
+	async t => {
+		t.timeout(10000);
+		const testDir = join(process.cwd(), 'test-read-empty-ranges-temp');
+
+		try {
+			mkdirSync(testDir, {recursive: true});
+			writeFileSync(join(testDir, 'empty.ts'), '');
+
+			const result = await readFileTool.tool.execute!(
+				{
+					path: join(testDir, 'empty.ts'),
+					start_line: 1,
+					end_line: 10,
+				},
+				{toolCallId: 'test', messages: []},
+			);
+
+			t.is(result, EMPTY_FILE_MARKER);
+		} finally {
+			rmSync(testDir, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
+	'read_file metadata_only returns file info for empty files without short-circuiting',
+	async t => {
+		t.timeout(10000);
+		const testDir = join(process.cwd(), 'test-read-empty-metadata-temp');
+
+		try {
+			mkdirSync(testDir, {recursive: true});
+			writeFileSync(join(testDir, 'empty.ts'), '');
+
+			const result = (await readFileTool.tool.execute!(
+				{
+					path: join(testDir, 'empty.ts'),
+					metadata_only: true,
+				},
+				{toolCallId: 'test', messages: []},
+			)) as string;
+
+			t.true(result.includes('File Information for'));
+			t.true(result.includes('Size: 0 bytes'));
+			t.false(result.includes(EMPTY_FILE_MARKER));
+		} finally {
+			rmSync(testDir, {recursive: true, force: true});
+		}
+	},
+);
 
 // ============================================================================
 // Edge Cases and Stress Tests

--- a/source/tools/read-file.tsx
+++ b/source/tools/read-file.tsx
@@ -97,9 +97,8 @@ const executeReadFile = async (args: {
 		const cached = await getCachedFileContent(absPath);
 		const content = cached.content;
 
-		// Check if file is empty (0 tokens)
 		if (content.length === 0) {
-			throw new Error(`File "${args.path}" exists but is empty (0 tokens)`);
+			return '[file is empty]';
 		}
 
 		const lines = cached.lines;
@@ -171,7 +170,6 @@ const executeReadFile = async (args: {
 			throw new Error(`File "${args.path}" does not exist`);
 		}
 
-		// Re-throw other errors (including our empty file error)
 		throw error;
 	}
 };

--- a/source/tools/read-file.tsx
+++ b/source/tools/read-file.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 import ToolMessage from '@/components/tool-message';
 import {
+	EMPTY_FILE_MARKER,
 	FILE_READ_CHUNK_SIZE_LINES,
 	FILE_READ_CHUNKING_HINT_THRESHOLD_LINES,
 	FILE_READ_METADATA_THRESHOLD_LINES,
@@ -98,7 +99,7 @@ const executeReadFile = async (args: {
 		const content = cached.content;
 
 		if (content.length === 0) {
-			return '[file is empty]';
+			return EMPTY_FILE_MARKER;
 		}
 
 		const lines = cached.lines;


### PR DESCRIPTION
## Description

`read_file` previously threw `File "..." exists but is empty (0 tokens)` whenever the target file was empty. Empty files are valid (`.gitkeep`, freshly-created stubs, log files truncated to zero), so the throw turned a successful FS read into an error and pushed the model into wasteful retries (`bash cat`, `list_directory`, `metadata_only`) just to confirm the same state.

This PR replaces the throw with a successful return of the marker string `[file is empty]`, so the model can distinguish "file is empty" from "file does not exist" without an exception path. Updates the corresponding AVA test.

Closes #530.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files (existing empty-file test updated to assert the new return value)
- [x] All existing tests pass (`pnpm run test:ava source/tools/read-file.spec.tsx` — 38/38 pass)
- [x] Tests cover both success and error scenarios (empty file returns marker; nonexistent file still throws)

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

_Change is provider-agnostic — the fix is in the local tool handler, not the LLM client path._

## Checklist

- [x] Code follows project style guidelines (Biome ran via lint-staged on commit)
- [x] Self-review completed
- [x] Documentation updated (if needed) — none required; behavior change is internal to the tool
- [x] No breaking changes (or clearly documented) — return type unchanged (`string`); callers that previously caught the throw will simply see a successful response
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging)) — N/A, no new log sites