### PR TITLE
feat: add mode-specific provider and model configuration

### DIFF
--- a/source/config/index.spec.ts
+++ b/source/config/index.spec.ts
@@ -579,7 +579,7 @@ test.serial('headless maxTurns ignores invalid env var', async t => {
 async function withModeProvidersConfig(
 	testName: string,
 	configData: Record<string, unknown>,
-	assertionFn: (modeProviders: any) => void,
+	assertionFn: (modeProviders: unknown) => void,
 ) {
 	const {tmpdir} = await import('os');
 	const {join} = await import('path');
@@ -606,7 +606,7 @@ async function withModeProvidersConfig(
 		const fullConfig = {
 			...configData,
 			nanocoder: {
-				...(configData.nanocoder as any || {}),
+				...(configData.nanocoder as Record<string, unknown> || {}),
 				providers,
 			}
 		};

--- a/source/config/index.spec.ts
+++ b/source/config/index.spec.ts
@@ -574,3 +574,172 @@ test.serial('headless maxTurns ignores invalid env var', async t => {
 		},
 	);
 });
+
+// Tests for modeProviders
+async function withModeProvidersConfig(
+	testName: string,
+	configData: Record<string, unknown>,
+	assertionFn: (modeProviders: any) => void,
+) {
+	const {tmpdir} = await import('os');
+	const {join} = await import('path');
+	const {mkdirSync, writeFileSync, rmSync} = await import('fs');
+	
+	const originalCwd = process.cwd();
+	const originalConfigDir = process.env.NANOCODER_CONFIG_DIR;
+	const testDir = join(tmpdir(), `nanocoder-modeproviders-test-${Date.now()}-${testName}`);
+	mkdirSync(testDir, {recursive: true});
+
+	try {
+		// Define some valid providers to test against
+		const providers = [
+			{
+				name: 'TestProvider1',
+				models: ['model1', 'model2'],
+			},
+			{
+				name: 'TestProvider2',
+				models: [],
+			}
+		];
+		
+		const fullConfig = {
+			...configData,
+			nanocoder: {
+				...(configData.nanocoder as any || {}),
+				providers,
+			}
+		};
+
+		writeFileSync(
+			join(testDir, 'agents.config.json'),
+			JSON.stringify(fullConfig),
+			'utf-8',
+		);
+		process.chdir(testDir);
+		process.env.NANOCODER_CONFIG_DIR = testDir;
+
+		const {
+			reloadAppConfig: reload,
+			getAppConfig,
+		} = await import('./index.js');
+		
+		reload();
+		assertionFn(getAppConfig().modeProviders);
+	} finally {
+		process.chdir(originalCwd);
+		if (originalConfigDir !== undefined) {
+			process.env.NANOCODER_CONFIG_DIR = originalConfigDir;
+		} else {
+			delete process.env.NANOCODER_CONFIG_DIR;
+		}
+		rmSync(testDir, {recursive: true, force: true});
+	}
+}
+
+test.serial('modeProviders loads valid config', async t => {
+	await withModeProvidersConfig(
+		'valid',
+		{
+			nanocoder: {
+				modeProviders: {
+					plan: {
+						provider: 'TestProvider1',
+						model: 'model1'
+					}
+				}
+			}
+		},
+		modeProviders => {
+			t.deepEqual(modeProviders, {
+				plan: {
+					provider: 'TestProvider1',
+					model: 'model1'
+				}
+			});
+		}
+	);
+});
+
+test.serial('modeProviders ignores missing provider or model string', async t => {
+	await withModeProvidersConfig(
+		'missing-fields',
+		{
+			nanocoder: {
+				modeProviders: {
+					plan: {
+						provider: 'TestProvider1'
+					},
+					yolo: {
+						model: 'model1'
+					}
+				}
+			}
+		},
+		modeProviders => {
+			t.is(modeProviders, undefined);
+		}
+	);
+});
+
+test.serial('modeProviders ignores unknown provider', async t => {
+	await withModeProvidersConfig(
+		'unknown-provider',
+		{
+			nanocoder: {
+				modeProviders: {
+					plan: {
+						provider: 'UnknownProvider',
+						model: 'model1'
+					}
+				}
+			}
+		},
+		modeProviders => {
+			t.is(modeProviders, undefined);
+		}
+	);
+});
+
+test.serial('modeProviders ignores unknown model for provider', async t => {
+	await withModeProvidersConfig(
+		'unknown-model',
+		{
+			nanocoder: {
+				modeProviders: {
+					plan: {
+						provider: 'TestProvider1',
+						model: 'unknown-model'
+					}
+				}
+			}
+		},
+		modeProviders => {
+			t.is(modeProviders, undefined);
+		}
+	);
+});
+
+test.serial('modeProviders accepts model if provider has empty models list', async t => {
+	await withModeProvidersConfig(
+		'empty-models-list',
+		{
+			nanocoder: {
+				modeProviders: {
+					plan: {
+						provider: 'TestProvider2',
+						model: 'any-model'
+					}
+				}
+			}
+		},
+		modeProviders => {
+			t.deepEqual(modeProviders, {
+				plan: {
+					provider: 'TestProvider2',
+					model: 'any-model'
+				}
+			});
+		}
+	);
+});

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -464,9 +464,6 @@ function loadModeProvidersConfig(
 				result[mode as DevelopmentMode] = {
 					provider: matchedProvider.name,
 					model: modelName,
-					...(typeof typedConfig.temperature === 'number'
-						? {temperature: typedConfig.temperature}
-						: {}),
 				};
 			}
 

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -407,13 +407,22 @@ function loadModeProvidersConfig(
 	return (
 		loadHierarchicalConfig('agents.config.json', 'modeProviders', config => {
 			const modeProviders = config.nanocoder?.modeProviders;
-			if (!modeProviders || typeof modeProviders !== 'object') {
+			if (
+				!modeProviders ||
+				typeof modeProviders !== 'object' ||
+				Array.isArray(modeProviders)
+			) {
 				return null;
 			}
 
 			const result: Partial<Record<DevelopmentMode, ModeProviderConfig>> = {};
 
 			for (const [mode, config] of Object.entries(modeProviders)) {
+				if (!(VALID_MODES as readonly string[]).includes(mode)) {
+					logError(`Invalid modeProviders config: unknown mode '${mode}'.`);
+					continue;
+				}
+
 				// Typecast to unknown first, then check object structure
 				const typedConfig = config as Record<string, unknown>;
 				if (!typedConfig || typeof typedConfig !== 'object') continue;
@@ -455,6 +464,9 @@ function loadModeProvidersConfig(
 				result[mode as DevelopmentMode] = {
 					provider: matchedProvider.name,
 					model: modelName,
+					...(typeof typedConfig.temperature === 'number'
+						? {temperature: typedConfig.temperature}
+						: {}),
 				};
 			}
 

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -19,8 +19,11 @@ import type {
 	Colors,
 	CompressionMode,
 	CompressionStrategy,
+	DevelopmentMode,
+	ModeProviderConfig,
 	NotificationsConfig,
 	PasteConfig,
+	ProviderConfig,
 	SystemPromptConfig,
 } from '@/types/index';
 import {logError} from '@/utils/message-queue';
@@ -398,6 +401,68 @@ function loadSystemPromptConfig(): SystemPromptConfig | undefined {
 	);
 }
 
+function loadModeProvidersConfig(
+	providers: ProviderConfig[],
+): Partial<Record<DevelopmentMode, ModeProviderConfig>> | undefined {
+	return (
+		loadHierarchicalConfig('agents.config.json', 'modeProviders', config => {
+			const modeProviders = config.nanocoder?.modeProviders;
+			if (!modeProviders || typeof modeProviders !== 'object') {
+				return null;
+			}
+
+			const result: Partial<Record<DevelopmentMode, ModeProviderConfig>> = {};
+
+			for (const [mode, config] of Object.entries(modeProviders)) {
+				// Typecast to unknown first, then check object structure
+				const typedConfig = config as Record<string, unknown>;
+				if (!typedConfig || typeof typedConfig !== 'object') continue;
+
+				const providerName =
+					typeof typedConfig.provider === 'string'
+						? typedConfig.provider
+						: undefined;
+				const modelName =
+					typeof typedConfig.model === 'string' ? typedConfig.model : undefined;
+
+				if (!providerName || !modelName) {
+					logError(
+						`Invalid modeProviders config for mode '${mode}': missing provider or model string.`,
+					);
+					continue;
+				}
+
+				const matchedProvider = providers.find(
+					p => p.name.toLowerCase() === providerName.toLowerCase(),
+				);
+				if (!matchedProvider) {
+					logError(
+						`Invalid modeProviders config for mode '${mode}': provider '${providerName}' not found in configured providers.`,
+					);
+					continue;
+				}
+
+				if (
+					matchedProvider.models.length > 0 &&
+					!matchedProvider.models.includes(modelName)
+				) {
+					logError(
+						`Invalid modeProviders config for mode '${mode}': model '${modelName}' not found in models for provider '${matchedProvider.name}'.`,
+					);
+					continue;
+				}
+
+				result[mode as DevelopmentMode] = {
+					provider: matchedProvider.name,
+					model: modelName,
+				};
+			}
+
+			return Object.keys(result).length > 0 ? result : null;
+		}) ?? undefined
+	);
+}
+
 // Load notifications configuration from preferences
 function loadNotificationsConfig(): NotificationsConfig | undefined {
 	return getNotificationsPreference();
@@ -454,6 +519,9 @@ function loadAppConfig(): AppConfig {
 	// Load notifications configuration
 	const notifications = loadNotificationsConfig();
 
+	// Load mode providers configuration
+	const modeProviders = loadModeProvidersConfig(providers);
+
 	return {
 		providers,
 		mcpServers,
@@ -466,6 +534,7 @@ function loadAppConfig(): AppConfig {
 		disabledTools,
 		systemPrompt,
 		notifications,
+		modeProviders,
 	};
 }
 

--- a/source/hooks/useAppHandlers.spec.tsx
+++ b/source/hooks/useAppHandlers.spec.tsx
@@ -1,12 +1,12 @@
 import test from 'ava';
-import { cleanup, render } from 'ink-testing-library';
+import {cleanup, render} from 'ink-testing-library';
 import React from 'react';
-import type { CheckpointListItem } from '@/types/checkpoint';
-import type { AIProviderConfig } from '@/types/config';
-import type { DevelopmentMode, LLMClient, Message } from '@/types/core';
-import type { CustomCommand } from '@/types/commands';
-import type { AppHandlers } from './useAppHandlers';
-import { useAppHandlers } from './useAppHandlers';
+import type {CheckpointListItem} from '@/types/checkpoint';
+import type {AIProviderConfig} from '@/types/config';
+import type {DevelopmentMode, LLMClient, Message} from '@/types/core';
+import type {CustomCommand} from '@/types/commands';
+import type {AppHandlers} from './useAppHandlers';
+import {useAppHandlers} from './useAppHandlers';
 
 import {
 	getKeyGeneratorSessionId,
@@ -51,9 +51,9 @@ function makeProps(overrides: ProbeOverrides) {
 	const setCheckpointLoadData = spy<
 		[
 			| {
-				checkpoints: CheckpointListItem[];
-				currentMessageCount: number;
-			}
+					checkpoints: CheckpointListItem[];
+					currentMessageCount: number;
+			  }
 			| null,
 		]
 	>();
@@ -153,7 +153,7 @@ function makeProps(overrides: ProbeOverrides) {
 
 function setup(overrides: ProbeOverrides = {}) {
 	captured = null;
-	const { props, spies } = makeProps(overrides);
+	const {props, spies} = makeProps(overrides);
 
 	function Probe() {
 		captured = useAppHandlers(props as never);
@@ -162,7 +162,7 @@ function setup(overrides: ProbeOverrides = {}) {
 
 	const instance = render(<Probe />);
 	if (!captured) throw new Error('useAppHandlers did not initialize');
-	return { handlers: captured as AppHandlers, instance, spies };
+	return {handlers: captured as AppHandlers, instance, spies};
 }
 
 test.afterEach(() => {
@@ -171,7 +171,7 @@ test.afterEach(() => {
 });
 
 test('returns the expected handler surface', t => {
-	const { handlers } = setup();
+	const {handlers} = setup();
 
 	t.is(typeof handlers.clearMessages, 'function');
 	t.is(typeof handlers.handleCancel, 'function');

--- a/source/hooks/useAppHandlers.spec.tsx
+++ b/source/hooks/useAppHandlers.spec.tsx
@@ -12,6 +12,8 @@ import {
 	getKeyGeneratorSessionId,
 	setKeyGeneratorSessionId,
 } from '@/session/key-generator';
+import {clearAppConfig} from '@/config/index';
+import {resetPreferencesCache} from '@/config/preferences';
 
 console.log('\nuseAppHandlers.spec.tsx');
 
@@ -220,17 +222,94 @@ test('handleToggleDevelopmentMode cycles through modes', t => {
 	t.deepEqual(s4.setDevelopmentMode.calls, [['normal']]);
 });
 
-test('handleToggleDevelopmentMode calls handleModelSelect on mode switch', async t => {
-	const { handlers, spies } = setup({ developmentMode: 'normal' });
+async function withMockConfig(
+	config: any,
+	preferences: any,
+	fn: () => Promise<void>
+) {
+	const {tmpdir} = await import('os');
+	const {join} = await import('path');
+	const {mkdirSync, writeFileSync, rmSync} = await import('fs');
+	
+	const originalConfigDir = process.env.NANOCODER_CONFIG_DIR;
+	const originalCwd = process.cwd();
+	const testDir = join(tmpdir(), `nanocoder-apphandlers-test-${Date.now()}-${Math.random()}`);
+	mkdirSync(testDir, {recursive: true});
 
-	handlers.handleToggleDevelopmentMode();
+	try {
+		writeFileSync(join(testDir, 'agents.config.json'), JSON.stringify(config));
+		writeFileSync(join(testDir, 'nanocoder-preferences.json'), JSON.stringify(preferences));
+		process.env.NANOCODER_CONFIG_DIR = testDir;
+		process.chdir(testDir);
+		clearAppConfig();
+		resetPreferencesCache();
+		
+		await fn();
+	} finally {
+		if (originalConfigDir) {
+			process.env.NANOCODER_CONFIG_DIR = originalConfigDir;
+		} else {
+			delete process.env.NANOCODER_CONFIG_DIR;
+		}
+		process.chdir(originalCwd);
+		clearAppConfig();
+		resetPreferencesCache();
+		rmSync(testDir, {recursive: true, force: true});
+	}
+}
 
-	// Wait a tick for the async void function to run
-	await new Promise(resolve => setTimeout(resolve, 0));
+test.serial('handleToggleDevelopmentMode calls handleModelSelect using modeProviders if configured', async t => {
+	const config = {
+		nanocoder: {
+			providers: [
+				{name: 'test-provider', models: ['model-1']}
+			],
+			modeProviders: {
+				'auto-accept': {provider: 'test-provider', model: 'model-1'}
+			}
+		}
+	};
+	
+	await withMockConfig(config, {}, async () => {
+		const {handlers, spies} = setup({developmentMode: 'normal'});
+		handlers.handleToggleDevelopmentMode();
+		
+		// Wait a tick for the async void function to run
+		await new Promise(resolve => setTimeout(resolve, 0));
+		
+		t.is(spies.handleModelSelect.calls.length, 1);
+		t.is(spies.handleModelSelect.calls[0]![0], 'test-provider');
+		t.is(spies.handleModelSelect.calls[0]![1], 'model-1');
+		t.is(spies.handleModelSelect.calls[0]![2], true);
+	});
+});
 
-	t.is(spies.handleModelSelect.calls.length, 1);
-	// We expect the third argument (isProgrammatic) to be true
-	t.is(spies.handleModelSelect.calls[0]![2], true);
+test.serial('handleToggleDevelopmentMode uses fallback if modeProviders is not configured', async t => {
+	const config = {
+		nanocoder: {
+			providers: [
+				{name: 'fallback-provider', models: ['fallback-model']}
+			]
+		}
+	};
+	
+	const prefs = {
+		lastProvider: 'fallback-provider',
+		lastModel: 'fallback-model',
+	};
+	
+	await withMockConfig(config, prefs, async () => {
+		const {handlers, spies} = setup({developmentMode: 'normal'});
+		handlers.handleToggleDevelopmentMode();
+		
+		// Wait a tick for the async void function to run
+		await new Promise(resolve => setTimeout(resolve, 0));
+		
+		t.is(spies.handleModelSelect.calls.length, 1);
+		t.is(spies.handleModelSelect.calls[0]![0], 'fallback-provider');
+		t.is(spies.handleModelSelect.calls[0]![1], 'fallback-model');
+		t.is(spies.handleModelSelect.calls[0]![2], true);
+	});
 });
 
 test('handleToggleDevelopmentMode preserves headless mode', t => {

--- a/source/hooks/useAppHandlers.spec.tsx
+++ b/source/hooks/useAppHandlers.spec.tsx
@@ -1,12 +1,12 @@
 import test from 'ava';
-import {cleanup, render} from 'ink-testing-library';
+import { cleanup, render } from 'ink-testing-library';
 import React from 'react';
-import type {CheckpointListItem} from '@/types/checkpoint';
-import type {AIProviderConfig} from '@/types/config';
-import type {DevelopmentMode, LLMClient, Message} from '@/types/core';
-import type {CustomCommand} from '@/types/commands';
-import type {AppHandlers} from './useAppHandlers';
-import {useAppHandlers} from './useAppHandlers';
+import type { CheckpointListItem } from '@/types/checkpoint';
+import type { AIProviderConfig } from '@/types/config';
+import type { DevelopmentMode, LLMClient, Message } from '@/types/core';
+import type { CustomCommand } from '@/types/commands';
+import type { AppHandlers } from './useAppHandlers';
+import { useAppHandlers } from './useAppHandlers';
 
 import {
 	getKeyGeneratorSessionId,
@@ -49,9 +49,9 @@ function makeProps(overrides: ProbeOverrides) {
 	const setCheckpointLoadData = spy<
 		[
 			| {
-					checkpoints: CheckpointListItem[];
-					currentMessageCount: number;
-			  }
+				checkpoints: CheckpointListItem[];
+				currentMessageCount: number;
+			}
 			| null,
 		]
 	>();
@@ -75,6 +75,7 @@ function makeProps(overrides: ProbeOverrides) {
 	const enterSchedulerMode = spy<[]>();
 	const handleChatMessage = spy<[string]>();
 	const dismissActiveEditor = spy<[]>();
+	const handleModelSelect = spy<[string, string, boolean?]>();
 
 	const baseProps = {
 		messages: overrides.messages ?? [],
@@ -122,6 +123,10 @@ function makeProps(overrides: ProbeOverrides) {
 			handleChatMessage(m);
 		},
 		dismissActiveEditor: () => dismissActiveEditor(),
+		developmentMode: overrides.developmentMode ?? 'normal',
+		handleModelSelect: async (provider: string, model: string, isProgrammatic?: boolean) => {
+			handleModelSelect(provider, model, isProgrammatic);
+		},
 	};
 
 	return {
@@ -139,13 +144,14 @@ function makeProps(overrides: ProbeOverrides) {
 			setChatComponents,
 			addToChatQueue,
 			dismissActiveEditor,
+			handleModelSelect,
 		},
 	};
 }
 
 function setup(overrides: ProbeOverrides = {}) {
 	captured = null;
-	const {props, spies} = makeProps(overrides);
+	const { props, spies } = makeProps(overrides);
 
 	function Probe() {
 		captured = useAppHandlers(props as never);
@@ -154,7 +160,7 @@ function setup(overrides: ProbeOverrides = {}) {
 
 	const instance = render(<Probe />);
 	if (!captured) throw new Error('useAppHandlers did not initialize');
-	return {handlers: captured as AppHandlers, instance, spies};
+	return { handlers: captured as AppHandlers, instance, spies };
 }
 
 test.afterEach(() => {
@@ -163,7 +169,7 @@ test.afterEach(() => {
 });
 
 test('returns the expected handler surface', t => {
-	const {handlers} = setup();
+	const { handlers } = setup();
 
 	t.is(typeof handlers.clearMessages, 'function');
 	t.is(typeof handlers.handleCancel, 'function');
@@ -179,7 +185,7 @@ test('returns the expected handler surface', t => {
 });
 
 test('handleCancel without an abort controller is a no-op', t => {
-	const {handlers, spies} = setup({abortController: null});
+	const { handlers, spies } = setup({ abortController: null });
 
 	handlers.handleCancel();
 
@@ -188,7 +194,7 @@ test('handleCancel without an abort controller is a no-op', t => {
 
 test('handleCancel aborts the controller and sets cancelling=true', t => {
 	const controller = new AbortController();
-	const {handlers, spies} = setup({abortController: controller});
+	const { handlers, spies } = setup({ abortController: controller });
 
 	handlers.handleCancel();
 
@@ -196,37 +202,49 @@ test('handleCancel aborts the controller and sets cancelling=true', t => {
 	t.true(controller.signal.aborted);
 });
 
-test('handleToggleDevelopmentMode cycles through modes via the updater', t => {
-	const {handlers, spies} = setup();
+test('handleToggleDevelopmentMode cycles through modes', t => {
+	const { handlers, spies } = setup({ developmentMode: 'normal' });
+	handlers.handleToggleDevelopmentMode();
+	t.deepEqual(spies.setDevelopmentMode.calls, [['auto-accept']]);
+
+	const { handlers: h2, spies: s2 } = setup({ developmentMode: 'auto-accept' });
+	h2.handleToggleDevelopmentMode();
+	t.deepEqual(s2.setDevelopmentMode.calls, [['yolo']]);
+
+	const { handlers: h3, spies: s3 } = setup({ developmentMode: 'yolo' });
+	h3.handleToggleDevelopmentMode();
+	t.deepEqual(s3.setDevelopmentMode.calls, [['plan']]);
+
+	const { handlers: h4, spies: s4 } = setup({ developmentMode: 'plan' });
+	h4.handleToggleDevelopmentMode();
+	t.deepEqual(s4.setDevelopmentMode.calls, [['normal']]);
+});
+
+test('handleToggleDevelopmentMode calls handleModelSelect on mode switch', async t => {
+	const { handlers, spies } = setup({ developmentMode: 'normal' });
 
 	handlers.handleToggleDevelopmentMode();
-	t.is(spies.setDevelopmentMode.calls.length, 1);
 
-	const updater = spies.setDevelopmentMode.calls[0]![0] as (
-		prev: DevelopmentMode,
-	) => DevelopmentMode;
-	t.is(updater('normal'), 'auto-accept');
-	t.is(updater('auto-accept'), 'yolo');
-	t.is(updater('yolo'), 'plan');
-	t.is(updater('plan'), 'normal');
+	// Wait a tick for the async void function to run
+	await new Promise(resolve => setTimeout(resolve, 0));
+
+	t.is(spies.handleModelSelect.calls.length, 1);
+	// We expect the third argument (isProgrammatic) to be true
+	t.is(spies.handleModelSelect.calls[0]![2], true);
 });
 
 test('handleToggleDevelopmentMode preserves headless mode', t => {
 	// Headless is entered by the daemon for triggered runs, not by the user.
 	// Shift+Tab cycles only through user-facing modes; if `developmentMode`
 	// is somehow `headless` when toggle fires, it should stay there.
-	const {handlers, spies} = setup();
+	const { handlers, spies } = setup({ developmentMode: 'headless' });
 
 	handlers.handleToggleDevelopmentMode();
-	const updater = spies.setDevelopmentMode.calls[0]![0] as (
-		prev: DevelopmentMode,
-	) => DevelopmentMode;
-
-	t.is(updater('headless'), 'headless');
+	t.is(spies.setDevelopmentMode.calls.length, 0);
 });
 
 test('handleCheckpointCancel clears active mode and checkpoint data', t => {
-	const {handlers, spies} = setup();
+	const { handlers, spies } = setup();
 
 	handlers.handleCheckpointCancel();
 
@@ -235,7 +253,7 @@ test('handleCheckpointCancel clears active mode and checkpoint data', t => {
 });
 
 test('handleSessionCancel clears active mode', t => {
-	const {handlers, spies} = setup();
+	const { handlers, spies } = setup();
 
 	handlers.handleSessionCancel();
 
@@ -243,10 +261,10 @@ test('handleSessionCancel clears active mode', t => {
 });
 
 test('enterCheckpointLoadMode sets data then activates the mode', t => {
-	const {handlers, spies} = setup();
+	const { handlers, spies } = setup();
 
 	const checkpoints = [
-		{name: 'cp1', timestamp: 0, messageCount: 0} as unknown as CheckpointListItem,
+		{ name: 'cp1', timestamp: 0, messageCount: 0 } as unknown as CheckpointListItem,
 	];
 
 	handlers.enterCheckpointLoadMode(checkpoints, 5);
@@ -260,7 +278,7 @@ test('enterCheckpointLoadMode sets data then activates the mode', t => {
 });
 
 test('enterSessionSelectorMode defaults showAll to false', t => {
-	const {handlers, spies} = setup();
+	const { handlers, spies } = setup();
 
 	handlers.enterSessionSelectorMode();
 
@@ -269,7 +287,7 @@ test('enterSessionSelectorMode defaults showAll to false', t => {
 });
 
 test('enterSessionSelectorMode forwards showAll=true when requested', t => {
-	const {handlers, spies} = setup();
+	const { handlers, spies } = setup();
 
 	handlers.enterSessionSelectorMode(true);
 
@@ -278,8 +296,8 @@ test('enterSessionSelectorMode forwards showAll=true when requested', t => {
 });
 
 test('clearMessages resets key generator session ID', async t => {
-	const {handlers} = setup({
-		messages: [{role: 'user', content: 'test'}],
+	const { handlers } = setup({
+		messages: [{ role: 'user', content: 'test' }],
 	});
 
 	setKeyGeneratorSessionId('old-session-id-prefix');

--- a/source/hooks/useAppHandlers.tsx
+++ b/source/hooks/useAppHandlers.tsx
@@ -233,30 +233,53 @@ export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 		const modeConfig = config.modeProviders?.[nextMode];
 
 		void (async () => {
+			let targetProvider: string | undefined;
+			let targetModel: string | undefined;
+
 			if (modeConfig) {
-				await props.handleModelSelect(
-					modeConfig.provider,
-					modeConfig.model,
-					true,
-				);
+				targetProvider = modeConfig.provider;
+				targetModel = modeConfig.model;
 			} else {
 				// Restore the user's currently configured default provider/model (stored in preferences)
 				const preferences = loadPreferences();
-				const targetProvider =
+				targetProvider =
 					preferences.lastProvider ||
 					config.providers?.[0]?.name ||
 					'openai-compatible';
-				const targetModel =
+				targetModel =
 					preferences.providerModels?.[targetProvider] ||
 					preferences.lastModel ||
 					config.providers?.find(p => p.name === targetProvider)?.models[0] ||
 					'';
-
-				if (targetProvider && targetModel) {
-					await props.handleModelSelect(targetProvider, targetModel, true);
-				}
 			}
-		})();
+
+			if (targetProvider && targetModel) {
+				if (
+					targetProvider === props.currentProvider &&
+					targetModel === props.currentModel
+				) {
+					return;
+				}
+
+				// Show a subtle toast when entering a mode that enforces a specific model,
+				// since programmatic switches suppress the default "Model changed to..." toast.
+				if (modeConfig) {
+					props.addToChatQueue(
+						<SuccessMessage
+							key={generateKey('mode-model-override')}
+							message={`[${nextMode} mode → ${targetModel}]`}
+							hideBox={true}
+						/>,
+					);
+				}
+
+				await props.handleModelSelect(targetProvider, targetModel, true);
+			}
+		})().catch(error => {
+			logger.error('Failed to switch model on mode toggle', {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		});
 	}, [
 		props.developmentMode,
 		props.setDevelopmentMode,

--- a/source/hooks/useAppHandlers.tsx
+++ b/source/hooks/useAppHandlers.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/message-box';
 import Status from '@/components/status';
 import {getAppConfig} from '@/config/index';
+import {loadPreferences} from '@/config/preferences';
 import {CustomCommandExecutor} from '@/custom-commands/executor';
 import {CustomCommandLoader} from '@/custom-commands/loader';
 import {getModelContextLimit} from '@/models/index';
@@ -103,7 +104,11 @@ interface UseAppHandlersProps {
 	enterExplorerMode: () => void;
 	enterIdeSelectionMode: () => void;
 	enterTune: () => void;
-	handleModelSelect: (provider: string, model: string) => Promise<boolean>;
+	handleModelSelect: (
+		provider: string,
+		model: string,
+		isProgrammatic?: boolean,
+	) => Promise<boolean>;
 
 	// Chat handler
 	handleChatMessage: (message: string, displayValue?: string) => Promise<void>;
@@ -198,33 +203,67 @@ export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 
 	// Toggle development mode handler
 	const handleToggleDevelopmentMode = React.useCallback(() => {
-		props.setDevelopmentMode(currentMode => {
-			// Don't allow toggling out of headless via Shift+Tab: it's a
-			// non-interactive mode entered by the daemon, not the user.
-			if (currentMode === 'headless') return currentMode;
+		// Don't allow toggling out of headless via Shift+Tab: it's a
+		// non-interactive mode entered by the daemon, not the user.
+		if (props.developmentMode === 'headless') return;
 
-			const modes: Array<'normal' | 'auto-accept' | 'yolo' | 'plan'> = [
-				'normal',
-				'auto-accept',
-				'yolo',
-				'plan',
-			];
-			const currentIndex = modes.indexOf(
-				currentMode as 'normal' | 'auto-accept' | 'yolo' | 'plan',
-			);
-			const nextIndex = (currentIndex + 1) % modes.length;
-			const nextMode = modes[nextIndex];
+		const modes: Array<'normal' | 'auto-accept' | 'yolo' | 'plan'> = [
+			'normal',
+			'auto-accept',
+			'yolo',
+			'plan',
+		];
+		const currentIndex = modes.indexOf(
+			props.developmentMode as 'normal' | 'auto-accept' | 'yolo' | 'plan',
+		);
+		const nextIndex = (currentIndex + 1) % modes.length;
+		const nextMode = modes[nextIndex];
 
-			logger.info('Development mode toggled', {
-				previousMode: currentMode,
-				nextMode,
-				modeIndex: nextIndex,
-				totalModes: modes.length,
-			});
-
-			return nextMode;
+		logger.info('Development mode toggled', {
+			previousMode: props.developmentMode,
+			nextMode,
+			modeIndex: nextIndex,
+			totalModes: modes.length,
 		});
-	}, [props.setDevelopmentMode, logger, props]);
+
+		props.setDevelopmentMode(nextMode);
+
+		// Handle mode-specific provider switching
+		const config = getAppConfig();
+		const modeConfig = config.modeProviders?.[nextMode];
+
+		void (async () => {
+			if (modeConfig) {
+				await props.handleModelSelect(
+					modeConfig.provider,
+					modeConfig.model,
+					true,
+				);
+			} else {
+				// Restore the user's currently configured default provider/model (stored in preferences)
+				const preferences = loadPreferences();
+				const targetProvider =
+					preferences.lastProvider ||
+					config.providers?.[0]?.name ||
+					'openai-compatible';
+				const targetModel =
+					preferences.providerModels?.[targetProvider] ||
+					preferences.lastModel ||
+					config.providers?.find(p => p.name === targetProvider)?.models[0] ||
+					'';
+
+				if (targetProvider && targetModel) {
+					await props.handleModelSelect(targetProvider, targetModel, true);
+				}
+			}
+		})();
+	}, [
+		props.developmentMode,
+		props.setDevelopmentMode,
+		props.handleModelSelect,
+		logger,
+		props,
+	]);
 
 	// Show status handler
 	const handleShowStatus = React.useCallback(async () => {

--- a/source/hooks/useAppInitialization.tsx
+++ b/source/hooks/useAppInitialization.tsx
@@ -113,6 +113,7 @@ export function useAppInitialization({
 	const initializeClient = async (
 		preferredProvider?: string,
 		preferredModel?: string,
+		isProgrammatic: boolean = false,
 	): Promise<LLMClient | null> => {
 		// Lint provider configs before instantiation so typos and misplaced
 		// blocks surface as warnings in the chat queue, without a box —
@@ -160,8 +161,10 @@ export function useAppInitialization({
 		setCurrentModel(finalModel);
 		setCurrentProviderConfig(client.getProviderConfig());
 
-		// Save the preference - use actualProvider and the model that was actually set
-		updateLastUsed(actualProvider, finalModel);
+		if (!isProgrammatic) {
+			// Save the preference - use actualProvider and the model that was actually set
+			updateLastUsed(actualProvider, finalModel);
+		}
 
 		return client;
 	};
@@ -358,10 +361,16 @@ export function useAppInitialization({
 		preferences: UserPreferences,
 	): Promise<void> => {
 		try {
-			// Use CLI provider/model if provided, otherwise use preferences
-			const provider = cliProvider || preferences.lastProvider;
-			const model = cliModel || undefined;
-			const client = await initializeClient(provider, model);
+			const config = getAppConfig();
+			const currentMode = developmentModeRef?.current || 'normal';
+			const modeConfig = config.modeProviders?.[currentMode];
+
+			// Use CLI provider/model if provided, otherwise mode-specific, otherwise preferences
+			const isProgrammatic = !cliProvider && !!modeConfig;
+			const provider =
+				cliProvider || modeConfig?.provider || preferences.lastProvider;
+			const model = cliModel || modeConfig?.model || undefined;
+			const client = await initializeClient(provider, model, isProgrammatic);
 
 			// Create and initialize the SubagentExecutor if client was successfully created
 			if (client) {

--- a/source/hooks/useAppInitialization.tsx
+++ b/source/hooks/useAppInitialization.tsx
@@ -366,7 +366,7 @@ export function useAppInitialization({
 			const modeConfig = config.modeProviders?.[currentMode];
 
 			// Use CLI provider/model if provided, otherwise mode-specific, otherwise preferences
-			const isProgrammatic = !cliProvider && !!modeConfig;
+			const isProgrammatic = !(cliProvider || cliModel) && !!modeConfig;
 			const provider =
 				cliProvider || modeConfig?.provider || preferences.lastProvider;
 			const model = cliModel || modeConfig?.model || undefined;

--- a/source/hooks/useModeHandlers.tsx
+++ b/source/hooks/useModeHandlers.tsx
@@ -98,6 +98,7 @@ export function useModeHandlers({
 	const handleModelSelect = async (
 		selectedProvider: string,
 		selectedModel: string,
+		isProgrammatic: boolean = false,
 	) => {
 		const sameProvider = selectedProvider === currentProvider;
 
@@ -114,16 +115,18 @@ export function useModeHandlers({
 
 				// Conversation is kept across model switches (see warnIfHistoryWontFit).
 
-				// Update preferences
-				updateLastUsed(currentProvider, selectedModel);
+				if (!isProgrammatic) {
+					// Update preferences
+					updateLastUsed(currentProvider, selectedModel);
 
-				addToChatQueue(
-					<SuccessMessage
-						key={generateKey('model-changed')}
-						message={`Model changed to: ${selectedModel}.`}
-						hideBox={true}
-					/>,
-				);
+					addToChatQueue(
+						<SuccessMessage
+							key={generateKey('model-changed')}
+							message={`Model changed to: ${selectedModel}.`}
+							hideBox={true}
+						/>,
+					);
+				}
 
 				await warnIfHistoryWontFit(selectedModel, client.getProviderConfig());
 				exitMode();
@@ -161,15 +164,17 @@ export function useModeHandlers({
 
 			// Conversation is kept across provider/model switches.
 
-			updateLastUsed(actualProvider, newModel);
+			if (!isProgrammatic) {
+				updateLastUsed(actualProvider, newModel);
 
-			addToChatQueue(
-				<SuccessMessage
-					key={generateKey('model-changed')}
-					message={`Model changed to: ${newModel} (${actualProvider}).`}
-					hideBox={true}
-				/>,
-			);
+				addToChatQueue(
+					<SuccessMessage
+						key={generateKey('model-changed')}
+						message={`Model changed to: ${newModel} (${actualProvider}).`}
+						hideBox={true}
+					/>,
+				);
+			}
 
 			await warnIfHistoryWontFit(newModel, newClient.getProviderConfig());
 

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -129,10 +129,12 @@ export interface NotificationsConfig {
 	};
 }
 
+// Note: temperature is intentionally excluded from this interface.
+// It cannot be applied during a mode switch without proper integration into
+// the tune/ModelParameters pipeline (tune.ts). Tracked as a follow-up.
 export interface ModeProviderConfig {
 	provider: string;
 	model: string;
-	temperature?: number;
 }
 
 export interface AppConfig {

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -1,4 +1,5 @@
 import type {TitleShape} from '@/components/ui/styled-title';
+import type {DevelopmentMode} from '@/types/core';
 import type {NanocoderShape, ThemePreset} from '@/types/ui';
 
 // Supported AI SDK provider packages
@@ -128,6 +129,11 @@ export interface NotificationsConfig {
 	};
 }
 
+export interface ModeProviderConfig {
+	provider: string;
+	model: string;
+}
+
 export interface AppConfig {
 	// Providers array structure - all OpenAI compatible
 	providers?: {
@@ -155,6 +161,8 @@ export interface AppConfig {
 		openrouter?: OpenRouterParameters;
 		[key: string]: unknown; // Allow additional provider-specific config
 	}[];
+
+	modeProviders?: Partial<Record<DevelopmentMode, ModeProviderConfig>>;
 
 	mcpServers?: MCPServerConfig[];
 

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -132,6 +132,7 @@ export interface NotificationsConfig {
 export interface ModeProviderConfig {
 	provider: string;
 	model: string;
+	temperature?: number;
 }
 
 export interface AppConfig {

--- a/source/wizards/provider-wizard.tsx
+++ b/source/wizards/provider-wizard.tsx
@@ -1,9 +1,15 @@
 import {Box, Text} from 'ink';
+import {useState} from 'react';
 import {getColors} from '@/config/index';
-import type {ProviderConfig} from '../types/config';
+import type {DevelopmentMode} from '@/types/core';
+import type {ModeProviderConfig, ProviderConfig} from '../types/config';
 import {BaseConfigWizard} from './base-config-wizard';
+import {ModeProviderStep} from './steps/mode-provider-step';
 import {ProviderStep} from './steps/provider-step';
-import {buildProviderConfigObject} from './validation';
+import {
+	buildProviderConfigObject,
+	type ProviderWizardState,
+} from './validation';
 
 interface ProviderWizardProps {
 	projectDir: string;
@@ -11,15 +17,24 @@ interface ProviderWizardProps {
 	onCancel?: () => void;
 }
 
-function parseProviderConfig(raw: unknown): ProviderConfig[] {
-	const config = raw as {nanocoder?: {providers?: ProviderConfig[]}} | null;
-	return config?.nanocoder?.providers ?? [];
+function parseProviderConfig(raw: unknown): ProviderWizardState {
+	const config = raw as {
+		nanocoder?: {
+			providers?: ProviderConfig[];
+			modeProviders?: Partial<Record<DevelopmentMode, ModeProviderConfig>>;
+		};
+	} | null;
+	return {
+		providers: config?.nanocoder?.providers ?? [],
+		modeProviders: config?.nanocoder?.modeProviders ?? {},
+	};
 }
 
-function ProviderSummaryItems({items}: {items: ProviderConfig[]}) {
+function ProviderSummaryItems({items}: {items: ProviderWizardState}) {
 	const colors = getColors();
+	const {providers, modeProviders} = items;
 
-	if (items.length === 0) {
+	if (providers.length === 0) {
 		return (
 			<Box marginBottom={1}>
 				<Text color={colors.warning}>No providers configured</Text>
@@ -29,8 +44,8 @@ function ProviderSummaryItems({items}: {items: ProviderConfig[]}) {
 
 	return (
 		<Box marginBottom={1} flexDirection="column">
-			<Text color={colors.secondary}>Providers ({items.length}):</Text>
-			{items.map((provider, index) => (
+			<Text color={colors.secondary}>Providers ({providers.length}):</Text>
+			{providers.map((provider, index) => (
 				<Text key={index} color={colors.success}>
 					• {provider.name}
 					<Text>
@@ -44,17 +59,30 @@ function ProviderSummaryItems({items}: {items: ProviderConfig[]}) {
 					</Text>
 				</Text>
 			))}
+
+			{modeProviders && Object.keys(modeProviders).length > 0 && (
+				<Box flexDirection="column" marginTop={1}>
+					<Text color={colors.secondary}>Mode-Specific Providers:</Text>
+					{Object.entries(modeProviders).map(([mode, config]) => (
+						<Text key={mode} color={colors.success}>
+							• {mode}: {config.provider} ({config.model})
+						</Text>
+					))}
+				</Box>
+			)}
 		</Box>
 	);
 }
 
-function ProviderCompleteExtras({items}: {items: ProviderConfig[]}) {
+function ProviderCompleteExtras({items}: {items: ProviderWizardState}) {
 	const colors = getColors();
-	const copilotProviders = items.filter(
+	const copilotProviders = items.providers.filter(
 		p => p.sdkProvider === 'github-copilot',
 	);
-	const codexProviders = items.filter(p => p.sdkProvider === 'chatgpt-codex');
-	const localProviders = items.filter(
+	const codexProviders = items.providers.filter(
+		p => p.sdkProvider === 'chatgpt-codex',
+	);
+	const localProviders = items.providers.filter(
 		p =>
 			!p.apiKey &&
 			p.baseUrl &&
@@ -93,35 +121,64 @@ function ProviderCompleteExtras({items}: {items: ProviderConfig[]}) {
 	);
 }
 
+function ProviderWizardSteps({
+	items,
+	onComplete,
+	onBack,
+	onDelete,
+	configExists,
+}: {
+	items: ProviderWizardState;
+	onComplete: (items: ProviderWizardState) => void;
+	onBack: () => void;
+	onDelete: () => void;
+	configExists: boolean;
+}) {
+	const [step, setStep] = useState<'providers' | 'modes'>('providers');
+	const [providers, setProviders] = useState(items.providers);
+
+	if (step === 'providers') {
+		return (
+			<ProviderStep
+				existingProviders={providers}
+				onComplete={newProviders => {
+					setProviders(newProviders);
+					setStep('modes');
+				}}
+				onBack={onBack}
+				onDelete={onDelete}
+				configExists={configExists}
+			/>
+		);
+	}
+
+	return (
+		<ModeProviderStep
+			providers={providers}
+			existingModeProviders={items.modeProviders}
+			onComplete={modeProviders => {
+				onComplete({providers, modeProviders});
+			}}
+			onBack={() => setStep('providers')}
+		/>
+	);
+}
+
 export function ProviderWizard({
 	projectDir,
 	onComplete,
 	onCancel,
 }: ProviderWizardProps) {
 	return (
-		<BaseConfigWizard<ProviderConfig[]>
+		<BaseConfigWizard<ProviderWizardState>
 			title="Provider Wizard"
 			focusId="config-wizard"
 			configFileName="agents.config.json"
-			initialItems={[]}
+			initialItems={{providers: [], modeProviders: {}}}
 			parseConfig={parseProviderConfig}
 			buildConfig={buildProviderConfigObject}
-			hasItems={items => items.length > 0}
-			renderConfigureStep={({
-				items,
-				onComplete: onItemsComplete,
-				onBack,
-				onDelete,
-				configExists,
-			}) => (
-				<ProviderStep
-					existingProviders={items}
-					onComplete={onItemsComplete}
-					onBack={onBack}
-					onDelete={onDelete}
-					configExists={configExists}
-				/>
-			)}
+			hasItems={items => items.providers.length > 0}
+			renderConfigureStep={args => <ProviderWizardSteps {...args} />}
 			renderSummaryItems={items => <ProviderSummaryItems items={items} />}
 			renderCompleteExtras={items => <ProviderCompleteExtras items={items} />}
 			projectDir={projectDir}

--- a/source/wizards/steps/mode-provider-step.tsx
+++ b/source/wizards/steps/mode-provider-step.tsx
@@ -1,0 +1,217 @@
+import {Box, Text, useInput} from 'ink';
+import SelectInput from 'ink-select-input';
+import {useState} from 'react';
+import {VALID_MODES} from '@/app/types';
+import TextInput from '@/components/text-input';
+import {getColors} from '@/config/index';
+import type {ModeProviderConfig, ProviderConfig} from '../../types/config';
+import type {DevelopmentMode} from '../../types/core';
+
+interface ModeProviderStepProps {
+	providers: ProviderConfig[];
+	existingModeProviders?: Partial<Record<DevelopmentMode, ModeProviderConfig>>;
+	onComplete: (
+		modeProviders: Partial<Record<DevelopmentMode, ModeProviderConfig>>,
+	) => void;
+	onBack: () => void;
+}
+
+type Mode =
+	| 'select-mode'
+	| 'select-provider'
+	| 'select-model'
+	| 'enter-temperature';
+type SelectModeValue = DevelopmentMode | 'done' | 'clear';
+type SelectProviderValue = string | 'clear';
+
+export function ModeProviderStep({
+	providers,
+	existingModeProviders = {},
+	onComplete,
+	onBack,
+}: ModeProviderStepProps) {
+	const colors = getColors();
+
+	const [modeProviders, setModeProviders] = useState<
+		Partial<Record<DevelopmentMode, ModeProviderConfig>>
+	>(existingModeProviders);
+	const [mode, setMode] = useState<Mode>('select-mode');
+
+	const [selectedDevMode, setSelectedDevMode] =
+		useState<DevelopmentMode | null>(null);
+	const [selectedProvider, setSelectedProvider] =
+		useState<ProviderConfig | null>(null);
+	const [selectedModel, setSelectedModel] = useState<string | null>(null);
+	const [temperatureStr, setTemperatureStr] = useState<string>('');
+
+	useInput((input, key) => {
+		if (key.escape || (input === 'b' && key.ctrl)) {
+			if (mode === 'select-mode') {
+				onBack();
+			} else if (mode === 'select-provider') {
+				setMode('select-mode');
+			} else if (mode === 'select-model') {
+				setMode('select-provider');
+			} else if (mode === 'enter-temperature') {
+				setMode('select-model');
+			}
+		}
+	});
+
+	if (providers.length === 0) {
+		return (
+			<Box flexDirection="column" gap={1}>
+				<Text color={colors.warning}>No providers configured yet.</Text>
+				<Text>
+					Please configure at least one provider before setting up mode-specific
+					providers.
+				</Text>
+				<SelectInput
+					items={[{label: 'Go back', value: 'back'}]}
+					onSelect={() => onBack()}
+				/>
+			</Box>
+		);
+	}
+
+	if (mode === 'select-mode') {
+		const items = (VALID_MODES as readonly string[]).map(m => {
+			const config = modeProviders[m as DevelopmentMode];
+			const label = config
+				? `${m} (Current: ${config.provider} - ${config.model})`
+				: `${m} (Unconfigured)`;
+			return {label, value: m as SelectModeValue};
+		});
+
+		return (
+			<Box flexDirection="column" gap={1}>
+				<Text color={colors.primary}>Configure Mode-Specific Providers</Text>
+				<Text>Select a mode to configure (Esc to go back):</Text>
+				<SelectInput<SelectModeValue>
+					items={[
+						...items,
+						{label: 'Clear All Mode Providers', value: 'clear'},
+						{label: 'Done', value: 'done'},
+					]}
+					onSelect={item => {
+						if (item.value === 'done') {
+							onComplete(modeProviders);
+						} else if (item.value === 'clear') {
+							setModeProviders({});
+						} else {
+							setSelectedDevMode(item.value as DevelopmentMode);
+							setMode('select-provider');
+						}
+					}}
+				/>
+			</Box>
+		);
+	}
+
+	if (mode === 'select-provider') {
+		const items = providers.map(p => ({
+			label: p.name,
+			value: p.name as SelectProviderValue,
+		}));
+
+		return (
+			<Box flexDirection="column" gap={1}>
+				<Text color={colors.primary}>
+					Select Provider for {selectedDevMode}
+				</Text>
+				<Text color={colors.secondary}>(Esc to go back)</Text>
+				<SelectInput<SelectProviderValue>
+					items={[...items, {label: 'Clear mode override', value: 'clear'}]}
+					onSelect={item => {
+						if (item.value === 'clear') {
+							setModeProviders(prev => {
+								const next = {...prev};
+								delete next[selectedDevMode!];
+								return next;
+							});
+							setMode('select-mode');
+						} else {
+							const provider = providers.find(p => p.name === item.value);
+							if (provider) {
+								setSelectedProvider(provider);
+								if (provider.models.length > 0) {
+									setMode('select-model');
+								} else {
+									setSelectedModel('default');
+									setTemperatureStr(
+										modeProviders[selectedDevMode!]?.temperature?.toString() ||
+											'',
+									);
+									setMode('enter-temperature');
+								}
+							}
+						}
+					}}
+				/>
+			</Box>
+		);
+	}
+
+	if (mode === 'select-model') {
+		const items = selectedProvider!.models.map(m => ({
+			label: m,
+			value: m,
+		}));
+
+		return (
+			<Box flexDirection="column" gap={1}>
+				<Text color={colors.primary}>
+					Select Model for {selectedDevMode} ({selectedProvider!.name})
+				</Text>
+				<Text color={colors.secondary}>(Esc to go back)</Text>
+				<SelectInput
+					items={items}
+					onSelect={item => {
+						setSelectedModel(item.value);
+						setTemperatureStr(
+							modeProviders[selectedDevMode!]?.temperature?.toString() || '',
+						);
+						setMode('enter-temperature');
+					}}
+				/>
+			</Box>
+		);
+	}
+
+	if (mode === 'enter-temperature') {
+		return (
+			<Box flexDirection="column" gap={1}>
+				<Text color={colors.primary}>
+					Temperature for {selectedDevMode} (optional, 0.0 to 2.0)
+				</Text>
+				<Box borderStyle="round" borderColor={colors.secondary}>
+					<TextInput
+						value={temperatureStr}
+						onChange={setTemperatureStr}
+						onSubmit={() => {
+							const temp = temperatureStr?.trim()
+								? parseFloat(temperatureStr)
+								: undefined;
+							setModeProviders(prev => ({
+								...prev,
+								[selectedDevMode!]: {
+									provider: selectedProvider!.name,
+									model: selectedModel!,
+									...(temp !== undefined && !isNaN(temp)
+										? {temperature: temp}
+										: {}),
+								},
+							}));
+							setMode('select-mode');
+						}}
+					/>
+				</Box>
+				<Text color={colors.secondary}>
+					Press Enter to save, or Esc to go back
+				</Text>
+			</Box>
+		);
+	}
+
+	return null;
+}

--- a/source/wizards/steps/mode-provider-step.tsx
+++ b/source/wizards/steps/mode-provider-step.tsx
@@ -2,7 +2,6 @@ import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 import {useState} from 'react';
 import {VALID_MODES} from '@/app/types';
-import TextInput from '@/components/text-input';
 import {getColors} from '@/config/index';
 import type {ModeProviderConfig, ProviderConfig} from '../../types/config';
 import type {DevelopmentMode} from '../../types/core';
@@ -16,11 +15,7 @@ interface ModeProviderStepProps {
 	onBack: () => void;
 }
 
-type Mode =
-	| 'select-mode'
-	| 'select-provider'
-	| 'select-model'
-	| 'enter-temperature';
+type Mode = 'select-mode' | 'select-provider' | 'select-model';
 type SelectModeValue = DevelopmentMode | 'done' | 'clear';
 type SelectProviderValue = string | 'clear';
 
@@ -41,8 +36,6 @@ export function ModeProviderStep({
 		useState<DevelopmentMode | null>(null);
 	const [selectedProvider, setSelectedProvider] =
 		useState<ProviderConfig | null>(null);
-	const [selectedModel, setSelectedModel] = useState<string | null>(null);
-	const [temperatureStr, setTemperatureStr] = useState<string>('');
 
 	useInput((input, key) => {
 		if (key.escape || (input === 'b' && key.ctrl)) {
@@ -52,8 +45,6 @@ export function ModeProviderStep({
 				setMode('select-mode');
 			} else if (mode === 'select-model') {
 				setMode('select-provider');
-			} else if (mode === 'enter-temperature') {
-				setMode('select-model');
 			}
 		}
 	});
@@ -137,12 +128,15 @@ export function ModeProviderStep({
 								if (provider.models.length > 0) {
 									setMode('select-model');
 								} else {
-									setSelectedModel('default');
-									setTemperatureStr(
-										modeProviders[selectedDevMode!]?.temperature?.toString() ||
-											'',
-									);
-									setMode('enter-temperature');
+									// Provider allows any model - use 'default' as placeholder
+									setModeProviders(prev => ({
+										...prev,
+										[selectedDevMode!]: {
+											provider: provider.name,
+											model: 'default',
+										},
+									}));
+									setMode('select-mode');
 								}
 							}
 						}
@@ -167,48 +161,16 @@ export function ModeProviderStep({
 				<SelectInput
 					items={items}
 					onSelect={item => {
-						setSelectedModel(item.value);
-						setTemperatureStr(
-							modeProviders[selectedDevMode!]?.temperature?.toString() || '',
-						);
-						setMode('enter-temperature');
+						setModeProviders(prev => ({
+							...prev,
+							[selectedDevMode!]: {
+								provider: selectedProvider!.name,
+								model: item.value,
+							},
+						}));
+						setMode('select-mode');
 					}}
 				/>
-			</Box>
-		);
-	}
-
-	if (mode === 'enter-temperature') {
-		return (
-			<Box flexDirection="column" gap={1}>
-				<Text color={colors.primary}>
-					Temperature for {selectedDevMode} (optional, 0.0 to 2.0)
-				</Text>
-				<Box borderStyle="round" borderColor={colors.secondary}>
-					<TextInput
-						value={temperatureStr}
-						onChange={setTemperatureStr}
-						onSubmit={() => {
-							const temp = temperatureStr?.trim()
-								? parseFloat(temperatureStr)
-								: undefined;
-							setModeProviders(prev => ({
-								...prev,
-								[selectedDevMode!]: {
-									provider: selectedProvider!.name,
-									model: selectedModel!,
-									...(temp !== undefined && !isNaN(temp)
-										? {temperature: temp}
-										: {}),
-								},
-							}));
-							setMode('select-mode');
-						}}
-					/>
-				</Box>
-				<Text color={colors.secondary}>
-					Press Enter to save, or Esc to go back
-				</Text>
 			</Box>
 		);
 	}

--- a/source/wizards/validation.spec.ts
+++ b/source/wizards/validation.spec.ts
@@ -551,7 +551,7 @@ test('buildProviderConfigObject: preserves the openrouter block on disk', t => {
 		},
 	];
 
-	const config = buildProviderConfigObject(providers);
+	const config = buildProviderConfigObject({providers, modeProviders: {}});
 	const p = config.nanocoder.providers[0];
 
 	t.deepEqual(p?.openrouter, {
@@ -572,7 +572,7 @@ test('buildProviderConfigObject: omits openrouter when undefined', t => {
 		},
 	];
 
-	const config = buildProviderConfigObject(providers);
+	const config = buildProviderConfigObject({providers, modeProviders: {}});
 	const p = config.nanocoder.providers[0];
 
 	t.false('openrouter' in (p ?? {}));
@@ -594,7 +594,7 @@ test('buildProviderConfigObject: openrouter block survives wizard buildConfig ro
 		},
 	};
 
-	const config = buildProviderConfigObject([fromWizard]);
+	const config = buildProviderConfigObject({providers: [fromWizard], modeProviders: {}});
 	const p = config.nanocoder.providers[0];
 
 	t.is(p?.openrouter?.service_tier, 'priority');

--- a/source/wizards/validation.ts
+++ b/source/wizards/validation.ts
@@ -1,10 +1,12 @@
 import {TIMEOUT_PROVIDER_CONNECTION_MS} from '@/constants';
 import {isLocalURL} from '@/utils/url-utils';
 import type {
+	ModeProviderConfig,
 	OpenRouterParameters,
 	ProviderConfig,
 	SdkProvider,
 } from '../types/config';
+import type {DevelopmentMode} from '../types/core';
 import type {McpServerConfig} from './templates/mcp-templates';
 
 interface ValidationResult {
@@ -161,7 +163,13 @@ interface ProviderConfigObject {
 			sdkProvider?: SdkProvider;
 			openrouter?: OpenRouterParameters;
 		}>;
+		modeProviders?: Partial<Record<DevelopmentMode, ModeProviderConfig>>;
 	};
+}
+
+export interface ProviderWizardState {
+	providers: ProviderConfig[];
+	modeProviders?: Partial<Record<DevelopmentMode, ModeProviderConfig>>;
 }
 
 /**
@@ -176,11 +184,11 @@ interface McpConfigObject {
  * Builds the provider configuration object for agents.config.json
  */
 export function buildProviderConfigObject(
-	providers: ProviderConfig[],
+	state: ProviderWizardState,
 ): ProviderConfigObject {
 	const config: ProviderConfigObject = {
 		nanocoder: {
-			providers: providers.map(p => {
+			providers: state.providers.map(p => {
 				const providerConfig: {
 					name: string;
 					models: string[];
@@ -228,6 +236,10 @@ export function buildProviderConfigObject(
 			}),
 		},
 	};
+
+	if (state.modeProviders && Object.keys(state.modeProviders).length > 0) {
+		config.nanocoder.modeProviders = state.modeProviders;
+	}
 
 	return config;
 }


### PR DESCRIPTION
Closes #277

## Description

This PR adds support for **mode-specific provider and model configuration** via a new `modeProviders` configuration in `agents.config.json`.

Previously, Nanocoder used a single global provider/model across all development modes (`normal`, `plan`, `yolo`, `auto-accept`, `headless`). With this change, users can configure different providers and models for individual modes, allowing workflows such as using a powerful cloud model for planning while using a fast local model for implementation.

### Highlights

* Introduces a new `modeProviders` configuration schema.
* Validates configured providers and models during configuration loading.
* Automatically switches to the configured provider/model when the development mode changes.
* Restores the user's default provider/model when leaving a mode without a dedicated configuration.
* Reuses the existing model-switch workflow, preserving current provider-switch behavior while keeping the client factory independent of development modes.
* Gracefully falls back to the default configuration when invalid mode-specific entries are encountered.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update

## Testing

### Automated Tests

* [x] New features include passing tests in `.spec.ts/tsx` files
* [x] All existing tests pass (`pnpm test:all` completes successfully)
* [x] Tests cover both success and error scenarios

### Manual Testing

* [x] Tested with Ollama
* [x] Tested with OpenRouter
* [x] Tested with OpenAI-compatible API
* [ ] Tested MCP integration (if applicable)

## Checklist

* [x] Code follows project style guidelines
* [x] Self-review completed
* [ ] Documentation updated (if needed)
* [x] No breaking changes (or clearly documented)
* [x] Appropriate logging added using structured logging (see `CONTRIBUTING.md#logging`)
