### PR TITLE
feat: recall in-flight message before streaming

### DIFF
--- a/source/app/components/chat-history.tsx
+++ b/source/app/components/chat-history.tsx
@@ -12,6 +12,7 @@ export interface ChatHistoryProps {
 	queuedComponents: React.ReactNode[];
 	/** Live component that renders outside Static (for real-time updates) */
 	liveComponent?: React.ReactNode;
+	renderLastQueuedComponentLive?: boolean;
 }
 
 /**
@@ -29,6 +30,7 @@ export function ChatHistory({
 	staticComponents,
 	queuedComponents,
 	liveComponent,
+	renderLastQueuedComponentLive,
 }: ChatHistoryProps): React.ReactElement {
 	return (
 		<Box flexGrow={1} flexDirection="column" minHeight={0}>
@@ -36,6 +38,7 @@ export function ChatHistory({
 				<ChatQueue
 					staticComponents={staticComponents}
 					queuedComponents={queuedComponents}
+					renderLastQueuedComponentLive={renderLastQueuedComponentLive}
 				/>
 			)}
 			{/* Live component renders outside Static for real-time updates */}

--- a/source/app/components/chat-input.tsx
+++ b/source/app/components/chat-input.tsx
@@ -16,6 +16,7 @@ import type {
 	ToolCall,
 	TuneConfig,
 } from '@/types';
+import type {RestoredInputDraft, SubmittedInputDraft} from '@/types/hooks';
 import type {PendingQuestion} from '@/utils/question-queue';
 import type {PendingToolApproval} from '@/utils/tool-approval-queue';
 import type {PendingToolConfirmation} from '@/utils/tool-confirm-queue';
@@ -51,6 +52,8 @@ export interface ChatInputProps {
 	// Input state
 	customCommands: string[];
 	inputDisabled: boolean;
+	onSubmittedDraft?: (draft: SubmittedInputDraft) => void;
+	restoreSubmittedDraft?: RestoredInputDraft | null;
 	// True when in-flight work makes Escape a cancel; lets UserInput defer to
 	// the section-level global cancel handler instead of clearing the input.
 	isBusy: boolean;
@@ -108,6 +111,8 @@ export function ChatInput({
 	client,
 	customCommands,
 	inputDisabled,
+	onSubmittedDraft,
+	restoreSubmittedDraft,
 	isBusy,
 	developmentMode,
 	contextPercentUsed,
@@ -179,6 +184,8 @@ export function ChatInput({
 						void onSubmit(msg, display, images)
 					}
 					disabled={inputDisabled}
+					onSubmittedDraft={onSubmittedDraft}
+					restoreSubmittedDraft={restoreSubmittedDraft}
 					isBusy={isBusy}
 					onToggleMode={onToggleMode}
 					onToggleReasoningExpanded={onToggleReasoningExpanded}

--- a/source/app/sections/interactive-app.spec.tsx
+++ b/source/app/sections/interactive-app.spec.tsx
@@ -1,6 +1,7 @@
 import test from 'ava';
 import {Text} from 'ink';
 import React from 'react';
+import type {Message} from '@/types';
 import {renderWithTheme} from '../../test-utils/render-with-theme.js';
 import {InteractiveApp} from './interactive-app.js';
 
@@ -21,6 +22,14 @@ interface Overrides {
 	pendingToolCalls?: Array<{id: string; function: {name: string; arguments: unknown}}>;
 	pendingSubagentApproval?: unknown;
 	handleCancel?: () => void;
+	streamingContent?: string;
+	messages?: Message[];
+	updateMessages?: (messages: Message[]) => void;
+	chatComponents?: React.ReactNode[];
+	setChatComponents?: (components: React.ReactNode[]) => void;
+	setIsCancelling?: (value: boolean) => void;
+	setAbortController?: (controller: AbortController | null) => void;
+	client?: unknown;
 }
 
 function makeProps(o: Overrides = {}) {
@@ -28,8 +37,8 @@ function makeProps(o: Overrides = {}) {
 	const noopAsync = async () => {};
 
 	const appState = {
-		client: null,
-		messages: [],
+		client: o.client ?? null,
+		messages: o.messages ?? [],
 		currentModel: 'mock-model',
 		currentProvider: 'mock',
 		startChat: o.startChat ?? false,
@@ -57,17 +66,24 @@ function makeProps(o: Overrides = {}) {
 		liveTaskList: null,
 		tune: {enabled: false, toolProfile: 'minimal', aggressiveCompact: false},
 		reasoningExpanded: false,
-		chatComponents: [],
+		chatComponents: o.chatComponents ?? [],
 		compactToolCountsRef: {current: {}},
 		setCompactToolDisplay: noop,
 		setCompactToolCounts: noop,
 		setReasoningExpanded: noop,
 		addToChatQueue: noop,
+		updateMessages: o.updateMessages ?? noop,
+		setChatComponents: o.setChatComponents ?? noop,
+		setIsCancelling: o.setIsCancelling ?? noop,
+		setAbortController: o.setAbortController ?? noop,
 	};
 
 	return {
 		appState,
-		chatHandler: {isGenerating: o.isGenerating ?? false},
+		chatHandler: {
+			isGenerating: o.isGenerating ?? false,
+			streamingContent: o.streamingContent ?? '',
+		},
 		modeHandlers: {
 			handleExplorerCancel: noop,
 			handleIdeSelectionCancel: noop,
@@ -162,6 +178,23 @@ const pressEscape = async (stdin: {write: (s: string) => void}) => {
 	await new Promise(resolve => setTimeout(resolve, 50));
 };
 
+const waitForCondition = async (
+	condition: () => boolean,
+	timeoutMs = 1000,
+) => {
+	const startedAt = Date.now();
+
+	while (Date.now() - startedAt < timeoutMs) {
+		if (condition()) {
+			return;
+		}
+
+		await new Promise(resolve => setTimeout(resolve, 25));
+	}
+
+	throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`);
+};
+
 test('Escape cancels in-flight LLM generation on the first press', async t => {
 	let cancelled = 0;
 	const {stdin} = renderWithTheme(
@@ -220,6 +253,184 @@ test('Escape cancels when only an abort controller is live (state flicker)', asy
 
 	await pressEscape(stdin);
 	t.is(cancelled, 1);
+});
+
+test('Escape recalls an in-flight user message before assistant streaming starts', async t => {
+	let cancelled = 0;
+	let latestMessages: Message[] = [];
+	let latestAbortController: AbortController | null = null;
+	let latestIsCancelling = true;
+
+	const RecallHarness = () => {
+		const [isGenerating, setIsGenerating] = React.useState(false);
+		const [messages, setMessages] = React.useState<Message[]>([]);
+		const [chatComponents, setChatComponents] = React.useState<
+			React.ReactNode[]
+		>([]);
+		const [abortController, setAbortController] =
+			React.useState<AbortController | null>(null);
+		const [isCancelling, setIsCancelling] = React.useState(false);
+
+		latestMessages = messages;
+		latestAbortController = abortController;
+		latestIsCancelling = isCancelling;
+
+		return (
+			<InteractiveApp
+				{...makeProps({
+					startChat: true,
+					client: {},
+					isGenerating,
+					abortController,
+					messages,
+					chatComponents,
+					updateMessages: setMessages,
+					setChatComponents,
+					setIsCancelling,
+					setAbortController,
+					handleCancel: () => {
+						cancelled++;
+						abortController?.abort();
+						setIsGenerating(false);
+						setIsCancelling(true);
+					},
+				})}
+				handleUserSubmit={async message => {
+					const controller = new AbortController();
+					setMessages([{role: 'user', content: message}]);
+					setChatComponents([<Text key="user">submitted bubble: {message}</Text>]);
+					setAbortController(controller);
+					setIsGenerating(true);
+				}}
+			/>
+		);
+	};
+
+	const {stdin, lastFrame} = renderWithTheme(<RecallHarness />);
+
+	stdin.write('fix the typo');
+	await waitForCondition(() => /fix the typo/.test(lastFrame() ?? ''));
+	stdin.write('\r');
+	await waitForCondition(() => latestMessages.length === 1);
+
+	await pressEscape(stdin);
+	await waitForCondition(() => /fix the typo/.test(lastFrame() ?? ''));
+
+	t.is(cancelled, 1);
+	t.deepEqual(latestMessages, []);
+	t.notRegex(lastFrame() ?? '', /submitted bubble: fix the typo/);
+	t.is(latestAbortController, null);
+	t.is(latestIsCancelling, false);
+});
+
+test('Escape recall does not remove a non-user chat component', async t => {
+	let latestMessages: Message[] = [];
+	let latestChatComponents: React.ReactNode[] = [];
+
+	const RecallHarness = () => {
+		const [isGenerating, setIsGenerating] = React.useState(false);
+		const [messages, setMessages] = React.useState<Message[]>([]);
+		const [chatComponents, setChatComponents] = React.useState<
+			React.ReactNode[]
+		>([]);
+		const [abortController, setAbortController] =
+			React.useState<AbortController | null>(null);
+
+		latestMessages = messages;
+		latestChatComponents = chatComponents;
+
+		return (
+			<InteractiveApp
+				{...makeProps({
+					startChat: true,
+					client: {},
+					isGenerating,
+					abortController,
+					messages,
+					chatComponents,
+					updateMessages: setMessages,
+					setChatComponents,
+					setAbortController,
+					handleCancel: () => {
+						abortController?.abort();
+					},
+				})}
+				handleUserSubmit={async () => {
+					setMessages([{role: 'assistant', content: 'custom command result'}]);
+					setChatComponents([
+						<Text key="custom-command">custom command result</Text>,
+					]);
+					setAbortController(new AbortController());
+					setIsGenerating(true);
+				}}
+			/>
+		);
+	};
+
+	const {stdin, lastFrame} = renderWithTheme(<RecallHarness />);
+
+	stdin.write('recall me');
+	await waitForCondition(() => /recall me/.test(lastFrame() ?? ''));
+	stdin.write('\r');
+	await waitForCondition(() => latestChatComponents.length === 1);
+
+	await pressEscape(stdin);
+
+	t.deepEqual(latestMessages, [
+		{role: 'assistant', content: 'custom command result'},
+	]);
+	t.is(latestChatComponents.length, 1);
+	t.regex(lastFrame() ?? '', /custom command result/);
+});
+
+test('Escape keeps existing cancel behavior after assistant streaming starts', async t => {
+	let cancelled = 0;
+	let latestMessages: Message[] = [];
+
+	const StreamingHarness = () => {
+		const [isGenerating, setIsGenerating] = React.useState(false);
+		const [messages, setMessages] = React.useState<Message[]>([]);
+		const [abortController, setAbortController] =
+			React.useState<AbortController | null>(null);
+
+		latestMessages = messages;
+
+		return (
+			<InteractiveApp
+				{...makeProps({
+					startChat: true,
+					client: {},
+					isGenerating,
+					streamingContent: isGenerating ? 'partial response' : '',
+					abortController,
+					messages,
+					updateMessages: setMessages,
+					setAbortController,
+					handleCancel: () => {
+						cancelled++;
+						abortController?.abort();
+					},
+				})}
+				handleUserSubmit={async message => {
+					setMessages([{role: 'user', content: message}]);
+					setAbortController(new AbortController());
+					setIsGenerating(true);
+				}}
+			/>
+		);
+	};
+
+	const {stdin, lastFrame} = renderWithTheme(<StreamingHarness />);
+
+	stdin.write('fix the typo');
+	await waitForCondition(() => /fix the typo/.test(lastFrame() ?? ''));
+	stdin.write('\r');
+	await waitForCondition(() => latestMessages.length === 1);
+
+	await pressEscape(stdin);
+
+	t.is(cancelled, 1);
+	t.is(latestMessages.length, 1);
 });
 
 test('Escape does NOT cancel when idle (clear-input owns it)', async t => {

--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -11,6 +11,7 @@ import type {useAppState} from '@/hooks/useAppState';
 import type {useModeHandlers} from '@/hooks/useModeHandlers';
 import type {useVSCodeServer} from '@/hooks/useVSCodeServer';
 import type {ImageAttachment} from '@/types/core';
+import type {RestoredInputDraft, SubmittedInputDraft} from '@/types/hooks';
 import type {PendingToolApproval} from '@/utils/tool-approval-queue';
 import type {PendingToolConfirmation} from '@/utils/tool-confirm-queue';
 import {displayCompactCountsSummary} from '@/utils/tool-result-display';
@@ -58,6 +59,12 @@ export function InteractiveApp({
 	handleUserSubmit,
 	handleIdeSelect,
 }: InteractiveAppProps): React.ReactElement {
+	const nextRestoredDraftIdRef = React.useRef(1);
+	const [submittedDraft, setSubmittedDraft] =
+		React.useState<SubmittedInputDraft | null>(null);
+	const [restoredDraft, setRestoredDraft] =
+		React.useState<RestoredInputDraft | null>(null);
+
 	const handleToggleCompactDisplay = () => {
 		const expanding = appState.compactToolDisplay;
 		appState.setCompactToolDisplay(!expanding);
@@ -97,6 +104,72 @@ export function InteractiveApp({
 			appState.isToolExecuting ||
 			appState.abortController !== null);
 
+	const recallableSubmittedDraft =
+		cancellable &&
+		chatHandler.isGenerating &&
+		chatHandler.streamingContent === '' &&
+		!appState.isToolExecuting &&
+		submittedDraft !== null;
+
+	React.useEffect(() => {
+		if (!submittedDraft) return;
+
+		if (!cancellable || chatHandler.streamingContent !== '') {
+			setSubmittedDraft(null);
+		}
+	}, [cancellable, chatHandler.streamingContent, submittedDraft]);
+
+	const handleSubmittedDraft = React.useCallback(
+		(draft: SubmittedInputDraft) => {
+			setSubmittedDraft({
+				inputState: {
+					displayValue: draft.inputState.displayValue,
+					placeholderContent: {...draft.inputState.placeholderContent},
+				},
+				attachments: [...draft.attachments],
+			});
+		},
+		[],
+	);
+
+	const handleRecallSubmittedDraft = React.useCallback(() => {
+		if (!submittedDraft) {
+			appHandlers.handleCancel();
+			return;
+		}
+
+		appHandlers.handleCancel();
+
+		if (appState.messages[appState.messages.length - 1]?.role === 'user') {
+			appState.updateMessages(appState.messages.slice(0, -1));
+
+			if (appState.chatComponents.length > 0) {
+				appState.setChatComponents(appState.chatComponents.slice(0, -1));
+			}
+		}
+
+		appState.setIsCancelling(false);
+		appState.setAbortController(null);
+		setRestoredDraft({
+			id: nextRestoredDraftIdRef.current++,
+			inputState: {
+				displayValue: submittedDraft.inputState.displayValue,
+				placeholderContent: {...submittedDraft.inputState.placeholderContent},
+			},
+			attachments: [...submittedDraft.attachments],
+		});
+		setSubmittedDraft(null);
+	}, [
+		appHandlers,
+		appState.messages,
+		appState.updateMessages,
+		appState.chatComponents,
+		appState.setChatComponents,
+		appState.setIsCancelling,
+		appState.setAbortController,
+		submittedDraft,
+	]);
+
 	// Single, always-mounted authority for Escape -> cancel. Because this lives
 	// at the section level (never swapped out like the ChatInput children), it
 	// fires on the FIRST press no matter what is running: an LLM message, a
@@ -106,6 +179,11 @@ export function InteractiveApp({
 	useInput(
 		(_input, key) => {
 			if (key.escape) {
+				if (recallableSubmittedDraft) {
+					handleRecallSubmittedDraft();
+					return;
+				}
+
 				appHandlers.handleCancel();
 			}
 		},
@@ -120,6 +198,7 @@ export function InteractiveApp({
 				staticComponents={staticComponents}
 				queuedComponents={appState.chatComponents}
 				liveComponent={liveComponent}
+				renderLastQueuedComponentLive={recallableSubmittedDraft}
 			/>
 
 			{appState.isExplorerMode && (
@@ -182,6 +261,8 @@ export function InteractiveApp({
 						client={appState.client}
 						customCommands={Array.from(appState.customCommandCache.keys())}
 						inputDisabled={chatHandler.isGenerating || appState.isToolExecuting}
+						onSubmittedDraft={handleSubmittedDraft}
+						restoreSubmittedDraft={restoredDraft}
 						isBusy={cancellable}
 						developmentMode={appState.developmentMode}
 						contextPercentUsed={appState.contextPercentUsed}

--- a/source/components/chat-queue.spec.tsx
+++ b/source/components/chat-queue.spec.tsx
@@ -58,6 +58,31 @@ test('ChatQueue merges static and queued components', t => {
 	t.truthy(output);
 });
 
+test('ChatQueue can render the last queued component outside Static', t => {
+	const {lastFrame, rerender} = render(
+		<ChatQueue
+			queuedComponents={[
+				<Box key="frozen">Frozen queued message</Box>,
+				<Box key="live">Recallable queued message</Box>,
+			]}
+			renderLastQueuedComponentLive
+		/>,
+	);
+
+	t.regex(lastFrame() ?? '', /Frozen queued message/);
+	t.regex(lastFrame() ?? '', /Recallable queued message/);
+
+	rerender(
+		<ChatQueue
+			queuedComponents={[<Box key="frozen">Frozen queued message</Box>]}
+			renderLastQueuedComponentLive
+		/>,
+	);
+
+	t.regex(lastFrame() ?? '', /Frozen queued message/);
+	t.notRegex(lastFrame() ?? '', /Recallable queued message/);
+});
+
 test('ChatQueue component can be unmounted', t => {
 	const {unmount} = render(<ChatQueue staticComponents={[]} queuedComponents={[]} />);
 

--- a/source/components/chat-queue.tsx
+++ b/source/components/chat-queue.tsx
@@ -6,12 +6,27 @@ import type {ChatQueueProps} from '@/types/index';
 export default memo(function ChatQueue({
 	staticComponents = [],
 	queuedComponents = [],
+	renderLastQueuedComponentLive = false,
 }: ChatQueueProps) {
+	const {staticQueuedComponents, liveQueuedComponents} = useMemo(() => {
+		if (!renderLastQueuedComponentLive) {
+			return {
+				staticQueuedComponents: queuedComponents,
+				liveQueuedComponents: [],
+			};
+		}
+
+		return {
+			staticQueuedComponents: queuedComponents.slice(0, -1),
+			liveQueuedComponents: queuedComponents.slice(-1),
+		};
+	}, [queuedComponents, renderLastQueuedComponentLive]);
+
 	// Move ALL messages to static - prevents any re-renders
 	// All messages are now immutable once rendered
 	const allStaticComponents = useMemo(
-		() => [...staticComponents, ...queuedComponents],
-		[staticComponents, queuedComponents],
+		() => [...staticComponents, ...staticQueuedComponents],
+		[staticComponents, staticQueuedComponents],
 	);
 
 	return (
@@ -34,6 +49,17 @@ export default memo(function ChatQueue({
 					}}
 				</Static>
 			)}
+			{liveQueuedComponents.map((component, index) => {
+				const key =
+					component &&
+					typeof component === 'object' &&
+					'key' in component &&
+					component.key
+						? component.key
+						: `live-${index}`;
+
+				return <RenderErrorBoundary key={key}>{component}</RenderErrorBoundary>;
+			})}
 		</Box>
 	);
 });

--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -31,6 +31,27 @@ const TestWrapper = ({children}: {children: React.ReactNode}) => (
 // Helper for async tests that need proper context and more time
 const wait = async (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));
 
+const waitForCondition = async (
+	condition: () => boolean,
+	timeoutMs = 1000,
+) => {
+	const startedAt = Date.now();
+
+	while (Date.now() - startedAt < timeoutMs) {
+		if (condition()) return;
+		await wait(25);
+	}
+
+	throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`);
+};
+
+const waitForFrame = async (
+	lastFrame: () => string | undefined,
+	pattern: RegExp,
+) => {
+	await waitForCondition(() => pattern.test(lastFrame() ?? ''));
+};
+
 // ============================================================================
 // Component Rendering Tests
 // ============================================================================
@@ -158,6 +179,64 @@ test('UserInput renders while busy (Escape deferred to global handler)', t => {
 	);
 
 	t.truthy(lastFrame());
+	unmount();
+});
+
+test('UserInput reports and restores submitted drafts with attachments', async t => {
+	let submittedMessage = '';
+	let submittedDraft:
+		| Parameters<
+				NonNullable<React.ComponentProps<typeof UserInput>['onSubmittedDraft']>
+		  >[0]
+		| null = null;
+
+	const restoreDraft = {
+		id: 1,
+		inputState: {
+			displayValue: 'edit this request',
+			placeholderContent: {},
+		},
+		attachments: [{data: 'abc', mediaType: 'image/png'}],
+	};
+
+	const {stdin, lastFrame, rerender, unmount} = render(
+		<TestWrapper>
+			<UserInput
+				forceFocus={true}
+				onSubmit={message => {
+					submittedMessage = message;
+				}}
+				onSubmittedDraft={draft => {
+					submittedDraft = draft;
+				}}
+			/>
+		</TestWrapper>,
+	);
+
+	stdin.write('original');
+	await waitForFrame(lastFrame, /original/);
+	stdin.write('\r');
+	await waitForCondition(() => submittedMessage === 'original');
+	await waitForCondition(() => !/original/.test(lastFrame() ?? ''));
+
+	t.is(submittedDraft?.inputState.displayValue, 'original');
+	t.deepEqual(submittedDraft?.inputState.placeholderContent, {});
+	t.deepEqual(submittedDraft?.attachments, []);
+
+	rerender(
+		<TestWrapper>
+			<UserInput
+				forceFocus={true}
+				onSubmit={message => {
+					submittedMessage = message;
+				}}
+				restoreSubmittedDraft={restoreDraft}
+			/>
+		</TestWrapper>,
+	);
+	await waitForFrame(lastFrame, /edit this request/);
+
+	t.regex(lastFrame()!, /\[image #1: image\]/);
 	unmount();
 });
 
@@ -595,6 +674,4 @@ test('UserInput does not show completions when input is empty', t => {
 	t.notRegex(output, /Available commands:/);
 	unmount();
 });
-
-
 

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -15,7 +15,11 @@ import type {
 	DevelopmentMode,
 	ImageAttachment,
 } from '@/types/core';
-import type {InputState} from '@/types/hooks';
+import type {
+	InputState,
+	RestoredInputDraft,
+	SubmittedInputDraft,
+} from '@/types/hooks';
 import {Completion} from '@/types/index';
 import {
 	extractImageReferences,
@@ -53,6 +57,8 @@ interface ChatProps {
 	activeEditor?: ActiveEditorState | null; // VS Code active file + optional selection
 	onDismissActiveEditor?: () => void; // Dismiss the active editor pill on clear/escape
 	forceFocus?: boolean; // Force focus for testing (bypasses useFocus)
+	onSubmittedDraft?: (draft: SubmittedInputDraft) => void;
+	restoreSubmittedDraft?: RestoredInputDraft | null;
 }
 
 export default function UserInput({
@@ -74,6 +80,8 @@ export default function UserInput({
 	activeEditor,
 	onDismissActiveEditor,
 	forceFocus = false,
+	onSubmittedDraft,
+	restoreSubmittedDraft = null,
 }: ChatProps) {
 	const {isFocused, focus} = useFocus({autoFocus: !disabled, id: 'user-input'});
 	const effectiveFocus = forceFocus || isFocused;
@@ -96,6 +104,7 @@ export default function UserInput({
 	const [selectedFileIndex, setSelectedFileIndex] = useState(0);
 	// Pending image attachments sent with the next submitted message.
 	const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+	const lastRestoredDraftIdRef = useRef<number | null>(null);
 
 	const {
 		input,
@@ -133,6 +142,28 @@ export default function UserInput({
 	useEffect(() => {
 		void promptHistory.loadHistory();
 	}, []);
+
+	useEffect(() => {
+		if (
+			!restoreSubmittedDraft ||
+			lastRestoredDraftIdRef.current === restoreSubmittedDraft.id
+		) {
+			return;
+		}
+
+		lastRestoredDraftIdRef.current = restoreSubmittedDraft.id;
+		setInputState({
+			displayValue: restoreSubmittedDraft.inputState.displayValue,
+			placeholderContent: {
+				...restoreSubmittedDraft.inputState.placeholderContent,
+			},
+		});
+		setAttachments([...restoreSubmittedDraft.attachments]);
+		resetUIState();
+		promptHistory.resetIndex();
+		setTextInputKey(prev => prev + 1);
+		focus('user-input');
+	}, [restoreSubmittedDraft, setInputState, resetUIState, focus]);
 
 	// Consume pending file mentions from explorer and insert into input
 	// Properly attach files by calling handleFileMention for each
@@ -339,12 +370,23 @@ export default function UserInput({
 
 		// Save the InputState to history and send assembled message to AI
 		promptHistory.addPrompt(currentState);
+		onSubmittedDraft?.({
+			inputState: currentState,
+			attachments: images,
+		});
 		onSubmit(assembled, display, images.length > 0 ? images : undefined);
 		resetInput();
 		resetUIState();
 		setAttachments([]);
 		promptHistory.resetIndex();
-	}, [attachments, onSubmit, resetInput, resetUIState, currentState]);
+	}, [
+		attachments,
+		onSubmit,
+		resetInput,
+		resetUIState,
+		currentState,
+		onSubmittedDraft,
+	]);
 
 	// Handle escape key logic
 	const handleEscape = useCallback(() => {

--- a/source/types/components.ts
+++ b/source/types/components.ts
@@ -13,6 +13,7 @@ export interface AssistantReasoningProps {
 export interface ChatQueueProps {
 	staticComponents?: ReactNode[];
 	queuedComponents?: ReactNode[];
+	renderLastQueuedComponentLive?: boolean;
 }
 
 export type Completion = {name: string; isCustom: boolean};

--- a/source/types/hooks.ts
+++ b/source/types/hooks.ts
@@ -1,3 +1,5 @@
+import type {ImageAttachment} from '@/types/core';
+
 // Enum for all supported placeholder types - ensures type safety
 export enum PlaceholderType {
 	PASTE = 'paste',
@@ -47,4 +49,13 @@ export interface InputState {
 	// A dictionary holding the full content and metadata for each placeholder.
 	// The key is the ID from the placeholder.
 	placeholderContent: Record<string, PlaceholderContent>;
+}
+
+export interface SubmittedInputDraft {
+	inputState: InputState;
+	attachments: ImageAttachment[];
+}
+
+export interface RestoredInputDraft extends SubmittedInputDraft {
+	id: number;
 }


### PR DESCRIPTION
## Description

Adds Escape recall support for an in-flight user message before assistant streaming starts. If the user submits a message and presses Escape before any assistant content streams, the submitted message is restored into the input, image attachments/placeholders are preserved, and the temporary user message is removed from chat state to avoid duplicates.

Escape keeps the existing cancel behavior once streaming has started, while tools/questions/confirmations are active, or when no recallable draft exists.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Verified:
- `./node_modules/.bin/ava --timeout=30s source/components/user-input.spec.tsx source/app/sections/interactive-app.spec.tsx` passed, 47 tests
- `./node_modules/.bin/biome check --no-errors-on-unmatched .` passed
- `./node_modules/.bin/tsc --noEmit --pretty false` passed
- `npm run build` passed
- `./node_modules/.bin/knip` passed
- `pnpm test:audit` passed

Notes:
- `pnpm run test:all` did not complete in this environment because pnpm failed at fetch.
- Direct full AVA run timed out on unrelated existing test `source/auth/chatgpt-codex.spec.ts` / `runCodexLoginFlow calls onShowCode and saves credential`; rerunning that spec alone reproduced the timeout.

Closes #598 
### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))