### PR TITLE
fix: prevent silent overwrite of corrupted config files

### DIFF
--- a/source/wizards/base-config-wizard.spec.tsx
+++ b/source/wizards/base-config-wizard.spec.tsx
@@ -191,3 +191,82 @@ test.serial('displays an error when the configuration file contains invalid JSON
 		unlinkSync(configPath);
 	} catch {}
 });
+
+test.serial('blocks saving corrupted config', async t => {
+	const configFileName = `.bad-save-${Date.now()}.json`;
+	const configPath = join(process.cwd(), configFileName);
+	writeFileSync(configPath, '{ invalid }', 'utf-8');
+
+	const {lastFrame, stdin} = renderWithTheme(
+		<BaseConfigWizard<FakeItems>
+			title="Title"
+			focusId="corrupt-save-wizard"
+			configFileName={configFileName}
+			initialItems={{entries: []}}
+			parseConfig={() => {
+				throw new Error('Parse error');
+			}}
+			buildConfig={items => items}
+			hasItems={items => items.entries.length > 0}
+			renderConfigureStep={({onComplete}) => {
+				setTimeout(() => onComplete({entries: [{name: 'new'}]}), 10);
+				return <></>;
+			}}
+			renderSummaryItems={noopRenderSummary}
+			projectDir={process.cwd()}
+			onComplete={() => {}}
+		/>,
+	);
+
+	stdin.write('\r');
+	await new Promise(r => setTimeout(r, 100));
+
+	stdin.write('\r');
+	await new Promise(r => setTimeout(r, 50));
+
+	const output = lastFrame()!;
+	t.regex(output, /Cannot save: the existing configuration file contains invalid/);
+	
+	try {
+		unlinkSync(configPath);
+	} catch {}
+});
+
+test.serial('deleting corrupted config clears corruption state', async t => {
+	const configFileName = `.bad-del-${Date.now()}.json`;
+	const configPath = join(process.cwd(), configFileName);
+	writeFileSync(configPath, '{ invalid }', 'utf-8');
+	let completedPath = '';
+
+	const {lastFrame, stdin} = renderWithTheme(
+		<BaseConfigWizard<FakeItems>
+			title="Title"
+			focusId="corrupt-del-wizard"
+			configFileName={configFileName}
+			initialItems={{entries: []}}
+			parseConfig={() => {
+				throw new Error('Parse error');
+			}}
+			buildConfig={items => items}
+			hasItems={items => items.entries.length > 0}
+			renderConfigureStep={({onDelete}) => {
+				setTimeout(() => onDelete?.(), 10);
+				return <></>;
+			}}
+			renderSummaryItems={noopRenderSummary}
+			projectDir={process.cwd()}
+			onComplete={(path) => { completedPath = path; }}
+		/>,
+	);
+
+	stdin.write('\r');
+	await new Promise(r => setTimeout(r, 100));
+
+	stdin.write('\r');
+	await new Promise(r => setTimeout(r, 50));
+
+	t.false(existsSync(configPath));
+	t.is(completedPath, configPath);
+});
+
+

--- a/source/wizards/base-config-wizard.spec.tsx
+++ b/source/wizards/base-config-wizard.spec.tsx
@@ -1,4 +1,5 @@
-import {existsSync, mkdirSync, unlinkSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
 import {Box, Text} from 'ink';
@@ -155,8 +156,12 @@ test('renders consistently across multiple mounts with the same props', t => {
 });
 
 test.serial('displays an error when the configuration file contains invalid JSON', async t => {
-	const configFileName = `.bad-${Date.now()}.json`;
-	const configPath = join(process.cwd(), configFileName);
+	const testDir = join(tmpdir(), `nanocoder-wizard-test-corrupt-${Date.now()}`);
+	mkdirSync(testDir, {recursive: true});
+	t.teardown(() => rmSync(testDir, {recursive: true, force: true}));
+
+	const configFileName = '.bad.json';
+	const configPath = join(testDir, configFileName);
 	writeFileSync(configPath, '{ this is bad json }', 'utf-8');
 
 	const {lastFrame, stdin} = renderWithTheme(
@@ -172,7 +177,7 @@ test.serial('displays an error when the configuration file contains invalid JSON
 			hasItems={items => items.entries.length > 0}
 			renderConfigureStep={noopRenderConfigure}
 			renderSummaryItems={noopRenderSummary}
-			projectDir={process.cwd()}
+			projectDir={testDir}
 			onComplete={() => {}}
 		/>,
 	);
@@ -186,15 +191,15 @@ test.serial('displays an error when the configuration file contains invalid JSON
 
 	const output = lastFrame()!;
 	t.regex(output, /Configuration file has invalid JSON and cannot be loaded/);
-
-	try {
-		unlinkSync(configPath);
-	} catch {}
 });
 
 test.serial('blocks saving corrupted config', async t => {
-	const configFileName = `.bad-save-${Date.now()}.json`;
-	const configPath = join(process.cwd(), configFileName);
+	const testDir = join(tmpdir(), `nanocoder-wizard-test-save-${Date.now()}`);
+	mkdirSync(testDir, {recursive: true});
+	t.teardown(() => rmSync(testDir, {recursive: true, force: true}));
+
+	const configFileName = '.bad-save.json';
+	const configPath = join(testDir, configFileName);
 	writeFileSync(configPath, '{ invalid }', 'utf-8');
 
 	const {lastFrame, stdin} = renderWithTheme(
@@ -213,7 +218,7 @@ test.serial('blocks saving corrupted config', async t => {
 				return <></>;
 			}}
 			renderSummaryItems={noopRenderSummary}
-			projectDir={process.cwd()}
+			projectDir={testDir}
 			onComplete={() => {}}
 		/>,
 	);
@@ -226,15 +231,15 @@ test.serial('blocks saving corrupted config', async t => {
 
 	const output = lastFrame()!;
 	t.regex(output, /Cannot save: the existing configuration file contains invalid/);
-	
-	try {
-		unlinkSync(configPath);
-	} catch {}
 });
 
 test.serial('deleting corrupted config clears corruption state', async t => {
-	const configFileName = `.bad-del-${Date.now()}.json`;
-	const configPath = join(process.cwd(), configFileName);
+	const testDir = join(tmpdir(), `nanocoder-wizard-test-del-${Date.now()}`);
+	mkdirSync(testDir, {recursive: true});
+	t.teardown(() => rmSync(testDir, {recursive: true, force: true}));
+
+	const configFileName = '.bad-del.json';
+	const configPath = join(testDir, configFileName);
 	writeFileSync(configPath, '{ invalid }', 'utf-8');
 	let completedPath = '';
 
@@ -254,7 +259,7 @@ test.serial('deleting corrupted config clears corruption state', async t => {
 				return <></>;
 			}}
 			renderSummaryItems={noopRenderSummary}
-			projectDir={process.cwd()}
+			projectDir={testDir}
 			onComplete={(path) => { completedPath = path; }}
 		/>,
 	);

--- a/source/wizards/base-config-wizard.spec.tsx
+++ b/source/wizards/base-config-wizard.spec.tsx
@@ -1,3 +1,5 @@
+import {existsSync, mkdirSync, unlinkSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
 import test from 'ava';
 import {Box, Text} from 'ink';
 import React from 'react';
@@ -150,4 +152,42 @@ test('renders consistently across multiple mounts with the same props', t => {
 	const b = renderWithTheme(<BaseConfigWizard<FakeItems> {...props} />);
 
 	t.is(a.lastFrame(), b.lastFrame());
+});
+
+test.serial('displays an error when the configuration file contains invalid JSON', async t => {
+	const configFileName = `.bad-${Date.now()}.json`;
+	const configPath = join(process.cwd(), configFileName);
+	writeFileSync(configPath, '{ this is bad json }', 'utf-8');
+
+	const {lastFrame, stdin} = renderWithTheme(
+		<BaseConfigWizard<FakeItems>
+			title="Title"
+			focusId="corrupt-wizard"
+			configFileName={configFileName}
+			initialItems={{entries: []}}
+			parseConfig={() => {
+				throw new Error('Parse error');
+			}}
+			buildConfig={items => items}
+			hasItems={items => items.entries.length > 0}
+			renderConfigureStep={noopRenderConfigure}
+			renderSummaryItems={noopRenderSummary}
+			projectDir={process.cwd()}
+			onComplete={() => {}}
+		/>,
+	);
+
+	// It will default to "existing config" since the file exists
+	// We send "Enter" to select "Edit this configuration"
+	stdin.write('\r');
+
+	// Wait for the async useEffect file read
+	await new Promise(r => setTimeout(r, 100));
+
+	const output = lastFrame()!;
+	t.regex(output, /Configuration file has invalid JSON and cannot be loaded/);
+
+	try {
+		unlinkSync(configPath);
+	} catch {}
 });

--- a/source/wizards/base-config-wizard.tsx
+++ b/source/wizards/base-config-wizard.tsx
@@ -149,7 +149,7 @@ export function BaseConfigWizard<T>({
 	};
 
 	const handleLocationComplete = (location: ConfigLocation) => {
-		const baseDir = location === 'project' ? process.cwd() : getConfigPath();
+		const baseDir = location === 'project' ? projectDir : getConfigPath();
 		setConfigPath(join(baseDir, configFileName));
 		setStep('configure');
 	};
@@ -195,7 +195,7 @@ export function BaseConfigWizard<T>({
 	const openInEditor = () => {
 		try {
 			// Skip writing when config is corrupted — open the existing
-			
+
 			if (!configCorrupted) {
 				writeConfigToDisk(items);
 			}

--- a/source/wizards/base-config-wizard.tsx
+++ b/source/wizards/base-config-wizard.tsx
@@ -94,6 +94,7 @@ export function BaseConfigWizard<T>({
 	const [configPath, setConfigPath] = useState('');
 	const [items, setItems] = useState<T>(initialItems);
 	const [error, setError] = useState<string | null>(null);
+	const [configCorrupted, setConfigCorrupted] = useState(false);
 	const {boxWidth, isNarrow} = useResponsiveTerminal();
 
 	useFocus({autoFocus: true, id: focusId});
@@ -108,11 +109,18 @@ export function BaseConfigWizard<T>({
 						const content = readFileSync(configPath, 'utf-8');
 						const raw = JSON.parse(content) as unknown;
 						setItems(parseConfig(raw));
+						setConfigCorrupted(false);
 					} catch (err) {
 						logError('Failed to load configuration', true, {
 							context: {configPath},
 							error: formatError(err),
 						});
+						setConfigCorrupted(true);
+						setError(
+							`Configuration file has invalid JSON and cannot be loaded. ` +
+								`Fix the syntax error or delete the file before proceeding. ` +
+								`File: ${configPath}`,
+						);
 					}
 				}
 			} catch (err) {
@@ -126,6 +134,12 @@ export function BaseConfigWizard<T>({
 
 	const writeConfigToDisk = (data: T): void => {
 		if (!hasItems(data)) return;
+		if (configCorrupted) {
+			throw new Error(
+				'Cannot save: the existing configuration file contains invalid JSON. ' +
+					'Fix the syntax error or delete the file before saving.',
+			);
+		}
 		const config = buildConfig(data);
 		const configDir = dirname(configPath);
 		if (!existsSync(configDir)) {
@@ -167,6 +181,8 @@ export function BaseConfigWizard<T>({
 				unlinkSync(configPath);
 				logInfo(`Deleted configuration file: ${configPath}`);
 			}
+			setConfigCorrupted(false);
+			setError(null);
 			onComplete(configPath);
 		} catch (err) {
 			setError(
@@ -178,7 +194,11 @@ export function BaseConfigWizard<T>({
 
 	const openInEditor = () => {
 		try {
-			writeConfigToDisk(items);
+			// Skip writing when config is corrupted — open the existing
+			
+			if (!configCorrupted) {
+				writeConfigToDisk(items);
+			}
 
 			const editor = detectEditor();
 
@@ -196,6 +216,7 @@ export function BaseConfigWizard<T>({
 						const editedContent = readFileSync(configPath, 'utf-8');
 						const editedRaw = JSON.parse(editedContent) as unknown;
 						setItems(parseConfig(editedRaw));
+						setConfigCorrupted(false);
 					} catch (parseErr) {
 						setError(
 							parseErr instanceof Error


### PR DESCRIPTION
## Description

When a configuration file contained invalid JSON, the wizard silently treated it as empty and allowed the user to proceed through setup, potentially overwriting their existing (albeit broken) config.

The fix:
- Surfaces the JSON parse error to the user via the wizard's error banner, explaining that the file has invalid syntax.
- Tracks a configCorrupted flag that blocks writeConfigToDisk from silently overwriting the broken file.
- When the user opens the editor (Ctrl+E), the existing broken file is opened directly so they can fix the JSON syntax.
- When the editor saves valid JSON, or when the user deletes the config file, the corruption flag is cleared and normal operation resumes.

Closes #551

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
