### PR TITLE
Adds "done and save" shortcut while selecting more models

### DIFF
--- a/source/wizards/steps/provider-step.tsx
+++ b/source/wizards/steps/provider-step.tsx
@@ -41,6 +41,8 @@ interface TemplateOption {
 	value: string;
 }
 
+const DONE_SHORTCUT_KEY = 'd';
+
 /**
  * Find the best matching template for an existing provider config.
  * Match by id, name, or baseUrl — then fall back to custom.
@@ -507,7 +509,9 @@ export function ProviderStep({
 		if (
 			mode === 'template-selection' &&
 			providers.length > 0 &&
-			input.toLowerCase() === 'd' &&
+			typeof input === 'string' &&
+			input.length > 0 &&
+			input.toLowerCase() === DONE_SHORTCUT_KEY &&
 			!key.ctrl &&
 			!key.meta
 		) {
@@ -619,7 +623,7 @@ export function ProviderStep({
 				{providers.length > 0 && (
 					<Box marginTop={1}>
 						<Text color={colors.success}>
-							Done is always available: press d
+							Done is always available: press {DONE_SHORTCUT_KEY}
 						</Text>
 					</Box>
 				)}

--- a/source/wizards/steps/provider-step.tsx
+++ b/source/wizards/steps/provider-step.tsx
@@ -155,13 +155,11 @@ export function ProviderStep({
 					{label: 'Add custom provider manually', value: 'custom'},
 				];
 
-	const getTemplateOptions = (): TemplateOption[] => [
-		...PROVIDER_TEMPLATES.map(template => ({
+	const getTemplateOptions = (): TemplateOption[] =>
+		PROVIDER_TEMPLATES.map(template => ({
 			label: template.name,
 			value: template.id,
-		})),
-		...(providers.length > 0 ? [{label: 'Done & Save', value: 'done'}] : []),
-	];
+		}));
 
 	const editOptions: TemplateOption[] = providers.map((provider, index) => ({
 		label: provider.name,
@@ -190,11 +188,6 @@ export function ProviderStep({
 	};
 
 	const handleTemplateSelect = (item: TemplateOption) => {
-		if (item.value === 'done') {
-			onComplete(providers);
-			return;
-		}
-
 		// Adding new provider
 		const template = PROVIDER_TEMPLATES.find(t => t.id === item.value);
 		if (template) {
@@ -509,7 +502,19 @@ export function ProviderStep({
 		setMode('field-input');
 	};
 
-	useInput((_input, key) => {
+	useInput((input, key) => {
+		// "Done & Save" shortcut
+		if (
+			mode === 'template-selection' &&
+			providers.length > 0 &&
+			input.toLowerCase() === 'd' &&
+			!key.ctrl &&
+			!key.meta
+		) {
+			onComplete(providers);
+			return;
+		}
+
 		// Handle Shift+Tab for going back
 		if (key.shift && key.tab) {
 			if (mode === 'field-input') {
@@ -611,6 +616,13 @@ export function ProviderStep({
 					items={getTemplateOptions()}
 					onSelect={(item: TemplateOption) => handleTemplateSelect(item)}
 				/>
+				{providers.length > 0 && (
+					<Box marginTop={1}>
+						<Text color={colors.success}>
+							Done is always available: press d
+						</Text>
+					</Box>
+				)}
 			</Box>
 		);
 	}


### PR DESCRIPTION
## Description

Adds done and save shortcut  and removes the redundant from the list.
fixes #559 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<img width="359" height="370" alt="image" src="https://github.com/user-attachments/assets/d182a35d-91e5-4848-b0a5-19900eb3ec31" />

You can now press 'd' and save the models added immediately

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

**Assisted using nanocoder XD  / copilot for greps (finding code)**
