### PR TITLE
fix: replace console.log with structured logger in message-queue.tsx

### DIFF
--- a/source/utils/message-queue.spec.tsx
+++ b/source/utils/message-queue.spec.tsx
@@ -1,5 +1,6 @@
 import test from 'ava';
 import React from 'react';
+import {getLogger} from './logging';
 import {
 	addToMessageQueue,
 	checkMessageQueueHealth,
@@ -33,6 +34,28 @@ function spy<T extends unknown[] = unknown[]>(): CallSpy<T> {
 test.beforeEach(() => {
 	resetMessageQueueStats();
 });
+
+test.serial(
+	'addToMessageQueue logs a warning when no queue has been registered yet',
+	t => {
+		const logger = getLogger();
+		const warn = spy<[string | object, ...unknown[]]>();
+		const originalWarn = logger.warn;
+		logger.warn = warn as typeof logger.warn;
+
+		try {
+			addToMessageQueue(React.createElement('div'));
+		} finally {
+			logger.warn = originalWarn;
+		}
+
+		t.is(warn.calls.length, 1);
+		t.is(
+			warn.calls[0][0],
+			'[message-queue] Queue not available, component not added',
+		);
+	},
+);
 
 test.serial('addToMessageQueue is a no-op when no queue is registered', t => {
 	setGlobalMessageQueue(() => {});

--- a/source/utils/message-queue.tsx
+++ b/source/utils/message-queue.tsx
@@ -80,7 +80,7 @@ let messageStats: MessageQueueStats = {
 // Add a React component directly to the queue
 export function addToMessageQueue(component: React.ReactNode) {
 	if (!globalAddToChatQueue) {
-		console.log('[message-queue] Queue not available, component not added');
+		logger.warn('[message-queue] Queue not available, component not added');
 		return;
 	}
 	globalAddToChatQueue(component);


### PR DESCRIPTION
## Description
Replaces a direct `console.log()` call in `addToMessageQueue` (`source/utils/message-queue.tsx`) with the structured logger that's already used elsewhere in the same file, logged at `warn` level since a missing queue handler indicates a real wiring problem.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
### Automated Tests
- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Added a regression test in `message-queue.spec.tsx` covering the previously-untested branch: when `addToMessageQueue` is called before `setGlobalMessageQueue`, it now logs a warning via the structured logger instead of `console.log`. Ran `pnpm exec ava source/utils/message-queue.spec.tsx` locally — all 13 tests in the file pass, including the new one and the existing ones (unmodified).

I wasn't able to run the full `pnpm test:all` locally due to a Windows-specific shell-script issue in my environment unrelated to this change (the test runner script invokes a bash script that doesn't resolve cleanly with `cmd.exe`/PowerShell on Windows). Happy to address anything CI surfaces.

### Manual Testing
- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Not applicable — this change is isolated to a logging fallback path and doesn't touch provider integration.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

Fixes #582