### PR TITLE
feat: add keyboard selection for slash completions

### DIFF
--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -94,10 +94,12 @@ export default function UserInput({
 		showClearMessage,
 		showCompletions,
 		completions,
+		selectedCompletionIndex,
 		pendingFileMentions,
 		setShowClearMessage,
 		setShowCompletions,
 		setCompletions,
+		setSelectedCompletionIndex,
 		setPendingFileMentions,
 		resetUIState,
 	} = uiState;
@@ -208,11 +210,19 @@ export default function UserInput({
 		if (commandCompletions.length > 0) {
 			setCompletions(commandCompletions);
 			setShowCompletions(true);
+			setSelectedCompletionIndex(0);
 		} else if (showCompletions) {
 			setCompletions([]);
 			setShowCompletions(false);
+			setSelectedCompletionIndex(0);
 		}
-	}, [commandCompletions, showCompletions, setCompletions, setShowCompletions]);
+	}, [
+		commandCompletions,
+		showCompletions,
+		setCompletions,
+		setSelectedCompletionIndex,
+		setShowCompletions,
+	]);
 
 	// Helper functions
 
@@ -261,6 +271,30 @@ export default function UserInput({
 		input,
 		currentState,
 		setInputState,
+	]);
+
+	const handleCommandSelection = useCallback(() => {
+		if (!showCompletions || completions.length === 0) {
+			return false;
+		}
+
+		const completion = completions[selectedCompletionIndex] ?? completions[0];
+		setInputState({
+			displayValue: `/${completion.name}`,
+			placeholderContent: currentState.placeholderContent,
+		});
+		setShowCompletions(false);
+		setSelectedCompletionIndex(0);
+		setTextInputKey(prev => prev + 1);
+		return true;
+	}, [
+		showCompletions,
+		completions,
+		selectedCompletionIndex,
+		setInputState,
+		currentState.placeholderContent,
+		setShowCompletions,
+		setSelectedCompletionIndex,
 	]);
 
 	// Handle form submission
@@ -400,6 +434,11 @@ export default function UserInput({
 
 		// Handle special keys
 		if (key.escape) {
+			if (showCompletions) {
+				setShowCompletions(false);
+				setSelectedCompletionIndex(0);
+				return;
+			}
 			handleEscape();
 			return;
 		}
@@ -446,6 +485,10 @@ export default function UserInput({
 			}
 		}
 
+		if (key.return && showCompletions && completions.length > 0) {
+			if (handleCommandSelection()) return;
+		}
+
 		// Space exits file autocomplete mode
 		if (inputChar === ' ' && isFileAutocompleteMode) {
 			setIsFileAutocompleteMode(false);
@@ -476,6 +519,13 @@ export default function UserInput({
 
 		// Handle navigation
 		if (key.upArrow) {
+			if (showCompletions && completions.length > 0) {
+				setSelectedCompletionIndex(prev =>
+					prev > 0 ? prev - 1 : completions.length - 1,
+				);
+				return;
+			}
+
 			// File autocomplete navigation takes priority
 			if (isFileAutocompleteMode && fileCompletions.length > 0) {
 				setSelectedFileIndex(prev =>
@@ -488,6 +538,13 @@ export default function UserInput({
 		}
 
 		if (key.downArrow) {
+			if (showCompletions && completions.length > 0) {
+				setSelectedCompletionIndex(prev =>
+					prev < completions.length - 1 ? prev + 1 : 0,
+				);
+				return;
+			}
+
 			// File autocomplete navigation takes priority
 			if (isFileAutocompleteMode && fileCompletions.length > 0) {
 				setSelectedFileIndex(prev =>
@@ -580,9 +637,17 @@ export default function UserInput({
 					{completions.map((completion, index) => (
 						<Text
 							key={index}
-							color={completion.isCustom ? colors.info : colors.primary}
+							color={
+								index === selectedCompletionIndex
+									? colors.info
+									: completion.isCustom
+										? colors.info
+										: colors.primary
+							}
+							bold={index === selectedCompletionIndex}
 						>
-							/{completion.name}
+							{index === selectedCompletionIndex ? '▸ ' : '  '}/
+							{completion.name}
 						</Text>
 					))}
 				</Box>

--- a/source/hooks/useUIState.spec.ts
+++ b/source/hooks/useUIState.spec.ts
@@ -38,9 +38,11 @@ test('UIStateProvider provides initial state', t => {
 	t.is(capturedState!.showClearMessage, false);
 	t.is(capturedState!.showCompletions, false);
 	t.deepEqual(capturedState!.completions, []);
+	t.is(capturedState!.selectedCompletionIndex, 0);
 	t.is(typeof capturedState!.setShowClearMessage, 'function');
 	t.is(typeof capturedState!.setShowCompletions, 'function');
 	t.is(typeof capturedState!.setCompletions, 'function');
+	t.is(typeof capturedState!.setSelectedCompletionIndex, 'function');
 	t.is(typeof capturedState!.resetUIState, 'function');
 });
 
@@ -173,6 +175,7 @@ test('resetUIState resets all state to initial values', t => {
 		{name: 'test1', isCustom: false},
 		{name: 'test2', isCustom: true},
 	]);
+	capturedState!.setSelectedCompletionIndex(1);
 
 	rerender(
 		React.createElement(
@@ -189,6 +192,7 @@ test('resetUIState resets all state to initial values', t => {
 	t.is(capturedState!.showClearMessage, true);
 	t.is(capturedState!.showCompletions, true);
 	t.is(capturedState!.completions.length, 2);
+	t.is(capturedState!.selectedCompletionIndex, 1);
 
 	// Reset the state
 	capturedState!.resetUIState();
@@ -207,6 +211,7 @@ test('resetUIState resets all state to initial values', t => {
 	t.is(capturedState!.showClearMessage, false);
 	t.is(capturedState!.showCompletions, false);
 	t.deepEqual(capturedState!.completions, []);
+	t.is(capturedState!.selectedCompletionIndex, 0);
 });
 
 test('UIStateProvider state updates are independent across renders', t => {

--- a/source/hooks/useUIState.ts
+++ b/source/hooks/useUIState.ts
@@ -11,10 +11,12 @@ type UIState = {
 	showClearMessage: boolean;
 	showCompletions: boolean;
 	completions: Completion[];
+	selectedCompletionIndex: number;
 	pendingFileMentions: string[];
 	setShowClearMessage: React.Dispatch<React.SetStateAction<boolean>>;
 	setShowCompletions: React.Dispatch<React.SetStateAction<boolean>>;
 	setCompletions: React.Dispatch<React.SetStateAction<Completion[]>>;
+	setSelectedCompletionIndex: React.Dispatch<React.SetStateAction<number>>;
 	setPendingFileMentions: React.Dispatch<React.SetStateAction<string[]>>;
 	resetUIState: () => void;
 };
@@ -26,12 +28,14 @@ function useUIState(): UIState {
 	const [showClearMessage, setShowClearMessage] = useState(false);
 	const [showCompletions, setShowCompletions] = useState(false);
 	const [completions, setCompletions] = useState<Completion[]>([]);
+	const [selectedCompletionIndex, setSelectedCompletionIndex] = useState(0);
 	const [pendingFileMentions, setPendingFileMentions] = useState<string[]>([]);
 
 	const resetUIState = useCallback(() => {
 		setShowClearMessage(false);
 		setShowCompletions(false);
 		setCompletions([]);
+		setSelectedCompletionIndex(0);
 		setPendingFileMentions([]);
 	}, []);
 
@@ -40,10 +44,12 @@ function useUIState(): UIState {
 			showClearMessage,
 			showCompletions,
 			completions,
+			selectedCompletionIndex,
 			pendingFileMentions,
 			setShowClearMessage,
 			setShowCompletions,
 			setCompletions,
+			setSelectedCompletionIndex,
 			setPendingFileMentions,
 			resetUIState,
 		}),
@@ -51,6 +57,7 @@ function useUIState(): UIState {
 			showClearMessage,
 			showCompletions,
 			completions,
+			selectedCompletionIndex,
 			pendingFileMentions,
 			resetUIState,
 		],


### PR DESCRIPTION
## Summary
- Track the selected slash-command completion in shared UI state
- Use Up/Down to move through visible slash completions with wraparound
- Use Enter to fill the selected command into the input
- Use Escape to dismiss the completion list without triggering the clear-input prompt
- Highlight the selected completion with the same marker pattern as file suggestions

## Why
The slash completion menu was display-only unless there was exactly one match. When multiple commands matched, users could not navigate the menu or select a highlighted command with Enter, even though the UI already showed a completion list.

This implements the keyboard-selection behavior requested in #575 while preserving existing file-autocomplete priority.

## Testing
- `npm run test:types`
- `npx ava source/hooks/useUIState.spec.ts source/components/user-input.spec.tsx --timeout=60s`
- `npm run test:format -- source/hooks/useUIState.ts source/hooks/useUIState.spec.ts source/components/user-input.tsx source/components/user-input.spec.tsx`
- `git diff --check`

Note: `test:format` reports existing Biome config schema/deprecation infos, but no formatting errors after this change.
