### PR TITLE
fix: Move stop handler setup before starting resources and wrap lockfile write in try/catch that calls stop() on failure.

### DIFF
--- a/source/daemon/daemon.ts
+++ b/source/daemon/daemon.ts
@@ -179,16 +179,6 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 		cron.register(sub.filter.cron);
 	}
 
-	await watcher.start();
-	await ipcServer.start();
-
-	await writeLockfile({
-		pid: process.pid,
-		socketPath: getSocketPath(opts.projectRoot),
-		startedAt: Date.now(),
-		projectRoot: opts.projectRoot,
-	});
-
 	let stopPromise: Promise<void> | null = null;
 	const stop = (): Promise<void> => {
 		// Idempotent: subsequent callers get the in-flight Promise so they
@@ -204,6 +194,21 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 		return stopPromise;
 	};
 	stopHandler.fn = stop;
+
+	await watcher.start();
+	await ipcServer.start();
+
+	try {
+		await writeLockfile({
+			pid: process.pid,
+			socketPath: getSocketPath(opts.projectRoot),
+			startedAt: Date.now(),
+			projectRoot: opts.projectRoot,
+		});
+	} catch (err) {
+		await stop();
+		throw err;
+	}
 
 	// Signal handling lives in the daemon's process entry point
 	// (source/daemon/entry.ts). Registering handlers here too would race


### PR DESCRIPTION
## Description

Fixes a resource leak in the daemon startup sequence. When `writeLockfile()` fails (due to permissions, disk issues, etc.) after the file watcher and IPC server have already started, the resources were not cleaned up because the shutdown handler was registered after the lockfile write operation.

Changes - `source/daemon/daemon.ts`: Moved `stop` function definition and `stopHandler.fn` assignment before `watcher.start()` and `ipcServer.start()`. Added try/catch around `writeLockfile()` that calls `await stop()` on failure before re-throwing.

Closes #549 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
