### PR TITLE
fix: resolve autosave race, history truncation, and resume rebase

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -146,7 +146,7 @@ Configure automatic session saving and retention. See [Session Management](../fe
 | `autoSave` | boolean | `true` | Enable/disable automatic session saving |
 | `saveInterval` | number | `30000` | Milliseconds between saves (minimum 1000) |
 | `maxSessions` | number | `100` | Maximum sessions to keep (minimum 1) |
-| `maxMessages` | number | `1000` | Maximum messages saved per session — older messages are truncated (minimum 1) |
+| `maxMessages` | number | `1000` | Maximum messages sent to the model in interactive/headless chat (minimum 1). Preserves on-disk history and system messages, capping only the context window. |
 | `retentionDays` | number | `30` | Auto-delete sessions older than this (minimum 1) |
 | `directory` | string | (platform default) | Custom storage directory for session files |
 

--- a/docs/features/session-management.md
+++ b/docs/features/session-management.md
@@ -74,6 +74,6 @@ Customize session behaviour in your `agents.config.json`:
 | `autoSave` | `true` | Enable/disable automatic saving |
 | `saveInterval` | `30000` | Milliseconds between saves (minimum 1000) |
 | `maxSessions` | `100` | Maximum sessions to keep (minimum 1) |
-| `maxMessages` | `1000` | Maximum messages saved per session — older messages are truncated (minimum 1) |
+| `maxMessages` | `1000` | Maximum messages sent to the model (context window capping) — on-disk history is NOT truncated (minimum 1) |
 | `retentionDays` | `30` | Auto-delete sessions older than this (minimum 1) |
 | `directory` | (platform default) | Custom storage directory |

--- a/source/acp/acp-conversation.ts
+++ b/source/acp/acp-conversation.ts
@@ -7,6 +7,7 @@ import {requestToolPermission} from '@/acp/acp-permission';
 import {requestUserChoice} from '@/acp/acp-question';
 import type {AcpSession} from '@/acp/acp-session';
 import {type AcpToolCallMeta, buildToolCallMeta} from '@/acp/acp-tool-call';
+import {getAppConfig} from '@/config/index';
 import {processToolUse} from '@/message-handler';
 import {parseToolCalls} from '@/tool-calling/index';
 import {resolveToolApproval} from '@/tools/approval-policy';
@@ -19,6 +20,7 @@ import type {
 	ToolCall,
 	ToolResult,
 } from '@/types/core';
+import {capMessagesForModel} from '@/utils/message-capping';
 import {toOptionString} from '@/utils/type-helpers';
 
 const MAX_TURNS = 50;
@@ -85,8 +87,12 @@ export async function runAcpConversation(
 			return {stopReason: 'end_turn'};
 		}
 
+		const sessionConfig = getAppConfig().sessions;
+		const maxMessages = sessionConfig?.maxMessages ?? 1000;
+		const cappedMessages = capMessagesForModel(messages, maxMessages);
+
 		const result = await client.chat(
-			[systemMessage, ...messages],
+			[systemMessage, ...cappedMessages],
 			tools,
 			callbacks,
 			abortController.signal,

--- a/source/hooks/chat-handler/conversation/conversation-loop.spec.ts
+++ b/source/hooks/chat-handler/conversation/conversation-loop.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {clearAppConfig} from '@/config/index.js';
+import {clearAppConfig, getAppConfig} from '@/config/index.js';
 import {resetShutdownManager} from '@/utils/shutdown/shutdown-manager.js';
 import {processAssistantResponse, resetFallbackNotice, resetLastTurnHadReasoning} from './conversation-loop.js';
 import type {
@@ -1544,5 +1544,96 @@ test.serial('processAssistantResponse - auto-nudge builds on compacted messages 
 			containsOriginalVerbose,
 			'Auto-nudge should be built on compacted messages, not original verbose history',
 		);
+	}
+});
+
+test.serial('processAssistantResponse - maxMessages caps history sent to the model but preserves system message', async t => {
+	const originalMaxMessages = getAppConfig().sessions?.maxMessages;
+	if (getAppConfig().sessions) {
+		getAppConfig().sessions!.maxMessages = 3;
+	}
+
+	let messagesSentToClient: Message[] = [];
+	const mockClient = {
+		chat: async (msgs: Message[]): Promise<LLMChatResponse> => {
+			messagesSentToClient = msgs;
+			return {
+				choices: [{message: {role: 'assistant', content: 'Capped response'}}],
+				toolsDisabled: false,
+			};
+		},
+	};
+
+	const params = createDefaultParams({
+		client: mockClient as any,
+		systemMessage: {role: 'system', content: 'system-prompt'} as Message,
+		messages: [
+			{role: 'user', content: 'msg 1'},
+			{role: 'assistant', content: 'msg 2'},
+			{role: 'user', content: 'msg 3'},
+			{role: 'assistant', content: 'msg 4'},
+			{role: 'user', content: 'msg 5'},
+		],
+	});
+
+	await processAssistantResponse(params);
+
+	// Should have systemMessage + last 3 messages = 4 messages total
+	t.is(messagesSentToClient.length, 4);
+	t.deepEqual(messagesSentToClient[0], {role: 'system', content: 'system-prompt'});
+	t.deepEqual(messagesSentToClient.slice(1), [
+		{role: 'user', content: 'msg 3'},
+		{role: 'assistant', content: 'msg 4'},
+		{role: 'user', content: 'msg 5'},
+	]);
+
+	if (getAppConfig().sessions && originalMaxMessages !== undefined) {
+		getAppConfig().sessions!.maxMessages = originalMaxMessages;
+	}
+});
+
+test.serial('processAssistantResponse - does not start request on orphaned tool result (tool boundary)', async t => {
+	const originalMaxMessages = getAppConfig().sessions?.maxMessages;
+	if (getAppConfig().sessions) {
+		getAppConfig().sessions!.maxMessages = 2;
+	}
+
+	let messagesSentToClient: Message[] = [];
+	const mockClient = {
+		chat: async (msgs: Message[]): Promise<LLMChatResponse> => {
+			messagesSentToClient = msgs;
+			return {
+				choices: [{message: {role: 'assistant', content: 'Tool boundary response'}}],
+				toolsDisabled: false,
+			};
+		},
+	};
+
+	const params = createDefaultParams({
+		client: mockClient as any,
+		systemMessage: {role: 'system', content: 'system-prompt'} as Message,
+		messages: [
+			{role: 'user', content: 'msg 1'},
+			{role: 'assistant', content: '', tool_calls: [{id: 'call_1', function: {name: 'bash', arguments: {}}}]},
+			{role: 'tool', tool_call_id: 'call_1', name: 'bash', content: 'output'},
+			{role: 'user', content: 'msg 2'},
+		],
+	});
+
+	await processAssistantResponse(params);
+
+	// The last 2 messages starts at index 2 (the tool result).
+	// Because of tool boundary adjustment, it walks back to index 1 (the assistant tool call).
+	// So we should have systemMessage + assistant + tool + user = 4 messages.
+	t.is(messagesSentToClient.length, 4);
+	t.deepEqual(messagesSentToClient[0], {role: 'system', content: 'system-prompt'});
+	t.deepEqual(messagesSentToClient.slice(1), [
+		{role: 'assistant', content: '', tool_calls: [{id: 'call_1', function: {name: 'bash', arguments: {}}}]},
+		{role: 'tool', tool_call_id: 'call_1', name: 'bash', content: 'output'},
+		{role: 'user', content: 'msg 2'},
+	]);
+
+	if (getAppConfig().sessions && originalMaxMessages !== undefined) {
+		getAppConfig().sessions!.maxMessages = originalMaxMessages;
 	}
 });

--- a/source/hooks/chat-handler/conversation/conversation-loop.tsx
+++ b/source/hooks/chat-handler/conversation/conversation-loop.tsx
@@ -245,8 +245,17 @@ export const processAssistantResponse = async (
 
 	let streamedContent = '';
 	let streamedReasoning = '';
+
+	// Apply maxMessages cap: limit how many history messages are sent to the
+	// model. This is a model-context concern only - the full history is always
+	// written to disk by useSessionAutosave. The system message is prepended
+	// outside the slice and is never counted against the limit.
+	const sessionConfig = getAppConfig().sessions;
+	const maxMessages = sessionConfig?.maxMessages ?? 1000;
+	const cappedMessages = messages.slice(-maxMessages);
+
 	const result = await client.chat(
-		[systemMessage, ...messages],
+		[systemMessage, ...cappedMessages],
 		tools,
 		{
 			onToken: (token: string) => {

--- a/source/hooks/chat-handler/conversation/conversation-loop.tsx
+++ b/source/hooks/chat-handler/conversation/conversation-loop.tsx
@@ -28,6 +28,7 @@ import type {
 import {performAutoCompact} from '@/utils/auto-compact';
 import {formatElapsedTime, getRandomAdjective} from '@/utils/completion-note';
 import {MessageBuilder} from '@/utils/message-builder';
+import {capMessagesForModel} from '@/utils/message-capping';
 import {infoMsg} from '@/utils/message-factory';
 import {createCancellationResults} from '@/utils/tool-cancellation';
 import {signalToolConfirm} from '@/utils/tool-confirm-queue';
@@ -252,7 +253,7 @@ export const processAssistantResponse = async (
 	// outside the slice and is never counted against the limit.
 	const sessionConfig = getAppConfig().sessions;
 	const maxMessages = sessionConfig?.maxMessages ?? 1000;
-	const cappedMessages = messages.slice(-maxMessages);
+	const cappedMessages = capMessagesForModel(messages, maxMessages);
 
 	const result = await client.chat(
 		[systemMessage, ...cappedMessages],

--- a/source/hooks/useAppHandlers.spec.tsx
+++ b/source/hooks/useAppHandlers.spec.tsx
@@ -8,6 +8,11 @@ import type {CustomCommand} from '@/types/commands';
 import type {AppHandlers} from './useAppHandlers';
 import {useAppHandlers} from './useAppHandlers';
 
+import {
+	getKeyGeneratorSessionId,
+	setKeyGeneratorSessionId,
+} from '@/session/key-generator';
+
 console.log('\nuseAppHandlers.spec.tsx');
 
 interface CallSpy<T extends unknown[] = unknown[]> {
@@ -270,4 +275,19 @@ test('enterSessionSelectorMode forwards showAll=true when requested', t => {
 
 	t.deepEqual(spies.setShowAllSessions.calls, [[true]]);
 	t.deepEqual(spies.setActiveMode.calls, [['sessionSelector']]);
+});
+
+test('clearMessages resets key generator session ID', async t => {
+	const {handlers} = setup({
+		messages: [{role: 'user', content: 'test'}],
+	});
+
+	setKeyGeneratorSessionId('old-session-id-prefix');
+	t.is(getKeyGeneratorSessionId(), 'old-session-id-prefix');
+
+	await handlers.clearMessages();
+
+	const newId = getKeyGeneratorSessionId();
+	t.not(newId, 'old-session-id-prefix');
+	t.regex(newId, /^[0-9a-f]{8}$/);
 });

--- a/source/hooks/useAppHandlers.tsx
+++ b/source/hooks/useAppHandlers.tsx
@@ -15,7 +15,7 @@ import {CustomCommandLoader} from '@/custom-commands/loader';
 import {getModelContextLimit} from '@/models/index';
 import {bashExecutor} from '@/services/bash-executor';
 import {CheckpointManager} from '@/services/checkpoint-manager';
-import {generateKey} from '@/session/key-generator';
+import {generateKey, setKeyGeneratorSessionId} from '@/session/key-generator';
 import type {Session} from '@/session/session-manager';
 import {sessionManager} from '@/session/session-manager';
 import {createTokenizer} from '@/tokenization/index';
@@ -442,6 +442,7 @@ export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 			props.setCurrentProvider(session.provider);
 			props.setCurrentModel(session.model);
 			props.setCurrentSessionId(session.id);
+			setKeyGeneratorSessionId(session.id);
 			props.addToChatQueue(
 				<SuccessMessage
 					key={generateKey('resume-success')}

--- a/source/hooks/useAppHandlers.tsx
+++ b/source/hooks/useAppHandlers.tsx
@@ -1,3 +1,4 @@
+import {randomBytes} from 'node:crypto';
 import React from 'react';
 import {
 	createClearMessagesHandler,
@@ -143,6 +144,10 @@ export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 			await baseClear();
 			props.setChatComponents([]);
 			props.setCurrentSessionId(null);
+			// Reset the key-generator session ID so keys in the new conversation
+			// are not prefixed with the cleared session's ID. A fresh random ID
+			// will be lazily generated on the next generateKey() call.
+			setKeyGeneratorSessionId(randomBytes(4).toString('hex'));
 			props.setLiveTaskList(null);
 			props.dismissActiveEditor?.();
 		},

--- a/source/hooks/useSessionAutosave.spec.ts
+++ b/source/hooks/useSessionAutosave.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * Regression tests for useSessionAutosave bugs (issue #542).
+ *
+ * These tests exercise the real SessionManager on a temp directory to verify
+ * the save-chain behaviour without needing to render a React hook.
+ * The three regressions covered:
+ *
+ *   A — Duplicate-session race: concurrent saves on the first turn must
+ *       coalesce into a single createSession() call. The key insight of the
+ *       fix is that doSave reads the live session-id ref AFTER the async
+ *       init-promise await, not the stale captured value from effect-fire time.
+ *       The serialised chain means the first save's setCurrentSessionId
+ *       (and ref update) always happens before the second doSave reads it.
+ *
+ *   B — On-disk truncation: persisted messages must not be truncated to
+ *       maxMessages; the full history must always be written to disk.
+ *       maxMessages is now enforced in the conversation loop at the LLM call
+ *       site, not in the autosave path.
+ *
+ *   C — Resume rebase: after applySession, getKeyGeneratorSessionId() must
+ *       return the resumed session's ID, not the startup random ID.
+ */
+import {mkdtemp, readdir, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import {SessionManager} from '../session/session-manager.js';
+import {
+	getKeyGeneratorSessionId,
+	resetKeyGeneratorForTests,
+	setKeyGeneratorSessionId,
+} from '../session/key-generator.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMessages(count: number) {
+	return Array.from({length: count}, (_, i) => ({
+		role: i % 2 === 0 ? ('user' as const) : ('assistant' as const),
+		content: `msg ${i + 1}`,
+	}));
+}
+
+// ---------------------------------------------------------------------------
+// Bug A — Duplicate-session race
+// ---------------------------------------------------------------------------
+
+test.serial(
+	'A: live-ref pattern creates exactly one session even with two queued saves',
+	async t => {
+		const dir = await mkdtemp(join(tmpdir(), 'nc-race-'));
+		t.teardown(() => rm(dir, {recursive: true, force: true}));
+
+		const manager = new SessionManager(dir);
+		await manager.initialize();
+
+		// Model the fixed hook's live-ref pattern.
+		// doSave reads `sessionIdRef` (analogous to currentSessionIdRef.current)
+		// AFTER the async init-await, NOT a value captured at effect-fire time.
+		// This means the second doSave in the chain reads the ID that the first
+		// doSave wrote — exactly what the fix achieves.
+		const sessionIdRef = {current: null as string | null};
+
+		const doSave = async () => {
+			// Simulate the initPromise await that happens inside the real hook.
+			await Promise.resolve();
+
+			// Read the live ref AFTER the await (the fix).
+			const liveId = sessionIdRef.current;
+
+			if (liveId) {
+				// Second save: update existing session
+				const session = await manager.readSession(liveId);
+				if (session) {
+					session.messages = makeMessages(3);
+					session.messageCount = 3;
+					await manager.saveSession(session);
+				}
+			} else {
+				// First save: create and update the ref immediately
+				const s = await manager.createSession({
+					title: 'Race test',
+					messageCount: 2,
+					provider: 'test',
+					model: 'test',
+					workingDirectory: dir,
+					messages: makeMessages(2),
+				});
+				sessionIdRef.current = s.id;
+			}
+		};
+
+		// Chain two saves as the fixed hook does. Because doSave reads the ref
+		// after the await, the second save sees the ID written by the first.
+		let chain = Promise.resolve();
+		chain = chain.then(doSave, doSave);
+		chain = chain.then(doSave, doSave);
+		await chain;
+
+		// Exactly one session file must exist (not two)
+		const entries = await readdir(dir);
+		const sessionFiles = entries.filter(
+			e => e.endsWith('.json') && e !== 'sessions.json',
+		);
+		t.is(
+			sessionFiles.length,
+			1,
+			`Expected 1 session file, found ${sessionFiles.length}: ${sessionFiles.join(', ')}`,
+		);
+
+		const sessions = await manager.listSessions();
+		t.is(sessions.length, 1);
+	},
+);
+
+test.serial(
+	'A: without serialisation, concurrent saves can create duplicate sessions (demonstrates the old bug)',
+	async t => {
+		const dir = await mkdtemp(join(tmpdir(), 'nc-race-old-'));
+		t.teardown(() => rm(dir, {recursive: true, force: true}));
+
+		const manager = new SessionManager(dir);
+		await manager.initialize();
+
+		// Both saves start simultaneously and both see null sessionId (old behaviour)
+		const create = () =>
+			manager.createSession({
+				title: 'Dup test',
+				messageCount: 1,
+				provider: 'test',
+				model: 'test',
+				workingDirectory: dir,
+				messages: makeMessages(1),
+			});
+
+		// Fire both without chaining
+		await Promise.all([create(), create()]);
+
+		const sessions = await manager.listSessions();
+		// Old code produces 2; document that this is expected in the un-fixed path
+		t.true(
+			sessions.length >= 1,
+			'At least one session must exist even in the buggy scenario',
+		);
+		// The key assertion: with the fix, the chained test above gets exactly 1.
+		// This test just sanity-checks that the manager itself doesn't explode.
+	},
+);
+
+// ---------------------------------------------------------------------------
+// Bug B — On-disk truncation
+// ---------------------------------------------------------------------------
+
+test.serial(
+	'B: full message history is written to disk regardless of maxMessages',
+	async t => {
+		const dir = await mkdtemp(join(tmpdir(), 'nc-trunc-'));
+		t.teardown(() => rm(dir, {recursive: true, force: true}));
+
+		const manager = new SessionManager(dir);
+		await manager.initialize();
+
+		const allMessages = makeMessages(5);
+
+		// Create the session with all 5 messages
+		const session = await manager.createSession({
+			title: 'Truncation test',
+			messageCount: allMessages.length,
+			provider: 'test',
+			model: 'test',
+			workingDirectory: dir,
+			messages: allMessages,
+		});
+
+		// Simulate what the FIXED hook does: write full history, no slice
+		const saved = await manager.readSession(session.id);
+		t.truthy(saved);
+		saved!.messages = allMessages; // full array, not .slice(-2)
+		saved!.messageCount = allMessages.length;
+		await manager.saveSession(saved!);
+
+		// Read back and verify all 5 are present
+		const loaded = await manager.readSession(session.id);
+		t.is(
+			loaded!.messages.length,
+			5,
+			'All 5 messages must be on disk after save',
+		);
+		t.deepEqual(
+			loaded!.messages.map(m => m.content),
+			allMessages.map(m => m.content),
+		);
+	},
+);
+
+test.serial(
+	'B: old truncation path would lose messages (demonstrates the old bug)',
+	async t => {
+		const dir = await mkdtemp(join(tmpdir(), 'nc-trunc-old-'));
+		t.teardown(() => rm(dir, {recursive: true, force: true}));
+
+		const manager = new SessionManager(dir);
+		await manager.initialize();
+
+		const allMessages = makeMessages(5);
+		const maxMessages = 2;
+
+		const session = await manager.createSession({
+			title: 'Old truncation',
+			messageCount: allMessages.length,
+			provider: 'test',
+			model: 'test',
+			workingDirectory: dir,
+			messages: allMessages,
+		});
+
+		// Replicate exactly what the OLD hook did: slice before writing
+		const messagesToSave =
+			allMessages.length > maxMessages
+				? allMessages.slice(-maxMessages)
+				: allMessages;
+
+		const saved = await manager.readSession(session.id);
+		saved!.messages = messagesToSave; // ← old bug: truncated array on disk
+		saved!.messageCount = messagesToSave.length;
+		await manager.saveSession(saved!);
+
+		const loaded = await manager.readSession(session.id);
+		// This demonstrates data loss: only 2 of 5 messages survive
+		t.is(loaded!.messages.length, 2, 'Old code loses 3 of 5 messages');
+	},
+);
+
+// ---------------------------------------------------------------------------
+// Bug C — /resume doesn't rebase the key-generator session ID
+// ---------------------------------------------------------------------------
+
+test.serial('C: setKeyGeneratorSessionId rebases ID on resume', t => {
+	resetKeyGeneratorForTests();
+
+	// Simulate the startup state: a random 8-hex ID is lazily generated
+	const startupId = getKeyGeneratorSessionId();
+	t.regex(startupId, /^[0-9a-f]{8}$/, 'startup ID is 8-hex random');
+
+	// Simulate /resume calling applySession with a full UUID session ID
+	const resumedSessionId = '12345678-1234-1234-1234-123456789abc';
+	setKeyGeneratorSessionId(resumedSessionId); // ← this is what the fix adds
+
+	// Verify: key generator now uses the resumed session's ID
+	const afterResumeId = getKeyGeneratorSessionId();
+	t.is(
+		afterResumeId,
+		resumedSessionId,
+		'After resume, key generator must reflect the resumed session ID',
+	);
+	t.not(
+		afterResumeId,
+		startupId,
+		'Key generator must not keep the random startup ID after resume',
+	);
+});
+
+test.serial(
+	'C: without setKeyGeneratorSessionId call, ID stays as startup random (old bug)',
+	t => {
+		resetKeyGeneratorForTests();
+
+		const startupId = getKeyGeneratorSessionId();
+
+		// Old applySession: setCurrentSessionId(session.id) is called but
+		// setKeyGeneratorSessionId is NOT called — nothing changes in key-generator.
+		// No-op here intentionally mirrors the missing call.
+
+		const afterResumeId = getKeyGeneratorSessionId();
+		t.is(
+			afterResumeId,
+			startupId,
+			'Without the fix, key generator keeps the random startup ID (old bug)',
+		);
+	},
+);

--- a/source/hooks/useSessionAutosave.ts
+++ b/source/hooks/useSessionAutosave.ts
@@ -17,6 +17,15 @@ interface UseSessionAutosaveProps {
  * Hook to handle automatic session saving.
  * Updates the current session when currentSessionId is set; otherwise creates a new session.
  * Clears currentSessionId when messages are cleared.
+ *
+ * Race safety: saves are serialised through a single chained promise stored in
+ * saveChainRef. A new save does not start until the previous one resolves, so
+ * only one createSession() call can be in-flight per conversation regardless of
+ * how many times the effect fires within a single turn.
+ *
+ * Persistence integrity: the full message array is always written to disk.
+ * maxMessages bounds only what is sent to the model (enforced at prompt-build
+ * time), not what is stored in the session file.
  */
 export function useSessionAutosave({
 	messages,
@@ -28,6 +37,13 @@ export function useSessionAutosave({
 	const initPromiseRef = useRef<Promise<boolean> | null>(null);
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const lastSaveRef = useRef<number>(0);
+
+	// Serialises saves: each new save is chained onto the tail of this promise.
+	// Replacing void saveSession() calls with promise chaining means two rapid
+	// effect invocations cannot both observe currentSessionId === null and both
+	// call createSession() — the second save starts only after the first has
+	// already called setCurrentSessionId().
+	const saveChainRef = useRef<Promise<void>>(Promise.resolve());
 
 	// Clear current session when conversation is cleared
 	useEffect(() => {
@@ -71,7 +87,6 @@ export function useSessionAutosave({
 		const sessionConfig = config.sessions;
 		const autoSave = sessionConfig?.autoSave ?? true;
 		const saveInterval = sessionConfig?.saveInterval ?? 30000;
-		const maxMessages = sessionConfig?.maxMessages ?? 1000;
 
 		if (!autoSave || !initPromiseRef.current || messages.length === 0) {
 			return;
@@ -84,55 +99,75 @@ export function useSessionAutosave({
 		const now = Date.now();
 		const timeSinceLastSave = now - lastSaveRef.current;
 
-		const saveSession = async () => {
+		// Capture all values needed for this save at the time the effect ran.
+		// The closure must not close over mutable refs that could change before
+		// the chained promise executes.
+		const capturedMessages = messages;
+		const capturedProvider = currentProvider;
+		const capturedModel = currentModel;
+		const capturedSessionId = currentSessionId;
+
+		const doSave = async () => {
 			try {
 				// Wait for initialization to complete before saving
 				const initialized = await initPromiseRef.current;
 				if (!initialized) return;
 
-				// Truncate to most recent messages to prevent unbounded session sizes
-				const messagesToSave =
-					messages.length > maxMessages
-						? messages.slice(-maxMessages)
-						: messages;
-
-				const userMessages = messagesToSave.filter(msg => msg.role === 'user');
+				// Derive a human-readable title from the most recent user message.
+				// Use the full message array — the model-context cap (maxMessages)
+				// is NOT applied here; it is enforced at prompt-build time so that
+				// the full conversation history is always preserved on disk.
+				const userMessages = capturedMessages.filter(
+					msg => msg.role === 'user',
+				);
 				const lastUserMessage = userMessages[userMessages.length - 1];
 				const title = lastUserMessage
 					? lastUserMessage.content.substring(0, 50) +
 						(lastUserMessage.content.length > 50 ? '...' : '')
 					: `Session ${new Date().toLocaleDateString()}`;
 
-				if (currentSessionId) {
-					const session = await sessionManager.readSession(currentSessionId);
+				// Re-check capturedSessionId (captured at effect time) to decide
+				// create vs update. Because saves are serialised via saveChainRef,
+				// a prior save in the same chain will already have called
+				// setCurrentSessionId before this closure runs, but React state
+				// updates are async — capturedSessionId reflects what React had at
+				// effect-fire time, which is the correct value for this save slot.
+				if (capturedSessionId) {
+					const session = await sessionManager.readSession(capturedSessionId);
 					if (session) {
-						session.messages = messagesToSave;
-						session.messageCount = messagesToSave.length;
+						// Write the full history — no truncation.
+						session.messages = capturedMessages;
+						session.messageCount = capturedMessages.length;
 						session.title = title;
-						session.provider = currentProvider;
-						session.model = currentModel;
+						session.provider = capturedProvider;
+						session.model = capturedModel;
 						// Don't set lastAccessedAt here — saveSession() handles
 						// the timestamp in both the file and index consistently.
 						await sessionManager.saveSession(session);
 					} else {
+						// The stored session was deleted externally; create a fresh one.
 						const newSession = await sessionManager.createSession({
 							title,
-							messageCount: messagesToSave.length,
-							provider: currentProvider,
-							model: currentModel,
+							messageCount: capturedMessages.length,
+							provider: capturedProvider,
+							model: capturedModel,
 							workingDirectory: process.cwd(),
-							messages: messagesToSave,
+							messages: capturedMessages,
 						});
 						setCurrentSessionId(newSession.id);
 					}
 				} else {
+					// No session yet for this conversation — create one.
+					// Because doSave() runs serially inside saveChainRef, at most
+					// one createSession() call executes per conversation even if the
+					// effect fired several times before this point.
 					const newSession = await sessionManager.createSession({
 						title,
-						messageCount: messagesToSave.length,
-						provider: currentProvider,
-						model: currentModel,
+						messageCount: capturedMessages.length,
+						provider: capturedProvider,
+						model: capturedModel,
 						workingDirectory: process.cwd(),
-						messages: messagesToSave,
+						messages: capturedMessages,
 					});
 					setCurrentSessionId(newSession.id);
 				}
@@ -143,13 +178,18 @@ export function useSessionAutosave({
 			}
 		};
 
+		const schedule = () => {
+			// Chain onto the tail of any in-flight save so saves are never
+			// concurrent. Errors inside doSave() are swallowed there; the chain
+			// itself must not reject so future saves are not blocked.
+			saveChainRef.current = saveChainRef.current.then(doSave, doSave);
+		};
+
 		if (timeSinceLastSave >= saveInterval) {
-			void saveSession();
+			schedule();
 		} else {
 			const delay = saveInterval - timeSinceLastSave;
-			timeoutRef.current = setTimeout(() => {
-				void saveSession();
-			}, delay);
+			timeoutRef.current = setTimeout(schedule, delay);
 		}
 	}, [
 		messages,

--- a/source/hooks/useSessionAutosave.ts
+++ b/source/hooks/useSessionAutosave.ts
@@ -19,13 +19,17 @@ interface UseSessionAutosaveProps {
  * Clears currentSessionId when messages are cleared.
  *
  * Race safety: saves are serialised through a single chained promise stored in
- * saveChainRef. A new save does not start until the previous one resolves, so
- * only one createSession() call can be in-flight per conversation regardless of
- * how many times the effect fires within a single turn.
+ * saveChainRef. A new save does not start until the previous one resolves.
+ * Critically, doSave reads currentSessionIdRef.current AFTER the
+ * initPromiseRef await so it sees the value set by any prior save in the same
+ * chain - not the stale captured value from effect-fire time. This guarantees
+ * at most one createSession() call per conversation even when the effect fires
+ * several times before React flushes any setCurrentSessionId update.
  *
  * Persistence integrity: the full message array is always written to disk.
- * maxMessages bounds only what is sent to the model (enforced at prompt-build
- * time), not what is stored in the session file.
+ * maxMessages bounds only what is sent to the model (enforced in the
+ * conversation loop before the LLM call), not what is stored in the
+ * session file.
  */
 export function useSessionAutosave({
 	messages,
@@ -39,11 +43,15 @@ export function useSessionAutosave({
 	const lastSaveRef = useRef<number>(0);
 
 	// Serialises saves: each new save is chained onto the tail of this promise.
-	// Replacing void saveSession() calls with promise chaining means two rapid
-	// effect invocations cannot both observe currentSessionId === null and both
-	// call createSession() — the second save starts only after the first has
-	// already called setCurrentSessionId().
 	const saveChainRef = useRef<Promise<void>>(Promise.resolve());
+
+	// Live mirror of currentSessionId. doSave reads this ref after the
+	// initPromiseRef await (i.e. at execution time, not effect-fire time) so
+	// it sees the ID written by any prior save in the same chain.
+	const currentSessionIdRef = useRef<string | null>(currentSessionId);
+	useEffect(() => {
+		currentSessionIdRef.current = currentSessionId;
+	}, [currentSessionId]);
 
 	// Clear current session when conversation is cleared
 	useEffect(() => {
@@ -99,13 +107,13 @@ export function useSessionAutosave({
 		const now = Date.now();
 		const timeSinceLastSave = now - lastSaveRef.current;
 
-		// Capture all values needed for this save at the time the effect ran.
-		// The closure must not close over mutable refs that could change before
-		// the chained promise executes.
+		// Capture message content at effect-fire time. Provider/model are also
+		// captured here since they describe this particular save slot.
+		// Note: we do NOT capture currentSessionId here - doSave reads the live
+		// ref at execution time so it sees any ID set by a prior save in the chain.
 		const capturedMessages = messages;
 		const capturedProvider = currentProvider;
 		const capturedModel = currentModel;
-		const capturedSessionId = currentSessionId;
 
 		const doSave = async () => {
 			try {
@@ -113,10 +121,15 @@ export function useSessionAutosave({
 				const initialized = await initPromiseRef.current;
 				if (!initialized) return;
 
+				// Read the live session ID AFTER the await above. Any prior save
+				// in this chain has already called setCurrentSessionId (and updated
+				// currentSessionIdRef.current) by this point, so we correctly take
+				// the update path instead of calling createSession() again.
+				const liveSessionId = currentSessionIdRef.current;
+
 				// Derive a human-readable title from the most recent user message.
-				// Use the full message array — the model-context cap (maxMessages)
-				// is NOT applied here; it is enforced at prompt-build time so that
-				// the full conversation history is always preserved on disk.
+				// The full message array is always written - maxMessages bounds only
+				// what is sent to the model (sliced in the conversation loop).
 				const userMessages = capturedMessages.filter(
 					msg => msg.role === 'user',
 				);
@@ -126,14 +139,8 @@ export function useSessionAutosave({
 						(lastUserMessage.content.length > 50 ? '...' : '')
 					: `Session ${new Date().toLocaleDateString()}`;
 
-				// Re-check capturedSessionId (captured at effect time) to decide
-				// create vs update. Because saves are serialised via saveChainRef,
-				// a prior save in the same chain will already have called
-				// setCurrentSessionId before this closure runs, but React state
-				// updates are async — capturedSessionId reflects what React had at
-				// effect-fire time, which is the correct value for this save slot.
-				if (capturedSessionId) {
-					const session = await sessionManager.readSession(capturedSessionId);
+				if (liveSessionId) {
+					const session = await sessionManager.readSession(liveSessionId);
 					if (session) {
 						// Write the full history — no truncation.
 						session.messages = capturedMessages;
@@ -154,13 +161,16 @@ export function useSessionAutosave({
 							workingDirectory: process.cwd(),
 							messages: capturedMessages,
 						});
+						// Update the ref immediately so any subsequent doSave in this
+						// chain takes the update path, not another createSession().
+						currentSessionIdRef.current = newSession.id;
 						setCurrentSessionId(newSession.id);
 					}
 				} else {
 					// No session yet for this conversation — create one.
-					// Because doSave() runs serially inside saveChainRef, at most
-					// one createSession() call executes per conversation even if the
-					// effect fired several times before this point.
+					// Because doSave() runs serially inside saveChainRef and reads
+					// the live ref, at most one createSession() call executes per
+					// conversation even if the effect fired several times.
 					const newSession = await sessionManager.createSession({
 						title,
 						messageCount: capturedMessages.length,
@@ -169,6 +179,9 @@ export function useSessionAutosave({
 						workingDirectory: process.cwd(),
 						messages: capturedMessages,
 					});
+					// Update the ref immediately so any subsequent doSave in this
+					// chain takes the update path, not another createSession().
+					currentSessionIdRef.current = newSession.id;
 					setCurrentSessionId(newSession.id);
 				}
 
@@ -191,11 +204,5 @@ export function useSessionAutosave({
 			const delay = saveInterval - timeSinceLastSave;
 			timeoutRef.current = setTimeout(schedule, delay);
 		}
-	}, [
-		messages,
-		currentProvider,
-		currentModel,
-		currentSessionId,
-		setCurrentSessionId,
-	]);
+	}, [messages, currentProvider, currentModel, setCurrentSessionId]);
 }

--- a/source/plain/conversation.ts
+++ b/source/plain/conversation.ts
@@ -1,3 +1,4 @@
+import {getAppConfig} from '@/config/index';
 import {processToolUse} from '@/message-handler';
 import {color, write, writeError, writeLine, writeStatus} from '@/plain/writer';
 import {parseToolCalls} from '@/tool-calling/index';
@@ -12,6 +13,7 @@ import type {
 	ToolCall,
 	ToolResult,
 } from '@/types/core';
+import {capMessagesForModel} from '@/utils/message-capping';
 
 export interface RunPlainConversationOptions {
 	client: LLMClient;
@@ -77,8 +79,12 @@ export async function runPlainConversation(
 		let reasoningPrinted = false;
 		let contentStarted = false;
 
+		const sessionConfig = getAppConfig().sessions;
+		const maxMessages = sessionConfig?.maxMessages ?? 1000;
+		const cappedMessages = capMessagesForModel(messages, maxMessages);
+
 		const result = await client.chat(
-			[systemMessage, ...messages],
+			[systemMessage, ...cappedMessages],
 			tools,
 			{
 				onReasoningToken: (token: string) => {

--- a/source/utils/message-capping.spec.ts
+++ b/source/utils/message-capping.spec.ts
@@ -1,0 +1,89 @@
+import test from 'ava';
+import type {Message} from '@/types/core';
+import {capMessagesForModel} from './message-capping.js';
+
+test('capMessagesForModel does not slice if history is within limit', t => {
+	const messages: Message[] = [
+		{role: 'user', content: 'hello'},
+		{role: 'assistant', content: 'hi'},
+	];
+	const capped = capMessagesForModel(messages, 5);
+	t.deepEqual(capped, messages);
+});
+
+test('capMessagesForModel slices normally when no tool calls are near the boundary', t => {
+	const messages: Message[] = [
+		{role: 'user', content: 'msg 1'},
+		{role: 'assistant', content: 'msg 2'},
+		{role: 'user', content: 'msg 3'},
+		{role: 'assistant', content: 'msg 4'},
+	];
+	const capped = capMessagesForModel(messages, 2);
+	t.deepEqual(capped, [
+		{role: 'user', content: 'msg 3'},
+		{role: 'assistant', content: 'msg 4'},
+	]);
+});
+
+test('capMessagesForModel walks back to avoid orphaned tool results', t => {
+	const messages: Message[] = [
+		{role: 'user', content: 'run command'},
+		{
+			role: 'assistant',
+			content: '',
+			tool_calls: [{id: 'call_1', function: {name: 'bash', arguments: {}}}],
+		},
+		{role: 'tool', tool_call_id: 'call_1', name: 'bash', content: 'output'},
+		{role: 'user', content: 'another command'},
+	];
+
+	// Cap at 2 messages. Naively, this would start at index 2: { role: 'tool' ... }.
+	// That would start with an orphaned tool result.
+	// Our helper must walk back to index 1 to include the assistant message.
+	const capped = capMessagesForModel(messages, 2);
+
+	t.deepEqual(capped, [
+		{
+			role: 'assistant',
+			content: '',
+			tool_calls: [{id: 'call_1', function: {name: 'bash', arguments: {}}}],
+		},
+		{role: 'tool', tool_call_id: 'call_1', name: 'bash', content: 'output'},
+		{role: 'user', content: 'another command'},
+	]);
+});
+
+test('capMessagesForModel walks back through multiple tool results', t => {
+	const messages: Message[] = [
+		{role: 'user', content: 'run parallel tools'},
+		{
+			role: 'assistant',
+			content: '',
+			tool_calls: [
+				{id: 'call_1', function: {name: 'bash', arguments: {}}},
+				{id: 'call_2', function: {name: 'read', arguments: {}}},
+			],
+		},
+		{role: 'tool', tool_call_id: 'call_1', name: 'bash', content: 'out 1'},
+		{role: 'tool', tool_call_id: 'call_2', name: 'read', content: 'out 2'},
+		{role: 'user', content: 'thanks'},
+	];
+
+	// Cap at 2 messages (start at index 3: { role: 'tool', tool_call_id: 'call_2' }).
+	// Must walk back to index 1 (the assistant message).
+	const capped = capMessagesForModel(messages, 2);
+
+	t.deepEqual(capped, [
+		{
+			role: 'assistant',
+			content: '',
+			tool_calls: [
+				{id: 'call_1', function: {name: 'bash', arguments: {}}},
+				{id: 'call_2', function: {name: 'read', arguments: {}}},
+			],
+		},
+		{role: 'tool', tool_call_id: 'call_1', name: 'bash', content: 'out 1'},
+		{role: 'tool', tool_call_id: 'call_2', name: 'read', content: 'out 2'},
+		{role: 'user', content: 'thanks'},
+	]);
+});

--- a/source/utils/message-capping.ts
+++ b/source/utils/message-capping.ts
@@ -1,0 +1,30 @@
+import type {Message} from '@/types/core';
+
+/**
+ * Caps the message history sent to the model to at most `maxMessages` messages.
+ * Avoids orphaning tool calls/results by snapping the slice boundary to complete turns.
+ *
+ * Specifically:
+ * - If the boundary lands on or within a sequence of tool results, we walk the start
+ *   index backwards to include the initiating `assistant` message and all its associated
+ *   tool results.
+ */
+export function capMessagesForModel(
+	messages: Message[],
+	maxMessages: number,
+): Message[] {
+	if (messages.length <= maxMessages) {
+		return messages;
+	}
+
+	let start = messages.length - maxMessages;
+
+	// Walk back to avoid starting in the middle of a tool-call sequence.
+	// If the boundary lands on a 'tool' role message, walk backward to find the
+	// initiating assistant message.
+	while (start > 0 && messages[start]?.role === 'tool') {
+		start--;
+	}
+
+	return messages.slice(start);
+}


### PR DESCRIPTION
## Description

Resolves three issues in the session subsystem (#542):

1. **Duplicate Session Race Condition** - Autosave operations are now serialized through a promise chain (`saveChainRef`), preventing concurrent session creation during the initial save flow.
2. **On-disk Message History Truncation** - Full conversation history is now persisted to disk. The `maxMessages` limit is treated as a model-context concern rather than a persistence concern.
3. **Session ID Rebase on `/resume`** - Added the missing `setKeyGeneratorSessionId(session.id)` call inside `applySession` so shared session state correctly reflects the resumed session.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

## Testing

### Automated Tests

* [x] All existing tests pass (`pnpm test:all`)
* [x] Build succeeds (`pnpm run build`)
* [x] Changes verified locally

### Manual Testing

* [x] Tested session creation and autosave behaviour
* [x] Tested session resume flow
* [x] Verified full message history persists across saves

## Checklist

* [x] Code follows project style guidelines
* [x] Self-review completed
* [x] No breaking changes introduced
* [x] Documentation updated where necessary