### PR TITLE
fix: patch malformed SSE termination string from providers

### DIFF
--- a/source/ai-sdk-client/providers/provider-factory.spec.ts
+++ b/source/ai-sdk-client/providers/provider-factory.spec.ts
@@ -3,8 +3,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type {AIProviderConfig} from '@/types/index';
-import {Agent} from 'undici';
-import {createProvider} from './provider-factory.js';
+import {Agent, MockAgent} from 'undici';
+import {createProvider, createUndiciFetch} from './provider-factory.js';
 
 test('createProvider creates provider with basic config', async t => {
 	const config: AIProviderConfig = {
@@ -397,4 +397,25 @@ test.serial('createProvider throws when github-copilot has no stored credential'
 		}
 		fs.rmSync(tmpDir, {recursive: true, force: true});
 	}
+});
+
+test('createUndiciFetch patches double spaces in SSE data: [DONE]', async t => {
+	const mockAgent = new MockAgent();
+	mockAgent.disableNetConnect();
+	
+	const mockPool = mockAgent.get('https://api.atlascloud.ai');
+	mockPool.intercept({
+		path: '/v1/chat/completions',
+		method: 'POST'
+	}).reply(200, 'data:  [DONE]', {
+		headers: { 'content-type': 'text/event-stream' }
+	});
+
+	const fetchFn = createUndiciFetch(mockAgent as unknown as Agent);
+	const response = await fetchFn('https://api.atlascloud.ai/v1/chat/completions', {
+		method: 'POST'
+	});
+	
+	const text = await response.text();
+	t.is(text, 'data: [DONE]');
 });

--- a/source/ai-sdk-client/providers/provider-factory.spec.ts
+++ b/source/ai-sdk-client/providers/provider-factory.spec.ts
@@ -402,20 +402,79 @@ test.serial('createProvider throws when github-copilot has no stored credential'
 test('createUndiciFetch patches double spaces in SSE data: [DONE]', async t => {
 	const mockAgent = new MockAgent();
 	mockAgent.disableNetConnect();
-	
+
 	const mockPool = mockAgent.get('https://api.atlascloud.ai');
 	mockPool.intercept({
 		path: '/v1/chat/completions',
-		method: 'POST'
+		method: 'POST',
 	}).reply(200, 'data:  [DONE]', {
-		headers: { 'content-type': 'text/event-stream' }
+		headers: {'content-type': 'text/event-stream'},
 	});
 
 	const fetchFn = createUndiciFetch(mockAgent as unknown as Agent);
 	const response = await fetchFn('https://api.atlascloud.ai/v1/chat/completions', {
-		method: 'POST'
+		method: 'POST',
 	});
-	
+
 	const text = await response.text();
 	t.is(text, 'data: [DONE]');
+});
+
+test('createUndiciFetch patches double spaces when data: [DONE] is split across chunks', async t => {
+	const http = await import('node:http');
+	const server = http.createServer((req, res) => {
+		res.writeHead(200, {'Content-Type': 'text/event-stream'});
+		res.write('data:');
+		setTimeout(() => {
+			res.write('  ');
+			setTimeout(() => {
+				res.end('[DONE]');
+			}, 10);
+		}, 10);
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const port = (server.address() as any).port;
+
+	const agent = new Agent();
+	const fetchFn = createUndiciFetch(agent);
+	const response = await fetchFn(`http://localhost:${port}/v1/chat/completions`, {
+		method: 'POST',
+	});
+
+	const text = await response.text();
+	server.close();
+	t.is(text, 'data: [DONE]');
+});
+
+test('createUndiciFetch does not corrupt multi-byte characters split across chunks', async t => {
+	const http = await import('node:http');
+	const emojiBytes = new TextEncoder().encode('👋');
+	const firstHalf = emojiBytes.subarray(0, 2);
+	const secondHalf = emojiBytes.subarray(2, 4);
+
+	const server = http.createServer((req, res) => {
+		res.writeHead(200, {'Content-Type': 'text/event-stream'});
+		res.write('data: ');
+		res.write(firstHalf);
+		setTimeout(() => {
+			res.write(secondHalf);
+			setTimeout(() => {
+				res.end('\n\ndata:  [DONE]');
+			}, 10);
+		}, 10);
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const port = (server.address() as any).port;
+
+	const agent = new Agent();
+	const fetchFn = createUndiciFetch(agent);
+	const response = await fetchFn(`http://localhost:${port}/v1/chat/completions`, {
+		method: 'POST',
+	});
+
+	const text = await response.text();
+	server.close();
+	t.is(text, 'data: 👋\n\ndata: [DONE]');
 });

--- a/source/ai-sdk-client/providers/provider-factory.ts
+++ b/source/ai-sdk-client/providers/provider-factory.ts
@@ -65,17 +65,31 @@ export function createUndiciFetch(undiciAgent: Agent) {
 
 		const contentType = response.headers.get('content-type') || '';
 		if (response.body && contentType.includes('text/event-stream')) {
+			const decoder = new TextDecoder('utf-8');
+			const encoder = new TextEncoder();
+			let buffer = '';
+
 			const transform = new TransformStream({
 				transform(chunk, controller) {
-					const str = new TextDecoder().decode(chunk);
-					if (str.includes('data:  [DONE]')) {
-						controller.enqueue(
-							new TextEncoder().encode(
-								str.replace(/data:\s+\[DONE\]/g, 'data: [DONE]'),
-							),
-						);
-					} else {
-						controller.enqueue(chunk);
+					buffer += decoder.decode(chunk, {stream: true});
+
+					if (buffer.includes('data:  [DONE]')) {
+						buffer = buffer.replace(/data:\s\s\[DONE\]/g, 'data: [DONE]');
+					}
+
+					if (buffer.length > 13) {
+						const toEnqueue = buffer.slice(0, -13);
+						buffer = buffer.slice(-13);
+						controller.enqueue(encoder.encode(toEnqueue));
+					}
+				},
+				flush(controller) {
+					buffer += decoder.decode();
+					if (buffer.includes('data:  [DONE]')) {
+						buffer = buffer.replace(/data:\s\s\[DONE\]/g, 'data: [DONE]');
+					}
+					if (buffer.length > 0) {
+						controller.enqueue(encoder.encode(buffer));
 					}
 				},
 			});

--- a/source/ai-sdk-client/providers/provider-factory.ts
+++ b/source/ai-sdk-client/providers/provider-factory.ts
@@ -53,15 +53,41 @@ export type TaggedProvider =
  * this fetch will honor the configured CA bundle — even Anthropic and Google,
  * which would otherwise use the global fetch and bypass our TLS settings.
  */
-function createUndiciFetch(undiciAgent: Agent) {
-	return (
+export function createUndiciFetch(undiciAgent: Agent) {
+	return async (
 		url: string | URL | Request,
 		options?: RequestInit,
 	): Promise<Response> => {
-		return undiciFetch(url as string | URL, {
+		const response = await undiciFetch(url as string | URL, {
 			...(options as UndiciRequestInit),
 			dispatcher: undiciAgent,
-		}) as Promise<Response>;
+		});
+
+		const contentType = response.headers.get('content-type') || '';
+		if (response.body && contentType.includes('text/event-stream')) {
+			const transform = new TransformStream({
+				transform(chunk, controller) {
+					const str = new TextDecoder().decode(chunk);
+					if (str.includes('data:  [DONE]')) {
+						controller.enqueue(
+							new TextEncoder().encode(
+								str.replace(/data:\s+\[DONE\]/g, 'data: [DONE]'),
+							),
+						);
+					} else {
+						controller.enqueue(chunk);
+					}
+				},
+			});
+
+			return new Response(response.body.pipeThrough(transform), {
+				status: response.status,
+				statusText: response.statusText,
+				headers: response.headers,
+			}) as unknown as Response;
+		}
+
+		return response as unknown as Response;
 	};
 }
 


### PR DESCRIPTION
## Description

Closes #614.

This PR fixes a bug where Nanocoder crashes with an `Unexpected token 'D', " [DONE]" is not valid JSON` error at the end of streams when using certain OpenAI-compatible APIs (like Atlas Cloud or DeepSeek endpoints). 

These providers send a slightly malformed termination string: `data:  [DONE]` (with two spaces). Because the Vercel `@ai-sdk/openai-compatible` parser strips only one space and does a strict string comparison, it fails to recognize the `[DONE]` signal. It then falls back to `JSON.parse(" [DONE]")`, which immediately crashes the application.

**Changes:**
- Added a `TransformStream` interceptor to `createUndiciFetch` that normalizes multiple spaces in SSE streams (replacing `/data:\s+\[DONE\]/g` with `data: [DONE]`).
- Added a unit test in `provider-factory.spec.ts` using `MockAgent` to ensure the double-space termination string is patched correctly before reaching the AI SDK.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

### ScreenShot
<img width="1636" height="954" alt="image" src="https://github.com/user-attachments/assets/cbc636fb-4908-4e75-9ae0-5d29f4d790f3" />
