### PR TITLE
feat(usage): show API-reported context usage with an estimate fallback

### DIFF
--- a/source/ai-sdk-client/chat/chat-handler.ts
+++ b/source/ai-sdk-client/chat/chat-handler.ts
@@ -287,19 +287,25 @@ export async function handleChat(
 			}
 			flushBuffer();
 
-			// After streaming completes, collect final results
+			// After streaming completes, collect final results.
+			// `result.usage` is the FINAL step's usage (not `totalUsage`, which
+			// sums across steps): with stopWhen=stepCountIs(MAX_TOOL_STEPS) a
+			// single chat() call may span multiple steps, and the final step's
+			// input+output tokens reflect the actual context window occupancy.
 			const [
 				fullText,
 				resolvedToolCalls,
 				resolvedSteps,
 				reasoning,
 				finishReason,
+				usage,
 			] = await Promise.all([
 				result.text,
 				result.toolCalls,
 				result.steps,
 				result.reasoningText,
 				result.finishReason,
+				result.usage,
 			]);
 
 			logger.debug('AI SDK response received', {
@@ -354,6 +360,11 @@ export async function handleChat(
 					},
 				],
 				toolsDisabled: shouldDisableTools,
+				usage: {
+					inputTokens: usage.inputTokens,
+					outputTokens: usage.outputTokens,
+					totalTokens: usage.totalTokens,
+				},
 			};
 		} catch (error) {
 			// Calculate performance metrics even for errors

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -215,6 +215,7 @@ export default function App({
 		compactToolCountsRef: appState.compactToolCountsRef,
 		onSetLiveTaskList: appState.setLiveTaskList,
 		setLiveComponent: appState.setLiveComponent,
+		setLastApiUsage: appState.setLastApiUsage,
 		tune: appState.tune,
 		subagentsReady: appState.subagentsReady,
 	});
@@ -238,8 +239,10 @@ export default function App({
 		toolManager: appState.toolManager,
 		streamingTokenCount: chatHandler.tokenCount,
 		contextLimit: appState.contextLimit,
+		lastApiUsage: appState.lastApiUsage,
 		setContextPercentUsed: appState.setContextPercentUsed,
 		setContextLimit: appState.setContextLimit,
+		setContextSource: appState.setContextSource,
 		developmentMode: appState.developmentMode,
 		tune: appState.tune,
 	});

--- a/source/app/components/chat-input.spec.tsx
+++ b/source/app/components/chat-input.spec.tsx
@@ -24,6 +24,7 @@ function createDefaultProps(
 		inputDisabled: false,
 		developmentMode: 'normal',
 		contextPercentUsed: null,
+		contextSource: null,
 		onToolConfirm: async () => {},
 		onToolCancel: () => {},
 		onSubmit: async () => {},

--- a/source/app/components/chat-input.tsx
+++ b/source/app/components/chat-input.tsx
@@ -9,7 +9,12 @@ import ToolExecutionIndicator from '@/components/tool-execution-indicator';
 import UserInput from '@/components/user-input';
 import {useTheme} from '@/hooks/useTheme';
 import type {Task} from '@/tools/tasks/types';
-import type {DevelopmentMode, ToolCall, TuneConfig} from '@/types';
+import type {
+	ContextSource,
+	DevelopmentMode,
+	ToolCall,
+	TuneConfig,
+} from '@/types';
 import type {PendingQuestion} from '@/utils/question-queue';
 import type {PendingToolApproval} from '@/utils/tool-approval-queue';
 import {LiveCompactCounts} from '@/utils/tool-result-display';
@@ -43,6 +48,7 @@ export interface ChatInputProps {
 	inputDisabled: boolean;
 	developmentMode: DevelopmentMode;
 	contextPercentUsed: number | null;
+	contextSource: ContextSource | null;
 	sessionName?: string;
 
 	// Tool display
@@ -93,6 +99,7 @@ export function ChatInput({
 	inputDisabled,
 	developmentMode,
 	contextPercentUsed,
+	contextSource,
 	sessionName,
 	compactToolCounts,
 	onToggleCompactDisplay,
@@ -167,6 +174,7 @@ export function ChatInput({
 					compactToolDisplay={compactToolDisplay}
 					developmentMode={developmentMode}
 					contextPercentUsed={contextPercentUsed}
+					contextSource={contextSource}
 					sessionName={sessionName}
 					tune={tune}
 					activeEditor={activeEditor}

--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -154,6 +154,7 @@ export function InteractiveApp({
 						inputDisabled={chatHandler.isGenerating || appState.isToolExecuting}
 						developmentMode={appState.developmentMode}
 						contextPercentUsed={appState.contextPercentUsed}
+						contextSource={appState.contextSource}
 						sessionName={appState.sessionName || undefined}
 						compactToolCounts={appState.compactToolCounts}
 						compactToolDisplay={appState.compactToolDisplay}

--- a/source/components/development-mode-indicator.spec.tsx
+++ b/source/components/development-mode-indicator.spec.tsx
@@ -140,7 +140,9 @@ test('DevelopmentModeIndicator shows context percentage when provided', t => {
 	);
 
 	const output = lastFrame();
-	t.regex(output!, /ctx: 42%/);
+	// Marker is optional here (no source given → estimated); see dedicated
+	// API-vs-estimate marker tests below.
+	t.regex(output!, /ctx: ~?42%/);
 });
 
 test('DevelopmentModeIndicator hides context percentage when null', t => {
@@ -150,6 +152,44 @@ test('DevelopmentModeIndicator hides context percentage when null', t => {
 
 	const output = lastFrame();
 	t.notRegex(output!, /ctx:/);
+});
+
+test('DevelopmentModeIndicator shows API-reported context without the ~ marker', t => {
+	const {lastFrame} = render(
+		<DevelopmentModeIndicator
+			developmentMode="normal"
+			colors={mockColors}
+			contextPercentUsed={42}
+			contextSource="api"
+		/>,
+	);
+
+	const output = lastFrame();
+	t.regex(output!, /ctx: 42%/);
+	t.notRegex(output!, /ctx: ~42%/);
+});
+
+test('DevelopmentModeIndicator marks estimated context with a leading ~', t => {
+	const {lastFrame} = render(
+		<DevelopmentModeIndicator
+			developmentMode="normal"
+			colors={mockColors}
+			contextPercentUsed={42}
+			contextSource="estimate"
+		/>,
+	);
+
+	const output = lastFrame();
+	t.regex(output!, /ctx: ~42%/);
+});
+
+test('DevelopmentModeIndicator defaults to the estimate marker when source is omitted', t => {
+	const {lastFrame} = render(
+		<DevelopmentModeIndicator developmentMode="normal" colors={mockColors} contextPercentUsed={42} />,
+	);
+
+	const output = lastFrame();
+	t.regex(output!, /ctx: ~42%/);
 });
 
 test('DevelopmentModeIndicator normal mode uses correct label', t => {
@@ -253,7 +293,7 @@ test('DevelopmentModeIndicator has correct structure', t => {
 	const output = lastFrame();
 	// Should have the mode label and context percentage
 	t.regex(output!, /normal mode on/);
-	t.regex(output!, /ctx: 25%/);
+	t.regex(output!, /ctx: ~?25%/);
 });
 
 test('DevelopmentModeIndicator component can be unmounted', t => {

--- a/source/components/development-mode-indicator.tsx
+++ b/source/components/development-mode-indicator.tsx
@@ -7,7 +7,7 @@ import {
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
 import type {useTheme} from '@/hooks/useTheme';
 import type {TuneConfig} from '@/types/config';
-import type {DevelopmentMode} from '@/types/core';
+import type {ContextSource, DevelopmentMode} from '@/types/core';
 import {
 	DEVELOPMENT_MODE_LABELS,
 	DEVELOPMENT_MODE_LABELS_NARROW,
@@ -18,6 +18,9 @@ interface DevelopmentModeIndicatorProps {
 	developmentMode: DevelopmentMode;
 	colors: ReturnType<typeof useTheme>['colors'];
 	contextPercentUsed: number | null;
+	// Whether contextPercentUsed is API-reported ('api') or client-side
+	// estimated ('estimate'/null). Estimated values render with a leading '~'.
+	contextSource?: ContextSource | null;
 	sessionName?: string;
 	tune?: TuneConfig;
 	activeEditor?: ActiveEditorState | null;
@@ -42,6 +45,7 @@ export const DevelopmentModeIndicator = React.memo(
 		developmentMode,
 		colors,
 		contextPercentUsed,
+		contextSource,
 		sessionName,
 		tune,
 		activeEditor,
@@ -56,6 +60,11 @@ export const DevelopmentModeIndicator = React.memo(
 				? 'tune: ✓'
 				: 'tune: enabled'
 			: '';
+
+		// Estimated context figures render with a leading '~' (≈); API-reported
+		// figures render bare. The marker is a single char so it barely affects
+		// the width budget below, where ctx never truncates.
+		const ctxPrefix = contextSource === 'api' ? '' : '~';
 
 		// Mode, tune, and ctx never truncate. Session name and the filename
 		// portion of the editor pill share whatever room is left, each
@@ -87,7 +96,9 @@ export const DevelopmentModeIndicator = React.memo(
 					: '';
 			const tuneSegment = tuneLabel ? ` · ${tuneLabel}` : '';
 			const ctxSegment =
-				contextPercentUsed !== null ? ` · ctx: ${contextPercentUsed}%` : '';
+				contextPercentUsed !== null
+					? ` · ctx: ${ctxPrefix}${contextPercentUsed}%`
+					: '';
 			const sessionSeparator = sessionName ? ' · ' : '';
 			const editorSeparator = editorFileName ? ' · ' : '';
 
@@ -209,7 +220,8 @@ export const DevelopmentModeIndicator = React.memo(
 					<>
 						<Text color={colors.secondary}> · </Text>
 						<Text color={getContextColor(contextPercentUsed, colors)}>
-							ctx: {contextPercentUsed}%
+							ctx: {ctxPrefix}
+							{contextPercentUsed}%
 						</Text>
 					</>
 				)}

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -10,7 +10,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {useUIStateContext} from '@/hooks/useUIState';
 import {promptHistory} from '@/prompt-history';
 import type {TuneConfig} from '@/types/config';
-import type {DevelopmentMode} from '@/types/core';
+import type {ContextSource, DevelopmentMode} from '@/types/core';
 import type {InputState} from '@/types/hooks';
 import {Completion} from '@/types/index';
 import {
@@ -33,6 +33,7 @@ interface ChatProps {
 	compactToolDisplay?: boolean; // Current compact display state
 	developmentMode?: DevelopmentMode; // Current development mode
 	contextPercentUsed?: number | null; // Context window usage percentage
+	contextSource?: ContextSource | null; // Whether ctx % is API-reported or estimated
 	sessionName?: string; // Optional session name for display
 	tune?: TuneConfig; // Model mode configuration
 	activeEditor?: ActiveEditorState | null; // VS Code active file + optional selection
@@ -51,6 +52,7 @@ export default function UserInput({
 	compactToolDisplay = true,
 	developmentMode = 'normal',
 	contextPercentUsed,
+	contextSource,
 	sessionName,
 	tune,
 	activeEditor,
@@ -514,6 +516,7 @@ export default function UserInput({
 					developmentMode={developmentMode}
 					colors={colors}
 					contextPercentUsed={contextPercentUsed ?? null}
+					contextSource={contextSource ?? null}
 					sessionName={sessionName}
 					tune={tune}
 				/>
@@ -602,6 +605,7 @@ export default function UserInput({
 				developmentMode={developmentMode}
 				colors={colors}
 				contextPercentUsed={contextPercentUsed ?? null}
+				contextSource={contextSource ?? null}
 				sessionName={sessionName}
 				tune={tune}
 				activeEditor={activeEditor}

--- a/source/hooks/chat-handler/conversation/conversation-loop.spec.ts
+++ b/source/hooks/chat-handler/conversation/conversation-loop.spec.ts
@@ -2,7 +2,13 @@ import test from 'ava';
 import {clearAppConfig} from '@/config/index.js';
 import {resetShutdownManager} from '@/utils/shutdown/shutdown-manager.js';
 import {processAssistantResponse, resetFallbackNotice, resetLastTurnHadReasoning} from './conversation-loop.js';
-import type {LLMChatResponse, Message, ToolCall, ToolResult} from '@/types/core';
+import type {
+	ApiUsageSnapshot,
+	LLMChatResponse,
+	Message,
+	ToolCall,
+	ToolResult,
+} from '@/types/core';
 import {
 	resetAutoCompactSession,
 	setAutoCompactEnabled,
@@ -35,7 +41,8 @@ const createMockClient = (response: {
 	toolCalls?: ToolCall[];
 	content?: string;
 	toolsDisabled?: boolean;
-	reasoning?: string
+	reasoning?: string;
+	usage?: {inputTokens?: number; outputTokens?: number; totalTokens?: number};
 }) => ({
 	chat: async (): Promise<LLMChatResponse> => ({
 		choices: [
@@ -49,6 +56,7 @@ const createMockClient = (response: {
 			},
 		],
 		toolsDisabled: response.toolsDisabled ?? false,
+		usage: response.usage,
 	}),
 });
 
@@ -418,6 +426,47 @@ test.serial('processAssistantResponse - strips <think> tags on the native path b
 	const lastAssistant = [...lastSetMessages].reverse().find(m => m.role === 'assistant');
 	t.truthy(lastAssistant, 'Should append an assistant message to history');
 	t.notRegex(lastAssistant!.content as string, /<think>/i, 'History must not contain <think> tags');
+});
+
+// ============================================================================
+// API Usage Snapshot Tests (#381)
+// ============================================================================
+
+test.serial('processAssistantResponse - captures API usage snapshot keyed to the post-response message count', async t => {
+	const usageCalls: (ApiUsageSnapshot | null)[] = [];
+
+	const params = createDefaultParams({
+		client: createMockClient({
+			content: 'Hi there',
+			usage: {inputTokens: 1200, outputTokens: 300, totalTokens: 1500},
+		}),
+		messages: [{role: 'user', content: 'Hello'}],
+		setLastApiUsage: (usage: ApiUsageSnapshot | null) => usageCalls.push(usage),
+	});
+
+	await processAssistantResponse(params);
+
+	// The user message plus the appended assistant reply → 2 messages.
+	t.deepEqual(usageCalls.at(-1), {
+		inputTokens: 1200,
+		outputTokens: 300,
+		totalTokens: 1500,
+		atMessageCount: 2,
+	});
+});
+
+test.serial('processAssistantResponse - clears the API usage snapshot when the provider reports no usage', async t => {
+	const usageCalls: (ApiUsageSnapshot | null)[] = [];
+
+	const params = createDefaultParams({
+		client: createMockClient({content: 'Hi there'}), // no usage reported
+		messages: [{role: 'user', content: 'Hello'}],
+		setLastApiUsage: (usage: ApiUsageSnapshot | null) => usageCalls.push(usage),
+	});
+
+	await processAssistantResponse(params);
+
+	t.is(usageCalls.at(-1), null);
 });
 
 test.serial('processAssistantResponse - strips JSON ghost-echo on the native path when tool calls are present', async t => {

--- a/source/hooks/chat-handler/conversation/conversation-loop.spec.ts
+++ b/source/hooks/chat-handler/conversation/conversation-loop.spec.ts
@@ -469,6 +469,20 @@ test.serial('processAssistantResponse - clears the API usage snapshot when the p
 	t.is(usageCalls.at(-1), null);
 });
 
+test.serial('processAssistantResponse - stores a snapshot when the provider reports only a totalTokens lump sum', async t => {
+	const usageCalls: (ApiUsageSnapshot | null)[] = [];
+
+	const params = createDefaultParams({
+		client: createMockClient({content: 'Hi there', usage: {totalTokens: 1500}}),
+		messages: [{role: 'user', content: 'Hello'}],
+		setLastApiUsage: (usage: ApiUsageSnapshot | null) => usageCalls.push(usage),
+	});
+
+	await processAssistantResponse(params);
+
+	t.deepEqual(usageCalls.at(-1), {totalTokens: 1500, atMessageCount: 2});
+});
+
 test.serial('processAssistantResponse - strips JSON ghost-echo on the native path when tool calls are present', async t => {
 	const queuedComponents: any[] = [];
 	const messagesSetCalls: Message[][] = [];

--- a/source/hooks/chat-handler/conversation/conversation-loop.tsx
+++ b/source/hooks/chat-handler/conversation/conversation-loop.tsx
@@ -515,18 +515,18 @@ export const processAssistantResponse = async (
 	// and let estimation recompute against the compressed history.
 	if (setLastApiUsage) {
 		const usage = result.usage;
+		// Store the snapshot when the provider reported any usable token field
+		// (input, output, or a lump-sum total). The indicator decides how to use
+		// it; a non-finite or wholly-empty report is treated as "no usage".
 		const hasReportedUsage =
 			!compactionOccurred &&
 			!!usage &&
-			(usage.inputTokens !== undefined || usage.outputTokens !== undefined);
+			(Number.isFinite(usage.inputTokens) ||
+				Number.isFinite(usage.outputTokens) ||
+				Number.isFinite(usage.totalTokens));
 		setLastApiUsage(
 			hasReportedUsage
-				? {
-						inputTokens: usage.inputTokens,
-						outputTokens: usage.outputTokens,
-						totalTokens: usage.totalTokens,
-						atMessageCount: updatedMessages.length,
-					}
+				? {...usage, atMessageCount: updatedMessages.length}
 				: null,
 		);
 	}

--- a/source/hooks/chat-handler/conversation/conversation-loop.tsx
+++ b/source/hooks/chat-handler/conversation/conversation-loop.tsx
@@ -17,6 +17,7 @@ import type {ToolManager} from '@/tools/tool-manager';
 import {isSingleToolProfile} from '@/tools/tool-profiles';
 import type {TuneConfig} from '@/types/config';
 import type {
+	ApiUsageSnapshot,
 	LLMClient,
 	Message,
 	ModeOverrides,
@@ -64,6 +65,10 @@ interface ProcessAssistantResponseParams {
 	compactToolCountsRef?: React.MutableRefObject<Record<string, number>>;
 	onSetLiveTaskList?: (tasks: Task[] | null) => void;
 	setLiveComponent?: (component: React.ReactNode) => void;
+	// Records the API-reported usage of the latest response (or null to clear
+	// it, e.g. after auto-compaction) so the context indicator can prefer
+	// API-accurate numbers over client-side estimation.
+	setLastApiUsage?: (usage: ApiUsageSnapshot | null) => void;
 	tune?: TuneConfig;
 	// Number of consecutive empty assistant turns that have already been
 	// nudged in this loop. The empty-response branch increments and
@@ -132,6 +137,7 @@ export const processAssistantResponse = async (
 		compactToolCountsRef,
 		onSetLiveTaskList,
 		setLiveComponent,
+		setLastApiUsage,
 		tune,
 		developmentMode,
 		emptyTurnCount = 0,
@@ -458,6 +464,7 @@ export const processAssistantResponse = async (
 	// Check for auto-compact after messages are updated
 	// Note: This is awaited to prevent race conditions where setMessages(compressed)
 	// could overwrite newer state updates that happen while compression is in progress
+	let compactionOccurred = false;
 	try {
 		const config = getAppConfig();
 		const autoCompactConfig = config.autoCompact;
@@ -494,10 +501,34 @@ export const processAssistantResponse = async (
 				// and recursive calls see the compressed messages instead of
 				// the pre-compression copy.
 				updatedMessages = compressed;
+				compactionOccurred = true;
 			}
 		}
 	} catch (_error) {
 		// Silently fail auto-compact, don't interrupt the conversation
+	}
+
+	// Record the API-reported usage for the context indicator. The snapshot is
+	// keyed to the post-response message count so the indicator can fall back
+	// to estimation once newer messages make it stale. After compaction the
+	// reported usage describes the pre-compaction context, so clear it (null)
+	// and let estimation recompute against the compressed history.
+	if (setLastApiUsage) {
+		const usage = result.usage;
+		const hasReportedUsage =
+			!compactionOccurred &&
+			!!usage &&
+			(usage.inputTokens !== undefined || usage.outputTokens !== undefined);
+		setLastApiUsage(
+			hasReportedUsage
+				? {
+						inputTokens: usage.inputTokens,
+						outputTokens: usage.outputTokens,
+						totalTokens: usage.totalTokens,
+						atMessageCount: updatedMessages.length,
+					}
+				: null,
+		);
 	}
 
 	// Clear streaming content (but don't set isGenerating=false yet —

--- a/source/hooks/chat-handler/types.ts
+++ b/source/hooks/chat-handler/types.ts
@@ -3,7 +3,12 @@ import type {CustomCommandLoader} from '@/custom-commands/loader';
 import type {Task} from '@/tools/tasks/types';
 import type {ToolManager} from '@/tools/tool-manager';
 import type {TuneConfig} from '@/types/config';
-import type {LLMClient, Message, ToolCall} from '@/types/core';
+import type {
+	ApiUsageSnapshot,
+	LLMClient,
+	Message,
+	ToolCall,
+} from '@/types/core';
 
 export interface UseChatHandlerProps {
 	client: LLMClient | null;
@@ -33,6 +38,9 @@ export interface UseChatHandlerProps {
 	compactToolCountsRef?: React.MutableRefObject<Record<string, number>>;
 	onSetLiveTaskList?: (tasks: Task[] | null) => void;
 	setLiveComponent?: (component: React.ReactNode) => void;
+	// Records the API-reported usage of the latest response for the context
+	// indicator (null clears it, e.g. after auto-compaction).
+	setLastApiUsage?: (usage: ApiUsageSnapshot | null) => void;
 	tune?: TuneConfig;
 	// Flips true after subagent loading completes; used to invalidate the
 	// cached system prompt so it includes the real agent list.

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -72,6 +72,7 @@ export function useChatHandler({
 	compactToolCountsRef,
 	onSetLiveTaskList,
 	setLiveComponent,
+	setLastApiUsage,
 	tune,
 	subagentsReady,
 }: UseChatHandlerProps): ChatHandlerReturn {
@@ -221,6 +222,7 @@ export function useChatHandler({
 					compactToolCountsRef,
 					onSetLiveTaskList,
 					setLiveComponent,
+					setLastApiUsage,
 					tune,
 				});
 			} catch (error) {
@@ -253,6 +255,7 @@ export function useChatHandler({
 			displayError,
 			resetStreamingState,
 			setLiveComponent,
+			setLastApiUsage,
 		],
 	);
 

--- a/source/hooks/useAppState.spec.tsx
+++ b/source/hooks/useAppState.spec.tsx
@@ -159,6 +159,22 @@ test('updateMessages updates both messages and displayMessages', t => {
 	t.deepEqual(captured!.displayMessages, msgs);
 });
 
+test('updateMessages invalidates the API usage snapshot', t => {
+	const {hook, instance} = setup();
+
+	hook.setLastApiUsage({inputTokens: 1000, outputTokens: 200, atMessageCount: 2});
+	instance.rerender(<Probe />);
+	t.not(captured!.lastApiUsage, null);
+
+	// Any wholesale message replacement (new turn, /clear, /compact, session
+	// resume, checkpoint restore) must clear the snapshot so the context
+	// indicator falls back to estimation rather than showing a stale API value.
+	captured!.updateMessages([{role: 'user', content: 'hi'} as Message]);
+	instance.rerender(<Probe />);
+
+	t.is(captured!.lastApiUsage, null);
+});
+
 test('resetToolConfirmationState clears all confirmation-related state', t => {
 	const {hook, instance} = setup();
 

--- a/source/hooks/useAppState.tsx
+++ b/source/hooks/useAppState.tsx
@@ -273,6 +273,14 @@ export function useAppState(
 	const updateMessages = useCallback((newMessages: Message[]) => {
 		setMessages(newMessages);
 		setDisplayMessages(newMessages);
+		// Any wholesale message change — new turn, /clear, manual /compact,
+		// session resume, checkpoint restore — invalidates the API usage
+		// snapshot, which was captured against the previous messages array.
+		// The chat loop re-establishes it right after via setLastApiUsage; every
+		// other path then correctly falls back to client-side estimation. This
+		// keeps the api-vs-estimate decision robust across all replacement paths
+		// rather than relying on each handler to clear it.
+		setLastApiUsage(null);
 	}, []);
 
 	// Reset tool confirmation state

--- a/source/hooks/useAppState.tsx
+++ b/source/hooks/useAppState.tsx
@@ -13,6 +13,8 @@ import type {CheckpointListItem} from '@/types/checkpoint';
 import type {CustomCommand} from '@/types/commands';
 import type {AIProviderConfig, TuneConfig} from '@/types/config';
 import {
+	ApiUsageSnapshot,
+	ContextSource,
 	DevelopmentMode,
 	LLMClient,
 	LSPConnectionStatus,
@@ -180,6 +182,15 @@ export function useAppState(
 		null,
 	);
 	const [contextLimit, setContextLimit] = useState<number | null>(null);
+	// Whether the displayed context percentage is API-reported or estimated
+	const [contextSource, setContextSource] = useState<ContextSource | null>(
+		null,
+	);
+	// Most recent API-reported usage, tagged with the conversation length at
+	// capture time (see ApiUsageSnapshot). Null when unavailable or stale.
+	const [lastApiUsage, setLastApiUsage] = useState<ApiUsageSnapshot | null>(
+		null,
+	);
 
 	// Tool confirmation state
 	const [pendingToolCalls, setPendingToolCalls] = useState<ToolCall[]>([]);
@@ -338,6 +349,8 @@ export function useAppState(
 		tune,
 		contextPercentUsed,
 		contextLimit,
+		contextSource,
+		lastApiUsage,
 		pendingToolCalls,
 		currentToolIndex,
 		completedToolResults,
@@ -388,6 +401,8 @@ export function useAppState(
 		setTune,
 		setContextPercentUsed,
 		setContextLimit,
+		setContextSource,
+		setLastApiUsage,
 		setPendingToolCalls,
 		setCurrentToolIndex,
 		setCompletedToolResults,

--- a/source/hooks/useContextPercentage.ts
+++ b/source/hooks/useContextPercentage.ts
@@ -3,12 +3,18 @@ import {getModelContextLimit} from '@/models/index';
 import type {ToolManager} from '@/tools/tool-manager';
 import type {AIProviderConfig, TuneConfig} from '@/types/config';
 import {getTuneToolMode} from '@/types/config';
-import type {DevelopmentMode, Message} from '@/types/core';
+import type {
+	ApiUsageSnapshot,
+	ContextSource,
+	DevelopmentMode,
+	Message,
+} from '@/types/core';
 import type {Tokenizer} from '@/types/tokenization';
 import {
 	calculateTokenBreakdown,
 	calculateToolDefinitionsTokens,
 } from '@/usage/calculator';
+import {resolveContextUsage} from '@/usage/context-source';
 import {getLastBuiltPrompt} from '@/utils/prompt-builder';
 
 interface UseContextPercentageProps {
@@ -21,8 +27,10 @@ interface UseContextPercentageProps {
 	toolManager: ToolManager | null;
 	streamingTokenCount: number;
 	contextLimit: number | null;
+	lastApiUsage: ApiUsageSnapshot | null;
 	setContextPercentUsed: (value: number | null) => void;
 	setContextLimit: (value: number | null) => void;
+	setContextSource: (value: ContextSource | null) => void;
 	developmentMode?: DevelopmentMode;
 	tune?: TuneConfig;
 }
@@ -37,8 +45,10 @@ export function useContextPercentage({
 	toolManager,
 	streamingTokenCount,
 	contextLimit,
+	lastApiUsage,
 	setContextPercentUsed,
 	setContextLimit,
+	setContextSource,
 	developmentMode = 'normal',
 	tune,
 }: UseContextPercentageProps): void {
@@ -52,6 +62,7 @@ export function useContextPercentage({
 			lastResolvedKeyRef.current = '';
 			setContextLimit(null);
 			setContextPercentUsed(null);
+			setContextSource(null);
 			return;
 		}
 
@@ -69,6 +80,7 @@ export function useContextPercentage({
 			setContextLimit(limit);
 			if (!limit) {
 				setContextPercentUsed(null);
+				setContextSource(null);
 			}
 		});
 
@@ -81,6 +93,7 @@ export function useContextPercentage({
 		currentProviderConfig,
 		setContextLimit,
 		setContextPercentUsed,
+		setContextSource,
 	]);
 
 	// Effect 2: Recalculate percentage when messages, streaming tokens, or context limit change
@@ -88,6 +101,7 @@ export function useContextPercentage({
 		const limit = contextLimitRef.current;
 		if (!limit) {
 			setContextPercentUsed(null);
+			setContextSource(null);
 			return;
 		}
 
@@ -121,8 +135,18 @@ export function useContextPercentage({
 				: 0;
 
 		const total = breakdown.total + toolDefTokens + streamingTokenCount;
-		const percent = Math.round((total / limit) * 100);
+
+		// Prefer API-reported usage when it is fresh (the snapshot's message
+		// count still matches the conversation); otherwise fall back to the
+		// estimate computed above so the figure never lags the conversation.
+		const {percent, source} = resolveContextUsage({
+			estimatedTotalTokens: total,
+			apiSnapshot: lastApiUsage,
+			currentMessageCount: messages.length,
+			contextLimit: limit,
+		});
 		setContextPercentUsed(percent);
+		setContextSource(source);
 		// contextLimit is included to re-trigger calculation after async limit resolution
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
@@ -131,7 +155,9 @@ export function useContextPercentage({
 		getMessageTokens,
 		toolManager,
 		streamingTokenCount,
+		lastApiUsage,
 		setContextPercentUsed,
+		setContextSource,
 		tune,
 	]);
 }

--- a/source/types/core.ts
+++ b/source/types/core.ts
@@ -164,6 +164,33 @@ interface LLMMessage {
 	reasoning?: string;
 }
 
+/**
+ * Token usage as reported by the provider/API for a single response.
+ * Fields are optional because not every provider reports usage (e.g. some
+ * local models), and OpenRouter only includes detailed usage when the request
+ * opts in via `usage: {include: true}`. Consumers must fall back to client-side
+ * estimation whenever a field is missing.
+ */
+export interface ApiUsage {
+	inputTokens?: number;
+	outputTokens?: number;
+	totalTokens?: number;
+}
+
+/**
+ * API-reported usage captured after a model response, tagged with the
+ * conversation length at capture time. The context indicator treats the
+ * snapshot as authoritative only while the message count is unchanged; once
+ * newer messages arrive it falls back to client-side estimation so the figure
+ * never lags the conversation.
+ */
+export interface ApiUsageSnapshot extends ApiUsage {
+	atMessageCount: number;
+}
+
+/** Whether a displayed context figure came from API usage or estimation. */
+export type ContextSource = 'api' | 'estimate';
+
 export interface LLMChatResponse {
 	choices: Array<{
 		message: LLMMessage;
@@ -171,6 +198,9 @@ export interface LLMChatResponse {
 	// Whether native tools were disabled for this request (XML fallback path)
 	// When true, the conversation loop should parse response text for XML tool calls
 	toolsDisabled?: boolean;
+	// Provider-reported token usage for this response, when available. Used to
+	// show API-accurate context usage in place of client-side estimation.
+	usage?: ApiUsage;
 }
 
 export interface StreamCallbacks {

--- a/source/usage/context-source.spec.ts
+++ b/source/usage/context-source.spec.ts
@@ -1,0 +1,70 @@
+import test from 'ava';
+import type {ApiUsageSnapshot} from '@/types/core.js';
+import {resolveContextUsage} from './context-source.js';
+
+console.log('\ncontext-source.spec.ts');
+
+const fresh: ApiUsageSnapshot = {
+	inputTokens: 8000,
+	outputTokens: 2000,
+	totalTokens: 10000,
+	atMessageCount: 4,
+};
+
+test('prefers API usage when the snapshot is fresh', t => {
+	const result = resolveContextUsage({
+		estimatedTotalTokens: 9000,
+		apiSnapshot: fresh,
+		currentMessageCount: 4,
+		contextLimit: 20000,
+	});
+	// (8000 + 2000) / 20000 = 50%, sourced from the API not the estimate.
+	t.is(result.source, 'api');
+	t.is(result.percent, 50);
+});
+
+test('falls back to estimation when the snapshot is stale (message count moved)', t => {
+	const result = resolveContextUsage({
+		estimatedTotalTokens: 9000,
+		apiSnapshot: fresh,
+		currentMessageCount: 5, // a new message arrived since capture
+		contextLimit: 20000,
+	});
+	// 9000 / 20000 = 45%, from the estimate.
+	t.is(result.source, 'estimate');
+	t.is(result.percent, 45);
+});
+
+test('falls back to estimation when there is no snapshot', t => {
+	const result = resolveContextUsage({
+		estimatedTotalTokens: 6000,
+		apiSnapshot: null,
+		currentMessageCount: 2,
+		contextLimit: 20000,
+	});
+	t.is(result.source, 'estimate');
+	t.is(result.percent, 30);
+});
+
+test('falls back to estimation when the snapshot reported no token fields', t => {
+	const result = resolveContextUsage({
+		estimatedTotalTokens: 6000,
+		apiSnapshot: {atMessageCount: 2},
+		currentMessageCount: 2,
+		contextLimit: 20000,
+	});
+	t.is(result.source, 'estimate');
+	t.is(result.percent, 30);
+});
+
+test('treats a partial snapshot (only inputTokens) as usable API data', t => {
+	const result = resolveContextUsage({
+		estimatedTotalTokens: 9999,
+		apiSnapshot: {inputTokens: 5000, atMessageCount: 3},
+		currentMessageCount: 3,
+		contextLimit: 20000,
+	});
+	// inputTokens (5000) + missing outputTokens (treated as 0) = 25%.
+	t.is(result.source, 'api');
+	t.is(result.percent, 25);
+});

--- a/source/usage/context-source.spec.ts
+++ b/source/usage/context-source.spec.ts
@@ -68,3 +68,49 @@ test('treats a partial snapshot (only inputTokens) as usable API data', t => {
 	t.is(result.source, 'api');
 	t.is(result.percent, 25);
 });
+
+test('uses a reported totalTokens lump sum when input/output are not split', t => {
+	const result = resolveContextUsage({
+		estimatedTotalTokens: 9999,
+		apiSnapshot: {totalTokens: 5000, atMessageCount: 3},
+		currentMessageCount: 3,
+		contextLimit: 20000,
+	});
+	// 5000 / 20000 = 25%, sourced from the reported total.
+	t.is(result.source, 'api');
+	t.is(result.percent, 25);
+});
+
+test('falls back to estimation when only outputTokens is reported (no context anchor)', t => {
+	const result = resolveContextUsage({
+		estimatedTotalTokens: 9000,
+		apiSnapshot: {outputTokens: 300, atMessageCount: 3},
+		currentMessageCount: 3,
+		contextLimit: 20000,
+	});
+	// A lone reply size must not masquerade as the whole context → estimate.
+	t.is(result.source, 'estimate');
+	t.is(result.percent, 45);
+});
+
+test('falls back to estimation when token fields are non-finite (NaN/Infinity)', t => {
+	const result = resolveContextUsage({
+		estimatedTotalTokens: 9000,
+		apiSnapshot: {inputTokens: Number.NaN, atMessageCount: 3},
+		currentMessageCount: 3,
+		contextLimit: 20000,
+	});
+	t.is(result.source, 'estimate');
+	t.is(result.percent, 45);
+});
+
+test('returns 0% estimate when the context limit is not positive', t => {
+	const result = resolveContextUsage({
+		estimatedTotalTokens: 9000,
+		apiSnapshot: fresh,
+		currentMessageCount: 4,
+		contextLimit: 0,
+	});
+	t.is(result.source, 'estimate');
+	t.is(result.percent, 0);
+});

--- a/source/usage/context-source.ts
+++ b/source/usage/context-source.ts
@@ -1,24 +1,49 @@
-import type {ApiUsageSnapshot, ContextSource} from '@/types/core';
+import type {ApiUsage, ApiUsageSnapshot, ContextSource} from '@/types/core';
 
 export interface ContextUsageResult {
 	percent: number;
 	source: ContextSource;
 }
 
+function isFiniteNumber(value: number | undefined): value is number {
+	return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Derive the context tokens occupied from a provider-reported usage object, or
+ * `undefined` when the report isn't usable as a context numerator.
+ *
+ * Preference order:
+ *   1. `inputTokens + outputTokens` — the prompt the model saw plus the reply
+ *      just appended to history, which together equal the context now occupied.
+ *   2. `totalTokens` — when the provider reports only a lump sum (no split).
+ *
+ * `inputTokens` (or a reported `totalTokens`) is required: a lone `outputTokens`
+ * value describes only the reply and must NOT masquerade as the whole context,
+ * which would otherwise show a confidently-wrong near-zero percentage. Non-finite
+ * fields (NaN/Infinity) are treated as absent.
+ */
+function apiContextTokens(usage: ApiUsage): number | undefined {
+	if (isFiniteNumber(usage.inputTokens)) {
+		const output = isFiniteNumber(usage.outputTokens) ? usage.outputTokens : 0;
+		return usage.inputTokens + output;
+	}
+	if (isFiniteNumber(usage.totalTokens)) {
+		return usage.totalTokens;
+	}
+	return undefined;
+}
+
 /**
  * Decide the context-usage percentage and whether it is API-reported or
  * estimated.
  *
- * API usage is preferred only while it is "fresh" — that is, no new messages
- * have been appended since it was captured (`atMessageCount` still matches the
- * current conversation length) and at least one token field was reported.
- * Otherwise we fall back to the live client-side estimate so the figure never
- * lags the conversation (e.g. right after the user types a new message, before
- * the next response refreshes the snapshot).
- *
- * The API numerator is `inputTokens + outputTokens`: the prompt the model saw
- * plus the assistant reply that was just appended to history, which together
- * equal the context now occupied.
+ * API usage is preferred only while it is "fresh" — no new messages have been
+ * appended since it was captured (`atMessageCount` still matches the current
+ * conversation length) and it carries a usable numerator. Otherwise we fall
+ * back to the live client-side estimate so the figure never lags the
+ * conversation (e.g. right after the user types a new message, before the next
+ * response refreshes the snapshot).
  */
 export function resolveContextUsage(params: {
 	estimatedTotalTokens: number;
@@ -29,15 +54,18 @@ export function resolveContextUsage(params: {
 	const {estimatedTotalTokens, apiSnapshot, currentMessageCount, contextLimit} =
 		params;
 
-	const apiFresh =
-		apiSnapshot !== null &&
-		apiSnapshot.atMessageCount === currentMessageCount &&
-		(apiSnapshot.inputTokens !== undefined ||
-			apiSnapshot.outputTokens !== undefined);
+	// Guard the exported helper against a zero/invalid limit; callers normally
+	// pass a positive limit (the hook bails when it can't resolve one).
+	if (!(contextLimit > 0)) {
+		return {percent: 0, source: 'estimate'};
+	}
 
-	if (apiFresh) {
-		const apiTotal =
-			(apiSnapshot.inputTokens ?? 0) + (apiSnapshot.outputTokens ?? 0);
+	const apiTotal =
+		apiSnapshot !== null && apiSnapshot.atMessageCount === currentMessageCount
+			? apiContextTokens(apiSnapshot)
+			: undefined;
+
+	if (apiTotal !== undefined) {
 		return {
 			percent: Math.round((apiTotal / contextLimit) * 100),
 			source: 'api',

--- a/source/usage/context-source.ts
+++ b/source/usage/context-source.ts
@@ -1,0 +1,51 @@
+import type {ApiUsageSnapshot, ContextSource} from '@/types/core';
+
+export interface ContextUsageResult {
+	percent: number;
+	source: ContextSource;
+}
+
+/**
+ * Decide the context-usage percentage and whether it is API-reported or
+ * estimated.
+ *
+ * API usage is preferred only while it is "fresh" — that is, no new messages
+ * have been appended since it was captured (`atMessageCount` still matches the
+ * current conversation length) and at least one token field was reported.
+ * Otherwise we fall back to the live client-side estimate so the figure never
+ * lags the conversation (e.g. right after the user types a new message, before
+ * the next response refreshes the snapshot).
+ *
+ * The API numerator is `inputTokens + outputTokens`: the prompt the model saw
+ * plus the assistant reply that was just appended to history, which together
+ * equal the context now occupied.
+ */
+export function resolveContextUsage(params: {
+	estimatedTotalTokens: number;
+	apiSnapshot: ApiUsageSnapshot | null;
+	currentMessageCount: number;
+	contextLimit: number;
+}): ContextUsageResult {
+	const {estimatedTotalTokens, apiSnapshot, currentMessageCount, contextLimit} =
+		params;
+
+	const apiFresh =
+		apiSnapshot !== null &&
+		apiSnapshot.atMessageCount === currentMessageCount &&
+		(apiSnapshot.inputTokens !== undefined ||
+			apiSnapshot.outputTokens !== undefined);
+
+	if (apiFresh) {
+		const apiTotal =
+			(apiSnapshot.inputTokens ?? 0) + (apiSnapshot.outputTokens ?? 0);
+		return {
+			percent: Math.round((apiTotal / contextLimit) * 100),
+			source: 'api',
+		};
+	}
+
+	return {
+		percent: Math.round((estimatedTotalTokens / contextLimit) * 100),
+		source: 'estimate',
+	};
+}


### PR DESCRIPTION
## Description

Wires the AI SDK's reported token usage into the context indicator (the `ctx: NN%` segment on `DevelopmentModeIndicator`) so it shows provider-accurate counts when available, falling back to the existing client-side estimation otherwise. This is the scoped first PR agreed in #381.

**What changed**
- **Capture** the final step's `usage` from the streamed result and return it on `LLMChatResponse`. Uses `result.usage` (final step), **not** `result.totalUsage`: `streamText` runs with `stopWhen: stepCountIs(MAX_TOOL_STEPS)`, so `totalUsage` sums input tokens across the tool loop and would overcount the context window, whereas the final step's `inputTokens + outputTokens` reflect actual occupancy.
- **Freshness** — record an `ApiUsageSnapshot` keyed to the post-response message count. The context hook prefers it while *fresh* (no new messages since capture) and falls back to estimation once the conversation moves on, or after auto-compaction (where the reported usage describes the pre-compaction context, so the snapshot is cleared).
- **Display** — estimated figures render with a leading `~` (`ctx: ~42%`); API-reported figures render bare (`ctx: 42%`). The marker is a single character so it stays within the indicator's width budget, where `ctx` never truncates.

**Fallback behaviour:** providers that don't report usage (local models, or OpenRouter without `usage: {include: true}`) keep showing the estimate — nothing regresses.

**Out of scope (per the issue discussion):** per-category n_token allocation, and `NANOCODER_MAX_CONTEXT` (already shipped via #379).

**Hardening (from self-review, commits 2–3):** the API path requires `inputTokens` (or a reported `totalTokens`) before it's trusted — a lone `outputTokens` can't masquerade as the whole context; a provider's `totalTokens` lump sum is used when input/output aren't split; non-finite usage fields are ignored. The snapshot is invalidated centrally in `useAppState.updateMessages`, so `/clear`, manual `/compact`, session resume, and checkpoint restore all correctly fall back to estimation rather than showing a stale API value.

## Type of Change

- [x] New feature

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

New/updated tests:
- `source/usage/context-source.spec.ts` — pure `resolveContextUsage()` decision logic (fresh API preferred, stale → fallback, no snapshot, partial usage)
- `source/components/development-mode-indicator.spec.tsx` — `~` marker for estimate vs bare for API
- `source/hooks/chat-handler/conversation/conversation-loop.spec.ts` — usage snapshot captured with message count, and cleared when no usage is reported

### Manual Testing

Verified end-to-end against a live, usage-reporting provider (**Anthropic `claude-haiku-4-5`** via `@ai-sdk/anthropic`):

- After a response → `▶ normal mode on · ctx: 5%` (**bare = API-sourced**).
- `/clear` → `ctx: ~4%` (**`~` = estimate**) — confirms the snapshot is invalidated on message replacement (no stale API value).
- Second response → `ctx: 5%` again (round-trip api → estimate → api).

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API

> The fallback/estimate path (providers that don't report usage) is covered by unit tests; the live **api** path was exercised on Anthropic. Happy to run Ollama/OpenRouter too if you'd like the non-reporting and `usage:{include:true}` paths confirmed in a real session.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed) — n/a
- [x] No breaking changes (the new `LLMChatResponse.usage` field is optional and additive)
- [ ] Appropriate logging added — n/a (no new failure paths)

---

Addresses #381 — the scoped first PR (API token tracking) agreed in the thread; per-category allocation and further usage-monitor work can follow. Thanks @will-lamerton for the go-ahead — cc @will-lamerton @cleyesode.
