### PR TITLE
fix(wizard): show friendly model labels in picker

### DIFF
--- a/source/wizards/steps/model-selection-list.spec.tsx
+++ b/source/wizards/steps/model-selection-list.spec.tsx
@@ -94,8 +94,8 @@ test('slash enters search mode and typing filters models', async t => {
 	const output = lastFrame() || '';
 	t.regex(output, /Search models: claude/);
 	t.regex(output, /1-1\/1 models \| filter: claude/);
-	t.regex(output, /anthropic\/claude-sonnet-4/);
-	t.notRegex(output, /Claude Sonnet 4/);
+	t.regex(output, /Claude Sonnet 4 — anthropic\/claude-sonnet-4/);
+	t.notRegex(output, /GPT-4o/);
 	t.notRegex(output, /openai\/gpt-4o/);
 	t.notRegex(output, /google\/gemini-pro/);
 
@@ -188,6 +188,19 @@ test('renders error for empty selection', t => {
 	});
 
 	t.regex(lastFrame() || '', /Please select at least one model/);
+	unmount();
+});
+
+test('shows friendly model names alongside ids when available', t => {
+	const models: FetchedModel[] = [
+		{id: 'openai/gpt-4o', name: 'GPT-4o'},
+		{id: 'ollama/qwen3', name: 'ollama/qwen3'},
+	];
+	const {lastFrame, unmount} = renderList({models});
+
+	t.regex(lastFrame() || '', /GPT-4o — openai\/gpt-4o/);
+	t.regex(lastFrame() || '', /ollama\/qwen3/);
+
 	unmount();
 });
 

--- a/source/wizards/steps/model-selection-list.tsx
+++ b/source/wizards/steps/model-selection-list.tsx
@@ -176,14 +176,17 @@ export function ModelSelectionList({
 						const actualIndex = scrollStart + index;
 						const isHighlighted = actualIndex === highlightedIndex;
 						const isSelected = selectedIds.has(model.id);
+						const label =
+							model.name !== model.id
+								? `${model.name} — ${model.id}`
+								: model.id;
 						return (
 							<Text
 								key={model.id}
 								color={isHighlighted ? colors.primary : colors.text}
 								bold={isHighlighted}
 							>
-								{isHighlighted ? '❯' : ' '} {isSelected ? '[✓]' : '[ ]'}{' '}
-								{model.id}
+								{isHighlighted ? '❯' : ' '} {isSelected ? '[✓]' : '[ ]'} {label}
 							</Text>
 						);
 					})


### PR DESCRIPTION
## Description

Fixes #560 by making the setup wizard's model picker show provider-friendly model names alongside raw model ids when both are available.

This keeps the existing scroll/search selection flow, but makes large model lists much easier to scan.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Ran locally:
- `npx --yes pnpm@11.0.9 test:ava source/wizards/steps/model-selection-list.spec.tsx`
- `npx --yes pnpm@11.0.9 exec biome check source/wizards/steps/model-selection-list.tsx source/wizards/steps/model-selection-list.spec.tsx`
- `npx --yes pnpm@11.0.9 exec tsc --noEmit`

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
