### PR TITLE
feat: queue user messages while busy

### DIFF
--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -38,8 +38,10 @@ import {useSessionAutosave} from '@/hooks/useSessionAutosave';
 import {ThemeContext} from '@/hooks/useTheme';
 import {TitleShapeContext, updateTitleShape} from '@/hooks/useTitleShape';
 import {UIStateProvider} from '@/hooks/useUIState';
+import {useUserMessageQueue} from '@/hooks/useUserMessageQueue';
 import {useVSCodeServer} from '@/hooks/useVSCodeServer';
 import {generateKey} from '@/session/key-generator';
+import type {ImageAttachment} from '@/types/core';
 import type {ThemePreset} from '@/types/ui';
 import {createPinoLogger} from '@/utils/logging/pino-logger';
 import {setGlobalMessageQueue} from '@/utils/message-queue';
@@ -75,6 +77,15 @@ export default function App({
 
 	// Use extracted hooks
 	const appState = useAppState(initialDevelopmentMode);
+	const userMessageQueue = useUserMessageQueue();
+	const queuedUserSubmitRef = React.useRef<
+		| ((
+				message: string,
+				displayValue: string,
+				images?: ImageAttachment[],
+		  ) => Promise<void>)
+		| null
+	>(null);
 	const {exit} = useApp();
 	const {isTrusted, handleConfirmTrust, isTrustLoading, isTrustedError} =
 		useDirectoryTrust();
@@ -159,6 +170,28 @@ export default function App({
 		}
 	}, []);
 
+	const drainQueuedUserMessage = React.useCallback(() => {
+		queueMicrotask(() => {
+			void userMessageQueue.drainNextMessage(async message => {
+				const submitQueuedMessage = queuedUserSubmitRef.current;
+				if (!submitQueuedMessage || !appState.client || !appState.toolManager) {
+					return false;
+				}
+
+				await submitQueuedMessage(
+					message.message,
+					message.displayValue,
+					message.images,
+				);
+				return true;
+			});
+		});
+	}, [
+		appState.client,
+		appState.toolManager,
+		userMessageQueue.drainNextMessage,
+	]);
+
 	// Setup chat handler
 	const chatHandler = useChatHandler({
 		client: appState.client,
@@ -180,6 +213,7 @@ export default function App({
 			appState.setCompactToolCounts(null);
 			appState.compactToolCountsRef.current = {};
 			appState.setLiveTaskList(null);
+			drainQueuedUserMessage();
 		},
 		reasoningExpandedRef: appState.reasoningExpandedRef,
 		compactToolDisplayRef: appState.compactToolDisplayRef,
@@ -404,6 +438,10 @@ export default function App({
 		activeEditor: vscodeServer.activeEditor,
 	});
 
+	React.useEffect(() => {
+		queuedUserSubmitRef.current = handleUserSubmit;
+	}, [handleUserSubmit]);
+
 	// Setup non-interactive mode
 	const {nonInteractiveLoadingMessage} = useNonInteractiveMode({
 		nonInteractivePrompt,
@@ -605,6 +643,7 @@ export default function App({
 						handleToolConfirmation={handleToolConfirmation}
 						handleQuestionAnswer={handleQuestionAnswer}
 						handleUserSubmit={handleUserSubmit}
+						userMessageQueue={userMessageQueue}
 						handleIdeSelect={handleIdeSelect}
 					/>
 				</UIStateProvider>

--- a/source/app/components/chat-input.spec.tsx
+++ b/source/app/components/chat-input.spec.tsx
@@ -102,6 +102,48 @@ test('ChatInput shows tool execution indicator when executing', t => {
 	unmount();
 });
 
+test('ChatInput keeps UserInput visible while a tool is executing', t => {
+	const mockToolCall = {
+		id: 'test-1',
+		function: {name: 'test_tool', arguments: {}},
+	};
+
+	const props = createDefaultProps({
+		isToolExecuting: true,
+		isBusy: true,
+		inputDisabled: true,
+		pendingToolCalls: [mockToolCall],
+		currentToolIndex: 0,
+	});
+
+	const {lastFrame, unmount} = renderWithTheme(<ChatInput {...props} />);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /hat would you like me to help with\?/);
+	t.regex(output!, /Press Esc to cancel/);
+	unmount();
+});
+
+test('ChatInput keeps modal decision states ahead of busy input', t => {
+	const mockToolCall = {
+		id: 'test-1',
+		function: {name: 'test_tool', arguments: {}},
+	};
+
+	const props = createDefaultProps({
+		isToolExecuting: true,
+		isBusy: true,
+		inputDisabled: true,
+		pendingToolConfirmation: {toolCall: mockToolCall as never},
+	});
+
+	const {lastFrame, unmount} = renderWithTheme(<ChatInput {...props} />);
+	const output = lastFrame();
+	t.truthy(output);
+	t.notRegex(output!, /What would you like me to help with\?/);
+	unmount();
+});
+
 test('ChatInput shows cancelling indicator when cancelling', t => {
 	const props = createDefaultProps({
 		isCancelling: true,

--- a/source/app/components/chat-input.tsx
+++ b/source/app/components/chat-input.tsx
@@ -8,6 +8,10 @@ import ToolConfirmation from '@/components/tool-confirmation';
 import ToolExecutionIndicator from '@/components/tool-execution-indicator';
 import UserInput from '@/components/user-input';
 import {useTheme} from '@/hooks/useTheme';
+import type {
+	QueuedUserMessage,
+	UserMessageQueueDraft,
+} from '@/hooks/useUserMessageQueue';
 import type {Task} from '@/tools/tasks/types';
 import type {
 	ContextSource,
@@ -51,6 +55,9 @@ export interface ChatInputProps {
 	// Input state
 	customCommands: string[];
 	inputDisabled: boolean;
+	queuedMessages?: QueuedUserMessage[];
+	onQueueMessage?: (message: UserMessageQueueDraft) => void;
+	onRemoveQueuedMessage?: (id: string) => void;
 	// True when in-flight work makes Escape a cancel; lets UserInput defer to
 	// the section-level global cancel handler instead of clearing the input.
 	isBusy: boolean;
@@ -108,6 +115,9 @@ export function ChatInput({
 	client,
 	customCommands,
 	inputDisabled,
+	queuedMessages = [],
+	onQueueMessage,
+	onRemoveQueuedMessage,
 	isBusy,
 	developmentMode,
 	contextPercentUsed,
@@ -126,6 +136,12 @@ export function ChatInput({
 	onDismissActiveEditor,
 }: ChatInputProps): React.ReactElement {
 	const {colors} = useTheme();
+	const activeToolCall = pendingToolCalls[currentToolIndex];
+	const showToolExecutionIndicator =
+		isToolExecuting &&
+		activeToolCall &&
+		activeToolCall.function.name !== 'execute_bash' &&
+		activeToolCall.function.name !== 'agent';
 
 	return (
 		<Box flexDirection="column" marginLeft={-1}>
@@ -141,6 +157,14 @@ export function ChatInput({
 
 			{isCancelling && <CancellingIndicator />}
 
+			{showToolExecutionIndicator && (
+				<ToolExecutionIndicator
+					toolName={activeToolCall.function.name}
+					currentIndex={currentToolIndex}
+					totalTools={pendingToolCalls.length}
+				/>
+			)}
+
 			{/* Subagent Tool Approval — takes priority since subagent is blocked */}
 			{pendingSubagentApproval ? (
 				<ToolConfirmation
@@ -155,16 +179,6 @@ export function ChatInput({
 					onConfirm={onToolConfirmation}
 					onCancel={() => onToolConfirmation(false)}
 				/>
-			) : /* Tool Execution - skip indicator for streaming tools (they show their own progress) */
-			isToolExecuting &&
-				pendingToolCalls[currentToolIndex] &&
-				pendingToolCalls[currentToolIndex].function.name !== 'execute_bash' &&
-				pendingToolCalls[currentToolIndex].function.name !== 'agent' ? (
-				<ToolExecutionIndicator
-					toolName={pendingToolCalls[currentToolIndex].function.name}
-					currentIndex={currentToolIndex}
-					totalTools={pendingToolCalls.length}
-				/>
 			) : /* Question Prompt (ask_question tool) */
 			isQuestionMode && pendingQuestion ? (
 				<QuestionPrompt
@@ -178,7 +192,10 @@ export function ChatInput({
 					onSubmit={(msg, display, images) =>
 						void onSubmit(msg, display, images)
 					}
-					disabled={inputDisabled}
+					onQueueMessage={onQueueMessage}
+					queuedMessages={queuedMessages}
+					onRemoveQueuedMessage={onRemoveQueuedMessage}
+					disabled={inputDisabled && !isBusy}
 					isBusy={isBusy}
 					onToggleMode={onToggleMode}
 					onToggleReasoningExpanded={onToggleReasoningExpanded}

--- a/source/app/sections/interactive-app.spec.tsx
+++ b/source/app/sections/interactive-app.spec.tsx
@@ -102,6 +102,16 @@ function makeProps(o: Overrides = {}) {
 		handleToolConfirmation: noop,
 		handleQuestionAnswer: noop,
 		handleUserSubmit: noopAsync,
+		userMessageQueue: {
+			queuedMessages: [],
+			enqueueMessage: () => ({
+				id: 'queued-test',
+				message: '',
+				displayValue: '',
+			}),
+			removeMessage: noop,
+			drainNextMessage: () => false,
+		},
 		handleIdeSelect: noop,
 	} as never;
 }

--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -9,6 +9,7 @@ import type {useChatHandler} from '@/hooks/chat-handler';
 import type {AppHandlers} from '@/hooks/useAppHandlers';
 import type {useAppState} from '@/hooks/useAppState';
 import type {useModeHandlers} from '@/hooks/useModeHandlers';
+import type {useUserMessageQueue} from '@/hooks/useUserMessageQueue';
 import type {useVSCodeServer} from '@/hooks/useVSCodeServer';
 import type {ImageAttachment} from '@/types/core';
 import type {PendingToolApproval} from '@/utils/tool-approval-queue';
@@ -33,6 +34,7 @@ interface InteractiveAppProps {
 		displayValue: string,
 		images?: ImageAttachment[],
 	) => Promise<void>;
+	userMessageQueue: ReturnType<typeof useUserMessageQueue>;
 	handleIdeSelect: (ide: string) => void;
 }
 
@@ -56,6 +58,7 @@ export function InteractiveApp({
 	handleToolConfirmation,
 	handleQuestionAnswer,
 	handleUserSubmit,
+	userMessageQueue,
 	handleIdeSelect,
 }: InteractiveAppProps): React.ReactElement {
 	const handleToggleCompactDisplay = () => {
@@ -181,7 +184,10 @@ export function InteractiveApp({
 						mcpInitialized={appState.mcpInitialized}
 						client={appState.client}
 						customCommands={Array.from(appState.customCommandCache.keys())}
-						inputDisabled={chatHandler.isGenerating || appState.isToolExecuting}
+						inputDisabled={false}
+						queuedMessages={userMessageQueue.queuedMessages}
+						onQueueMessage={userMessageQueue.enqueueMessage}
+						onRemoveQueuedMessage={userMessageQueue.removeMessage}
 						isBusy={cancellable}
 						developmentMode={appState.developmentMode}
 						contextPercentUsed={appState.contextPercentUsed}

--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -31,6 +31,34 @@ const TestWrapper = ({children}: {children: React.ReactNode}) => (
 // Helper for async tests that need proper context and more time
 const wait = async (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));
 
+const waitForCondition = async (
+	condition: () => boolean,
+	timeoutMs = 1000,
+) => {
+	const startedAt = Date.now();
+
+	while (Date.now() - startedAt < timeoutMs) {
+		if (condition()) {
+			return;
+		}
+
+		await wait(25);
+	}
+
+	throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`);
+};
+
+const waitForFrame = async (
+	lastFrame: () => string | undefined,
+	pattern: RegExp,
+	timeoutMs = 1000,
+) => {
+	await waitForCondition(
+		() => pattern.test(lastFrame() ?? ''),
+		timeoutMs,
+	);
+};
+
 // ============================================================================
 // Component Rendering Tests
 // ============================================================================
@@ -183,9 +211,10 @@ test('UserInput queues submitted messages while busy', async t => {
 	);
 
 	stdin.write('queued while busy');
-	await wait(50);
+	await waitForFrame(lastFrame, /queued while busy/);
 	stdin.write('\r');
-	await wait(50);
+	await waitForCondition(() => queuedMessage === 'queued while busy');
+	await waitForCondition(() => !/queued while busy/.test(lastFrame() ?? ''));
 
 	t.is(submittedMessage, '');
 	t.is(queuedMessage, 'queued while busy');
@@ -198,7 +227,7 @@ test('UserInput submits slash commands immediately while busy', async t => {
 	let submittedMessage = '';
 	let queuedMessage = '';
 
-	const {stdin, unmount} = render(
+	const {stdin, lastFrame, unmount} = render(
 		<TestWrapper>
 			<UserInput
 				forceFocus={true}
@@ -214,9 +243,9 @@ test('UserInput submits slash commands immediately while busy', async t => {
 	);
 
 	stdin.write('/help');
-	await wait(50);
+	await waitForFrame(lastFrame, /\/help/);
 	stdin.write('\r');
-	await wait(50);
+	await waitForCondition(() => submittedMessage === '/help');
 
 	t.is(submittedMessage, '/help');
 	t.is(queuedMessage, '');

--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -161,6 +161,191 @@ test('UserInput renders while busy (Escape deferred to global handler)', t => {
 	unmount();
 });
 
+test('UserInput queues submitted messages while busy', async t => {
+	let submittedMessage = '';
+	let queuedMessage = '';
+	let queuedDisplay = '';
+
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput
+				forceFocus={true}
+				isBusy={true}
+				onSubmit={message => {
+					submittedMessage = message;
+				}}
+				onQueueMessage={message => {
+					queuedMessage = message.message;
+					queuedDisplay = message.displayValue;
+				}}
+			/>
+		</TestWrapper>,
+	);
+
+	stdin.write('queued while busy');
+	await wait(50);
+	stdin.write('\r');
+	await wait(50);
+
+	t.is(submittedMessage, '');
+	t.is(queuedMessage, 'queued while busy');
+	t.is(queuedDisplay, 'queued while busy');
+	t.notRegex(lastFrame()!, /queued while busy/);
+	unmount();
+});
+
+test('UserInput submits slash commands immediately while busy', async t => {
+	let submittedMessage = '';
+	let queuedMessage = '';
+
+	const {stdin, unmount} = render(
+		<TestWrapper>
+			<UserInput
+				forceFocus={true}
+				isBusy={true}
+				onSubmit={message => {
+					submittedMessage = message;
+				}}
+				onQueueMessage={message => {
+					queuedMessage = message.message;
+				}}
+			/>
+		</TestWrapper>,
+	);
+
+	stdin.write('/help');
+	await wait(50);
+	stdin.write('\r');
+	await wait(50);
+
+	t.is(submittedMessage, '/help');
+	t.is(queuedMessage, '');
+	unmount();
+});
+
+test('UserInput renders queued messages while busy', t => {
+	const {lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput
+				isBusy={true}
+				queuedMessages={[
+					{
+						id: 'queued-1',
+						message: 'first full message',
+						displayValue: 'first queued message',
+					},
+					{
+						id: 'queued-2',
+						message: 'second full message',
+						displayValue: 'second queued message',
+						images: [{data: 'abc', mediaType: 'image/png'}],
+					},
+				]}
+			/>
+		</TestWrapper>,
+	);
+
+	const output = lastFrame()!;
+	t.regex(output, /Queued messages/);
+	t.regex(output, /first queued message/);
+	t.regex(output, /second queued message/);
+	t.regex(output, /1 image/);
+	unmount();
+});
+
+test('UserInput navigates queued messages while busy with empty input', async t => {
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput
+				forceFocus={true}
+				isBusy={true}
+				queuedMessages={[
+					{id: 'queued-1', message: 'first', displayValue: 'first queued'},
+					{id: 'queued-2', message: 'second', displayValue: 'second queued'},
+				]}
+			/>
+		</TestWrapper>,
+	);
+
+	stdin.write('\u001B[B');
+	await wait(50);
+
+	const output = lastFrame()!;
+	t.regex(output, /▸ first queued/);
+	t.notRegex(output, /▸ second queued/);
+	unmount();
+});
+
+test('UserInput loads selected queued message for editing', async t => {
+	let removedId = '';
+
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput
+				forceFocus={true}
+				isBusy={true}
+				queuedMessages={[
+					{id: 'queued-1', message: 'first', displayValue: 'first queued'},
+					{id: 'queued-2', message: 'second', displayValue: 'second queued'},
+				]}
+				onRemoveQueuedMessage={id => {
+					removedId = id;
+				}}
+			/>
+		</TestWrapper>,
+	);
+
+	stdin.write('\u001B[B');
+	await wait(50);
+	stdin.write('\u001B[B');
+	await wait(50);
+	stdin.write('\r');
+	await wait(50);
+
+	t.is(removedId, 'queued-2');
+	t.regex(lastFrame()!, /second queued/);
+	unmount();
+});
+
+test('UserInput removes selected queued message with Ctrl+Delete', async t => {
+	let removedId = '';
+	const QueueHarness = () => {
+		const [messages, setMessages] = React.useState([
+			{id: 'queued-1', message: 'first', displayValue: 'first queued'},
+			{id: 'queued-2', message: 'second', displayValue: 'second queued'},
+		]);
+
+		return (
+			<UserInput
+				forceFocus={true}
+				isBusy={true}
+				queuedMessages={messages}
+				onRemoveQueuedMessage={id => {
+					removedId = id;
+					setMessages(current =>
+						current.filter(message => message.id !== id),
+					);
+				}}
+			/>
+		);
+	};
+
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<QueueHarness />
+		</TestWrapper>,
+	);
+
+	stdin.write('\u001B[B');
+	await wait(50);
+	stdin.write('\u001B[3;5~');
+	await wait(50);
+
+	t.is(removedId, 'queued-1');
+	t.notRegex(lastFrame()!, /first queued/);
+	unmount();
+});
+
 test('UserInput calls onToggleMode when provided', t => {
 	let toggleCalled = false;
 	const handleToggle = () => {
@@ -595,6 +780,3 @@ test('UserInput does not show completions when input is empty', t => {
 	t.notRegex(output, /Available commands:/);
 	unmount();
 });
-
-
-

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -8,6 +8,10 @@ import {useInputState} from '@/hooks/useInputState';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
 import {useUIStateContext} from '@/hooks/useUIState';
+import type {
+	QueuedUserMessage,
+	UserMessageQueueDraft,
+} from '@/hooks/useUserMessageQueue';
 import {promptHistory} from '@/prompt-history';
 import type {TuneConfig} from '@/types/config';
 import type {
@@ -36,6 +40,9 @@ interface ChatProps {
 		displayValue: string,
 		images?: ImageAttachment[],
 	) => void;
+	onQueueMessage?: (message: UserMessageQueueDraft) => void;
+	queuedMessages?: QueuedUserMessage[];
+	onRemoveQueuedMessage?: (id: string) => void;
 	placeholder?: string;
 	customCommands?: string[]; // List of custom command names and aliases
 	disabled?: boolean; // Disable input when AI is processing
@@ -57,6 +64,9 @@ interface ChatProps {
 
 export default function UserInput({
 	onSubmit,
+	onQueueMessage,
+	queuedMessages = [],
+	onRemoveQueuedMessage,
 	placeholder,
 	customCommands = [],
 	disabled = false,
@@ -94,6 +104,7 @@ export default function UserInput({
 		Array<{path: string; score: number}>
 	>([]);
 	const [selectedFileIndex, setSelectedFileIndex] = useState(0);
+	const [selectedQueuedIndex, setSelectedQueuedIndex] = useState(-1);
 	// Pending image attachments sent with the next submitted message.
 	const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
 
@@ -133,6 +144,17 @@ export default function UserInput({
 	useEffect(() => {
 		void promptHistory.loadHistory();
 	}, []);
+
+	useEffect(() => {
+		if (queuedMessages.length === 0) {
+			setSelectedQueuedIndex(-1);
+			return;
+		}
+
+		setSelectedQueuedIndex(index =>
+			index >= queuedMessages.length ? queuedMessages.length - 1 : index,
+		);
+	}, [queuedMessages.length]);
 
 	// Consume pending file mentions from explorer and insert into input
 	// Properly attach files by calling handleFileMention for each
@@ -313,7 +335,7 @@ export default function UserInput({
 
 	// Handle form submission
 	const handleSubmit = useCallback(() => {
-		if (!onSubmit) return;
+		if (!onSubmit && !onQueueMessage) return;
 
 		let images = attachments;
 		let assembled = assemblePrompt(currentState);
@@ -337,14 +359,46 @@ export default function UserInput({
 		// Nothing to send: no text and no attachments.
 		if (!assembled.trim() && images.length === 0) return;
 
+		const inputStateForHistory: InputState = {
+			displayValue: currentState.displayValue,
+			placeholderContent: {...currentState.placeholderContent},
+		};
+
+		if (isBusy && !assembled.trim().startsWith('/') && onQueueMessage) {
+			promptHistory.addPrompt(inputStateForHistory);
+			onQueueMessage({
+				message: assembled,
+				displayValue: display,
+				images: images.length > 0 ? images : undefined,
+				inputState: inputStateForHistory,
+			});
+			resetInput();
+			resetUIState();
+			setAttachments([]);
+			promptHistory.resetIndex();
+			setSelectedQueuedIndex(-1);
+			return;
+		}
+
+		if (!onSubmit) return;
+
 		// Save the InputState to history and send assembled message to AI
-		promptHistory.addPrompt(currentState);
+		promptHistory.addPrompt(inputStateForHistory);
 		onSubmit(assembled, display, images.length > 0 ? images : undefined);
 		resetInput();
 		resetUIState();
 		setAttachments([]);
 		promptHistory.resetIndex();
-	}, [attachments, onSubmit, resetInput, resetUIState, currentState]);
+		setSelectedQueuedIndex(-1);
+	}, [
+		attachments,
+		onSubmit,
+		onQueueMessage,
+		resetInput,
+		resetUIState,
+		currentState,
+		isBusy,
+	]);
 
 	// Handle escape key logic
 	const handleEscape = useCallback(() => {
@@ -435,6 +489,80 @@ export default function UserInput({
 		],
 	);
 
+	const handleQueueNavigation = useCallback(
+		(direction: 'up' | 'down') => {
+			if (!isBusy || input.length > 0 || queuedMessages.length === 0) {
+				return false;
+			}
+
+			setSelectedQueuedIndex(index => {
+				if (direction === 'down') {
+					return index < 0 || index >= queuedMessages.length - 1
+						? 0
+						: index + 1;
+				}
+
+				return index <= 0 ? queuedMessages.length - 1 : index - 1;
+			});
+			return true;
+		},
+		[isBusy, input.length, queuedMessages.length],
+	);
+
+	const loadSelectedQueuedMessage = useCallback(() => {
+		if (
+			!isBusy ||
+			input.length > 0 ||
+			selectedQueuedIndex < 0 ||
+			selectedQueuedIndex >= queuedMessages.length
+		) {
+			return false;
+		}
+
+		const queuedMessage = queuedMessages[selectedQueuedIndex];
+		setInputState(
+			queuedMessage.inputState ?? {
+				displayValue: queuedMessage.displayValue,
+				placeholderContent: {},
+			},
+		);
+		setAttachments(queuedMessage.images ?? []);
+		onRemoveQueuedMessage?.(queuedMessage.id);
+		setSelectedQueuedIndex(-1);
+		setTextInputKey(prev => prev + 1);
+		return true;
+	}, [
+		isBusy,
+		input.length,
+		selectedQueuedIndex,
+		queuedMessages,
+		setInputState,
+		onRemoveQueuedMessage,
+	]);
+
+	const removeSelectedQueuedMessage = useCallback(() => {
+		if (
+			!isBusy ||
+			input.length > 0 ||
+			selectedQueuedIndex < 0 ||
+			selectedQueuedIndex >= queuedMessages.length
+		) {
+			return false;
+		}
+
+		onRemoveQueuedMessage?.(queuedMessages[selectedQueuedIndex].id);
+		setSelectedQueuedIndex(index =>
+			index >= queuedMessages.length - 1 ? queuedMessages.length - 2 : index,
+		);
+		return true;
+	}, [
+		isBusy,
+		input.length,
+		selectedQueuedIndex,
+		queuedMessages,
+		onRemoveQueuedMessage,
+	]);
+
 	useInput((inputChar, key) => {
 		// Cancelling in-flight work is owned by the single section-level Escape
 		// handler (see InteractiveApp), which fires no matter which component is
@@ -459,6 +587,10 @@ export default function UserInput({
 		// Handle ctrl+r to toggle expanded reasoning traces (always available)
 		if (key.ctrl && inputChar === 'r' && onToggleReasoningExpanded) {
 			onToggleReasoningExpanded();
+			return;
+		}
+
+		if (key.ctrl && key.delete && removeSelectedQueuedMessage()) {
 			return;
 		}
 
@@ -574,6 +706,9 @@ export default function UserInput({
 
 		// Handle Enter to submit (fallthrough - if completion handler didn't return)
 		if (key.return && !key.shift) {
+			if (loadSelectedQueuedMessage()) {
+				return;
+			}
 			handleSubmit();
 			return;
 		}
@@ -592,6 +727,9 @@ export default function UserInput({
 				setSelectedCompletionIndex(prev =>
 					prev > 0 ? prev - 1 : completions.length - 1,
 				);
+				return;
+			}
+			if (handleQueueNavigation('up')) {
 				return;
 			}
 			handleHistoryNavigation('up');
@@ -613,12 +751,28 @@ export default function UserInput({
 				);
 				return;
 			}
+			if (handleQueueNavigation('down')) {
+				return;
+			}
 			handleHistoryNavigation('down');
 			return;
 		}
 	});
 
 	const textColor = disabled || !input ? colors.secondary : colors.primary;
+	const formatQueuedMessage = (message: QueuedUserMessage) => {
+		const imageSuffix =
+			message.images && message.images.length > 0
+				? ` (${message.images.length} image${message.images.length === 1 ? '' : 's'})`
+				: '';
+		const maxLength = Math.max(20, boxWidth - imageSuffix.length - 6);
+		const singleLine = message.displayValue.replace(/\s+/g, ' ').trim();
+		const text =
+			singleLine.length > maxLength
+				? `${singleLine.slice(0, Math.max(0, maxLength - 1))}…`
+				: singleLine;
+		return `${text}${imageSuffix}`;
+	};
 
 	// When disabled, show minimal UI to avoid cluttering the screen
 	if (disabled) {
@@ -735,6 +889,38 @@ export default function UserInput({
 							</Text>
 						))}
 					</Box>
+				)}
+				{queuedMessages.length > 0 && (
+					<Box flexDirection="column" marginTop={1}>
+						<Text color={colors.secondary}>
+							Queued messages (↑/↓ select, Enter edit, Ctrl+Delete remove):
+						</Text>
+						{queuedMessages.map((message, index) => {
+							const isSelected = index === selectedQueuedIndex;
+							return (
+								<Text
+									key={message.id}
+									color={isSelected ? colors.info : colors.primary}
+									bold={isSelected}
+								>
+									{isSelected ? '▸ ' : '  '}
+									{formatQueuedMessage(message)}
+								</Text>
+							);
+						})}
+					</Box>
+				)}
+				{isBusy && (
+					<Text color={colors.secondary}>
+						<Spinner type="dots" /> Press Esc to cancel
+						{onToggleCompactDisplay && (
+							<Text>
+								{' '}
+								· ctrl-o {compactToolDisplay ? 'expand' : 'compact'}{' '}
+								{isNarrow ? '' : 'tool results'}
+							</Text>
+						)}
+					</Text>
 				)}
 			</Box>
 

--- a/source/hooks/chat-handler/useChatHandler.spec.tsx
+++ b/source/hooks/chat-handler/useChatHandler.spec.tsx
@@ -4,6 +4,7 @@ import {render} from 'ink-testing-library';
 import {getBaseSystemPrompt, useChatHandler} from './useChatHandler';
 import type {UseChatHandlerProps, ChatHandlerReturn} from './types';
 import type {LLMClient, Message} from '../../types/core';
+import {useUserMessageQueue} from '../useUserMessageQueue';
 
 // Test component that uses the hook and exposes results
 function TestHookComponent(props: UseChatHandlerProps & {onResult?: (result: ChatHandlerReturn) => void}) {
@@ -59,6 +60,23 @@ const createMockToolManager = () => ({
 	getFilteredTools: () => ({}),
 	getFilteredToolsForProvider: () => ({}),
 }) as NonNullable<UseChatHandlerProps['toolManager']>;
+
+const waitForCondition = async (
+	condition: () => boolean,
+	timeoutMs = 1000,
+) => {
+	const startedAt = Date.now();
+
+	while (Date.now() - startedAt < timeoutMs) {
+		if (condition()) {
+			return;
+		}
+
+		await new Promise(resolve => setTimeout(resolve, 25));
+	}
+
+	throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`);
+};
 
 test('useChatHandler - returns correct interface', t => {
 	let hookResult: ChatHandlerReturn | null = null;
@@ -317,6 +335,85 @@ test('useChatHandler - callbacks are provided', t => {
 	t.truthy(hookResult);
 	// The hook should successfully initialize with callbacks
 	t.is(typeof props.onConversationComplete, 'function');
+});
+
+test('useChatHandler - drains queued message when setup fails before conversation loop', async t => {
+	type QueueDrainHarnessResult = {
+		chatHandler: ChatHandlerReturn;
+		messageQueue: ReturnType<typeof useUserMessageQueue>;
+		drainedMessages: string[];
+	};
+
+	let hookResult: QueueDrainHarnessResult | null = null;
+	const throwingToolManager = {
+		...createMockToolManager(),
+		getToolNames: () => {
+			throw new Error('command prompt failed');
+		},
+	} as NonNullable<UseChatHandlerProps['toolManager']>;
+	const customCommandLoader = {
+		findRelevantCommands: () => [],
+	} as unknown as NonNullable<UseChatHandlerProps['customCommandLoader']>;
+
+	function QueueDrainHarness({
+		onResult,
+	}: {
+		onResult: (result: QueueDrainHarnessResult) => void;
+	}) {
+		const messageQueue = useUserMessageQueue();
+		const drainedMessagesRef = React.useRef<string[]>([]);
+		const chatHandler = useChatHandler(
+			createMockProps({
+				client: createMockClient(),
+				toolManager: throwingToolManager,
+				customCommandLoader,
+				onConversationComplete: () => {
+					void messageQueue.drainNextMessage(message => {
+						drainedMessagesRef.current.push(message.message);
+						return true;
+					});
+				},
+			}),
+		);
+
+		React.useEffect(() => {
+			onResult({
+				chatHandler,
+				messageQueue,
+				drainedMessages: drainedMessagesRef.current,
+			});
+		}, [chatHandler, messageQueue, onResult]);
+
+		return <></>;
+	}
+
+	const rendered = render(
+		<QueueDrainHarness
+			onResult={result => {
+				hookResult = result;
+			}}
+		/>,
+	);
+
+	await waitForCondition(() => hookResult !== null);
+
+	hookResult!.messageQueue.enqueueMessage({
+		message: 'queued after failure',
+		displayValue: 'Queued after failure',
+	});
+
+	await waitForCondition(() => hookResult!.messageQueue.queuedMessages.length === 1);
+
+	await hookResult!.chatHandler.handleChatMessage('current turn');
+
+	await waitForCondition(
+		() => hookResult!.drainedMessages[0] === 'queued after failure',
+	);
+	await waitForCondition(() => hookResult!.messageQueue.queuedMessages.length === 0);
+
+	t.deepEqual(hookResult!.drainedMessages, ['queued after failure']);
+	t.is(hookResult!.messageQueue.queuedMessages.length, 0);
+	rendered.unmount();
 });
 
 test('useChatHandler - streaming state types are correct', t => {

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -348,6 +348,7 @@ export function useChatHandler({
 			);
 		} catch (error) {
 			displayError(error, 'chat-error');
+			onConversationComplete?.();
 		} finally {
 			resetStreamingState();
 		}

--- a/source/hooks/useUserMessageQueue.spec.tsx
+++ b/source/hooks/useUserMessageQueue.spec.tsx
@@ -1,0 +1,187 @@
+import test from 'ava';
+import {render} from 'ink-testing-library';
+import React from 'react';
+import type {ImageAttachment} from '@/types/core';
+import {PlaceholderType} from '@/types/hooks';
+import {useUserMessageQueue} from './useUserMessageQueue';
+
+type HookResult = ReturnType<typeof useUserMessageQueue>;
+
+function TestHook({onResult}: {onResult: (result: HookResult) => void}) {
+	const result = useUserMessageQueue();
+
+	React.useEffect(() => {
+		onResult(result);
+	}, [result, onResult]);
+
+	return <></>;
+}
+
+async function renderHook() {
+	let hook: HookResult | null = null;
+	const rendered = render(
+		<TestHook
+			onResult={result => {
+				hook = result;
+			}}
+		/>,
+	);
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	if (!hook) {
+		throw new Error('hook did not render');
+	}
+
+	return {
+		...rendered,
+		get hook() {
+			if (!hook) {
+				throw new Error('hook did not render');
+			}
+			return hook;
+		},
+	};
+}
+
+test('useUserMessageQueue enqueues messages with stable payloads', async t => {
+	const result = await renderHook();
+	const image: ImageAttachment = {
+		data: 'abc123',
+		mediaType: 'image/png',
+		source: 'screenshot.png',
+	};
+
+	result.hook.enqueueMessage({
+		message: 'full message',
+		displayValue: 'display message',
+		images: [image],
+	});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	t.is(result.hook.queuedMessages.length, 1);
+	t.is(result.hook.queuedMessages[0].message, 'full message');
+	t.is(result.hook.queuedMessages[0].displayValue, 'display message');
+	t.deepEqual(result.hook.queuedMessages[0].images, [image]);
+	t.truthy(result.hook.queuedMessages[0].id);
+	result.unmount();
+});
+
+test('useUserMessageQueue preserves placeholder input state metadata', async t => {
+	const result = await renderHook();
+	const inputState = {
+		displayValue: 'summarize [@file:1]',
+		placeholderContent: {
+			'file:1': {
+				type: PlaceholderType.FILE,
+				content: 'file contents',
+				displayText: '[@file:1]',
+				filePath: 'source/example.ts',
+			},
+		},
+	};
+
+	result.hook.enqueueMessage({
+		message: 'summarize file contents',
+		displayValue: inputState.displayValue,
+		inputState,
+	});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	t.deepEqual(result.hook.queuedMessages[0].inputState, inputState);
+	result.unmount();
+});
+
+test('useUserMessageQueue drains messages in FIFO order', async t => {
+	const result = await renderHook();
+	const sent: string[] = [];
+
+	result.hook.enqueueMessage({message: 'first', displayValue: 'First'});
+	result.hook.enqueueMessage({message: 'second', displayValue: 'Second'});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	const firstDrained = await result.hook.drainNextMessage(message => {
+		sent.push(message.message);
+		return true;
+	});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	const secondDrained = await result.hook.drainNextMessage(message => {
+		sent.push(message.message);
+		return true;
+	});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	t.true(firstDrained);
+	t.true(secondDrained);
+	t.deepEqual(sent, ['first', 'second']);
+	t.is(result.hook.queuedMessages.length, 0);
+	result.unmount();
+});
+
+test('useUserMessageQueue keeps message queued when dispatch cannot run', async t => {
+	const result = await renderHook();
+
+	result.hook.enqueueMessage({
+		message: 'retry later',
+		displayValue: 'Retry later',
+	});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	const drained = await result.hook.drainNextMessage(() => false);
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	t.false(drained);
+	t.is(result.hook.queuedMessages.length, 1);
+	t.is(result.hook.queuedMessages[0].message, 'retry later');
+	result.unmount();
+});
+
+test('useUserMessageQueue keeps message queued when async dispatch rejects', async t => {
+	const result = await renderHook();
+
+	result.hook.enqueueMessage({
+		message: 'retry after rejection',
+		displayValue: 'Retry after rejection',
+	});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	const drained = await result.hook.drainNextMessage(async () => {
+		throw new Error('dispatch failed');
+	});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	t.false(drained);
+	t.is(result.hook.queuedMessages.length, 1);
+	t.is(result.hook.queuedMessages[0].message, 'retry after rejection');
+	result.unmount();
+});
+
+test('useUserMessageQueue removes a queued message by id', async t => {
+	const result = await renderHook();
+
+	result.hook.enqueueMessage({message: 'keep', displayValue: 'Keep'});
+	result.hook.enqueueMessage({message: 'remove', displayValue: 'Remove'});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	const idToRemove = result.hook.queuedMessages[1].id;
+	result.hook.removeMessage(idToRemove);
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	t.deepEqual(
+		result.hook.queuedMessages.map(message => message.message),
+		['keep'],
+	);
+	result.unmount();
+});

--- a/source/hooks/useUserMessageQueue.spec.tsx
+++ b/source/hooks/useUserMessageQueue.spec.tsx
@@ -124,6 +124,47 @@ test('useUserMessageQueue drains messages in FIFO order', async t => {
 	result.unmount();
 });
 
+test('useUserMessageQueue removes a draining message before dispatch resolves', async t => {
+	const result = await renderHook();
+	const sent: string[] = [];
+	let resolveFirstDispatch!: () => void;
+	const firstDispatchFinished = new Promise<void>(resolve => {
+		resolveFirstDispatch = resolve;
+	});
+
+	result.hook.enqueueMessage({message: 'first', displayValue: 'First'});
+	result.hook.enqueueMessage({message: 'second', displayValue: 'Second'});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	const firstDrain = result.hook.drainNextMessage(async message => {
+		sent.push(message.message);
+		await firstDispatchFinished;
+		return true;
+	});
+
+	await new Promise(resolve => setTimeout(resolve, 20));
+
+	t.deepEqual(
+		result.hook.queuedMessages.map(message => message.message),
+		['second'],
+	);
+
+	const secondDrain = await result.hook.drainNextMessage(message => {
+		sent.push(message.message);
+		return true;
+	});
+
+	resolveFirstDispatch();
+
+	t.true(await firstDrain);
+	t.true(secondDrain);
+	await new Promise(resolve => setTimeout(resolve, 20));
+	t.deepEqual(sent, ['first', 'second']);
+	t.is(result.hook.queuedMessages.length, 0);
+	result.unmount();
+});
+
 test('useUserMessageQueue keeps message queued when dispatch cannot run', async t => {
 	const result = await renderHook();
 

--- a/source/hooks/useUserMessageQueue.ts
+++ b/source/hooks/useUserMessageQueue.ts
@@ -50,14 +50,17 @@ export function useUserMessageQueue() {
 			const [nextMessage, ...remainingMessages] = queuedMessagesRef.current;
 			if (!nextMessage) return false;
 
+			setQueue(remainingMessages);
+
 			try {
-				if (!(await dispatch(nextMessage))) return false;
+				if (await dispatch(nextMessage)) return true;
 			} catch {
-				return false;
+				// If dispatch never started cleanly, put the message back at the
+				// front so it can be retried after the next turn.
 			}
 
-			setQueue(remainingMessages);
-			return true;
+			setQueue([nextMessage, ...queuedMessagesRef.current]);
+			return false;
 		},
 		[setQueue],
 	);

--- a/source/hooks/useUserMessageQueue.ts
+++ b/source/hooks/useUserMessageQueue.ts
@@ -1,0 +1,71 @@
+import React from 'react';
+import type {ImageAttachment} from '@/types/core';
+import type {InputState} from '@/types/hooks';
+
+export interface QueuedUserMessage {
+	id: string;
+	message: string;
+	displayValue: string;
+	images?: ImageAttachment[];
+	inputState?: InputState;
+}
+
+export type UserMessageQueueDraft = Omit<QueuedUserMessage, 'id'>;
+
+export function useUserMessageQueue() {
+	const [queuedMessages, setQueuedMessages] = React.useState<
+		QueuedUserMessage[]
+	>([]);
+	const queuedMessagesRef = React.useRef<QueuedUserMessage[]>([]);
+	const nextIdRef = React.useRef(0);
+
+	const setQueue = React.useCallback((next: QueuedUserMessage[]) => {
+		queuedMessagesRef.current = next;
+		setQueuedMessages(next);
+	}, []);
+
+	const enqueueMessage = React.useCallback(
+		(message: UserMessageQueueDraft) => {
+			const queuedMessage: QueuedUserMessage = {
+				...message,
+				id: `queued-user-${nextIdRef.current++}`,
+			};
+			setQueue([...queuedMessagesRef.current, queuedMessage]);
+			return queuedMessage;
+		},
+		[setQueue],
+	);
+
+	const removeMessage = React.useCallback(
+		(id: string) => {
+			setQueue(queuedMessagesRef.current.filter(message => message.id !== id));
+		},
+		[setQueue],
+	);
+
+	const drainNextMessage = React.useCallback(
+		async (
+			dispatch: (message: QueuedUserMessage) => boolean | Promise<boolean>,
+		) => {
+			const [nextMessage, ...remainingMessages] = queuedMessagesRef.current;
+			if (!nextMessage) return false;
+
+			try {
+				if (!(await dispatch(nextMessage))) return false;
+			} catch {
+				return false;
+			}
+
+			setQueue(remainingMessages);
+			return true;
+		},
+		[setQueue],
+	);
+
+	return {
+		queuedMessages,
+		enqueueMessage,
+		removeMessage,
+		drainNextMessage,
+	};
+}


### PR DESCRIPTION

  ## Description

  Adds an in-memory queued user-message flow while the agent is busy. The chat input stays interactive during LLM streaming/tool execution,
  submitted messages are queued FIFO, queued items can be selected with ↑/↓, edited with Enter, and removed with Ctrl+Delete.

  Fixes #597

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [ ] Documentation update

  ## Testing

  ### Automated Tests

  - [x] New features include passing tests in `.spec.ts/tsx` files
  - [x] All existing tests pass (`pnpm test:all` completes successfully)
  - [x] Tests cover both success and error scenarios

  Notes:
  - `npm run build` passed
  - `npm run test:format` passed
  - `npm run test:lint` passed
  - `npm run test:knip` passed
  - Changed-area AVA passed: 69 tests
  - `node_modules/.bin/tsc --noEmit` passed
  - Full fail-fast AVA reached 406 passing tests, then stopped on existing timeout in `source/auth/chatgpt-codex.spec.ts`

  ### Manual Testing

  - [ ] Tested with Ollama
  - [ ] Tested with OpenRouter
  - [ ] Tested with OpenAI-compatible API
  - [ ] Tested MCP integration (if applicable)

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-review completed
  - [ ] Documentation updated (if needed)
  - [x] No breaking changes (or clearly documented)
  - [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))