### PR TITLE
feat: add semantic memory storage foundation(Phase 1)

### DIFF
--- a/source/memory/semantic-memory-manager.spec.ts
+++ b/source/memory/semantic-memory-manager.spec.ts
@@ -20,6 +20,8 @@ test('SemanticMemoryManager stores and reloads repo-scoped memories', async t =>
 	});
 
 	t.is(memory.content, 'Use the existing auth adapter pattern for Clerk changes.');
+	t.is(memory.category, 'project');
+	t.regex(memory.timestamp, /^\d{4}-\d{2}-\d{2}T/);
 	t.is(memory.sourceSessionId, 'session-1');
 
 	const reloaded = new SemanticMemoryManager({memoryDir: dir, cwd});
@@ -39,6 +41,21 @@ test('SemanticMemoryManager keeps different repositories isolated', async t => {
 
 	const repoBManager = new SemanticMemoryManager({memoryDir: dir, cwd: repoB});
 	t.deepEqual(await repoBManager.listMemories(), []);
+});
+
+test('SemanticMemoryManager stores memory category', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+	const memory = await manager.addMemory({
+		content: 'Follow the existing provider abstraction.',
+		category: 'architecture',
+	});
+
+	t.is(memory.category, 'architecture');
+	t.deepEqual(await manager.listMemories(), [memory]);
 });
 
 test('SemanticMemoryManager deletes and clears memories', async t => {

--- a/source/memory/semantic-memory-manager.spec.ts
+++ b/source/memory/semantic-memory-manager.spec.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'ava';
+import {SemanticMemoryManager} from './semantic-memory-manager.js';
+
+async function createTempDir(): Promise<string> {
+	return fs.mkdtemp(path.join(os.tmpdir(), 'nanocoder-memory-'));
+}
+
+test('SemanticMemoryManager stores and reloads repo-scoped memories', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+	const memory = await manager.addMemory({
+		content: '  Use the existing auth adapter pattern for Clerk changes.  ',
+		sourceSessionId: 'session-1',
+	});
+
+	t.is(memory.content, 'Use the existing auth adapter pattern for Clerk changes.');
+	t.is(memory.sourceSessionId, 'session-1');
+
+	const reloaded = new SemanticMemoryManager({memoryDir: dir, cwd});
+	t.deepEqual(await reloaded.listMemories(), [memory]);
+});
+
+test('SemanticMemoryManager keeps different repositories isolated', async t => {
+	const dir = await createTempDir();
+	const repoA = path.join(dir, 'repo-a');
+	const repoB = path.join(dir, 'repo-b');
+	await fs.mkdir(repoA);
+	await fs.mkdir(repoB);
+
+	await new SemanticMemoryManager({memoryDir: dir, cwd: repoA}).addMemory({
+		content: 'Repo A uses route handlers.',
+	});
+
+	const repoBManager = new SemanticMemoryManager({memoryDir: dir, cwd: repoB});
+	t.deepEqual(await repoBManager.listMemories(), []);
+});
+
+test('SemanticMemoryManager deletes and clears memories', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+
+	const first = await manager.addMemory({content: 'Keep components small.'});
+	const second = await manager.addMemory({content: 'Prefer existing hooks.'});
+
+	t.true(await manager.deleteMemory(first.id));
+	t.false(await manager.deleteMemory(first.id));
+	t.deepEqual(await manager.listMemories(), [second]);
+
+	await manager.clearMemories();
+	t.deepEqual(await manager.listMemories(), []);
+});
+
+test('SemanticMemoryManager returns relevant memories before unrelated ones', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+
+	const auth = await manager.addMemory({
+		content: 'Auth flow uses Clerk and avoids middleware.',
+	});
+	await manager.addMemory({
+		content: 'Release notes are generated from contributor history.',
+	});
+
+	t.deepEqual(await manager.findRelevantMemories('refactor clerk auth', 3), [
+		auth,
+	]);
+});
+
+test('SemanticMemoryManager rejects empty memory content', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+
+	await t.throwsAsync(manager.addMemory({content: '   '}), {
+		message: 'Memory content cannot be empty',
+	});
+});

--- a/source/memory/semantic-memory-manager.ts
+++ b/source/memory/semantic-memory-manager.ts
@@ -10,12 +10,14 @@ const execFileAsync = promisify(execFile);
 export interface SemanticMemory {
 	id: string;
 	content: string;
-	createdAt: string;
+	category: string;
+	timestamp: string;
 	sourceSessionId?: string;
 }
 
 export interface CreateMemoryInput {
 	content: string;
+	category?: string;
 	sourceSessionId?: string;
 }
 
@@ -33,7 +35,8 @@ function isSemanticMemory(value: unknown): value is SemanticMemory {
 	return (
 		typeof value.id === 'string' &&
 		typeof value.content === 'string' &&
-		typeof value.createdAt === 'string' &&
+		typeof value.category === 'string' &&
+		typeof value.timestamp === 'string' &&
 		(value.sourceSessionId === undefined ||
 			typeof value.sourceSessionId === 'string')
 	);
@@ -83,10 +86,12 @@ export class SemanticMemoryManager {
 			throw new Error('Memory content cannot be empty');
 		}
 
+		const category = input.category?.trim() || 'project';
 		const memory: SemanticMemory = {
 			id: crypto.randomUUID(),
 			content,
-			createdAt: new Date().toISOString(),
+			category,
+			timestamp: new Date().toISOString(),
 			...(input.sourceSessionId
 				? {sourceSessionId: input.sourceSessionId}
 				: {}),
@@ -151,7 +156,7 @@ export class SemanticMemoryManager {
 			.filter(result => result.score > 0)
 			.sort((a, b) => {
 				if (a.score !== b.score) return b.score - a.score;
-				return b.memory.createdAt.localeCompare(a.memory.createdAt);
+				return b.memory.timestamp.localeCompare(a.memory.timestamp);
 			})
 			.slice(0, limit)
 			.map(result => result.memory);

--- a/source/memory/semantic-memory-manager.ts
+++ b/source/memory/semantic-memory-manager.ts
@@ -1,0 +1,189 @@
+import {execFile} from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {promisify} from 'node:util';
+import {getAppDataPath} from '@/config/paths';
+
+const execFileAsync = promisify(execFile);
+
+export interface SemanticMemory {
+	id: string;
+	content: string;
+	createdAt: string;
+	sourceSessionId?: string;
+}
+
+export interface CreateMemoryInput {
+	content: string;
+	sourceSessionId?: string;
+}
+
+export interface SemanticMemoryManagerOptions {
+	memoryDir?: string;
+	cwd?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSemanticMemory(value: unknown): value is SemanticMemory {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.id === 'string' &&
+		typeof value.content === 'string' &&
+		typeof value.createdAt === 'string' &&
+		(value.sourceSessionId === undefined ||
+			typeof value.sourceSessionId === 'string')
+	);
+}
+
+async function atomicWriteFile(filePath: string, data: string): Promise<void> {
+	const tmpPath = `${filePath}.${crypto.randomUUID()}.tmp`;
+	try {
+		await fs.writeFile(tmpPath, data, {mode: 0o600});
+		await fs.rename(tmpPath, filePath);
+	} catch (error) {
+		try {
+			await fs.unlink(tmpPath);
+		} catch (_cleanupError) {
+			// Ignore cleanup errors.
+		}
+		throw error;
+	}
+}
+
+function hashScope(scope: string): string {
+	return crypto.createHash('sha256').update(scope).digest('hex').slice(0, 32);
+}
+
+function tokenize(value: string): Set<string> {
+	return new Set(
+		value
+			.toLowerCase()
+			.split(/[^a-z0-9]+/u)
+			.filter(part => part.length > 1),
+	);
+}
+
+export class SemanticMemoryManager {
+	private readonly memoryDir: string;
+	private readonly cwd: string;
+	private memoryFilePath?: string;
+
+	constructor(options: SemanticMemoryManagerOptions = {}) {
+		this.memoryDir = options.memoryDir ?? path.join(getAppDataPath(), 'memory');
+		this.cwd = options.cwd ?? process.cwd();
+	}
+
+	async addMemory(input: CreateMemoryInput): Promise<SemanticMemory> {
+		const content = input.content.trim();
+		if (!content) {
+			throw new Error('Memory content cannot be empty');
+		}
+
+		const memory: SemanticMemory = {
+			id: crypto.randomUUID(),
+			content,
+			createdAt: new Date().toISOString(),
+			...(input.sourceSessionId
+				? {sourceSessionId: input.sourceSessionId}
+				: {}),
+		};
+
+		const memories = await this.listMemories();
+		memories.push(memory);
+		await this.writeMemories(memories);
+		return memory;
+	}
+
+	async listMemories(): Promise<SemanticMemory[]> {
+		const filePath = await this.getMemoryFilePath();
+		try {
+			const data = await fs.readFile(filePath, 'utf-8');
+			const parsed: unknown = JSON.parse(data);
+			if (!Array.isArray(parsed)) return [];
+			return parsed.filter(isSemanticMemory);
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				'code' in error &&
+				error.code === 'ENOENT'
+			) {
+				return [];
+			}
+			throw error;
+		}
+	}
+
+	async deleteMemory(id: string): Promise<boolean> {
+		const memories = await this.listMemories();
+		const filtered = memories.filter(memory => memory.id !== id);
+		if (filtered.length === memories.length) {
+			return false;
+		}
+
+		await this.writeMemories(filtered);
+		return true;
+	}
+
+	async clearMemories(): Promise<void> {
+		await this.writeMemories([]);
+	}
+
+	async findRelevantMemories(
+		query: string,
+		limit = 5,
+	): Promise<SemanticMemory[]> {
+		const queryTerms = tokenize(query);
+		if (queryTerms.size === 0 || limit <= 0) return [];
+
+		return (await this.listMemories())
+			.map(memory => {
+				const memoryTerms = tokenize(memory.content);
+				let score = 0;
+				for (const term of queryTerms) {
+					if (memoryTerms.has(term)) score++;
+				}
+				return {memory, score};
+			})
+			.filter(result => result.score > 0)
+			.sort((a, b) => {
+				if (a.score !== b.score) return b.score - a.score;
+				return b.memory.createdAt.localeCompare(a.memory.createdAt);
+			})
+			.slice(0, limit)
+			.map(result => result.memory);
+	}
+
+	private async getMemoryFilePath(): Promise<string> {
+		if (this.memoryFilePath) return this.memoryFilePath;
+
+		await fs.mkdir(this.memoryDir, {recursive: true, mode: 0o700});
+		const scope = await this.getRepositoryScope();
+		this.memoryFilePath = path.join(this.memoryDir, `${hashScope(scope)}.json`);
+		return this.memoryFilePath;
+	}
+
+	private async getRepositoryScope(): Promise<string> {
+		try {
+			const {stdout} = await execFileAsync(
+				'git',
+				['config', '--get', 'remote.origin.url'],
+				{cwd: this.cwd},
+			);
+			const remote = stdout.trim();
+			if (remote) return remote;
+		} catch {
+			// Non-git directories fall back to their absolute path.
+		}
+
+		return path.resolve(this.cwd);
+	}
+
+	private async writeMemories(memories: SemanticMemory[]): Promise<void> {
+		const filePath = await this.getMemoryFilePath();
+		await atomicWriteFile(filePath, JSON.stringify(memories, null, 2));
+	}
+}


### PR DESCRIPTION
## Description

Adds the step-one foundation for Continuous Semantic Memory: a repo-scoped local memory manager with JSON persistence, add/list/delete/clear operations, and simple relevance lookup. This PR does not add commands, prompt injection, SQLite/vector search, or UI changes.

Phase 1: #619 
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
