### PR TITLE
fix: surface model discovery errors instead of silent fallback

### DIFF
--- a/source/wizards/steps/provider-step.spec.tsx
+++ b/source/wizards/steps/provider-step.spec.tsx
@@ -731,3 +731,39 @@ test('findTemplateForProvider: ChatGPT resolves to chatgpt-codex by baseUrl', t 
 	t.truthy(template);
 	t.is(template!.id, 'chatgpt-codex');
 });
+
+// ============================================================================
+// Tests for fetchModels error handling 
+// ============================================================================
+
+test.serial('ProviderStep surfaces fetchModels errors', async t => {
+	const originalFetch = global.fetch;
+	global.fetch = async () =>
+		({
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+		}) as Response;
+
+	try {
+		const {lastFrame, stdin} = render(<ProviderStep onComplete={() => {}} />);
+
+		stdin.write('\r');
+		await new Promise(r => setTimeout(r, 50));
+
+		stdin.write('\r');
+		await new Promise(r => setTimeout(r, 50));
+
+		stdin.write('\r');
+		await new Promise(r => setTimeout(r, 50));
+
+		stdin.write('\r');
+		await new Promise(r => setTimeout(r, 150));
+
+		const output = lastFrame();
+		t.truthy(output);
+		t.regex(output!, /Server returned 401: Unauthorized/);
+	} finally {
+		global.fetch = originalFetch;
+	}
+});

--- a/source/wizards/steps/provider-step.tsx
+++ b/source/wizards/steps/provider-step.tsx
@@ -79,17 +79,21 @@ export function ProviderStep({
 	onComplete,
 	onBack,
 	onDelete,
-	existingProviders = [],
+	existingProviders,
 	configExists = false,
 }: ProviderStepProps) {
 	const colors = getColors();
 	const {isNarrow} = useResponsiveTerminal();
-	const [providers, setProviders] =
-		useState<ProviderConfig[]>(existingProviders);
+	const [providers, setProviders] = useState<ProviderConfig[]>(
+		existingProviders || [],
+	);
 
-	// Update providers when existingProviders prop changes
+	// Update providers when existingProviders prop changes,
+	// checking length/contents instead of reference if it's undefined
 	useEffect(() => {
-		setProviders(existingProviders);
+		if (existingProviders) {
+			setProviders(existingProviders);
+		}
 	}, [existingProviders]);
 
 	const [mode, setMode] = useState<Mode>('select-template-or-custom');
@@ -402,8 +406,7 @@ export function ProviderStep({
 			}
 		} catch (err) {
 			if (!isMountedRef.current) return;
-			const message =
-				err instanceof Error ? err.message : 'Unknown error';
+			const message = err instanceof Error ? err.message : 'Unknown error';
 			setError(
 				`Model discovery failed: ${message}. Enter model name(s) manually.`,
 			);

--- a/source/wizards/steps/provider-step.tsx
+++ b/source/wizards/steps/provider-step.tsx
@@ -393,8 +393,20 @@ export function ProviderStep({
 				setMode('model-selection');
 				return;
 			}
-		} catch {
-			// Silent failure
+
+			// Discovery returned a non-success result — surface the reason
+			if (result.error) {
+				setError(
+					`Model discovery failed: ${result.error}. Enter model name(s) manually.`,
+				);
+			}
+		} catch (err) {
+			if (!isMountedRef.current) return;
+			const message =
+				err instanceof Error ? err.message : 'Unknown error';
+			setError(
+				`Model discovery failed: ${message}. Enter model name(s) manually.`,
+			);
 		}
 
 		if (!isMountedRef.current) return;


### PR DESCRIPTION
## Description

When `fetchModels()` failed during provider setup, the wizard silently fell back to manual model entry without showing the underlying error. Users had no indication whether the failure was caused by an incorrect URL, authentication issue, unavailable server, or network problem.

This PR surfaces the error from `fetchModels` (both from non-success results and caught exceptions) via `setError()` before falling back to manual input. The existing `FieldInputView` already renders error state, so users now see messages like *"Model discovery failed: Server returned 401: Unauthorized. Enter model name(s) manually."*

The manual fallback behavior is preserved — users just now know **why** discovery failed so they can correct their configuration.

Closes #552

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
