### PR TITLE
fix(wizard): show model names in selection list

### DIFF
--- a/source/wizards/steps/model-selection-list.spec.tsx
+++ b/source/wizards/steps/model-selection-list.spec.tsx
@@ -94,10 +94,9 @@ test('slash enters search mode and typing filters models', async t => {
 	const output = lastFrame() || '';
 	t.regex(output, /Search models: claude/);
 	t.regex(output, /1-1\/1 models \| filter: claude/);
-	t.regex(output, /anthropic\/claude-sonnet-4/);
-	t.notRegex(output, /Claude Sonnet 4/);
-	t.notRegex(output, /openai\/gpt-4o/);
-	t.notRegex(output, /google\/gemini-pro/);
+	t.regex(output, /Claude Sonnet 4 — anthropic\/claude-sonnet-4/);
+	t.notRegex(output, /GPT-4o — openai\/gpt-4o/);
+	t.notRegex(output, /Gemini Pro — google\/gemini-pro/);
 
 	unmount();
 });
@@ -203,5 +202,19 @@ test('m triggers manual entry callback', async t => {
 	await wait();
 
 	t.is(manualEntryCalls, 1);
+	unmount();
+});
+
+test('renders model name alongside id when available', t => {
+	const models: FetchedModel[] = [
+		{id: 'openai/gpt-4o', name: 'GPT-4o'},
+		{id: 'ollama/llama3.1', name: 'ollama/llama3.1'},
+	];
+	const {lastFrame, unmount} = renderList({models});
+	const output = lastFrame() || '';
+
+	t.regex(output, /GPT-4o — openai\/gpt-4o/);
+	t.regex(output, /ollama\/llama3\.1/);
+
 	unmount();
 });

--- a/source/wizards/steps/model-selection-list.tsx
+++ b/source/wizards/steps/model-selection-list.tsx
@@ -183,7 +183,9 @@ export function ModelSelectionList({
 								bold={isHighlighted}
 							>
 								{isHighlighted ? '❯' : ' '} {isSelected ? '[✓]' : '[ ]'}{' '}
-								{model.id}
+								{model.name === model.id
+									? model.id
+									: `${model.name} — ${model.id}`}
 							</Text>
 						);
 					})


### PR DESCRIPTION
## Description

Adds human-readable model names to the provider wizard's model selection list while keeping the canonical model id visible. This makes long model lists easier to scan without forcing users to rely on raw ids alone.

Fixes #560.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
