### PR TITLE
refactor: migrate to stateless API and history-boundary rehydration

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"@anthropic-ai/tokenizer": "^0.0.4",
 		"@modelcontextprotocol/sdk": "^1.26.0",
 		"@nanocollective/get-md": "^1.4.0",
-		"@nanocollective/prompt-scrub": "^1.0.0",
+		"@nanocollective/prompt-scrub": "file:../prompt-scrubber",
 		"ai": "6.0.193",
 		"chalk": "^5.2.0",
 		"chokidar": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^1.4.0
         version: 1.5.0(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@4.0.8(zod@4.4.3))(@ai-sdk/openai-compatible@3.0.5(zod@4.4.3))(ai@6.0.193(zod@4.4.3))
       '@nanocollective/prompt-scrub':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: file:../prompt-scrubber
+        version: file:../prompt-scrubber
       ai:
         specifier: 6.0.193
         version: 6.0.193(zod@4.4.3)
@@ -849,8 +849,8 @@ packages:
       node-llama-cpp:
         optional: true
 
-  '@nanocollective/prompt-scrub@1.0.0':
-    resolution: {integrity: sha512-qaNQXKraKOBJzXoYBqGBNt96eCCX3jZXJdfksM97IoIitqDmfUCpS0M7oXYzD2wfaxH1NtFtHUWcPoMJ2uNS7g==}
+  '@nanocollective/prompt-scrub@file:../prompt-scrubber':
+    resolution: {directory: ../prompt-scrubber, type: directory}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4272,7 +4272,7 @@ snapshots:
       '@ai-sdk/openai-compatible': 3.0.5(zod@4.4.3)
       ai: 6.0.193(zod@4.4.3)
 
-  '@nanocollective/prompt-scrub@1.0.0':
+  '@nanocollective/prompt-scrub@file:../prompt-scrubber':
     dependencies:
       commander: 15.0.0
 

--- a/source/ai-sdk-client/ai-sdk-client.ts
+++ b/source/ai-sdk-client/ai-sdk-client.ts
@@ -186,7 +186,7 @@ export class AISDKClient implements LLMClient {
 			signal,
 			maxRetries: this.maxRetries,
 			modeOverrides,
-			privacySessionIdRef: modeOverrides?.privacySessionIdRef,
+			privacySessionMapRef: modeOverrides?.privacySessionMapRef,
 			privacyEnabled: modeOverrides?.privacyEnabled,
 			onPrivacyEvent: callbacks.onPrivacyEvent,
 		});

--- a/source/ai-sdk-client/chat/chat-handler.ts
+++ b/source/ai-sdk-client/chat/chat-handler.ts
@@ -1,3 +1,7 @@
+import type {
+	RehydrateRequest,
+	ScrubRequest,
+} from '@nanocollective/prompt-scrub';
 import type {LanguageModel} from 'ai';
 import {
 	InvalidToolInputError,
@@ -52,7 +56,7 @@ export interface ChatHandlerParams {
 	maxRetries: number;
 	skipTools?: boolean;
 	modeOverrides?: ModeOverrides;
-	privacySessionIdRef?: React.MutableRefObject<string>;
+	privacySessionMapRef?: React.MutableRefObject<Record<string, string>>;
 	privacyEnabled?: boolean;
 	onPrivacyEvent?: (scrubbedDelta: number) => void;
 }
@@ -74,7 +78,7 @@ export async function handleChat(
 		maxRetries,
 		skipTools = false,
 		modeOverrides,
-		privacySessionIdRef,
+		privacySessionMapRef,
 		privacyEnabled,
 		onPrivacyEvent,
 	} = params;
@@ -156,30 +160,32 @@ export async function handleChat(
 			// Scrub prompts if privacy scrubbing is enabled
 			let finalSystemContent = systemContent;
 			let finalNonSystemMessages = nonSystemMessages;
-			if (privacyEnabled && privacySessionIdRef) {
+			if (privacyEnabled && privacySessionMapRef) {
 				const {scrub} = await import('@nanocollective/prompt-scrub');
-				const {SessionManager} = await import(
-					'@nanocollective/prompt-scrub/dist/session/session-manager.js'
-				);
-				const prevCount = Object.keys(
-					new SessionManager(privacySessionIdRef.current).getMap(),
-				).length;
+
+				const prevCount = Object.keys(privacySessionMapRef.current).length;
 
 				finalSystemContent = scrub({
 					content: systemContent,
-					sessionId: privacySessionIdRef.current,
-				}).scrubbedContent as string;
-				finalNonSystemMessages = nonSystemMessages.map(m => ({
-					...m,
-					content: scrub({
-						content: m.content,
-						sessionId: privacySessionIdRef.current,
-					}).scrubbedContent as string,
-				}));
+					sessionMap: privacySessionMapRef.current,
+					options: {disabledDetectors: ['PathDetector', 'UrlDetector']},
+				} as ScrubRequest & {sessionMap: Record<string, string>})
+					.scrubbedContent as string;
 
-				const newCount = Object.keys(
-					new SessionManager(privacySessionIdRef.current).getMap(),
-				).length;
+				finalNonSystemMessages = nonSystemMessages.map(m => {
+					if (m.role === 'tool') return m;
+					return {
+						...m,
+						content: scrub({
+							content: m.content,
+							sessionMap: privacySessionMapRef.current,
+							options: {disabledDetectors: ['PathDetector', 'UrlDetector']},
+						} as ScrubRequest & {sessionMap: Record<string, string>})
+							.scrubbedContent as string,
+					};
+				});
+
+				const newCount = Object.keys(privacySessionMapRef.current).length;
 				const delta = newCount - prevCount;
 				if (delta > 0 && onPrivacyEvent) {
 					onPrivacyEvent(delta);
@@ -378,6 +384,71 @@ export async function handleChat(
 
 			const content = fullText || accumulatedText;
 
+			let finalContent = content;
+			let finalReasoning = reasoning;
+			let finalToolCalls = toolCalls;
+
+			if (privacyEnabled && privacySessionMapRef) {
+				const {rehydrate} = await import('@nanocollective/prompt-scrub');
+
+				if (finalContent) {
+					const result = rehydrate({
+						content: finalContent,
+						sessionMap: privacySessionMapRef.current,
+					} as RehydrateRequest & {sessionMap: Record<string, string>});
+					finalContent = result.content as string;
+					if (result.warnings && result.warnings.length > 0) {
+						logger.warn('Prompt-scrub rehydration warnings (content)', {
+							warnings: result.warnings,
+						});
+					}
+				}
+
+				if (finalReasoning) {
+					const result = rehydrate({
+						content: finalReasoning,
+						sessionMap: privacySessionMapRef.current,
+					} as RehydrateRequest & {sessionMap: Record<string, string>});
+					finalReasoning = result.content as string;
+					if (result.warnings && result.warnings.length > 0) {
+						logger.warn('Prompt-scrub rehydration warnings (reasoning)', {
+							warnings: result.warnings,
+						});
+					}
+				}
+
+				if (finalToolCalls.length > 0) {
+					finalToolCalls = finalToolCalls.map(tc => {
+						try {
+							const argsStr = JSON.stringify(tc.function.arguments);
+							const result = rehydrate({
+								content: argsStr,
+								sessionMap: privacySessionMapRef.current,
+							} as RehydrateRequest & {sessionMap: Record<string, string>});
+							if (result.warnings && result.warnings.length > 0) {
+								logger.warn('Prompt-scrub rehydration warnings (tool args)', {
+									toolName: tc.function.name,
+									warnings: result.warnings,
+								});
+							}
+							return {
+								...tc,
+								function: {
+									...tc.function,
+									arguments: JSON.parse(result.content as string),
+								},
+							};
+						} catch (e) {
+							logger.error('Failed to rehydrate tool call', {
+								toolName: tc.function.name,
+								error: e,
+							});
+							return tc;
+						}
+					});
+				}
+			}
+
 			// Calculate performance metrics
 			const finalMetrics = endMetrics(metrics);
 
@@ -401,9 +472,10 @@ export async function handleChat(
 					{
 						message: {
 							role: 'assistant',
-							content,
-							tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
-							reasoning,
+							content: finalContent,
+							tool_calls:
+								finalToolCalls.length > 0 ? finalToolCalls : undefined,
+							reasoning: finalReasoning,
 						},
 					},
 				],

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -234,7 +234,7 @@ export default function App({
 			appState.setApiCallHistory(prev => [...prev, record]),
 		tune: appState.tune,
 		subagentsReady: appState.subagentsReady,
-		privacySessionIdRef: appState.privacySessionIdRef,
+		privacySessionMapRef: appState.privacySessionMapRef,
 		privacyEnabled: getPrivacyPreference(),
 	});
 
@@ -647,7 +647,7 @@ export default function App({
 					<PrivacyContext.Provider
 						value={{
 							privacyEnabled: getPrivacyPreference(),
-							privacySessionIdRef: appState.privacySessionIdRef,
+							privacySessionMapRef: appState.privacySessionMapRef,
 						}}
 					>
 						<InteractiveApp

--- a/source/commands/privacy.tsx
+++ b/source/commands/privacy.tsx
@@ -1,8 +1,8 @@
 import {scrub} from '@nanocollective/prompt-scrub';
-import {SessionManager} from '@nanocollective/prompt-scrub/dist/session/session-manager.js';
+
 import {Box, Text} from 'ink';
 import {useTheme} from '@/hooks/useTheme';
-import {generateKey} from '@/session/key-generator';
+
 import type {Command} from '@/types/index';
 import {errorMsg, infoMsg} from '@/utils/message-factory';
 
@@ -26,26 +26,25 @@ export const privacyCommand: Command = {
 				return errorMsg('Please provide text to inspect.', 'privacy');
 			}
 
-			const tempSessionId = generateKey('inspect');
-
-			// Scrub the input
+			// Scrub the input using a stateless map
 			const result = scrub({
 				content: text,
-				sessionId: tempSessionId,
-			});
+				sessionMap: {},
+				options: {disabledDetectors: ['PathDetector', 'UrlDetector']},
+			} as import('@nanocollective/prompt-scrub').ScrubRequest & {
+				sessionMap: Record<string, string>;
+			}) as import('@nanocollective/prompt-scrub').ScrubResult & {
+				sessionMap: Record<string, string>;
+			};
 
 			// Collect the replacements map
-			const session = new SessionManager(tempSessionId);
-			const map = session.getMap();
+			const map = result.sessionMap || {};
 			const replacements = Object.entries(map).map(
 				([placeholder, original]) => ({
 					placeholder,
-					original,
+					original: original as string,
 				}),
 			);
-
-			// Clean up the temporary session
-			session.destroy();
 
 			if (replacements.length === 0) {
 				return infoMsg(

--- a/source/components/assistant-message.tsx
+++ b/source/components/assistant-message.tsx
@@ -1,7 +1,5 @@
-import {rehydrate} from '@nanocollective/prompt-scrub';
 import {Box, Text} from 'ink';
 import {memo, useMemo} from 'react';
-import {usePrivacyContext} from '@/context/privacy-context';
 import {useNonInteractiveRender} from '@/hooks/useNonInteractiveRender';
 import {useTerminalWidth} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
@@ -48,26 +46,11 @@ export default memo(function AssistantMessage({
 	const boxWidth = useTerminalWidth();
 	const nonInteractive = useNonInteractiveRender();
 	const tokens = calculateTokens(message);
-	const {privacyEnabled, privacySessionIdRef} = usePrivacyContext();
 
 	// Inner text width: outer width minus left border (1) and padding (1 each side)
 	const textWidth = nonInteractive ? boxWidth : boxWidth - 3;
 
-	// Rehydrate the message if privacy scrubbing is enabled
-	const displayMessage = useMemo(() => {
-		if (privacyEnabled && privacySessionIdRef?.current) {
-			try {
-				const result = rehydrate({
-					content: message,
-					sessionId: privacySessionIdRef.current,
-				});
-				return result.content as string;
-			} catch (_e) {
-				return message;
-			}
-		}
-		return message;
-	}, [message, privacyEnabled, privacySessionIdRef]);
+	const displayMessage = message;
 
 	// Render markdown into segments: text parts (rendered inside the bordered box)
 	// and code parts (rendered without a border so they can be copied cleanly).

--- a/source/context/privacy-context.tsx
+++ b/source/context/privacy-context.tsx
@@ -2,12 +2,12 @@ import React, {createContext, useContext} from 'react';
 
 export interface PrivacyContextType {
 	privacyEnabled: boolean;
-	privacySessionIdRef: React.MutableRefObject<string> | null;
+	privacySessionMapRef: React.MutableRefObject<Record<string, string>> | null;
 }
 
 export const PrivacyContext = createContext<PrivacyContextType>({
 	privacyEnabled: false,
-	privacySessionIdRef: null,
+	privacySessionMapRef: null,
 });
 
 export function usePrivacyContext() {

--- a/source/hooks/chat-handler/conversation/conversation-loop.tsx
+++ b/source/hooks/chat-handler/conversation/conversation-loop.tsx
@@ -93,7 +93,7 @@ interface ProcessAssistantResponseParams {
 	// provider-reported token counts rather than client-side estimates.
 	onApiCallComplete?: (record: ApiCallRecord) => void;
 	tune?: TuneConfig;
-	privacySessionIdRef?: React.MutableRefObject<string>;
+	privacySessionMapRef?: React.MutableRefObject<Record<string, string>>;
 	privacyEnabled?: boolean;
 	onPrivacyEvent?: (scrubbedDelta: number) => void;
 	// Number of consecutive empty assistant turns that have already been
@@ -182,7 +182,7 @@ export const processAssistantResponse = async (
 		compactRetryCount = 0,
 		lastToolSignature,
 		repeatedToolCallCount = 0,
-		privacySessionIdRef,
+		privacySessionMapRef,
 		privacyEnabled = false,
 		onPrivacyEvent,
 	} = params;
@@ -264,14 +264,14 @@ export const processAssistantResponse = async (
 					nonInteractiveMode,
 					nonInteractiveAlwaysAllow,
 					modelParameters,
-					privacySessionIdRef,
+					privacySessionMapRef,
 					privacyEnabled,
 				}
 			: {
 					nonInteractiveMode: false,
 					nonInteractiveAlwaysAllow: [],
 					modelParameters,
-					privacySessionIdRef,
+					privacySessionMapRef,
 					privacyEnabled,
 				};
 
@@ -774,10 +774,6 @@ export const processAssistantResponse = async (
 				conversationStateManager,
 				addToChatQueue,
 				{...displayOptions, setLiveComponent, signal: controller.signal},
-				{
-					privacyEnabled: params.privacyEnabled ?? false,
-					privacySessionIdRef: params.privacySessionIdRef ?? null,
-				},
 			);
 			turnResults.push(...directResults);
 		}
@@ -847,10 +843,6 @@ export const processAssistantResponse = async (
 					processToolUse,
 					setLiveComponent,
 					controller.signal,
-					{
-						privacyEnabled: params.privacyEnabled ?? false,
-						privacySessionIdRef: params.privacySessionIdRef ?? null,
-					},
 				);
 				turnResults.push(execution.result);
 				await displayExecutedTool(

--- a/source/hooks/chat-handler/conversation/tool-executor.tsx
+++ b/source/hooks/chat-handler/conversation/tool-executor.tsx
@@ -1,4 +1,3 @@
-import {rehydrate} from '@nanocollective/prompt-scrub';
 import React from 'react';
 import type {ConversationStateManager} from '@/app/utils/conversation-state';
 import AgentProgress, {MultiAgentProgress} from '@/components/agent-progress';
@@ -28,40 +27,6 @@ import {
 	LIVE_TASK_TOOLS,
 } from '@/utils/tool-result-display';
 
-export interface PrivacyOptions {
-	privacyEnabled: boolean;
-	privacySessionIdRef: React.MutableRefObject<string> | null;
-}
-
-const rehydrateToolCall = (
-	toolCall: ToolCall,
-	privacyOptions?: PrivacyOptions,
-): ToolCall => {
-	if (
-		privacyOptions?.privacyEnabled &&
-		privacyOptions?.privacySessionIdRef?.current
-	) {
-		try {
-			const argsString = JSON.stringify(toolCall.function.arguments);
-			const result = rehydrate({
-				content: argsString,
-				sessionId: privacyOptions.privacySessionIdRef.current,
-			});
-			return {
-				...toolCall,
-				function: {
-					...toolCall.function,
-					arguments: JSON.parse(result.content as string),
-				},
-			};
-		} catch (_e) {
-			// fallback to original if parsing/rehydration fails
-			return toolCall;
-		}
-	}
-	return toolCall;
-};
-
 /**
  * Validates and executes a single tool call.
  * Returns the tool call paired with its result for sequential post-processing.
@@ -69,14 +34,12 @@ const rehydrateToolCall = (
 const executeOne = async (
 	toolCall: ToolCall,
 	processToolUse: (toolCall: ToolCall) => Promise<ToolResult>,
-	privacyOptions?: PrivacyOptions,
 ): Promise<{
 	toolCall: ToolCall;
 	result: ToolResult;
 }> => {
 	try {
-		const callToExecute = rehydrateToolCall(toolCall, privacyOptions);
-		const result = await processToolUse(callToExecute);
+		const result = await processToolUse(toolCall);
 		return {toolCall, result};
 	} catch (error) {
 		return {
@@ -102,11 +65,9 @@ const executeBashStreaming = async (
 	toolManager: ToolManager | null,
 	setLiveComponent: (component: React.ReactNode) => void,
 	signal?: AbortSignal,
-	privacyOptions?: PrivacyOptions,
 ): Promise<StreamingBashRun> => {
-	const callToExecute = rehydrateToolCall(toolCall, privacyOptions);
 	const execution = await runStreamingBashTool(
-		callToExecute,
+		toolCall,
 		toolManager,
 		setLiveComponent,
 		'direct-bash',
@@ -135,7 +96,6 @@ export const executeApprovedTool = (
 	processToolUse: (toolCall: ToolCall) => Promise<ToolResult>,
 	setLiveComponent?: (component: React.ReactNode) => void,
 	signal?: AbortSignal,
-	privacyOptions?: PrivacyOptions,
 ): Promise<StreamingBashRun | {toolCall: ToolCall; result: ToolResult}> => {
 	if (toolCall.function.name === 'execute_bash' && setLiveComponent) {
 		return executeBashStreaming(
@@ -143,10 +103,9 @@ export const executeApprovedTool = (
 			toolManager,
 			setLiveComponent,
 			signal,
-			privacyOptions,
 		);
 	}
-	return executeOne(toolCall, processToolUse, privacyOptions);
+	return executeOne(toolCall, processToolUse);
 };
 
 /**
@@ -300,7 +259,6 @@ const executeAgentBatch = async (
 	onCompactToolCount?: (toolName: string) => void,
 	nonInteractiveMode?: boolean,
 	signal?: AbortSignal,
-	privacyOptions?: PrivacyOptions,
 ): Promise<
 	Array<{
 		toolCall: ToolCall;
@@ -328,8 +286,7 @@ const executeAgentBatch = async (
 
 	// Start all agents
 	const agentExecutions = toExecute.map(toolCall => {
-		const callToExecute = rehydrateToolCall(toolCall, privacyOptions);
-		const parsedArgs = parseToolArguments(callToExecute.function.arguments);
+		const parsedArgs = parseToolArguments(toolCall.function.arguments);
 		// Coerce, don't assert: a weak model can emit these as objects/numbers,
 		// and a non-string flowing into the progress UI crashes the renderer.
 		const agentName =
@@ -511,7 +468,6 @@ export const executeToolsDirectly = async (
 		 */
 		signal?: AbortSignal;
 	},
-	privacyOptions?: PrivacyOptions,
 ): Promise<ToolResult[]> => {
 	// Import processToolUse here to avoid circular dependencies
 	const {processToolUse} = await import('@/message-handler');
@@ -541,7 +497,6 @@ export const executeToolsDirectly = async (
 				options?.onCompactToolCount,
 				options?.nonInteractiveMode,
 				options?.signal,
-				privacyOptions,
 			);
 
 			// Agent results are already displayed by executeAgentBatch
@@ -558,9 +513,7 @@ export const executeToolsDirectly = async (
 		if (type === 'readOnly' && group.length > 1) {
 			// Parallel execution for consecutive read-only tools
 			executions = await Promise.all(
-				group.map(toolCall =>
-					executeOne(toolCall, processToolUse, privacyOptions),
-				),
+				group.map(toolCall => executeOne(toolCall, processToolUse)),
 			);
 		} else {
 			// Sequential execution for non-parallelizable tools (or single-item groups)
@@ -573,7 +526,6 @@ export const executeToolsDirectly = async (
 						processToolUse,
 						options?.setLiveComponent,
 						options?.signal,
-						privacyOptions,
 					),
 				);
 			}

--- a/source/hooks/chat-handler/types.ts
+++ b/source/hooks/chat-handler/types.ts
@@ -47,7 +47,7 @@ export interface UseChatHandlerProps {
 	// Flips true after subagent loading completes; used to invalidate the
 	// cached system prompt so it includes the real agent list.
 	subagentsReady?: boolean;
-	privacySessionIdRef?: React.MutableRefObject<string>;
+	privacySessionMapRef?: React.MutableRefObject<Record<string, string>>;
 	privacyEnabled?: boolean;
 }
 

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -88,7 +88,7 @@ export function useChatHandler({
 	onApiCallComplete,
 	tune,
 	subagentsReady,
-	privacySessionIdRef,
+	privacySessionMapRef,
 	privacyEnabled,
 }: UseChatHandlerProps): ChatHandlerReturn {
 	// Conversation state manager for enhanced context
@@ -205,11 +205,11 @@ export function useChatHandler({
 	React.useEffect(() => {
 		if (messages.length === 0) {
 			conversationStateManager.current.reset();
-			if (privacySessionIdRef) {
-				privacySessionIdRef.current = generateKey('privacy-session');
+			if (privacySessionMapRef) {
+				privacySessionMapRef.current = {};
 			}
 		}
-	}, [messages.length, privacySessionIdRef]);
+	}, [messages.length, privacySessionMapRef]);
 
 	// Wrapper for processAssistantResponse that includes error handling
 	const processAssistantResponseWithErrorHandling = React.useCallback(
@@ -247,7 +247,7 @@ export function useChatHandler({
 					setLastApiUsage,
 					onApiCallComplete,
 					tune,
-					privacySessionIdRef,
+					privacySessionMapRef,
 					privacyEnabled,
 					onPrivacyEvent: (count: number) => {
 						addToChatQueue(
@@ -290,7 +290,7 @@ export function useChatHandler({
 			setLiveComponent,
 			setLastApiUsage,
 			onApiCallComplete,
-			privacySessionIdRef,
+			privacySessionMapRef,
 			privacyEnabled,
 		],
 	);

--- a/source/hooks/useAppState.tsx
+++ b/source/hooks/useAppState.tsx
@@ -195,7 +195,7 @@ export function useAppState(
 	const [liveComponent, setLiveComponent] = useState<React.ReactNode>(null);
 
 	// Prompt Scrubbing Session
-	const privacySessionIdRef = useRef<string>(generateKey('privacy-session'));
+	const privacySessionMapRef = useRef<Record<string, string>>({});
 
 	// Helper function to add components to the chat queue with stable keys
 	const addToChatQueue = useCallback((component: React.ReactNode) => {
@@ -410,7 +410,7 @@ export function useAppState(
 		setChatComponents,
 		liveComponent,
 		setLiveComponent,
-		privacySessionIdRef,
+		privacySessionMapRef,
 
 		// Utilities
 		addToChatQueue,

--- a/source/types/core.ts
+++ b/source/types/core.ts
@@ -201,7 +201,9 @@ export interface ModeOverrides {
 	nonInteractiveMode: boolean;
 	nonInteractiveAlwaysAllow: string[];
 	modelParameters?: import('@/types/config').ModelParameters;
-	privacySessionIdRef?: import('react').MutableRefObject<string>;
+	privacySessionMapRef?: import('react').MutableRefObject<
+		Record<string, string>
+	>;
 	privacyEnabled?: boolean;
 }
 


### PR DESCRIPTION
## Description

This PR completes the prompt-scrub integration by adopting the new stateless API and addressing all architectural feedback from the implementation review. https://github.com/Nano-Collective/nanocoder/issues/635

### Highlights

- Rehydrates assistant responses at the conversation history boundary before they are committed to the canonical transcript.
- Replaces `privacySessionIdRef` with an in-memory `privacySessionMapRef`, eliminating hidden session state.
- Removes duplicate rehydration logic from `assistant-message.tsx` and `tool-executor.tsx`.
- Uses the new stateless prompt-scrub API throughout the integration.
- Skips scrubbing tool messages.
- Disables `PathDetector` and `UrlDetector` for coding workflows to preserve useful coding context.
- Surfaces rehydration warnings through Nanocoder logging.
- Updates `/privacy inspect` to execute completely in-memory without creating temporary on-disk sessions.

> **Note**
>
> This PR temporarily references `@nanocollective/prompt-scrub` via:
>
> ```json
> "file:../prompt-scrubber"
> ```
>
> because the required package changes have not yet been published.
>
> This should be reverted to the published package version (for example `^1.1.0`) before the final merge once the package release is available.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Testing Notes

### Automated Tests

- Updated integration tests.
- Verified scrub → provider → rehydrate round-trip.
- Verified transcript/export behavior after history-boundary rehydration.
- Verified tool execution receives restored values.
- Verified `/privacy inspect` operates statelessly.

### Manual Verification

- Enabled Prompt Scrubbing in Settings.
- Sent prompts containing emails, secrets and API keys.
- Verified only scrubbed placeholders are sent to the provider.
- Verified assistant responses are restored before entering conversation history.
- Verified exported conversations contain original values instead of placeholders.
- Verified tool execution receives original values.
- Verified coding workflows preserve filesystem paths and URLs.

## Checklist

- [x] I have self-reviewed my code.
- [x] I have formatted, linted, and passed all tests (`pnpm run check`).
- [x] I have added/updated documentation if necessary.
- [x] I have added/updated tests if necessary.
- [x] I have NOT bumped the version in `package.json` (maintainers will handle this).