### PR TITLE
fix: add timeout, output limits, and abort support

### DIFF
--- a/source/constants.ts
+++ b/source/constants.ts
@@ -77,6 +77,8 @@ export const DELAY_COMMAND_COMPLETE_MS = 100;
 // === BASH EXECUTION ===
 export const INTERVAL_BASH_PROGRESS_MS = 500;
 export const BASH_OUTPUT_PREVIEW_LENGTH = 150;
+export const TIMEOUT_BASH_DEFAULT_MS = 120_000;
+export const BASH_MAX_OUTPUT_BYTES = 5 * 1024 * 1024;
 
 // === FILE SCANNER ===
 export const MAX_FILES_TO_SCAN = 1000;

--- a/source/services/bash-executor.spec.ts
+++ b/source/services/bash-executor.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {BashExecutor} from './bash-executor';
+import { BashExecutor } from './bash-executor';
 
 console.log(`\nbash-executor.spec.ts`);
 
@@ -29,7 +29,7 @@ test.afterEach(() => {
 // Basic execution tests
 test('execute - returns executionId and promise', async t => {
 	const executor = createExecutor();
-	const {executionId, promise} = executor.execute('echo hello');
+	const { executionId, promise } = executor.execute('echo hello');
 
 	t.is(typeof executionId, 'string');
 	t.true(executionId.length > 0);
@@ -55,7 +55,7 @@ test('execute - generates unique execution IDs', async t => {
 
 test('execute - captures stdout output', async t => {
 	const executor = createExecutor();
-	const {promise} = executor.execute('echo "test output"');
+	const { promise } = executor.execute('echo "test output"');
 	const result = await promise;
 
 	t.true(result.fullOutput.includes('test output'));
@@ -66,7 +66,7 @@ test('execute - captures stdout output', async t => {
 
 test('execute - captures stderr output', async t => {
 	const executor = createExecutor();
-	const {promise} = executor.execute('echo "error message" >&2');
+	const { promise } = executor.execute('echo "error message" >&2');
 	const result = await promise;
 
 	t.true(result.stderr.includes('error message'));
@@ -76,7 +76,7 @@ test('execute - captures stderr output', async t => {
 
 test('execute - captures exit code for successful command', async t => {
 	const executor = createExecutor();
-	const {promise} = executor.execute('exit 0');
+	const { promise } = executor.execute('exit 0');
 	const result = await promise;
 
 	t.is(result.exitCode, 0);
@@ -85,7 +85,7 @@ test('execute - captures exit code for successful command', async t => {
 
 test('execute - captures exit code for failed command', async t => {
 	const executor = createExecutor();
-	const {promise} = executor.execute('exit 42');
+	const { promise } = executor.execute('exit 42');
 	const result = await promise;
 
 	t.is(result.exitCode, 42);
@@ -95,7 +95,7 @@ test('execute - captures exit code for failed command', async t => {
 test('execute - stores command in result state', async t => {
 	const executor = createExecutor();
 	const command = 'echo "my command"';
-	const {promise} = executor.execute(command);
+	const { promise } = executor.execute(command);
 	const result = await promise;
 
 	t.is(result.command, command);
@@ -104,7 +104,7 @@ test('execute - stores command in result state', async t => {
 test('execute - creates output preview from last 150 chars', async t => {
 	const executor = createExecutor();
 	// Generate output longer than 150 chars using a portable command
-	const {promise} = executor.execute('seq 200 | xargs -I {} printf "-"');
+	const { promise } = executor.execute('seq 200 | xargs -I {} printf "-"');
 	const result = await promise;
 
 	t.true(result.fullOutput.length >= 150);
@@ -123,12 +123,12 @@ test('execute - emits start event', async t => {
 		startState = state;
 	});
 
-	const {executionId, promise} = executor.execute('echo test');
+	const { executionId, promise } = executor.execute('echo test');
 
 	// Start event should be emitted synchronously
 	t.true(startEventReceived);
 	t.truthy(startState);
-	t.is((startState as {executionId: string}).executionId, executionId);
+	t.is((startState as { executionId: string }).executionId, executionId);
 
 	await promise;
 });
@@ -143,19 +143,19 @@ test('execute - emits complete event when done', async t => {
 		completeState = state;
 	});
 
-	const {executionId, promise} = executor.execute('echo test');
+	const { executionId, promise } = executor.execute('echo test');
 	await promise;
 
 	t.true(completeEventReceived);
 	t.truthy(completeState);
-	t.is((completeState as {executionId: string}).executionId, executionId);
-	t.true((completeState as {isComplete: boolean}).isComplete);
+	t.is((completeState as { executionId: string }).executionId, executionId);
+	t.true((completeState as { isComplete: boolean }).isComplete);
 });
 
 // Cancel tests
 test('cancel - returns true for active execution', async t => {
 	const executor = createExecutor();
-	const {executionId, promise} = executor.execute('sleep 10');
+	const { executionId, promise } = executor.execute('sleep 10');
 
 	const cancelled = executor.cancel(executionId);
 
@@ -175,7 +175,7 @@ test('cancel - returns false for unknown execution ID', t => {
 
 test('cancel - resolves the promise with cancelled state', async t => {
 	const executor = createExecutor();
-	const {executionId, promise} = executor.execute('sleep 10');
+	const { executionId, promise } = executor.execute('sleep 10');
 
 	executor.cancel(executionId);
 	const result = await promise;
@@ -192,17 +192,17 @@ test('cancel - emits complete event with error', async t => {
 		completeState = state;
 	});
 
-	const {executionId, promise} = executor.execute('sleep 10');
+	const { executionId, promise } = executor.execute('sleep 10');
 	executor.cancel(executionId);
 	await promise;
 
 	t.truthy(completeState);
-	t.is((completeState as {error: string}).error, 'Cancelled by user');
+	t.is((completeState as { error: string }).error, 'Cancelled by user');
 });
 
 test('cancel - removes execution from active list', async t => {
 	const executor = createExecutor();
-	const {executionId, promise} = executor.execute('sleep 10');
+	const { executionId, promise } = executor.execute('sleep 10');
 
 	t.true(executor.hasActiveExecutions());
 	executor.cancel(executionId);
@@ -215,7 +215,7 @@ test('cancel - removes execution from active list', async t => {
 // getState tests
 test('getState - returns state for active execution', async t => {
 	const executor = createExecutor();
-	const {executionId, promise} = executor.execute('sleep 10');
+	const { executionId, promise } = executor.execute('sleep 10');
 
 	const state = executor.getState(executionId);
 
@@ -238,7 +238,7 @@ test('getState - returns undefined for unknown execution ID', t => {
 
 test('getState - returns copy of state (immutable)', async t => {
 	const executor = createExecutor();
-	const {executionId, promise} = executor.execute('sleep 10');
+	const { executionId, promise } = executor.execute('sleep 10');
 
 	const state1 = executor.getState(executionId);
 	const state2 = executor.getState(executionId);
@@ -260,7 +260,7 @@ test('hasActiveExecutions - returns false when no executions', t => {
 
 test('hasActiveExecutions - returns true when executions active', async t => {
 	const executor = createExecutor();
-	const {executionId, promise} = executor.execute('sleep 10');
+	const { executionId, promise } = executor.execute('sleep 10');
 
 	t.true(executor.hasActiveExecutions());
 
@@ -271,7 +271,7 @@ test('hasActiveExecutions - returns true when executions active', async t => {
 
 test('hasActiveExecutions - returns false after execution completes', async t => {
 	const executor = createExecutor();
-	const {promise} = executor.execute('echo fast');
+	const { promise } = executor.execute('echo fast');
 
 	await promise;
 
@@ -344,7 +344,7 @@ test('execute - supports multiple concurrent executions', async t => {
 // Edge cases
 test('execute - handles empty command output', async t => {
 	const executor = createExecutor();
-	const {promise} = executor.execute('true');
+	const { promise } = executor.execute('true');
 	const result = await promise;
 
 	t.is(result.fullOutput, '');
@@ -353,7 +353,7 @@ test('execute - handles empty command output', async t => {
 
 test('execute - handles command with special characters', async t => {
 	const executor = createExecutor();
-	const {promise} = executor.execute('echo "hello $USER"');
+	const { promise } = executor.execute('echo "hello $USER"');
 	const result = await promise;
 
 	t.true(result.fullOutput.length > 0);
@@ -362,7 +362,7 @@ test('execute - handles command with special characters', async t => {
 
 test('execute - handles multiline output', async t => {
 	const executor = createExecutor();
-	const {promise} = executor.execute('echo "line1"; echo "line2"; echo "line3"');
+	const { promise } = executor.execute('echo "line1"; echo "line2"; echo "line3"');
 	const result = await promise;
 
 	t.true(result.fullOutput.includes('line1'));
@@ -379,7 +379,7 @@ test('complete event - provides immutable state copy', async t => {
 		eventState = state;
 	});
 
-	const {promise} = executor.execute('echo test');
+	const { promise } = executor.execute('echo test');
 	const promiseResult = await promise;
 
 	// Both should have same content
@@ -387,4 +387,99 @@ test('complete event - provides immutable state copy', async t => {
 
 	// But be different objects
 	t.not(eventState, promiseResult);
+});
+
+test('timeout resolves with the timeout error after timeoutMs', async t => {
+	const executor = createExecutor();
+	const start = Date.now();
+
+	// Pass a very short timeout
+	const { promise } = executor.execute('sleep 10', { timeoutMs: 100 });
+	const result = await promise;
+
+	const elapsed = Date.now() - start;
+
+	t.true(result.isComplete, 'Command should be marked complete');
+	t.is(result.error, 'Command timed out after 100ms', 'Should have the specific timeout error');
+	t.true(elapsed < 1000, `Command ran ${elapsed}ms — it was successfully killed early by the timeout`);
+});
+
+test('signal abort resolves with the cancel error', async t => {
+	const executor = createExecutor();
+	const controller = new AbortController();
+	controller.abort(); // signal already aborted before execute() is called
+
+	const start = Date.now();
+	const { promise } = executor.execute('sleep 10', { signal: controller.signal });
+	const result = await promise;
+	const elapsed = Date.now() - start;
+
+	t.true(
+		elapsed < 500,
+		`Command aborted immediately (${elapsed}ms) instead of hanging`,
+	);
+	t.is(result.error, 'Cancelled via AbortSignal', 'Has correct abort error');
+	t.true(result.isComplete, 'Command should be marked complete');
+});
+
+test('output cap trips and appends the truncation marker exactly once', async t => {
+	// Dynamically import the limit so we test against the actual cap
+	const { BASH_MAX_OUTPUT_BYTES } = await import('../constants.js');
+	const executor = createExecutor();
+
+	// We'll write more than BASH_MAX_OUTPUT_BYTES using python to avoid
+	// large bash allocations. This will emit slightly over the limit.
+	const { promise } = executor.execute(`python3 -c "print('A' * (${BASH_MAX_OUTPUT_BYTES} + 1000))"`);
+	const result = await promise;
+
+	const truncationMarker = '... [Output truncated to prevent memory exhaustion]';
+
+	t.true(
+		result.fullOutput.includes(truncationMarker),
+		'The output should have the truncation message appended',
+	);
+
+	// Ensure it only appears exactly once
+	const matches = result.fullOutput.split(truncationMarker).length - 1;
+	t.is(matches, 1, 'The truncation marker should be appended exactly once');
+
+	t.true(
+		result.fullOutput.length < BASH_MAX_OUTPUT_BYTES + 10000,
+		`fullOutput length ${result.fullOutput.length} is capped properly`,
+	);
+});
+
+test('cancel() on a detached process kills a spawned child (process-group assertion)', async t => {
+	const executor = createExecutor();
+	const { promise, executionId } = executor.execute('node -e "setInterval(() => {}, 1000)" & echo $!');
+
+	// Wait briefly for the output to appear
+	await new Promise(resolve => setTimeout(resolve, 300));
+
+	const state = executor.getState(executionId);
+	t.truthy(state, 'Execution should be active');
+
+	const match = state?.fullOutput.match(/(\d+)/);
+	t.truthy(match, 'Should have captured the background child PID');
+	const childPid = parseInt(match![1]!, 10);
+
+	// Verify child is alive
+	try {
+		process.kill(childPid, 0);
+		t.pass('Child is alive before cancel');
+	} catch {
+		t.fail('Child should be alive before cancel');
+	}
+
+	// Cancel the execution tree
+	executor.cancel(executionId);
+	await promise;
+
+	// Give the OS a moment to reap the process
+	await new Promise(resolve => setTimeout(resolve, 300));
+
+	// Verify child is dead
+	t.throws(() => {
+		process.kill(childPid, 0);
+	}, undefined, 'process.kill(pid, 0) should throw because the child was killed by the process-group signal');
 });

--- a/source/services/bash-executor.ts
+++ b/source/services/bash-executor.ts
@@ -4,8 +4,10 @@ import {EventEmitter} from 'node:events';
 import {platform} from 'node:process';
 
 import {
+	BASH_MAX_OUTPUT_BYTES,
 	BASH_OUTPUT_PREVIEW_LENGTH,
 	INTERVAL_BASH_PROGRESS_MS,
+	TIMEOUT_BASH_DEFAULT_MS,
 } from '@/constants';
 
 const isWindows = platform === 'win32';
@@ -26,12 +28,18 @@ interface ExecutionEntry {
 	process: ChildProcess;
 	intervalId: NodeJS.Timeout;
 	resolve: (state: BashExecutionState) => void;
+	timeoutId?: NodeJS.Timeout;
+	signal?: AbortSignal;
+	abortListener?: () => void;
 }
 
 export class BashExecutor extends EventEmitter {
 	private executions = new Map<string, ExecutionEntry>();
 
-	execute(command: string): {
+	execute(
+		command: string,
+		options?: {timeoutMs?: number; signal?: AbortSignal},
+	): {
 		executionId: string;
 		promise: Promise<BashExecutionState>;
 	} {
@@ -56,9 +64,19 @@ export class BashExecutor extends EventEmitter {
 				// children keep running in the background.
 				spawn('sh', ['-c', command], {detached: true});
 
+		let outputBytes = 0;
+
 		// Collect output
 		proc.stdout.on('data', (data: Buffer) => {
-			state.fullOutput += data.toString();
+			if (outputBytes < BASH_MAX_OUTPUT_BYTES) {
+				const chunk = data.toString();
+				state.fullOutput += chunk;
+				outputBytes += Buffer.byteLength(chunk);
+				if (outputBytes >= BASH_MAX_OUTPUT_BYTES) {
+					state.fullOutput +=
+						'\n... [Output truncated to prevent memory exhaustion]';
+				}
+			}
 			state.outputPreview = state.fullOutput.slice(-BASH_OUTPUT_PREVIEW_LENGTH);
 			// Emit progress immediately when output is received
 			// This ensures fast commands still show streaming output
@@ -66,7 +84,15 @@ export class BashExecutor extends EventEmitter {
 		});
 
 		proc.stderr.on('data', (data: Buffer) => {
-			state.stderr += data.toString();
+			if (outputBytes < BASH_MAX_OUTPUT_BYTES) {
+				const chunk = data.toString();
+				state.stderr += chunk;
+				outputBytes += Buffer.byteLength(chunk);
+				if (outputBytes >= BASH_MAX_OUTPUT_BYTES) {
+					state.stderr +=
+						'\n... [Stderr truncated to prevent memory exhaustion]';
+				}
+			}
 			// Emit progress immediately when stderr is received
 			this.emit('progress', {...state});
 		});
@@ -80,15 +106,42 @@ export class BashExecutor extends EventEmitter {
 		intervalId.unref();
 
 		const promise = new Promise<BashExecutionState>((resolve, _reject) => {
-			// Store resolve function so cancel() can resolve the promise
-			this.executions.set(executionId, {
+			const entry: ExecutionEntry = {
 				state,
 				process: proc,
 				intervalId,
 				resolve,
-			});
+				signal: options?.signal,
+			};
+
+			const ms = options?.timeoutMs ?? TIMEOUT_BASH_DEFAULT_MS;
+			if (ms > 0) {
+				entry.timeoutId = setTimeout(() => {
+					this.cancel(executionId, `Command timed out after ${ms}ms`);
+				}, ms);
+				entry.timeoutId.unref();
+			}
+
+			if (options?.signal) {
+				entry.abortListener = () => {
+					this.cancel(executionId, 'Cancelled via AbortSignal');
+				};
+
+				if (options.signal.aborted) {
+					process.nextTick(entry.abortListener);
+				} else {
+					options.signal.addEventListener('abort', entry.abortListener);
+				}
+			}
+
+			this.executions.set(executionId, entry);
 
 			proc.on('close', (code: number | null) => {
+				if (entry.timeoutId) clearTimeout(entry.timeoutId);
+				if (entry.signal && entry.abortListener) {
+					entry.signal.removeEventListener('abort', entry.abortListener);
+				}
+
 				// Only process if not already handled by cancel()
 				if (!this.executions.has(executionId)) return;
 
@@ -101,6 +154,11 @@ export class BashExecutor extends EventEmitter {
 			});
 
 			proc.on('error', (error: Error) => {
+				if (entry.timeoutId) clearTimeout(entry.timeoutId);
+				if (entry.signal && entry.abortListener) {
+					entry.signal.removeEventListener('abort', entry.abortListener);
+				}
+
 				// Only process if not already handled by cancel()
 				if (!this.executions.has(executionId)) return;
 
@@ -119,11 +177,15 @@ export class BashExecutor extends EventEmitter {
 		return {executionId, promise};
 	}
 
-	cancel(executionId: string): boolean {
+	cancel(executionId: string, reason = 'Cancelled by user'): boolean {
 		const execution = this.executions.get(executionId);
 		if (!execution) return false;
 
 		clearInterval(execution.intervalId);
+		if (execution.timeoutId) clearTimeout(execution.timeoutId);
+		if (execution.signal && execution.abortListener) {
+			execution.signal.removeEventListener('abort', execution.abortListener);
+		}
 
 		// Destroy stdio streams to prevent them from keeping the event loop alive
 		execution.process.stdout?.destroy();
@@ -132,7 +194,7 @@ export class BashExecutor extends EventEmitter {
 
 		this.killProcessTree(execution.process);
 		execution.state.isComplete = true;
-		execution.state.error = 'Cancelled by user';
+		execution.state.error = reason;
 		this.emit('complete', {...execution.state});
 
 		// Resolve the promise with the cancelled state

--- a/source/services/bash-executor.ts
+++ b/source/services/bash-executor.ts
@@ -65,14 +65,18 @@ export class BashExecutor extends EventEmitter {
 				spawn('sh', ['-c', command], {detached: true});
 
 		let outputBytes = 0;
+		let outputTruncated = false;
 
 		// Collect output
 		proc.stdout.on('data', (data: Buffer) => {
 			if (outputBytes < BASH_MAX_OUTPUT_BYTES) {
-				const chunk = data.toString();
-				state.fullOutput += chunk;
-				outputBytes += Buffer.byteLength(chunk);
-				if (outputBytes >= BASH_MAX_OUTPUT_BYTES) {
+				const remaining = BASH_MAX_OUTPUT_BYTES - outputBytes;
+				const limitedChunk = data.subarray(0, remaining);
+				state.fullOutput += limitedChunk.toString();
+				outputBytes += limitedChunk.length;
+
+				if (outputBytes >= BASH_MAX_OUTPUT_BYTES && !outputTruncated) {
+					outputTruncated = true;
 					state.fullOutput +=
 						'\n... [Output truncated to prevent memory exhaustion]';
 				}
@@ -85,10 +89,13 @@ export class BashExecutor extends EventEmitter {
 
 		proc.stderr.on('data', (data: Buffer) => {
 			if (outputBytes < BASH_MAX_OUTPUT_BYTES) {
-				const chunk = data.toString();
-				state.stderr += chunk;
-				outputBytes += Buffer.byteLength(chunk);
-				if (outputBytes >= BASH_MAX_OUTPUT_BYTES) {
+				const remaining = BASH_MAX_OUTPUT_BYTES - outputBytes;
+				const limitedChunk = data.subarray(0, remaining);
+				state.stderr += limitedChunk.toString();
+				outputBytes += limitedChunk.length;
+
+				if (outputBytes >= BASH_MAX_OUTPUT_BYTES && !outputTruncated) {
+					outputTruncated = true;
 					state.stderr +=
 						'\n... [Stderr truncated to prevent memory exhaustion]';
 				}
@@ -127,10 +134,11 @@ export class BashExecutor extends EventEmitter {
 					this.cancel(executionId, 'Cancelled via AbortSignal');
 				};
 
+				options.signal.addEventListener('abort', entry.abortListener, {
+					once: true,
+				});
 				if (options.signal.aborted) {
 					process.nextTick(entry.abortListener);
-				} else {
-					options.signal.addEventListener('abort', entry.abortListener);
 				}
 			}
 

--- a/source/tools/execute-bash.tsx
+++ b/source/tools/execute-bash.tsx
@@ -17,11 +17,14 @@ import {jsonSchema, tool} from '@/types/core';
  * @param command - The bash command to execute
  * @returns Object containing executionId and promise for the result
  */
-export function executeBashCommand(command: string): {
+export function executeBashCommand(
+	command: string,
+	options?: {timeoutMs?: number; signal?: AbortSignal},
+): {
 	executionId: string;
 	promise: Promise<BashExecutionState>;
 } {
-	return bashExecutor.execute(command);
+	return bashExecutor.execute(command, options);
 }
 
 /**
@@ -58,8 +61,13 @@ export function formatBashResultForLLM(result: BashExecutionState): string {
  * Note: For streaming tools, the tool handler will use executeBashCommand directly
  * and this function serves as a fallback/compatibility layer
  */
-const executeExecuteBash = async (args: {command: string}): Promise<string> => {
-	const {promise} = bashExecutor.execute(args.command);
+const executeExecuteBash = async (
+	args: {command: string},
+	options?: {abortSignal?: AbortSignal},
+): Promise<string> => {
+	const {promise} = bashExecutor.execute(args.command, {
+		signal: options?.abortSignal,
+	});
 	const result = await promise;
 	return formatBashResultForLLM(result);
 };
@@ -77,8 +85,8 @@ const executeBashCoreTool = tool({
 		},
 		required: ['command'],
 	}),
-	execute: async (args, _options) => {
-		return await executeExecuteBash(args);
+	execute: async (args, options) => {
+		return await executeExecuteBash(args, options);
 	},
 });
 


### PR DESCRIPTION
## Description

Resolves the remaining valid findings from Issue #541 in the `execute_bash` tool and `BashExecutor`.

### Changes

* Added a default per-command timeout (`TIMEOUT_BASH_DEFAULT_MS = 120000`) so commands no longer run indefinitely.
* Added output buffering limits (`BASH_MAX_OUTPUT_BYTES = 5MB`) to prevent unbounded memory growth from commands that generate excessive output.
* Wired `AbortSignal` support from the tool layer through to `BashExecutor`, allowing running commands to be cancelled programmatically.
* Added regression tests covering timeout handling, output truncation, AbortSignal cancellation, and process-group cleanup behaviour.
* Verified that the orphaned child-process issue reported in #541 had already been resolved in a previous change through process-group termination.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

## Testing

### Automated Tests

* [x] New features include passing tests in `.spec.ts/tsx` files
* [x] All existing tests pass (`pnpm test:all` completes successfully)
* [x] Tests cover both success and error scenarios

### Manual Testing

* [x] Tested command timeout behaviour
* [x] Tested command cancellation via `AbortSignal`
* [x] Verified output truncation under large-output scenarios
* [ ] Tested MCP integration (if applicable)

## Checklist

* [x] Code follows project style guidelines
* [x] Self-review completed
* [x] Documentation updated (if needed)
* [x] No breaking changes (or clearly documented)