### PR TITLE
fix: remove strip-ansi runtime dependency

### DIFF
--- a/source/utils/ansi-truncate.spec.ts
+++ b/source/utils/ansi-truncate.spec.ts
@@ -1,5 +1,13 @@
+import {readFileSync} from 'node:fs';
 import test from 'ava';
 import {truncateAnsi} from './ansi-truncate';
+
+test('does not require strip-ansi at runtime', t => {
+	const source = readFileSync(new URL('./ansi-truncate.ts', import.meta.url), 'utf8');
+
+	t.false(/\bfrom\s+['"]strip-ansi['"]/.test(source));
+	t.false(/\bimport\s*\(\s*['"]strip-ansi['"]\s*\)/.test(source));
+});
 
 test('returns original string if within maxWidth', t => {
 	t.is(truncateAnsi('hello', 10), 'hello');

--- a/source/utils/ansi-truncate.ts
+++ b/source/utils/ansi-truncate.ts
@@ -1,11 +1,11 @@
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters} from 'node:util';
 
 /**
  * Truncate a string containing ANSI escape codes to fit a given visual width.
  * Preserves ANSI formatting while counting only visible characters.
  */
 export function truncateAnsi(str: string, maxWidth: number): string {
-	const plainText = stripAnsi(str);
+	const plainText = stripVTControlCharacters(str);
 	if (plainText.length <= maxWidth) return str;
 
 	let visibleCount = 0;


### PR DESCRIPTION
## Description

Fixes #643.

Replaces the runtime `strip-ansi` import in `ansi-truncate` with Node built-in `stripVTControlCharacters`. This keeps the published CLI from requiring a dev-only package at runtime and avoids the `ERR_MODULE_NOT_FOUND` failure when the package is installed without dev dependencies.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] Regression test added in `source/utils/ansi-truncate.spec.ts`
- [x] `pnpm test:ava source/utils/ansi-truncate.spec.ts`
- [x] `git diff --check HEAD`
- [ ] All existing tests pass (`pnpm test:all` completes successfully)

`pnpm test:all` was attempted locally and did not complete because unrelated suites failed. On GitHub Actions, the remaining failing checks also appear unrelated to this change: Unit Tests fail in `source/components/user-input.spec.tsx` for queued-message truncation, and Semgrep reports pre-existing repository/workflow/package-manager configuration findings. Format, lint, type checks, unused dependencies, package audit, and build verification pass.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

N/A: this change only removes a runtime ANSI-stripping dependency from a utility module.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

N/A: no logging path was changed.