### PR TITLE
docs: add Atomic Chat local provider

### DIFF
--- a/docs/configuration/providers/atomic-chat.md
+++ b/docs/configuration/providers/atomic-chat.md
@@ -1,0 +1,53 @@
+---
+title: "Atomic Chat"
+description: "Configure Atomic Chat as a local AI provider for Nanocoder"
+sidebar_order: 4
+---
+
+# Atomic Chat
+
+[Atomic Chat](https://atomic.chat) is a desktop application for running local models with a built-in OpenAI-compatible API server at `http://127.0.0.1:1337/v1`.
+
+## Configuration
+
+```json
+{
+	"name": "Atomic Chat",
+	"baseUrl": "http://127.0.0.1:1337/v1",
+	"apiKey": "atomic",
+	"models": ["your-model-name"]
+}
+```
+
+The `apiKey` field is optional for local use; Atomic Chat accepts the placeholder value `"atomic"` when a key is required by the client.
+
+## Setup
+
+1. Download and install Atomic Chat from [atomic.chat](https://atomic.chat)
+2. Load a model in the app
+3. Verify the API is running:
+
+```bash
+curl http://127.0.0.1:1337/v1/models
+```
+
+## Docker
+
+If Nanocoder runs inside a container, use `host.docker.internal` to reach Atomic Chat on the host:
+
+```json
+{
+	"name": "Atomic Chat",
+	"baseUrl": "http://host.docker.internal:1337/v1",
+	"apiKey": "atomic",
+	"models": ["your-model-name"]
+}
+```
+
+## Context Length
+
+Load your model with a context length as high as your system's memory can handle. Agentic coding needs enough context to track conversation history, tool calls, and file contents. Increase context in Atomic Chat's model settings before starting a session.
+
+## Fetching Available Models
+
+The `/setup-providers` wizard can automatically fetch your loaded models from Atomic Chat when configuring this provider.

--- a/docs/configuration/providers/index.md
+++ b/docs/configuration/providers/index.md
@@ -27,6 +27,7 @@ Run on your machine, typically no API key required.
 - [Ollama](ollama.md) - Popular local model runner
 - [llama.cpp](llama-cpp.md) - High-performance inference server
 - [LM Studio](lm-studio.md) - Desktop app for running local models
+- [Atomic Chat](atomic-chat.md) - Desktop app with OpenAI-compatible local API
 - [MLX Server](mlx-server.md) - Apple Silicon optimized inference
 - [vLLM](vllm.md) - High-throughput serving engine
 - [LocalAI](localai.md) - OpenAI-compatible local API


### PR DESCRIPTION
## Summary
- Adds `docs/configuration/providers/atomic-chat.md` documenting Atomic Chat as a local OpenAI-compatible provider (`http://127.0.0.1:1337/v1`), including JSON config, setup, Docker (`host.docker.internal`), and context-length guidance for agentic coding.
- Lists Atomic Chat under **Local Providers** in `docs/configuration/providers/index.md` (after LM Studio).

Docs-only change, parallel in structure and intent to the existing LM Studio provider page.

## Test plan
- [ ] Review markdown renders correctly in the docs site
- [ ] Confirm index link resolves to `atomic-chat.md`
- [ ] Spot-check JSON examples match Atomic Chat’s local API defaults

Made with [Cursor](https://cursor.com)