### PR TITLE
feat: add diff_edit tool for nano profile models (#604)

### DIFF
--- a/source/components/question-prompt.tsx
+++ b/source/components/question-prompt.tsx
@@ -55,10 +55,24 @@ export default function QuestionPrompt({
 		setSelectedIndex(0);
 	}
 
+	// Fix stale closures in useInput by keeping a ref to the latest state
+	const stateRef = useRef({
+		items,
+		selectedIndex,
+		isFreeformMode,
+		onAnswer,
+	});
+	stateRef.current = {
+		items,
+		selectedIndex,
+		isFreeformMode,
+		onAnswer,
+	};
+
 	const submitAnswer = (answer: string) => {
 		if (answeredRef.current) return;
 		answeredRef.current = true;
-		onAnswer(answer);
+		stateRef.current.onAnswer(answer);
 	};
 
 	const handleSelect = (item: OptionItem | undefined) => {
@@ -77,8 +91,9 @@ export default function QuestionPrompt({
 	};
 
 	useInput((input, key) => {
+		const state = stateRef.current;
 		// In freeform mode the TextInput owns typing; only handle Escape (back).
-		if (isFreeformMode) {
+		if (state.isFreeformMode) {
 			if (key.escape) {
 				setIsFreeformMode(false);
 				setFreeformValue('');
@@ -90,14 +105,14 @@ export default function QuestionPrompt({
 			submitAnswer('User declined to answer');
 			return;
 		}
-		if (items.length === 0) return;
+		if (state.items.length === 0) return;
 
 		if (key.upArrow || input === 'k') {
-			setSelectedIndex(i => (i - 1 + items.length) % items.length);
+			setSelectedIndex(i => (i - 1 + state.items.length) % state.items.length);
 		} else if (key.downArrow || input === 'j') {
-			setSelectedIndex(i => (i + 1) % items.length);
+			setSelectedIndex(i => (i + 1) % state.items.length);
 		} else if (key.return) {
-			handleSelect(items[selectedIndex]);
+			handleSelect(state.items[state.selectedIndex]);
 		}
 	});
 

--- a/source/tools/file-ops/diff-edit.spec.tsx
+++ b/source/tools/file-ops/diff-edit.spec.tsx
@@ -152,6 +152,37 @@ test('diff_edit applies multiple blocks atomically', async t => {
 	t.regex(result, /Successfully applied 2 diff blocks/);
 });
 
+test('diff_edit rejects duplicate search blocks and leaves file unchanged', async t => {
+	const filePath = await createTestFile('test.ts', 'alpha\n');
+
+	await t.throwsAsync(
+		async () => {
+			await executeDiffEdit({
+				path: filePath,
+				diff: [diffBlock('alpha', 'alphaX'), diffBlock('alpha', 'beta')].join(
+					'\n',
+				),
+			});
+		},
+		{message: /Search block 2 duplicates an earlier search block/},
+	);
+
+	t.is(await readFile(filePath, 'utf-8'), 'alpha\n');
+});
+
+test('diff_edit returns updated file contents for the model', async t => {
+	const filePath = await createTestFile('test.ts', 'alpha\n');
+
+	const result = await executeDiffEdit({
+		path: filePath,
+		diff: diffBlock('alpha', 'beta'),
+	});
+
+	t.regex(result, /Successfully applied 1 diff block/);
+	t.regex(result, /Updated file contents:/);
+	t.regex(result, /1: beta/);
+});
+
 test('diff_edit rejects missing search content and leaves file unchanged', async t => {
 	const filePath = await createTestFile('test.ts', 'alpha\ngamma\n');
 
@@ -247,4 +278,11 @@ test('diff_edit formatter renders a preview', async t => {
 	t.regex(lastFrame()!, /test\.ts/);
 	t.regex(lastFrame()!, /const oldValue/);
 	t.regex(lastFrame()!, /const newValue/);
+});
+
+test('diff_edit description tells models not to wrap diff in code fences', t => {
+	t.regex(
+		diffEditTool.tool.description,
+		/do not wrap.*code fence|code fence.*do not wrap/i,
+	);
 });

--- a/source/tools/file-ops/diff-edit.spec.tsx
+++ b/source/tools/file-ops/diff-edit.spec.tsx
@@ -1,0 +1,250 @@
+import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {join, relative} from 'node:path';
+import test from 'ava';
+import {render} from 'ink-testing-library';
+import React from 'react';
+import {themes} from '../../config/themes.js';
+import {ThemeContext} from '../../hooks/useTheme.js';
+import {resolveToolApproval} from '../approval-policy.js';
+import {clearReadTracker, markFileSeen} from '../../utils/read-tracker.js';
+import {diffEditTool, parseDiffEditBlocks} from './diff-edit.js';
+
+console.log(`\ndiff-edit.spec.tsx - ${React.version}`);
+
+function TestThemeProvider({children}: {children: React.ReactNode}) {
+	const themeContextValue = {
+		currentTheme: 'tokyo-night' as const,
+		colors: themes['tokyo-night'].colors,
+		setCurrentTheme: () => {},
+	};
+
+	return (
+		<ThemeContext.Provider value={themeContextValue}>
+			{children}
+		</ThemeContext.Provider>
+	);
+}
+
+let testDir: string;
+
+test.beforeEach(async () => {
+	testDir = await mkdtemp(join(process.cwd(), '.diff-edit-test-'));
+	clearReadTracker();
+});
+
+test.afterEach(async () => {
+	if (testDir) {
+		await rm(testDir, {recursive: true, force: true});
+	}
+});
+
+async function createTestFile(
+	filename: string,
+	content: string,
+): Promise<string> {
+	const filePath = join(testDir, filename);
+	await writeFile(filePath, content, 'utf-8');
+	return filePath;
+}
+
+function projectRelativePath(filePath: string): string {
+	return relative(process.cwd(), filePath);
+}
+
+async function executeDiffEdit(args: {
+	path: string;
+	diff: string;
+}): Promise<string> {
+	// biome-ignore lint/suspicious/noExplicitAny: Tool internals require any
+	return await (diffEditTool.tool as any).execute(args, {
+		toolCallId: 'test',
+		messages: [],
+	});
+}
+
+const searchMarker = '<'.repeat(7) + ' SEARCH';
+const separatorMarker = '='.repeat(7);
+const replaceMarker = '>'.repeat(7) + ' REPLACE';
+
+function diffBlock(search: string, replace: string): string {
+	return [
+		searchMarker,
+		search,
+		separatorMarker,
+		replace,
+		replaceMarker,
+	].join('\n');
+}
+
+const sampleDiff = diffBlock('const oldValue = 1;', 'const newValue = 2;');
+
+test('diff_edit requires approval in normal mode', async t => {
+	t.true(
+		await resolveToolApproval(diffEditTool.name, diffEditTool, {
+			path: 'test.ts',
+			diff: sampleDiff,
+		}, {mode: 'normal'}),
+	);
+});
+
+test('parseDiffEditBlocks parses a single search replace block', t => {
+	t.deepEqual(parseDiffEditBlocks(sampleDiff), [
+		{search: 'const oldValue = 1;', replace: 'const newValue = 2;'},
+	]);
+});
+
+test('parseDiffEditBlocks parses multiple blocks', t => {
+	const diff = [diffBlock('alpha', 'beta'), diffBlock('gamma', 'delta')].join(
+		'\n\n',
+	);
+
+	t.deepEqual(parseDiffEditBlocks(diff), [
+		{search: 'alpha', replace: 'beta'},
+		{search: 'gamma', replace: 'delta'},
+	]);
+});
+
+test('parseDiffEditBlocks rejects malformed input with missing separator', t => {
+	t.throws(
+		() =>
+			parseDiffEditBlocks([searchMarker, 'old', replaceMarker].join('\n')),
+		{message: /missing ======= separator/i},
+	);
+});
+
+test('parseDiffEditBlocks rejects unterminated blocks', t => {
+	t.throws(
+		() =>
+			parseDiffEditBlocks(
+				[searchMarker, 'old', separatorMarker, 'new'].join('\n'),
+			),
+		{message: /missing >>>>>>> REPLACE/i},
+	);
+});
+
+test('diff_edit applies a single block', async t => {
+	const filePath = await createTestFile(
+		'test.ts',
+		'const oldValue = 1;\nconsole.log(oldValue);\n',
+	);
+
+	const result = await executeDiffEdit({
+		path: filePath,
+		diff: sampleDiff,
+	});
+
+	t.is(
+		await readFile(filePath, 'utf-8'),
+		'const newValue = 2;\nconsole.log(oldValue);\n',
+	);
+	t.regex(result, /Successfully applied 1 diff block/);
+});
+
+test('diff_edit applies multiple blocks atomically', async t => {
+	const filePath = await createTestFile('test.ts', 'alpha\ngamma\n');
+
+	const result = await executeDiffEdit({
+		path: filePath,
+		diff: [diffBlock('alpha', 'beta'), diffBlock('gamma', 'delta')].join('\n'),
+	});
+
+	t.is(await readFile(filePath, 'utf-8'), 'beta\ndelta\n');
+	t.regex(result, /Successfully applied 2 diff blocks/);
+});
+
+test('diff_edit rejects missing search content and leaves file unchanged', async t => {
+	const filePath = await createTestFile('test.ts', 'alpha\ngamma\n');
+
+	await t.throwsAsync(
+		async () => {
+			await executeDiffEdit({
+				path: filePath,
+				diff: [diffBlock('alpha', 'beta'), diffBlock('missing', 'delta')].join(
+					'\n',
+				),
+			});
+		},
+		{message: /Search block 2 was not found/},
+	);
+
+	t.is(await readFile(filePath, 'utf-8'), 'alpha\ngamma\n');
+});
+
+test('diff_edit rejects ambiguous search content', async t => {
+	const filePath = await createTestFile('test.ts', 'same\nsame\n');
+
+	await t.throwsAsync(
+		async () => {
+			await executeDiffEdit({
+				path: filePath,
+				diff: diffBlock('same', 'changed'),
+			});
+		},
+		{message: /Search block 1 matched 2 times/},
+	);
+});
+
+test('diff_edit validator rejects empty path', async t => {
+	const validator = diffEditTool.validator;
+	if (!validator) {
+		t.fail('diff_edit validator not defined');
+		return;
+	}
+
+	const result = await validator({path: '', diff: sampleDiff});
+
+	t.false(result.valid);
+	if (!result.valid) t.regex(result.error, /Invalid file path/);
+});
+
+test('diff_edit validator rejects unread files', async t => {
+	const validator = diffEditTool.validator;
+	if (!validator) {
+		t.fail('diff_edit validator not defined');
+		return;
+	}
+	const filePath = await createTestFile('test.ts', 'const oldValue = 1;\n');
+
+	const result = await validator({
+		path: projectRelativePath(filePath),
+		diff: sampleDiff,
+	});
+
+	t.false(result.valid);
+	if (!result.valid) t.regex(result.error, /must read/);
+});
+
+test('diff_edit validator accepts a unique block after file is read', async t => {
+	const validator = diffEditTool.validator;
+	if (!validator) {
+		t.fail('diff_edit validator not defined');
+		return;
+	}
+	const filePath = await createTestFile('test.ts', 'const oldValue = 1;\n');
+	markFileSeen(filePath);
+
+	const result = await validator({
+		path: projectRelativePath(filePath),
+		diff: sampleDiff,
+	});
+
+	t.deepEqual(result, {valid: true});
+});
+
+test('diff_edit formatter renders a preview', async t => {
+	const formatter = diffEditTool.formatter;
+	if (!formatter) {
+		t.fail('diff_edit formatter not defined');
+		return;
+	}
+
+	const preview = await formatter({path: 'test.ts', diff: sampleDiff});
+	const {lastFrame} = render(
+		<TestThemeProvider>{preview}</TestThemeProvider>,
+	);
+
+	t.regex(lastFrame()!, /diff_edit/);
+	t.regex(lastFrame()!, /test\.ts/);
+	t.regex(lastFrame()!, /const oldValue/);
+	t.regex(lastFrame()!, /const newValue/);
+});

--- a/source/tools/file-ops/diff-edit.tsx
+++ b/source/tools/file-ops/diff-edit.tsx
@@ -110,9 +110,18 @@ function countOccurrences(content: string, search: string): number {
 }
 
 function validateBlocks(fileContent: string, blocks: DiffEditBlock[]): void {
+	const seenSearchBlocks = new Set<string>();
+
 	blocks.forEach((block, index) => {
-		const occurrences = countOccurrences(fileContent, block.search);
 		const blockNumber = index + 1;
+		if (seenSearchBlocks.has(block.search)) {
+			throw new Error(
+				`Search block ${blockNumber} duplicates an earlier search block. Each SEARCH block must target a distinct original file range.`,
+			);
+		}
+		seenSearchBlocks.add(block.search);
+
+		const occurrences = countOccurrences(fileContent, block.search);
 
 		if (occurrences === 0) {
 			throw new Error(
@@ -178,7 +187,7 @@ const executeDiffEdit = async (args: DiffEditArgs): Promise<string> => {
 
 const diffEditCoreTool = tool({
 	description:
-		'Apply one or more SEARCH/REPLACE edit blocks to a file. Use this for weak local models when exact string_replace arguments are hard to produce. Every SEARCH block must match the file exactly once. Format: <<<<<<< SEARCH, old content, =======, new content, >>>>>>> REPLACE.',
+		'Apply one or more SEARCH/REPLACE edit blocks to a file. Use this for weak local models when exact string_replace arguments are hard to produce. Every SEARCH block must match the file exactly once. Format: <<<<<<< SEARCH, old content, =======, new content, >>>>>>> REPLACE. Do not wrap the diff in a markdown code fence.',
 	inputSchema: jsonSchema<DiffEditArgs>({
 		type: 'object',
 		properties: {
@@ -189,7 +198,7 @@ const diffEditCoreTool = tool({
 			diff: {
 				type: 'string',
 				description:
-					'One or more SEARCH/REPLACE blocks using <<<<<<< SEARCH, =======, and >>>>>>> REPLACE markers.',
+					'One or more SEARCH/REPLACE blocks using <<<<<<< SEARCH, =======, and >>>>>>> REPLACE markers. Do not wrap the diff in markdown code fences or backticks.',
 			},
 		},
 		required: ['path', 'diff'],
@@ -212,13 +221,16 @@ function DiffEditPreview({
 	}
 	const {colors} = themeContext;
 
-	let blocks: DiffEditBlock[] = [];
-	let parseError: string | null = null;
-	try {
-		blocks = parseDiffEditBlocks(args.diff);
-	} catch (error) {
-		parseError = formatError(error);
-	}
+	const {blocks, parseError} = React.useMemo<{
+		blocks: DiffEditBlock[];
+		parseError: string | null;
+	}>(() => {
+		try {
+			return {blocks: parseDiffEditBlocks(args.diff), parseError: null};
+		} catch (error) {
+			return {blocks: [], parseError: formatError(error)};
+		}
+	}, [args.diff]);
 
 	const messageContent = (
 		<Box flexDirection="column">
@@ -272,6 +284,10 @@ const diffEditFormatter = async (
 			);
 
 			if (changeId) {
+				const previousChangeId = vscodeChangeIds.get(absPath);
+				if (previousChangeId) {
+					closeDiffInVSCode(previousChangeId);
+				}
 				vscodeChangeIds.set(absPath, changeId);
 			}
 		} catch {

--- a/source/tools/file-ops/diff-edit.tsx
+++ b/source/tools/file-ops/diff-edit.tsx
@@ -1,0 +1,348 @@
+import {constants} from 'node:fs';
+import {access, writeFile} from 'node:fs/promises';
+import {resolve} from 'node:path';
+import {Box, Text} from 'ink';
+import React from 'react';
+import ToolMessage from '@/components/tool-message';
+import {ThemeContext} from '@/hooks/useTheme';
+import type {NanocoderToolExport} from '@/types/core';
+import {jsonSchema, tool} from '@/types/core';
+import {formatError} from '@/utils/error-formatter';
+import {getCachedFileContent, invalidateCache} from '@/utils/file-cache';
+import {validatePath} from '@/utils/path-validators';
+import {hasSeenFile, markFileSeen} from '@/utils/read-tracker';
+import {createFileToolApproval} from '@/utils/tool-approval';
+import {
+	closeDiffInVSCode,
+	isVSCodeConnected,
+	sendFileChangeToVSCode,
+} from '@/vscode/index';
+
+interface DiffEditArgs {
+	path: string;
+	diff: string;
+}
+
+export interface DiffEditBlock {
+	search: string;
+	replace: string;
+}
+
+const SEARCH_MARKER = '<<<<<<< SEARCH';
+const SEPARATOR_MARKER = '=======';
+const REPLACE_MARKER = '>>>>>>> REPLACE';
+
+function stripSingleBoundaryNewline(value: string): string {
+	if (value.startsWith('\r\n')) return value.slice(2);
+	if (value.startsWith('\n')) return value.slice(1);
+	return value;
+}
+
+function stripTrailingBoundaryNewline(value: string): string {
+	if (value.endsWith('\r\n')) return value.slice(0, -2);
+	if (value.endsWith('\n')) return value.slice(0, -1);
+	return value;
+}
+
+function normalizeBlockContent(value: string): string {
+	return stripTrailingBoundaryNewline(stripSingleBoundaryNewline(value));
+}
+
+export function parseDiffEditBlocks(diff: string): DiffEditBlock[] {
+	if (!diff || diff.trim().length === 0) {
+		throw new Error(
+			'diff cannot be empty. Provide at least one SEARCH/REPLACE block.',
+		);
+	}
+
+	const blocks: DiffEditBlock[] = [];
+	let index = 0;
+
+	while (index < diff.length) {
+		const searchStart = diff.indexOf(SEARCH_MARKER, index);
+		if (searchStart === -1) {
+			if (diff.slice(index).trim().length > 0 && blocks.length === 0) {
+				throw new Error(`Missing ${SEARCH_MARKER} marker.`);
+			}
+			break;
+		}
+
+		const searchContentStart = searchStart + SEARCH_MARKER.length;
+		const separatorStart = diff.indexOf(SEPARATOR_MARKER, searchContentStart);
+		if (separatorStart === -1) {
+			throw new Error(
+				`Diff block ${blocks.length + 1} is missing ======= separator.`,
+			);
+		}
+
+		const replaceContentStart = separatorStart + SEPARATOR_MARKER.length;
+		const replaceEnd = diff.indexOf(REPLACE_MARKER, replaceContentStart);
+		if (replaceEnd === -1) {
+			throw new Error(
+				`Diff block ${blocks.length + 1} is missing >>>>>>> REPLACE marker.`,
+			);
+		}
+
+		const search = normalizeBlockContent(
+			diff.slice(searchContentStart, separatorStart),
+		);
+		const replace = normalizeBlockContent(
+			diff.slice(replaceContentStart, replaceEnd),
+		);
+
+		if (search.length === 0) {
+			throw new Error(`Search block ${blocks.length + 1} cannot be empty.`);
+		}
+
+		blocks.push({search, replace});
+		index = replaceEnd + REPLACE_MARKER.length;
+	}
+
+	if (blocks.length === 0) {
+		throw new Error('No SEARCH/REPLACE blocks found in diff.');
+	}
+
+	return blocks;
+}
+
+function countOccurrences(content: string, search: string): number {
+	return content.split(search).length - 1;
+}
+
+function validateBlocks(fileContent: string, blocks: DiffEditBlock[]): void {
+	blocks.forEach((block, index) => {
+		const occurrences = countOccurrences(fileContent, block.search);
+		const blockNumber = index + 1;
+
+		if (occurrences === 0) {
+			throw new Error(
+				`Search block ${blockNumber} was not found in file. The file may have changed since you last read it.`,
+			);
+		}
+
+		if (occurrences > 1) {
+			throw new Error(
+				`Search block ${blockNumber} matched ${occurrences} times. Add surrounding context so it is unique.`,
+			);
+		}
+	});
+}
+
+function applyBlocks(fileContent: string, blocks: DiffEditBlock[]): string {
+	let newContent = fileContent;
+
+	blocks.forEach((block, index) => {
+		const occurrences = countOccurrences(newContent, block.search);
+		if (occurrences !== 1) {
+			throw new Error(
+				`Search block ${index + 1} could not be applied cleanly after earlier edits.`,
+			);
+		}
+
+		newContent = newContent.replace(block.search, block.replace);
+	});
+
+	return newContent;
+}
+
+function formatUpdatedFileContext(content: string): string {
+	const lines = content.split('\n');
+	let fileContext = '\n\nUpdated file contents:\n';
+
+	for (let i = 0; i < lines.length; i++) {
+		const lineNumStr = String(i + 1).padStart(4, ' ');
+		const line = lines[i] || '';
+		fileContext += `${lineNumStr}: ${line}\n`;
+	}
+
+	return fileContext;
+}
+
+const executeDiffEdit = async (args: DiffEditArgs): Promise<string> => {
+	const {path, diff} = args;
+	const absPath = resolve(path);
+	const blocks = parseDiffEditBlocks(diff);
+	const cached = await getCachedFileContent(absPath);
+	const fileContent = cached.content;
+
+	validateBlocks(fileContent, blocks);
+	const newContent = applyBlocks(fileContent, blocks);
+
+	await writeFile(absPath, newContent, 'utf-8');
+	invalidateCache(absPath);
+	markFileSeen(absPath);
+
+	const blockLabel = blocks.length === 1 ? 'block' : 'blocks';
+	return `Successfully applied ${blocks.length} diff ${blockLabel}.${formatUpdatedFileContext(newContent)}`;
+};
+
+const diffEditCoreTool = tool({
+	description:
+		'Apply one or more SEARCH/REPLACE edit blocks to a file. Use this for weak local models when exact string_replace arguments are hard to produce. Every SEARCH block must match the file exactly once. Format: <<<<<<< SEARCH, old content, =======, new content, >>>>>>> REPLACE.',
+	inputSchema: jsonSchema<DiffEditArgs>({
+		type: 'object',
+		properties: {
+			path: {
+				type: 'string',
+				description: 'The path to the file to edit.',
+			},
+			diff: {
+				type: 'string',
+				description:
+					'One or more SEARCH/REPLACE blocks using <<<<<<< SEARCH, =======, and >>>>>>> REPLACE markers.',
+			},
+		},
+		required: ['path', 'diff'],
+	}),
+	execute: async (args, _options) => {
+		return await executeDiffEdit(args);
+	},
+});
+
+function DiffEditPreview({
+	args,
+	result,
+}: {
+	args: DiffEditArgs;
+	result?: string;
+}) {
+	const themeContext = React.useContext(ThemeContext);
+	if (!themeContext) {
+		throw new Error('ThemeContext is required');
+	}
+	const {colors} = themeContext;
+
+	let blocks: DiffEditBlock[] = [];
+	let parseError: string | null = null;
+	try {
+		blocks = parseDiffEditBlocks(args.diff);
+	} catch (error) {
+		parseError = formatError(error);
+	}
+
+	const messageContent = (
+		<Box flexDirection="column">
+			<Text color={colors.tool}>diff_edit</Text>
+			<Box>
+				<Text color={colors.secondary}>Path: </Text>
+				<Text color={colors.text}>{args.path}</Text>
+			</Box>
+			{result ? (
+				<Text color={colors.success}>{result.split('\n\n')[0]}</Text>
+			) : parseError ? (
+				<Text color={colors.error}>{parseError}</Text>
+			) : (
+				<Box flexDirection="column" marginTop={1}>
+					{blocks.map((block, index) => (
+						<Box key={index} flexDirection="column" marginBottom={1}>
+							<Text color={colors.secondary}>Block {index + 1}</Text>
+							<Text color={colors.error}>- {block.search}</Text>
+							<Text color={colors.success}>+ {block.replace}</Text>
+						</Box>
+					))}
+				</Box>
+			)}
+		</Box>
+	);
+
+	return <ToolMessage message={messageContent} hideBox={true} />;
+}
+
+const vscodeChangeIds = new Map<string, string>();
+
+const diffEditFormatter = async (
+	args: DiffEditArgs,
+	result?: string,
+): Promise<React.ReactElement> => {
+	const absPath = resolve(args.path);
+
+	if (result === undefined && isVSCodeConnected()) {
+		try {
+			const blocks = parseDiffEditBlocks(args.diff);
+			const cached = await getCachedFileContent(absPath);
+			const fileContent = cached.content;
+			validateBlocks(fileContent, blocks);
+			const newContent = applyBlocks(fileContent, blocks);
+			const changeId = sendFileChangeToVSCode(
+				absPath,
+				fileContent,
+				newContent,
+				'diff_edit',
+				{path: args.path, diff: args.diff},
+			);
+
+			if (changeId) {
+				vscodeChangeIds.set(absPath, changeId);
+			}
+		} catch {
+			// Preview rendering should not fail because VS Code diff setup failed.
+		}
+	} else if (result !== undefined && isVSCodeConnected()) {
+		const changeId = vscodeChangeIds.get(absPath);
+		if (changeId) {
+			closeDiffInVSCode(changeId);
+			vscodeChangeIds.delete(absPath);
+		}
+	}
+
+	return <DiffEditPreview args={args} result={result} />;
+};
+
+const diffEditValidator = async (
+	args: DiffEditArgs,
+): Promise<{valid: true} | {valid: false; error: string}> => {
+	const pathResult = validatePath(args.path);
+	if (!pathResult.valid) return pathResult;
+
+	let blocks: DiffEditBlock[];
+	try {
+		blocks = parseDiffEditBlocks(args.diff);
+	} catch (error) {
+		return {valid: false, error: formatError(error)};
+	}
+
+	const absPath = resolve(args.path);
+	try {
+		await access(absPath, constants.F_OK);
+	} catch (error) {
+		if (error && typeof error === 'object' && 'code' in error) {
+			if (error.code === 'ENOENT') {
+				return {
+					valid: false,
+					error: `File "${args.path}" does not exist`,
+				};
+			}
+		}
+		return {
+			valid: false,
+			error: `Cannot access file "${args.path}": ${formatError(error)}`,
+		};
+	}
+
+	if (!hasSeenFile(absPath)) {
+		return {
+			valid: false,
+			error: `You must read "${args.path}" before editing it. Call read_file on it first, then retry diff_edit with SEARCH blocks copied from the file.`,
+		};
+	}
+
+	try {
+		const cached = await getCachedFileContent(absPath);
+		validateBlocks(cached.content, blocks);
+	} catch (error) {
+		return {
+			valid: false,
+			error: formatError(error),
+		};
+	}
+
+	return {valid: true};
+};
+
+export const diffEditTool: NanocoderToolExport = {
+	name: 'diff_edit' as const,
+	tool: diffEditCoreTool,
+	formatter: diffEditFormatter,
+	validator: diffEditValidator,
+	approval: createFileToolApproval('diff_edit'),
+};

--- a/source/tools/file-tools-path-validation.spec.ts
+++ b/source/tools/file-tools-path-validation.spec.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 import {mkdir, rm, writeFile as fsWriteFile} from 'node:fs/promises';
 import {join, resolve} from 'node:path';
 import {tmpdir} from 'node:os';
+import {diffEditTool} from './file-ops/diff-edit.js';
 import {writeFileTool} from './file-ops/write-file.js';
 import {stringReplaceTool} from './file-ops/string-replace.js';
 import {readFileTool} from './read-file.js';
@@ -301,6 +302,126 @@ test('string_replace validator: accepts valid relative paths', async (t) => {
 });
 
 // ============================================================================
+// diff_edit Validator Tests
+// ============================================================================
+
+const diffEditSample = '<<<<<<< SEARCH\nold content\n=======\nnew content\n>>>>>>> REPLACE';
+
+test('diff_edit validator: rejects directory traversal attempts', async (t) => {
+	const validator = diffEditTool.validator;
+	if (!validator) {
+		t.fail('diff_edit validator not defined');
+		return;
+	}
+
+	const originalCwd = process.cwd();
+
+	try {
+		process.chdir(testDir);
+
+		const result1 = await validator({
+			path: '../etc/passwd',
+			diff: diffEditSample,
+		});
+		t.false(result1.valid, 'Should reject ../ path');
+		if (!result1.valid) {
+			t.regex(result1.error, /Invalid file path/i);
+		}
+
+		const result2 = await validator({
+			path: '../../secret.txt',
+			diff: diffEditSample,
+		});
+		t.false(result2.valid, 'Should reject ../../ path');
+	} finally {
+		process.chdir(originalCwd);
+	}
+});
+
+test('diff_edit validator: rejects absolute paths', async (t) => {
+	const validator = diffEditTool.validator;
+	if (!validator) {
+		t.fail('diff_edit validator not defined');
+		return;
+	}
+
+	const originalCwd = process.cwd();
+
+	try {
+		process.chdir(testDir);
+
+		const result1 = await validator({
+			path: '/etc/passwd',
+			diff: diffEditSample,
+		});
+		t.false(result1.valid, 'Should reject Unix absolute path');
+		if (!result1.valid) {
+			t.regex(result1.error, /Invalid file path/i);
+		}
+
+		const result2 = await validator({
+			path: 'C:\\Windows\\System32',
+			diff: diffEditSample,
+		});
+		t.false(result2.valid, 'Should reject Windows absolute path');
+	} finally {
+		process.chdir(originalCwd);
+	}
+});
+
+test('diff_edit validator: rejects null byte injection', async (t) => {
+	const validator = diffEditTool.validator;
+	if (!validator) {
+		t.fail('diff_edit validator not defined');
+		return;
+	}
+
+	const originalCwd = process.cwd();
+
+	try {
+		process.chdir(testDir);
+
+		const result = await validator({
+			path: 'file\0.txt',
+			diff: diffEditSample,
+		});
+		t.false(result.valid, 'Should reject null byte in path');
+		if (!result.valid) {
+			t.regex(result.error, /Invalid file path/i);
+		}
+	} finally {
+		process.chdir(originalCwd);
+	}
+});
+
+test('diff_edit validator: accepts valid relative paths', async (t) => {
+	const validator = diffEditTool.validator;
+	if (!validator) {
+		t.fail('diff_edit validator not defined');
+		return;
+	}
+
+	const originalCwd = process.cwd();
+
+	try {
+		process.chdir(testDir);
+
+		const testFile = join(testDir, 'test.txt');
+		await fsWriteFile(testFile, 'old content', 'utf-8');
+		markFileSeen(resolve('test.txt'));
+
+		const result = await validator({
+			path: 'test.txt',
+			diff: diffEditSample,
+		});
+
+		t.true(result.valid, 'Should accept valid relative path');
+	} finally {
+		process.chdir(originalCwd);
+	}
+});
+
+// ============================================================================
 // read_file Validator Tests
 // ============================================================================
 
@@ -452,6 +573,18 @@ test('all tools: consistently reject common attack vectors', async (t) => {
 				t.false(
 					replaceResult.valid,
 					`string_replace should reject: ${vector}`,
+				);
+			}
+
+			// Test diff_edit
+			if (diffEditTool.validator) {
+				const diffResult = await diffEditTool.validator({
+					path: vector,
+					diff: diffEditSample,
+				});
+				t.false(
+					diffResult.valid,
+					`diff_edit should reject: ${vector}`,
 				);
 			}
 

--- a/source/tools/index.ts
+++ b/source/tools/index.ts
@@ -3,6 +3,7 @@ import {askQuestionTool} from '@/tools/ask-question';
 import {executeBashTool} from '@/tools/execute-bash';
 import {fetchUrlTool} from '@/tools/fetch-url';
 import {getFileOpTools} from '@/tools/file-ops';
+import {diffEditTool} from '@/tools/file-ops/diff-edit';
 import {stringReplaceTool} from '@/tools/file-ops/string-replace';
 import {writeFileTool} from '@/tools/file-ops/write-file';
 import {findFilesTool} from '@/tools/find-files';
@@ -21,6 +22,7 @@ const staticTools: NanocoderToolExport[] = [
 	readFileTool,
 	writeFileTool,
 	stringReplaceTool,
+	diffEditTool,
 	executeBashTool,
 	webSearchTool,
 	fetchUrlTool,

--- a/source/tools/needs-approval.spec.ts
+++ b/source/tools/needs-approval.spec.ts
@@ -3,6 +3,7 @@ import type {DevelopmentMode, NanocoderToolExport} from '../types/core.js';
 import {resolveToolApproval} from './approval-policy.js';
 import {executeBashTool} from './execute-bash.js';
 import {fetchUrlTool} from './fetch-url.js';
+import {diffEditTool} from './file-ops/diff-edit.js';
 import {fileOpTool} from './file-ops/file-op.js';
 import {stringReplaceTool} from './file-ops/string-replace.js';
 import {writeFileTool} from './file-ops/write-file.js';
@@ -109,6 +110,33 @@ test('string_replace requires approval in plan mode', async t => {
 	);
 });
 
+test('diff_edit requires approval in normal mode', async t => {
+	t.true(
+		await evaluateNeedsApproval(diffEditTool, 'normal', {
+			path: 'test.txt',
+			diff: '<<<<<<< SEARCH\nold\n=======\nnew\n>>>>>>> REPLACE',
+		}),
+	);
+});
+
+test('diff_edit does NOT require approval in auto-accept mode', async t => {
+	t.false(
+		await evaluateNeedsApproval(diffEditTool, 'auto-accept', {
+			path: 'test.txt',
+			diff: '<<<<<<< SEARCH\nold\n=======\nnew\n>>>>>>> REPLACE',
+		}),
+	);
+});
+
+test('diff_edit requires approval in plan mode', async t => {
+	t.true(
+		await evaluateNeedsApproval(diffEditTool, 'plan', {
+			path: 'test.txt',
+			diff: '<<<<<<< SEARCH\nold\n=======\nnew\n>>>>>>> REPLACE',
+		}),
+	);
+});
+
 // ============================================================================
 // LOW RISK: Read-Only Tools (never require approval, via !readOnly default)
 // ============================================================================
@@ -176,6 +204,15 @@ test('string_replace does NOT require approval in headless mode', async t => {
 			path: 'test.txt',
 			old_str: 'old',
 			new_str: 'new',
+		}),
+	);
+});
+
+test('diff_edit does NOT require approval in headless mode', async t => {
+	t.false(
+		await evaluateNeedsApproval(diffEditTool, 'headless', {
+			path: 'test.txt',
+			diff: '<<<<<<< SEARCH\nold\n=======\nnew\n>>>>>>> REPLACE',
 		}),
 	);
 });

--- a/source/tools/tool-manager.ts
+++ b/source/tools/tool-manager.ts
@@ -43,6 +43,7 @@ const MODE_EXCLUDED_TOOLS: Record<DevelopmentMode, string[]> = {
 		// No mutation tools — plan mode is read-only exploration
 		'write_file',
 		'string_replace',
+		'diff_edit',
 		'file_op',
 		'execute_bash',
 		// No task tool — plan mode produces the plan itself

--- a/source/tools/tool-profiles.spec.ts
+++ b/source/tools/tool-profiles.spec.ts
@@ -59,19 +59,20 @@ test('getToolsForProfile - minimal profile includes execute_bash', t => {
 	t.true(result.includes('execute_bash'));
 });
 
-test('getToolsForProfile - nano profile returns 5 core tools', t => {
+test('getToolsForProfile - nano profile returns 5 core tools with diff_edit', t => {
 	const result = getToolsForProfile('nano');
 	t.deepEqual(result, [
 		'read_file',
-		'string_replace',
+		'diff_edit',
 		'write_file',
 		'execute_bash',
 		'search_file_contents',
 	]);
 });
 
-test('getToolsForProfile - nano omits agent, find_files, list_directory', t => {
+test('getToolsForProfile - nano omits exact replace and broader exploration tools', t => {
 	const result = getToolsForProfile('nano');
+	t.false(result.includes('string_replace'));
 	t.false(result.includes('agent'));
 	t.false(result.includes('find_files'));
 	t.false(result.includes('list_directory'));

--- a/source/tools/tool-profiles.ts
+++ b/source/tools/tool-profiles.ts
@@ -21,7 +21,7 @@ const TOOL_PROFILES: Record<ConcreteProfile, string[]> = {
 	],
 	nano: [
 		'read_file',
-		'string_replace',
+		'diff_edit',
 		'write_file',
 		'execute_bash',
 		'search_file_contents',
@@ -33,7 +33,7 @@ export const TOOL_PROFILE_DESCRIPTIONS: Record<ToolProfile, string> = {
 	full: 'All tools including MCP',
 	minimal:
 		'Core editing, bash, and exploration tools — slim prompt, single-tool mode enabled automatically',
-	nano: 'Strictest budget — 5 tools, ultra-slim prompt. For low-end hardware running larger models.',
+	nano: 'Strictest budget — 5 tools, diff-block editing, ultra-slim prompt. For low-end hardware running tiny models.',
 };
 
 export const TOOL_PROFILE_TOOLTIPS: Record<ToolProfile, string> = {
@@ -41,7 +41,7 @@ export const TOOL_PROFILE_TOOLTIPS: Record<ToolProfile, string> = {
 	full: 'No filtering. All registered tools including MCP servers.',
 	minimal:
 		'8 core tools (edit, bash, search, agent) with slim prompt and single-tool enforcement. Recommended for small models.',
-	nano: '5 tools (read, edit, write, bash, search) with an ultra-slim prompt and single-tool enforcement. AGENTS.md is omitted from the system prompt by default. Recommended for tiny models or low-end hardware.',
+	nano: '5 tools (read, diff edit, write, bash, search) with an ultra-slim prompt and single-tool enforcement. AGENTS.md is omitted from the system prompt by default. Recommended for tiny models or low-end hardware.',
 };
 
 /**


### PR DESCRIPTION
## Description

Adds a new `diff_edit` tool (`source/tools/file-ops/diff-edit.tsx`) designed specifically for weak local models (nano profile) that struggle with the exact-string matching required by the existing `string_replace` tool. 

Key changes:
- Implements parsing and atomic application of SEARCH/REPLACE blocks.
- Adds strict validation: search blocks must be unique and non-empty, and files must be read before editing (`hasSeenFile`).
- Includes VS Code extension integration for diff previews.
- Updates the `nano` profile to use `diff_edit` instead of `string_replace`.
- Excludes `diff_edit` from `plan` mode in `tool-manager.ts`.
- Full test coverage for parser, validator, formatter preview, and approval conditions.

Fixes #604

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [x] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
