### PR TITLE
feat(providers): default MiniMax Coding to MiniMax-M3

### DIFF
--- a/docs/configuration/providers/minimax.md
+++ b/docs/configuration/providers/minimax.md
@@ -16,7 +16,7 @@ sidebar_order: 24
 	"sdkProvider": "anthropic",
 	"baseUrl": "https://api.minimax.io/anthropic/v1",
 	"apiKey": "your-minimax-api-key",
-	"models": ["your-model-name"]
+	"models": ["MiniMax-M3", "MiniMax-M2.7"]
 }
 ```
 

--- a/source/wizards/templates/provider-templates.spec.ts
+++ b/source/wizards/templates/provider-templates.spec.ts
@@ -497,16 +497,19 @@ test('minimax-coding template: sets sdkProvider to anthropic with minimax baseUr
 	const template = PROVIDER_TEMPLATES.find(t => t.id === 'minimax-coding');
 	t.truthy(template);
 
+	const modelField = template!.fields.find(f => f.name === 'model');
+	t.is(modelField?.default, 'MiniMax-M3,MiniMax-M2.7');
+
 	const config = template!.buildConfig({
 		apiKey: 'test-key',
-		model: 'MiniMax-M2.7',
+		model: 'MiniMax-M3',
 		providerName: '',
 	});
 
 	t.is(config.sdkProvider, 'anthropic');
 	t.is(config.baseUrl, 'https://api.minimax.io/anthropic/v1');
 	t.is(config.name, 'MiniMax Coding');
-	t.deepEqual(config.models, ['MiniMax-M2.7']);
+	t.deepEqual(config.models, ['MiniMax-M3']);
 });
 
 test('no template id matches an sdkProvider value used by a different template', t => {

--- a/source/wizards/templates/provider-templates.ts
+++ b/source/wizards/templates/provider-templates.ts
@@ -509,7 +509,7 @@ export const PROVIDER_TEMPLATES: ProviderTemplate[] = [
 		name: 'MiniMax Coding Plan',
 		defaultProviderName: 'MiniMax Coding',
 		baseUrl: 'https://api.minimax.io/anthropic/v1',
-		modelDefault: 'MiniMax-M2.7',
+		modelDefault: 'MiniMax-M3,MiniMax-M2.7',
 		sdkProvider: 'anthropic',
 	}),
 	apiKeyTemplate({


### PR DESCRIPTION
## Summary
Default the MiniMax Coding provider template to MiniMax-M3.

## Changes
- Set the MiniMax Coding wizard `modelDefault` to `MiniMax-M3,MiniMax-M2.7` (M3 first, M2.7 retained as an alternative)
- Update the docs example in `docs/configuration/providers/minimax.md` to list `MiniMax-M3` and `MiniMax-M2.7`
- Update the provider-templates unit test to cover the new default

## Why
MiniMax-M3 is the new flagship model with a 1M context window and image input support across both OpenAI-compatible and Anthropic-compatible interfaces.

## Testing
- `pnpm test:ava source/wizards/templates/provider-templates.spec.ts` (35 passed)
- `pnpm test:types` (tsc --noEmit, clean)