### PR TITLE
Auto-run diagnostics after file edits

### DIFF
--- a/source/hooks/chat-handler/conversation/auto-diagnostics.spec.ts
+++ b/source/hooks/chat-handler/conversation/auto-diagnostics.spec.ts
@@ -1,0 +1,450 @@
+import test from 'ava';
+import {setToolRegistryGetter} from '@/message-handler.js';
+import type {LLMChatResponse, Message, ToolCall, ToolResult} from '@/types/core';
+import {resetShutdownManager} from '@/utils/shutdown/shutdown-manager.js';
+import {
+	buildAutoDiagnosticsMessage,
+	collectEditedPaths,
+} from './auto-diagnostics.js';
+import {processAssistantResponse} from './conversation-loop.js';
+
+test.before(() => {
+	resetShutdownManager();
+});
+
+test.after.always(() => {
+	resetShutdownManager();
+});
+
+const toolCall = (
+	id: string,
+	name: string,
+	args: Record<string, unknown> | string,
+): ToolCall => ({
+	id,
+	function: {
+		name,
+		arguments: args as ToolCall['function']['arguments'],
+	},
+});
+
+const toolResult = (
+	toolCallId: string,
+	name: string,
+	content = 'ok',
+	overrides: Partial<ToolResult> = {},
+): ToolResult => ({
+	tool_call_id: toolCallId,
+	role: 'tool',
+	name,
+	content,
+	...overrides,
+});
+
+const createLoopParams = (overrides = {}) => ({
+	systemMessage: {role: 'system', content: 'You are a helpful assistant'} as Message,
+	messages: [{role: 'user', content: 'Hello'}] as Message[],
+	client: null as any,
+	toolManager: null,
+	abortController: null,
+	setAbortController: () => {},
+	setIsGenerating: () => {},
+	setStreamingReasoning: () => {},
+	setStreamingContent: () => {},
+	setTokenCount: () => {},
+	setMessages: () => {},
+	addToChatQueue: () => {},
+	currentModel: 'test-model',
+	currentProvider: 'openai',
+	developmentMode: 'normal' as const,
+	nonInteractiveMode: false,
+	conversationStateManager: {
+		current: {
+			updateAssistantMessage: () => {},
+			updateAfterToolExecution: () => {},
+		},
+	} as any,
+	onConversationComplete: () => {},
+	...overrides,
+});
+
+const createLoopToolManager = (availableTools: string[]) =>
+	({
+		hasTool: (name: string) => availableTools.includes(name),
+		getToolNames: () => availableTools,
+		getToolEntry: (name: string) => ({
+			name,
+			approval: false,
+		}),
+		getToolValidator: () => undefined,
+		getToolFormatter: () => undefined,
+		getAvailableToolNames: () => availableTools,
+		getFilteredTools: (names: string[]) => {
+			const tools: Record<string, unknown> = {};
+			for (const name of names) {
+				tools[name] = {
+					name,
+					description: `Mock tool ${name}`,
+					input_schema: {type: 'object', properties: {}},
+				};
+			}
+
+			return tools;
+		},
+		isReadOnly: () => false,
+	}) as any;
+
+async function runAutoDiagnosticsAfterEditScenario(
+	editToolName: 'write_file' | 'string_replace',
+	availableTools: string[],
+) {
+	let chatCallCount = 0;
+	let editCalls = 0;
+	let diagnosticsCalls = 0;
+	let secondChatMessages: Message[] = [];
+	const editedPath = 'source/example.ts';
+
+	setToolRegistryGetter(() => ({
+		[editToolName]: async () => {
+			editCalls += 1;
+			return 'Edit complete';
+		},
+		lsp_get_diagnostics: async (args: Record<string, unknown>) => {
+			diagnosticsCalls += 1;
+			return {
+				llmContent: `Diagnostics for ${args.path}:\n\nERROR at line 1:1: Missing semicolon`,
+				structured: {
+					diagnostics: [
+						{
+							file: args.path,
+							line: 1,
+							character: 1,
+							severity: 'error',
+							message: 'Missing semicolon',
+						},
+					],
+				},
+			};
+		},
+	}));
+
+	const editToolCall = toolCall(`call_${editToolName}`, editToolName, {
+		path: editedPath,
+	});
+	const trackingClient = {
+		chat: async (messages: Message[]): Promise<LLMChatResponse> => {
+			chatCallCount += 1;
+			if (chatCallCount === 1) {
+				return {
+					choices: [
+						{
+							message: {
+								role: 'assistant',
+								content: '',
+								tool_calls: [editToolCall],
+							},
+						},
+					],
+					toolsDisabled: false,
+				};
+			}
+
+			secondChatMessages = messages;
+			return {
+				choices: [
+					{
+						message: {
+							role: 'assistant',
+							content: 'Done.',
+							tool_calls: undefined,
+						},
+					},
+				],
+				toolsDisabled: false,
+			};
+		},
+	};
+
+	await processAssistantResponse(
+		createLoopParams({
+			client: trackingClient,
+			toolManager: createLoopToolManager(availableTools),
+			addToChatQueue: () => {},
+		}),
+	);
+
+	return {
+		chatCallCount,
+		editCalls,
+		diagnosticsCalls,
+		secondChatMessages,
+	};
+}
+
+test('collectEditedPaths returns unique paths from successful edit tools', t => {
+	const paths = collectEditedPaths(
+		[
+			toolCall('call_1', 'write_file', {path: 'source/a.ts'}),
+			toolCall('call_2', 'string_replace', '{"path":"source/b.ts"}'),
+			toolCall('call_3', 'read_file', {path: 'source/c.ts'}),
+			toolCall('call_4', 'write_file', {path: 'source/a.ts'}),
+			toolCall('call_5', 'write_file', {file_path: 'source/d.ts'}),
+		],
+		[
+			toolResult('call_1', 'write_file'),
+			toolResult('call_2', 'string_replace'),
+			toolResult('call_3', 'read_file'),
+			toolResult('call_4', 'write_file'),
+			toolResult('call_5', 'write_file'),
+		],
+	);
+
+	t.deepEqual(paths, ['source/a.ts', 'source/b.ts', 'source/d.ts']);
+});
+
+test('collectEditedPaths skips failed or cancelled edits', t => {
+	const paths = collectEditedPaths(
+		[
+			toolCall('call_1', 'write_file', {path: 'source/a.ts'}),
+			toolCall('call_2', 'string_replace', {path: 'source/b.ts'}),
+			toolCall('call_3', 'write_file', {path: 'source/c.ts'}),
+		],
+		[
+			toolResult('call_1', 'write_file', 'Error: no permissions'),
+			toolResult('call_2', 'string_replace', '⚒ Validation failed: old_str'),
+			toolResult(
+				'call_3',
+				'write_file',
+				'Tool execution was cancelled by the user.',
+			),
+		],
+	);
+
+	t.deepEqual(paths, []);
+});
+
+test('buildAutoDiagnosticsMessage returns null when diagnostics are clean', async t => {
+	const message = await buildAutoDiagnosticsMessage(
+		[toolCall('call_1', 'write_file', {path: 'source/a.ts'})],
+		[toolResult('call_1', 'write_file')],
+		async toolCall =>
+			toolResult(
+				toolCall.id,
+				toolCall.function.name,
+				'No diagnostics found for source/a.ts',
+			),
+	);
+
+	t.is(message, null);
+});
+
+test('buildAutoDiagnosticsMessage surfaces thrown diagnostics failures', async t => {
+	const message = await buildAutoDiagnosticsMessage(
+		[toolCall('call_1', 'write_file', {path: 'source/a.ts'})],
+		[toolResult('call_1', 'write_file')],
+		async () => {
+			throw new Error('diagnostics unavailable');
+		},
+	);
+
+	t.truthy(message);
+	t.true(message?.content.includes('Error: diagnostics unavailable'));
+	t.true(message?.content.includes('source/a.ts'));
+});
+
+test('buildAutoDiagnosticsMessage surfaces error tool results', async t => {
+	const message = await buildAutoDiagnosticsMessage(
+		[toolCall('call_1', 'write_file', {path: 'source/a.ts'})],
+		[toolResult('call_1', 'write_file')],
+		async toolCall =>
+			toolResult(
+				toolCall.id,
+				toolCall.function.name,
+				'Error: LSP server crashed',
+			),
+	);
+
+	t.truthy(message);
+	t.true(message?.content.includes('Error: LSP server crashed'));
+	t.true(message?.content.includes('source/a.ts'));
+});
+
+test('buildAutoDiagnosticsMessage identifies the path for diagnostics failures across multiple edits', async t => {
+	const message = await buildAutoDiagnosticsMessage(
+		[
+			toolCall('call_1', 'write_file', {path: 'source/a.ts'}),
+			toolCall('call_2', 'write_file', {path: 'source/b.ts'}),
+		],
+		[
+			toolResult('call_1', 'write_file'),
+			toolResult('call_2', 'write_file'),
+		],
+		async toolCall => {
+			const args = toolCall.function.arguments;
+			if (args.path === 'source/a.ts') {
+				return toolResult(
+					toolCall.id,
+					toolCall.function.name,
+					'No diagnostics found for source/a.ts',
+				);
+			}
+
+			return toolResult(
+				toolCall.id,
+				toolCall.function.name,
+				'Error: LSP server crashed',
+			);
+		},
+	);
+
+	t.truthy(message);
+	t.true(
+		message?.content.includes('Diagnostics for source/b.ts:\nError: LSP'),
+	);
+	t.true(message?.content.includes('- source/b.ts'));
+	t.false(message?.content.includes('Paths needing attention:\n- source/a.ts'));
+});
+
+test('buildAutoDiagnosticsMessage surfaces unexpected diagnostic tool names', async t => {
+	const message = await buildAutoDiagnosticsMessage(
+		[toolCall('call_1', 'write_file', {path: 'source/a.ts'})],
+		[toolResult('call_1', 'write_file')],
+		async toolCall =>
+			toolResult(
+				toolCall.id,
+				'unexpected_tool',
+				'No diagnostics found for source/a.ts',
+			),
+	);
+
+	t.truthy(message);
+	t.true(
+		message?.content.includes(
+			'expected lsp_get_diagnostics but received unexpected_tool',
+		),
+	);
+});
+
+test('buildAutoDiagnosticsMessage ignores non-actionable info diagnostics', async t => {
+	const message = await buildAutoDiagnosticsMessage(
+		[toolCall('call_1', 'write_file', {path: 'source/a.ts'})],
+		[toolResult('call_1', 'write_file')],
+		async toolCall =>
+			toolResult(
+				toolCall.id,
+				toolCall.function.name,
+				'Diagnostics for source/a.ts:\n\nINFO at line 1:1: Consider renaming',
+				{
+					structuredContent: {
+						diagnostics: [
+							{
+								file: 'source/a.ts',
+								line: 1,
+								character: 1,
+								severity: 'info',
+								message: 'Consider renaming',
+							},
+						],
+					},
+				},
+			),
+	);
+
+	t.is(message, null);
+});
+
+test('buildAutoDiagnosticsMessage asks the model to fix reported diagnostics', async t => {
+	const message = await buildAutoDiagnosticsMessage(
+		[toolCall('call_1', 'write_file', {path: 'source/a.ts'})],
+		[toolResult('call_1', 'write_file')],
+		async toolCall =>
+			toolResult(
+				toolCall.id,
+				toolCall.function.name,
+				'Diagnostics for source/a.ts:\n\nERROR at line 1:1: Missing semicolon',
+				{
+					structuredContent: {
+						diagnostics: [
+							{
+								file: 'source/a.ts',
+								line: 1,
+								character: 1,
+								severity: 'error',
+								message: 'Missing semicolon',
+							},
+						],
+					},
+				},
+			),
+	);
+
+	t.truthy(message);
+	if (!message) {
+		t.fail('Expected diagnostics message');
+		return;
+	}
+
+	t.is(message.role, 'user');
+	t.true(message.content.includes('Automatic diagnostics'));
+	t.true(message.content.includes('source/a.ts'));
+	t.true(message.content.includes('Missing semicolon'));
+});
+
+test.serial('processAssistantResponse auto-runs diagnostics after successful write_file before the next model turn', async t => {
+	const result = await runAutoDiagnosticsAfterEditScenario('write_file', [
+		'write_file',
+		'lsp_get_diagnostics',
+	]);
+
+	t.is(result.chatCallCount, 2);
+	t.is(result.editCalls, 1);
+	t.is(result.diagnosticsCalls, 1);
+	const automaticDiagnosticsMessage = result.secondChatMessages.find(
+		message =>
+			message.role === 'user' &&
+			typeof message.content === 'string' &&
+			message.content.includes('Automatic diagnostics'),
+	);
+	t.truthy(automaticDiagnosticsMessage);
+	t.true(
+		typeof automaticDiagnosticsMessage?.content === 'string' &&
+			automaticDiagnosticsMessage.content.includes('Missing semicolon'),
+	);
+});
+
+test.serial('processAssistantResponse auto-runs diagnostics after successful string_replace before the next model turn', async t => {
+	const result = await runAutoDiagnosticsAfterEditScenario('string_replace', [
+		'string_replace',
+		'lsp_get_diagnostics',
+	]);
+
+	t.is(result.chatCallCount, 2);
+	t.is(result.editCalls, 1);
+	t.is(result.diagnosticsCalls, 1);
+	t.true(
+		result.secondChatMessages.some(
+			message =>
+				message.role === 'user' &&
+				typeof message.content === 'string' &&
+				message.content.includes('Automatic diagnostics'),
+		),
+	);
+});
+
+test.serial('processAssistantResponse skips auto diagnostics when diagnostics tool is filtered out', async t => {
+	const result = await runAutoDiagnosticsAfterEditScenario('write_file', [
+		'write_file',
+	]);
+
+	t.is(result.chatCallCount, 2);
+	t.is(result.editCalls, 1);
+	t.is(result.diagnosticsCalls, 0);
+	t.false(
+		result.secondChatMessages.some(
+			message =>
+				message.role === 'user' &&
+				typeof message.content === 'string' &&
+				message.content.includes('Automatic diagnostics'),
+		),
+	);
+});

--- a/source/hooks/chat-handler/conversation/auto-diagnostics.ts
+++ b/source/hooks/chat-handler/conversation/auto-diagnostics.ts
@@ -1,0 +1,176 @@
+import type {Message, ToolCall, ToolResult} from '@/types/core';
+
+const DIAGNOSTICS_TOOL_NAME = 'lsp_get_diagnostics';
+// Keep in sync with edit tools that produce a single changed file path.
+const EDIT_TOOL_NAMES = new Set(['write_file', 'string_replace']);
+const ACTIONABLE_DIAGNOSTIC_SEVERITIES = new Set(['error', 'warning']);
+
+type ProcessToolUse = (toolCall: ToolCall) => Promise<ToolResult>;
+type AutoDiagnosticFinding = {
+	path: string;
+	result: ToolResult;
+};
+
+function parseToolArgs(
+	args: ToolCall['function']['arguments'],
+): Record<string, unknown> {
+	if (typeof args === 'string') {
+		try {
+			const parsed = JSON.parse(args);
+			return parsed && typeof parsed === 'object' ? parsed : {};
+		} catch {
+			return {};
+		}
+	}
+	return args && typeof args === 'object' ? args : {};
+}
+
+function isSuccessfulToolResult(result: ToolResult): boolean {
+	return !(
+		result.content.startsWith('Error: ') ||
+		result.content.startsWith('⚒ Validation failed') ||
+		result.content === 'Tool execution was cancelled by the user.'
+	);
+}
+
+export function collectEditedPaths(
+	toolCalls: ToolCall[],
+	results: ToolResult[],
+): string[] {
+	const resultsById = new Map(
+		results.map(result => [result.tool_call_id, result]),
+	);
+	const seen = new Set<string>();
+	const paths: string[] = [];
+
+	for (const toolCall of toolCalls) {
+		if (!EDIT_TOOL_NAMES.has(toolCall.function.name)) continue;
+
+		const result = resultsById.get(toolCall.id);
+		if (!result || !isSuccessfulToolResult(result)) continue;
+
+		const args = parseToolArgs(toolCall.function.arguments);
+		const path = args.path ?? args.file_path;
+		if (typeof path !== 'string' || path.length === 0 || seen.has(path)) {
+			continue;
+		}
+
+		seen.add(path);
+		paths.push(path);
+	}
+
+	return paths;
+}
+
+function diagnosticsHaveFindings(result: ToolResult): boolean {
+	if (result.name !== DIAGNOSTICS_TOOL_NAME) return true;
+	if (result.content.startsWith('Error: ')) return true;
+
+	const structured = result.structuredContent;
+	if (
+		structured &&
+		typeof structured === 'object' &&
+		'diagnostics' in structured &&
+		Array.isArray(structured.diagnostics)
+	) {
+		const severities = structured.diagnostics
+			.map(diagnostic => {
+				if (!diagnostic || typeof diagnostic !== 'object') return null;
+				if (!('severity' in diagnostic)) return null;
+				return String(diagnostic.severity).toLowerCase();
+			})
+			.filter((severity): severity is string => severity !== null);
+		if (severities.length > 0) {
+			return severities.some(severity =>
+				ACTIONABLE_DIAGNOSTIC_SEVERITIES.has(severity),
+			);
+		}
+	}
+
+	if (
+		result.content.startsWith('No diagnostics found') ||
+		result.content.startsWith('No diagnostics source available') ||
+		result.content.startsWith('No language server available')
+	) {
+		return false;
+	}
+
+	return /\b(?:ERROR|WARNING)\b/i.test(result.content);
+}
+
+function errorContent(error: unknown): string {
+	const message =
+		error instanceof Error
+			? error.message
+			: typeof error === 'string'
+				? error
+				: 'Unknown diagnostics failure';
+	return message.startsWith('Error: ') ? message : `Error: ${message}`;
+}
+
+function formatDiagnosticFinding({
+	path,
+	result,
+}: AutoDiagnosticFinding): string {
+	const header = `Diagnostics for ${path}:`;
+	if (result.name !== DIAGNOSTICS_TOOL_NAME) {
+		return `${header}\nAutomatic diagnostics expected ${DIAGNOSTICS_TOOL_NAME} but received ${result.name}:\n${result.content}`;
+	}
+
+	if (result.content.startsWith(`Diagnostics for ${path}`)) {
+		return result.content;
+	}
+
+	return `${header}\n${result.content}`;
+}
+
+export async function buildAutoDiagnosticsMessage(
+	toolCalls: ToolCall[],
+	results: ToolResult[],
+	processToolUse: ProcessToolUse,
+): Promise<Message | null> {
+	const editedPaths = collectEditedPaths(toolCalls, results);
+	if (editedPaths.length === 0) return null;
+
+	const diagnosticFindings: AutoDiagnosticFinding[] = [];
+	for (const [index, path] of editedPaths.entries()) {
+		let result: ToolResult;
+		try {
+			result = await processToolUse({
+				id: `auto_diagnostics_${index + 1}`,
+				function: {
+					name: DIAGNOSTICS_TOOL_NAME,
+					arguments: {path},
+				},
+			});
+		} catch (error) {
+			result = {
+				tool_call_id: `auto_diagnostics_${index + 1}`,
+				role: 'tool',
+				name: DIAGNOSTICS_TOOL_NAME,
+				content: errorContent(error),
+			};
+		}
+
+		if (diagnosticsHaveFindings(result)) {
+			diagnosticFindings.push({path, result});
+		}
+	}
+
+	if (diagnosticFindings.length === 0) return null;
+
+	const diagnosticsText = diagnosticFindings
+		.map(formatDiagnosticFinding)
+		.join('\n\n');
+	const pathsNeedingAttentionText = diagnosticFindings
+		.map(({path}) => `- ${path}`)
+		.join('\n');
+
+	return {
+		role: 'user',
+		content:
+			'Automatic diagnostics after the recent edits found issues. Please fix the diagnostics you introduced before finishing.\n\n' +
+			`Paths needing attention:\n${pathsNeedingAttentionText}\n\n` +
+			diagnosticsText,
+	};
+}

--- a/source/hooks/chat-handler/conversation/conversation-loop.tsx
+++ b/source/hooks/chat-handler/conversation/conversation-loop.tsx
@@ -44,6 +44,7 @@ import {displayCompactCountsSummary} from '@/utils/tool-result-display';
 import {closeAllDiffsInVSCode} from '@/vscode/index';
 import {filterValidToolCalls} from '../utils/tool-filters';
 import {computeToolCallSignature} from '../utils/tool-signature';
+import {buildAutoDiagnosticsMessage} from './auto-diagnostics';
 import {
 	displayExecutedTool,
 	executeApprovedTool,
@@ -829,8 +830,20 @@ export const processAssistantResponse = async (
 
 		// 4) Feed all results back to the model and continue the loop.
 		if (turnResults.length > 0) {
+			let autoDiagnosticsMessage: Message | null = null;
+			if (availableNames.includes('lsp_get_diagnostics')) {
+				const {processToolUse} = await import('@/message-handler');
+				autoDiagnosticsMessage = await buildAutoDiagnosticsMessage(
+					validToolCalls,
+					turnResults,
+					processToolUse,
+				);
+			}
 			const builder = new MessageBuilder(updatedMessages);
 			builder.addToolResults(turnResults);
+			if (autoDiagnosticsMessage) {
+				builder.addMessage(autoDiagnosticsMessage);
+			}
 			const nextMessages = builder.build();
 			setMessages(nextMessages);
 			await processAssistantResponse({


### PR DESCRIPTION
## Description

Runs `lsp_get_diagnostics` automatically after successful `write_file` and `string_replace` tool calls, then feeds reported diagnostics back as a user message before the next model turn.

This keeps the behavior scoped to the current turn's filtered tool set: automatic diagnostics only run when `lsp_get_diagnostics` is available, so disabled tool/profile/mode filtering is respected.

Fixes #538

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Ran:

- `PATH=/home/miku/.local/devspace-node/node_modules/node/bin:$PATH corepack pnpm exec ava --verbose source/hooks/chat-handler/conversation/auto-diagnostics.spec.ts`
- `PATH=/home/miku/.local/devspace-node/node_modules/node/bin:$PATH corepack pnpm exec ava --verbose source/hooks/chat-handler/conversation/conversation-loop.spec.ts`
- `PATH=/home/miku/.local/devspace-node/node_modules/node/bin:$PATH corepack pnpm exec tsc --noEmit`
- `PATH=/home/miku/.local/devspace-node/node_modules/node/bin:$PATH corepack pnpm exec biome check source/hooks/chat-handler/conversation/auto-diagnostics.ts source/hooks/chat-handler/conversation/auto-diagnostics.spec.ts source/hooks/chat-handler/conversation/conversation-loop.tsx`
- `PATH=/home/miku/.local/devspace-node/node_modules/node/bin:$PATH corepack pnpm build`
- `git diff --check -- source/hooks/chat-handler/conversation/auto-diagnostics.spec.ts source/hooks/chat-handler/conversation/conversation-loop.tsx`

Also ran:

- `PATH=/home/miku/.local/devspace-node/node_modules/node/bin:$PATH corepack pnpm test:all`

`pnpm test:all` passed format, typecheck, lint, AVA (`5852 tests passed`, `8 tests skipped`), knip, and audit, then failed in the existing Semgrep scan with 42 blocking findings unrelated to this PR. The findings are in repository configuration files such as `.github/workflows/*.yml`, `.github/dependabot.yml`, and `pnpm-workspace.yaml`.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Not manually tested against live providers; the change is covered by conversation-loop regression tests.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
