### PR TITLE
fix(ui): bound slash command completions

### DIFF
--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -869,6 +869,44 @@ test('UserInput renders completions text when typing /', async t => {
 	unmount();
 });
 
+test('UserInput windows long slash completion lists', async t => {
+	const commands = Array.from(
+		{length: 14},
+		(_, index) => `zz-window-${String(index).padStart(2, '0')}`,
+	);
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput forceFocus={true} customCommands={commands} />
+		</TestWrapper>,
+	);
+
+	stdin.write('/zz');
+	await wait();
+
+	const firstFrame = lastFrame()!;
+	const firstVisibleCommands = firstFrame
+		.split('\n')
+		.filter(line => /\/zz-window-\d{2}/.test(line));
+
+	t.is(firstVisibleCommands.length, 10);
+	t.regex(firstFrame, /\/zz-window-00/);
+	t.regex(firstFrame, /\/zz-window-09/);
+	t.notRegex(firstFrame, /\/zz-window-10/);
+	t.regex(firstFrame, /Showing 1-10 of 14/);
+
+	for (let i = 0; i < 11; i++) {
+		stdin.write('\u001B[B');
+		await wait(25);
+	}
+
+	const laterFrame = lastFrame()!;
+	t.notRegex(laterFrame, /\/zz-window-00/);
+	t.regex(laterFrame, /▸ \/zz-window-11/);
+	t.regex(laterFrame, /Showing 5-14 of 14/);
+
+	unmount();
+});
+
 test('UserInput renders completions BEFORE the mode indicator (inside the input box)', async t => {
 	const {stdin, lastFrame, unmount} = render(
 		<TestWrapper>
@@ -936,5 +974,4 @@ test('UserInput does not show completions when input is empty', t => {
 	t.notRegex(output, /Available commands:/);
 	unmount();
 });
-
 

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -38,6 +38,8 @@ import {handleFileMention} from '@/utils/file-mention-handler';
 import {assemblePrompt} from '@/utils/prompt-processor';
 import type {ActiveEditorState} from '@/vscode/vscode-server';
 
+const MAX_COMMAND_COMPLETION_ROWS = 10;
+
 interface ChatProps {
 	onSubmit?: (
 		message: string,
@@ -833,6 +835,21 @@ export default function UserInput({
 		const text = truncate(singleLine, maxLength);
 		return `${text}${imageSuffix}`;
 	};
+	const commandCompletionWindow = useMemo(() => {
+		if (completions.length <= MAX_COMMAND_COMPLETION_ROWS) {
+			return {start: 0, end: completions.length, items: completions};
+		}
+
+		const selectedIndex =
+			selectedCompletionIndex >= 0 ? selectedCompletionIndex : 0;
+		const centeredStart =
+			selectedIndex - Math.floor(MAX_COMMAND_COMPLETION_ROWS / 2);
+		const maxStart = completions.length - MAX_COMMAND_COMPLETION_ROWS;
+		const start = Math.min(Math.max(centeredStart, 0), maxStart);
+		const end = start + MAX_COMMAND_COMPLETION_ROWS;
+
+		return {start, end, items: completions.slice(start, end)};
+	}, [completions, selectedCompletionIndex]);
 
 	// When disabled, show minimal UI to avoid cluttering the screen
 	if (disabled) {
@@ -911,11 +928,12 @@ export default function UserInput({
 				{showCompletions && completions.length > 0 && (
 					<Box flexDirection="column" marginTop={1}>
 						<Text color={colors.secondary}>Available commands:</Text>
-						{completions.map((completion, index) => {
-							const isSelected = index === selectedCompletionIndex;
+						{commandCompletionWindow.items.map((completion, index) => {
+							const completionIndex = commandCompletionWindow.start + index;
+							const isSelected = completionIndex === selectedCompletionIndex;
 							return (
 								<Text
-									key={index}
+									key={`${completion.isCustom ? 'custom' : 'built-in'}-${completion.name}`}
 									color={
 										isSelected
 											? colors.info
@@ -929,6 +947,12 @@ export default function UserInput({
 								</Text>
 							);
 						})}
+						{completions.length > MAX_COMMAND_COMPLETION_ROWS && (
+							<Text color={colors.secondary}>
+								Showing {commandCompletionWindow.start + 1}-
+								{commandCompletionWindow.end} of {completions.length}
+							</Text>
+						)}
 					</Box>
 				)}
 				{isFileAutocompleteMode && fileCompletions.length > 0 && (


### PR DESCRIPTION
## Description

Fixes #624.

Slash command completions now render in a bounded 10-row window instead of printing every matching command. The window follows the selected item while navigating with ↑/↓ and shows a compact `Showing x-y of n` range indicator when there are more matches.

Before: the `/` completion list could overflow small terminal windows. The reproduction screenshot is attached in #624.

After: local manual verification shows the menu rendering `Showing 1-10 of 37` without overflowing the terminal view.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Commands run:

- `pnpm exec ava --verbose source/components/user-input.spec.tsx --match='UserInput windows long slash completion lists'`
- `pnpm exec ava --verbose source/components/user-input.spec.tsx`
- `pnpm run test:format`
- `pnpm run test:types`
- `pnpm test:all`

Notes:

- The targeted regression test and full `source/components/user-input.spec.tsx` pass.
- `pnpm run test:format` and `pnpm run test:types` pass.
- `pnpm test:all` was attempted locally but does not complete in this sandbox. The failures are outside this UI change path: child process spawning/listening is blocked with `EPERM`, remote HTTP/MCP fetches fail, and live `models.dev` expectations return non-number results.
- Existing style warning observed during format/lint: `source/plain/conversation.ts` uses `Record<string, any>`.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Manual check performed:

- Built and ran `node dist/cli.js`.
- Opened a small Ubuntu GNOME terminal window.
- Typed `/`.
- Confirmed the slash completion list is bounded to 10 rows and shows `Showing 1-10 of 37`.

Provider and MCP manual checks are not applicable to this render-only CLI/TUI change.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

Logging note: no logging was added because this is a deterministic render-only UI change and there is no runtime event/error path to instrument.
