### PR TITLE
Add Requesty provider

### DIFF
--- a/docs/configuration/providers/index.md
+++ b/docs/configuration/providers/index.md
@@ -37,6 +37,7 @@ Run on your machine, typically no API key required.
 Hosted services using the OpenAI-compatible API format.
 
 - [OpenRouter](openrouter.md) - Unified API for multiple AI providers
+- [Requesty](requesty.md) - OpenAI-compatible LLM router for multiple AI providers
 - [OpenAI](openai.md) - GPT models via OpenAI's API
 - [Mistral AI](mistral.md) - Mistral and Codestral models
 - [GitHub Models](github-models.md) - AI models via GitHub's marketplace

--- a/docs/configuration/providers/requesty.md
+++ b/docs/configuration/providers/requesty.md
@@ -1,0 +1,34 @@
+---
+title: "Requesty"
+description: "Configure Requesty as a cloud AI provider for Nanocoder"
+sidebar_order: 18
+---
+
+# Requesty
+
+[Requesty](https://requesty.ai) is an OpenAI-compatible LLM router that gives you a single endpoint and API key to access models from OpenAI, Anthropic, Google, Meta, and many other providers. Because it speaks the OpenAI Chat Completions API, it works as a drop-in coding provider for Nanocoder.
+
+## Configuration
+
+```json
+{
+	"name": "Requesty",
+	"baseUrl": "https://router.requesty.ai/v1",
+	"apiKey": "${REQUESTY_API_KEY}",
+	"models": ["openai/gpt-4o-mini"]
+}
+```
+
+## Setup
+
+1. Create an account at [requesty.ai](https://requesty.ai)
+2. Generate an API key from the [API keys page](https://app.requesty.ai/api-keys)
+3. Browse available models in the [model list](https://app.requesty.ai/router/list)
+
+Model names follow the `provider/model-name` format, e.g. `openai/gpt-4o-mini` or `anthropic/claude-3.5-sonnet`.
+
+## Fetching Available Models
+
+The `/setup-providers` wizard can automatically fetch available models from your Requesty account.
+
+See the [Requesty documentation](https://docs.requesty.ai) for the full model catalog and routing options.

--- a/source/ai-sdk-client/providers/provider-factory.spec.ts
+++ b/source/ai-sdk-client/providers/provider-factory.spec.ts
@@ -45,6 +45,24 @@ test('createProvider adds OpenRouter headers for openrouter provider', async t =
 	t.truthy(provider);
 });
 
+test('createProvider adds Requesty headers for requesty provider', async t => {
+	const config: AIProviderConfig = {
+		name: 'Requesty',
+		type: 'openai',
+		models: ['openai/gpt-4o-mini'],
+		config: {
+			baseURL: 'https://router.requesty.ai/v1',
+			apiKey: 'test-key',
+		},
+	};
+
+	const agent = new Agent();
+	const provider = await createProvider(config, agent);
+
+	t.truthy(provider);
+	t.is(provider.kind, 'openai-compatible');
+});
+
 test('createProvider handles provider with no API key', async t => {
 	const config: AIProviderConfig = {
 		name: 'TestProvider',

--- a/source/ai-sdk-client/providers/provider-factory.ts
+++ b/source/ai-sdk-client/providers/provider-factory.ts
@@ -30,6 +30,7 @@ import {
 import type {AIProviderConfig} from '@/types/index';
 import {getLogger} from '@/utils/logging';
 import {isOpenRouterProvider} from './openrouter.js';
+import {isRequestyProvider} from './requesty.js';
 
 /**
  * Discriminated union pairing each underlying SDK provider with its `kind`.
@@ -273,6 +274,13 @@ export async function createProvider(
 	// Add OpenRouter-specific headers for app attribution
 	const headers: Record<string, string> = config.headers ?? {};
 	if (isOpenRouterProvider(providerConfig.name)) {
+		headers['HTTP-Referer'] = 'https://github.com/Nano-Collective/nanocoder';
+		headers['X-Title'] = 'Nanocoder';
+	}
+
+	// Requesty (https://requesty.ai) is an OpenAI-compatible router and uses
+	// the same app-attribution headers as OpenRouter.
+	if (isRequestyProvider(providerConfig.name)) {
 		headers['HTTP-Referer'] = 'https://github.com/Nano-Collective/nanocoder';
 		headers['X-Title'] = 'Nanocoder';
 	}

--- a/source/ai-sdk-client/providers/requesty.ts
+++ b/source/ai-sdk-client/providers/requesty.ts
@@ -1,0 +1,16 @@
+/**
+ * Single source of truth for "is this a Requesty provider?". Used by:
+ *   - provider-factory.ts to attach Requesty attribution headers
+ *
+ * Matching by `name` (case-insensitive) keeps configuration simple — users
+ * just name the provider "requesty" / "Requesty" / "REQUESTY" and everything
+ * Requesty-specific lights up. Mirrors `isOpenRouterProvider`.
+ *
+ * Requesty (https://requesty.ai) is an OpenAI-compatible router, so it flows
+ * through the generic `openai-compatible` SDK path with a fixed base URL
+ * (https://router.requesty.ai/v1) and provider/model naming like OpenRouter
+ * (e.g. `openai/gpt-4o-mini`).
+ */
+export function isRequestyProvider(providerName: string): boolean {
+	return providerName.toLowerCase() === 'requesty';
+}

--- a/source/wizards/templates/provider-templates.spec.ts
+++ b/source/wizards/templates/provider-templates.spec.ts
@@ -451,6 +451,42 @@ test('atlas-cloud template: uses default provider name when empty', t => {
 	t.is(config.name, 'Atlas Cloud');
 });
 
+test('requesty template: sets baseUrl, default model, and parses models', t => {
+	const template = PROVIDER_TEMPLATES.find(t => t.id === 'requesty');
+	t.truthy(template);
+
+	const config = template!.buildConfig({
+		providerName: 'Requesty',
+		apiKey: 'test-key',
+		model: 'openai/gpt-4o-mini, anthropic/claude-3.5-sonnet',
+	});
+
+	t.is(config.name, 'Requesty');
+	t.is(config.baseUrl, 'https://router.requesty.ai/v1');
+	t.is(config.apiKey, 'test-key');
+	t.is(config.sdkProvider, undefined);
+	t.deepEqual(config.models, [
+		'openai/gpt-4o-mini',
+		'anthropic/claude-3.5-sonnet',
+	]);
+});
+
+test('requesty template: uses default provider name and model default', t => {
+	const template = PROVIDER_TEMPLATES.find(t => t.id === 'requesty');
+	t.truthy(template);
+
+	const modelField = template!.fields.find(f => f.name === 'model');
+	t.is(modelField?.default, 'openai/gpt-4o-mini');
+
+	const config = template!.buildConfig({
+		providerName: '',
+		apiKey: 'test-key',
+		model: 'openai/gpt-4o-mini',
+	});
+
+	t.is(config.name, 'Requesty');
+});
+
 // ============================================================================
 // Tests for template ID vs sdkProvider collision prevention
 // Providers that use sdkProvider: 'anthropic' (like MiniMax, Kimi) must not

--- a/source/wizards/templates/provider-templates.ts
+++ b/source/wizards/templates/provider-templates.ts
@@ -409,6 +409,13 @@ export const PROVIDER_TEMPLATES: ProviderTemplate[] = [
 			return config;
 		},
 	},
+	apiKeyTemplate({
+		id: 'requesty',
+		name: 'Requesty',
+		baseUrl: 'https://router.requesty.ai/v1',
+		apiKeyPrompt: 'API Key (from https://app.requesty.ai/api-keys)',
+		modelDefault: 'openai/gpt-4o-mini',
+	}),
 	{
 		id: 'openai',
 		name: 'OpenAI',


### PR DESCRIPTION
## Summary

Adds [Requesty](https://requesty.ai) as a first-class, OpenAI-compatible provider, mirroring the existing OpenRouter integration as closely as possible. Requesty is an OpenAI-compatible LLM router (single endpoint + key, `provider/model` naming like OpenRouter), so it flows through the generic `@ai-sdk/openai-compatible` path already used by the factory — no new heavy dependency is added.

## Files changed

Code:
- `source/ai-sdk-client/providers/requesty.ts` — new `isRequestyProvider()` name matcher, mirroring `isOpenRouterProvider()`.
- `source/ai-sdk-client/providers/provider-factory.ts` — attaches app-attribution headers (`HTTP-Referer` / `X-Title`) for the Requesty provider, mirroring the OpenRouter branch; requests use the existing `openai-compatible` SDK path with base URL `https://router.requesty.ai/v1`.
- `source/wizards/templates/provider-templates.ts` — Requesty onboarding template (base URL `https://router.requesty.ai/v1`, API key prompt linking the keys page, default model `openai/gpt-4o-mini`).

Tests:
- `source/ai-sdk-client/providers/provider-factory.spec.ts` — asserts the Requesty provider resolves through the `openai-compatible` kind.
- `source/wizards/templates/provider-templates.spec.ts` — covers the Requesty wizard template (base URL, default model, model parsing, default provider name).

Docs:
- `docs/configuration/providers/requesty.md` — new dedicated provider page (config, setup, model naming, links to requesty.ai / app.requesty.ai / docs.requesty.ai).
- `docs/configuration/providers/index.md` — Requesty added to the Cloud Providers list.

## Verification

- `pnpm run test:types` (`tsc --noEmit`) — passes.
- `pnpm run test:ava` for the two affected specs — 52 tests pass (including the new Requesty cases).
- Biome pre-commit hook (`biome check --write`) — clean.
- Live test: loaded `REQUESTY_API_KEY`, `GET https://router.requesty.ai/v1/models` returned `200`, and a `POST /v1/chat/completions` with `openai/gpt-4o-mini` returned a real completion (`finish_reason: stop`).

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it is not a fit.
