### PR TITLE
feat: multiline cursor navigation and word-jump

### DIFF
--- a/source/components/text-input.spec.ts
+++ b/source/components/text-input.spec.ts
@@ -1,4 +1,8 @@
 import test from 'ava';
+import {
+	getVisualLineSegments,
+	moveCursorToVisualLine,
+} from '../utils/text-wrapping';
 
 /**
  * Tests for readline keybind logic in the custom TextInput component.
@@ -396,6 +400,123 @@ test('handleEnter=true calls onEnter when provided', (t) => {
 	// Simulates: if (handleEnter && onEnter) { onEnter(value) }
 	if (true && onEnter) onEnter();
 	t.true(called);
+});
+
+// --- Up/Down over text-wrapped prompts (no \n, soft-wrapped visual lines) ---
+
+/**
+ * Mirrors the useInput up/down block in text-input.tsx:
+ * - single visual line → passthrough (parent handles history)
+ * - first/last visual line edge → history handoff (onEdgeArrow)
+ * - otherwise → cursor moves one visual line
+ */
+function pressVerticalArrow(
+	value: string,
+	cursorOffset: number,
+	direction: 'up' | 'down',
+	wrapWidth?: number,
+):
+	| {type: 'passthrough'}
+	| {type: 'history'; direction: 'up' | 'down'}
+	| {type: 'move'; cursorOffset: number} {
+	const segments = getVisualLineSegments(value, wrapWidth);
+	if (segments.length <= 1) {
+		return {type: 'passthrough'};
+	}
+	const next = moveCursorToVisualLine(segments, cursorOffset, direction);
+	if (next === null) {
+		return {type: 'history', direction};
+	}
+	return {type: 'move', cursorOffset: next};
+}
+
+// A single-line prompt with no \n that text-wraps into ~4 visual rows
+// (the reported iTerm2 scenario) — 'word0 word1 ... word19'
+const LONG_PROMPT = Array.from({length: 20}, (_, i) => `word${i}`).join(' ');
+const WRAP_WIDTH = 40;
+
+test('long wrapped prompt is multiple visual lines despite having no newline', (t) => {
+	t.false(LONG_PROMPT.includes('\n'));
+	const segments = getVisualLineSegments(LONG_PROMPT, WRAP_WIDTH);
+	t.true(segments.length >= 3);
+});
+
+test('Down on first visual row of wrapped prompt moves cursor, not history', (t) => {
+	const result = pressVerticalArrow(LONG_PROMPT, 0, 'down', WRAP_WIDTH);
+	t.is(result.type, 'move');
+});
+
+test('Up from a middle visual row of wrapped prompt moves cursor up one row', (t) => {
+	const segments = getVisualLineSegments(LONG_PROMPT, WRAP_WIDTH);
+	const secondRowStart = segments[1].start;
+	const result = pressVerticalArrow(
+		LONG_PROMPT,
+		secondRowStart,
+		'up',
+		WRAP_WIDTH,
+	);
+	t.is(result.type, 'move');
+	if (result.type === 'move') {
+		t.true(result.cursorOffset < secondRowStart);
+		t.true(result.cursorOffset >= segments[0].start);
+	}
+});
+
+test('Up on first visual row of wrapped prompt hands off to history', (t) => {
+	const result = pressVerticalArrow(LONG_PROMPT, 3, 'up', WRAP_WIDTH);
+	t.deepEqual(result, {type: 'history', direction: 'up'});
+});
+
+test('Down on last visual row of wrapped prompt hands off to history', (t) => {
+	const result = pressVerticalArrow(
+		LONG_PROMPT,
+		LONG_PROMPT.length,
+		'down',
+		WRAP_WIDTH,
+	);
+	t.deepEqual(result, {type: 'history', direction: 'down'});
+});
+
+test('Down through every visual row of wrapped prompt reaches the last row', (t) => {
+	const segments = getVisualLineSegments(LONG_PROMPT, WRAP_WIDTH);
+	let offset = 0;
+	let moves = 0;
+	for (;;) {
+		const result = pressVerticalArrow(LONG_PROMPT, offset, 'down', WRAP_WIDTH);
+		if (result.type !== 'move') break;
+		offset = result.cursorOffset;
+		moves++;
+	}
+	t.is(moves, segments.length - 1);
+	const last = segments[segments.length - 1];
+	t.true(offset >= last.start && offset <= last.start + last.length);
+});
+
+test('short single-line prompt passes through so parent handles history', (t) => {
+	t.deepEqual(pressVerticalArrow('hi there', 4, 'up', WRAP_WIDTH), {
+		type: 'passthrough',
+	});
+	t.deepEqual(pressVerticalArrow('hi there', 4, 'down', WRAP_WIDTH), {
+		type: 'passthrough',
+	});
+});
+
+test('prompt exactly at wrap width stays single visual line', (t) => {
+	const exact = 'a'.repeat(WRAP_WIDTH);
+	t.deepEqual(pressVerticalArrow(exact, 10, 'up', WRAP_WIDTH), {
+		type: 'passthrough',
+	});
+});
+
+test('wrapped prompt with real newlines mixes both kinds of visual lines', (t) => {
+	// First logical line wraps into 2+ rows, second is short
+	const value = `${'x'.repeat(WRAP_WIDTH + 10)}\nshort`;
+	const segments = getVisualLineSegments(value, WRAP_WIDTH);
+	t.true(segments.length >= 3);
+	// Down from the wrapped tail lands on 'short'
+	const tailRow = segments[segments.length - 2];
+	const result = pressVerticalArrow(value, tailRow.start, 'down', WRAP_WIDTH);
+	t.is(result.type, 'move');
 });
 
 test('handleEnter=true calls onSubmit when onEnter not provided', (t) => {

--- a/source/components/text-input.spec.ts
+++ b/source/components/text-input.spec.ts
@@ -12,20 +12,20 @@ interface TextInputState {
 	cursorOffset: number;
 }
 
-// Simulate Ctrl+W: backward-kill-word
+// Simulate Ctrl+W: backward-kill-word (newlines are word boundaries)
 function backwardKillWord(state: TextInputState): TextInputState {
 	const {value, cursorOffset} = state;
 	if (cursorOffset <= 0) return state;
 
 	let i = cursorOffset;
 
-	// Skip whitespace immediately before cursor
-	while (i > 0 && value[i - 1] === ' ') {
+	// Skip whitespace (spaces + newlines) immediately before cursor
+	while (i > 0 && (value[i - 1] === ' ' || value[i - 1] === '\n')) {
 		i--;
 	}
 
-	// Delete back to next whitespace or start
-	while (i > 0 && value[i - 1] !== ' ') {
+	// Delete back to next whitespace/newline or start
+	while (i > 0 && value[i - 1] !== ' ' && value[i - 1] !== '\n') {
 		i--;
 	}
 
@@ -273,6 +273,99 @@ test('backspace at start does nothing', (t) => {
 	const result = backspace({value: 'hello', cursorOffset: 0});
 	t.is(result.value, 'hello');
 	t.is(result.cursorOffset, 0);
+});
+
+// --- Ctrl+Left / Ctrl+Right (word-jump) ---
+
+function moveToPrevWord(value: string, offset: number): number {
+	let i = offset;
+	// Skip whitespace (spaces + newlines) backward, then word backward
+	while (i > 0 && (value[i - 1] === ' ' || value[i - 1] === '\n')) i--;
+	while (i > 0 && value[i - 1] !== ' ' && value[i - 1] !== '\n') i--;
+	return i;
+}
+
+function moveToNextWord(value: string, offset: number): number {
+	let i = offset;
+	// Skip word forward, then whitespace (spaces + newlines) forward
+	while (i < value.length && value[i] !== ' ' && value[i] !== '\n') i++;
+	while (i < value.length && (value[i] === ' ' || value[i] === '\n')) i++;
+	return i;
+}
+
+test('Ctrl+Left jumps to start of previous word', (t) => {
+	t.is(moveToPrevWord('hello world', 11), 6);
+});
+
+test('Ctrl+Left from middle of word jumps to word start', (t) => {
+	t.is(moveToPrevWord('hello world', 8), 6);
+});
+
+test('Ctrl+Left at start stays at start', (t) => {
+	t.is(moveToPrevWord('hello', 0), 0);
+});
+
+test('Ctrl+Left skips multiple spaces', (t) => {
+	// Skips word backward from 'r' to 'w' start — lands at word start, not before whitespace
+	t.is(moveToPrevWord('hello   world', 10), 8);
+});
+
+test('Ctrl+Right jumps to start of next word', (t) => {
+	t.is(moveToNextWord('hello world', 0), 6);
+});
+
+test('Ctrl+Right from start of second word jumps to its end', (t) => {
+	t.is(moveToNextWord('hello world', 6), 11);
+});
+
+test('Ctrl+Right at end stays at end', (t) => {
+	t.is(moveToNextWord('hello', 5), 5);
+});
+
+test('Ctrl+Right skips spaces before next word', (t) => {
+	// From pos 5 (space), skips word (none), then skips spaces to 'w'
+	t.is(moveToNextWord('hello   world', 5), 8);
+});
+
+// --- Ctrl+Left / Ctrl+Right with newlines (multiline word-jump) ---
+
+test('Ctrl+Left crosses newline to previous line', (t) => {
+	// From start of "foo" after newline, crosses newline to "world" on line 1
+	t.is(moveToPrevWord('hello world\nfoo bar', 12), 6);
+});
+
+test('Ctrl+Left from word on line 2 jumps to start of that word', (t) => {
+	// From end of "bar" on line 2, jumps to start of "bar"
+	t.is(moveToPrevWord('hello world\nfoo bar', 19), 16);
+});
+
+test('Ctrl+Left from start of second word on line 2 jumps to first word', (t) => {
+	// From start of "bar", skips space, jumps to start of "foo"
+	t.is(moveToPrevWord('hello world\nfoo bar', 16), 12);
+});
+
+test('Ctrl+Right from end of line 1 crosses newline to start of next word', (t) => {
+	// From newline, skips to start of "foo"
+	t.is(moveToNextWord('hello world\nfoo bar', 11), 12);
+});
+
+test('Ctrl+Right from start of "foo" jumps to start of next word', (t) => {
+	t.is(moveToNextWord('hello world\nfoo bar', 12), 16);
+});
+
+test('Ctrl+Left on blank line crosses to previous line', (t) => {
+	// After newline at end, crosses newline to start of "hello"
+	t.is(moveToPrevWord('hello\n', 6), 0);
+});
+
+test('Ctrl+Right from before newline crosses to next word', (t) => {
+	// From "d" in "world", crosses newline to start of "foo"
+	t.is(moveToNextWord('hello world\nfoo', 10), 12);
+});
+
+test('Ctrl+Left with multiple newlines crosses one line at a time', (t) => {
+	// From start of "ccc", crosses newline to start of "bbb"
+	t.is(moveToPrevWord('aaa\nbbb\nccc', 8), 4);
 });
 
 // --- Unknown ctrl combos should not insert characters ---

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -1,7 +1,11 @@
 import chalk from 'chalk';
 import {Text, useInput} from 'ink';
 import {useEffect, useRef, useState} from 'react';
-import {wrapWithTrimmedContinuations} from '@/utils/text-wrapping';
+import {
+	getVisualLineSegments,
+	moveCursorToVisualLine,
+	wrapWithTrimmedContinuations,
+} from '@/utils/text-wrapping';
 
 export type Props = {
 	readonly placeholder?: string;
@@ -119,47 +123,30 @@ function TextInput({
 				return;
 			}
 
-			// Multiline: Up/Down navigate between lines instead of history
+			// Multiline: Up/Down navigate between visual lines instead of history.
+			// Visual lines include soft-wrapped rows — a single long line with no
+			// \n that wraps at wrapWidth is still multiline for navigation.
 			if (key.upArrow || key.downArrow) {
 				const val = originalValueRef.current;
 				const cur = cursorOffsetRef.current;
-				if (!showCursor || !val.includes('\n')) {
+				if (!showCursor) {
 					return;
 				}
 
-				const lines = val.split('\n');
-				let pos = 0;
-				let currentLine = 0;
-				for (let l = 0; l < lines.length; l++) {
-					if (pos + lines[l].length >= cur) {
-						currentLine = l;
-						break;
-					}
-					pos += lines[l].length + 1;
+				const segments = getVisualLineSegments(val, wrapWidth);
+				if (segments.length <= 1) {
+					// Single visual line — parent's useInput handles history
+					return;
 				}
-				const col = cur - pos;
 
-				if (key.upArrow && currentLine > 0) {
-					// Navigate to previous line
-					const prevLen = lines[currentLine - 1].length;
-					const newCol = Math.min(col, prevLen);
-					let newPos = 0;
-					for (let l = 0; l < currentLine - 1; l++)
-						newPos += lines[l].length + 1;
-					cursorOffsetRef.current = newPos + newCol;
-					setState(s => ({...s, cursorOffset: newPos + newCol}));
-				} else if (key.downArrow && currentLine < lines.length - 1) {
-					// Navigate to next line
-					const newCol = Math.min(col, lines[currentLine + 1].length);
-					const newPos = pos + lines[currentLine].length + 1;
-					cursorOffsetRef.current = newPos + newCol;
-					setState(s => ({...s, cursorOffset: newPos + newCol}));
-				} else if (key.upArrow) {
-					// On first line — history up
-					onEdgeArrow?.('up');
-				} else if (key.downArrow) {
-					// On last line — history down
-					onEdgeArrow?.('down');
+				const direction = key.upArrow ? 'up' : 'down';
+				const next = moveCursorToVisualLine(segments, cur, direction);
+				if (next === null) {
+					// First/last visual line — hand off to history navigation
+					onEdgeArrow?.(direction);
+				} else {
+					cursorOffsetRef.current = next;
+					setState(s => ({...s, cursorOffset: next}));
 				}
 				return;
 			}

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import {Text, useInput} from 'ink';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {wrapWithTrimmedContinuations} from '@/utils/text-wrapping';
 
 export type Props = {
@@ -15,6 +15,7 @@ export type Props = {
 	readonly onEnter?: (value: string) => void;
 	readonly wrapWidth?: number;
 	readonly handleEnter?: boolean;
+	readonly onEdgeArrow?: (direction: 'up' | 'down') => void;
 };
 
 function TextInput({
@@ -29,6 +30,7 @@ function TextInput({
 	onEnter,
 	wrapWidth,
 	handleEnter = true,
+	onEdgeArrow,
 }: Props) {
 	const [state, setState] = useState({
 		cursorOffset: (originalValue || '').length,
@@ -36,6 +38,12 @@ function TextInput({
 	});
 
 	const {cursorOffset, cursorWidth} = state;
+
+	// Refs so useInput handlers always read the latest values (avoids stale closures)
+	const cursorOffsetRef = useRef(cursorOffset);
+	const originalValueRef = useRef(originalValue);
+	cursorOffsetRef.current = cursorOffset;
+	originalValueRef.current = originalValue;
 
 	useEffect(() => {
 		setState(previousState => {
@@ -56,6 +64,24 @@ function TextInput({
 		});
 	}, [originalValue, focus, showCursor]);
 
+	// Word-jump helpers (whitespace-delimited, like readline Alt+B/F)
+	// Newlines are treated as whitespace — Ctrl+Left/Right cross line boundaries.
+	function moveToPrevWord(value: string, offset: number): number {
+		let i = offset;
+		// Skip whitespace (spaces + newlines) backward, then word backward
+		while (i > 0 && (value[i - 1] === ' ' || value[i - 1] === '\n')) i--;
+		while (i > 0 && value[i - 1] !== ' ' && value[i - 1] !== '\n') i--;
+		return i;
+	}
+
+	function moveToNextWord(value: string, offset: number): number {
+		let i = offset;
+		// Skip word forward, then whitespace (spaces + newlines) forward
+		while (i < value.length && value[i] !== ' ' && value[i] !== '\n') i++;
+		while (i < value.length && (value[i] === ' ' || value[i] === '\n')) i++;
+		return i;
+	}
+
 	const cursorActualWidth = highlightPastedText ? cursorWidth : 0;
 	const value = mask ? mask.repeat(originalValue.length) : originalValue;
 	let renderedValue = value;
@@ -72,10 +98,12 @@ function TextInput({
 		let i = 0;
 
 		for (const char of value) {
-			renderedValue +=
-				i >= cursorOffset - cursorActualWidth && i <= cursorOffset
-					? chalk.inverse(char)
-					: char;
+			if (i >= cursorOffset - cursorActualWidth && i <= cursorOffset) {
+				renderedValue +=
+					char === '\n' ? chalk.inverse(' ') + '\n' : chalk.inverse(char);
+			} else {
+				renderedValue += char;
+			}
 
 			i++;
 		}
@@ -87,104 +115,163 @@ function TextInput({
 
 	useInput(
 		(input, key) => {
-			if (
-				key.upArrow ||
-				key.downArrow ||
-				(key.ctrl && input === 'c') ||
-				key.tab ||
-				(key.shift && key.tab)
-			) {
+			if ((key.ctrl && input === 'c') || key.tab || (key.shift && key.tab)) {
+				return;
+			}
+
+			// Multiline: Up/Down navigate between lines instead of history
+			if (key.upArrow || key.downArrow) {
+				const val = originalValueRef.current;
+				const cur = cursorOffsetRef.current;
+				if (!showCursor || !val.includes('\n')) {
+					return;
+				}
+
+				const lines = val.split('\n');
+				let pos = 0;
+				let currentLine = 0;
+				for (let l = 0; l < lines.length; l++) {
+					if (pos + lines[l].length >= cur) {
+						currentLine = l;
+						break;
+					}
+					pos += lines[l].length + 1;
+				}
+				const col = cur - pos;
+
+				if (key.upArrow && currentLine > 0) {
+					// Navigate to previous line
+					const prevLen = lines[currentLine - 1].length;
+					const newCol = Math.min(col, prevLen);
+					let newPos = 0;
+					for (let l = 0; l < currentLine - 1; l++)
+						newPos += lines[l].length + 1;
+					cursorOffsetRef.current = newPos + newCol;
+					setState(s => ({...s, cursorOffset: newPos + newCol}));
+				} else if (key.downArrow && currentLine < lines.length - 1) {
+					// Navigate to next line
+					const newCol = Math.min(col, lines[currentLine + 1].length);
+					const newPos = pos + lines[currentLine].length + 1;
+					cursorOffsetRef.current = newPos + newCol;
+					setState(s => ({...s, cursorOffset: newPos + newCol}));
+				} else if (key.upArrow) {
+					// On first line — history up
+					onEdgeArrow?.('up');
+				} else if (key.downArrow) {
+					// On last line — history down
+					onEdgeArrow?.('down');
+				}
 				return;
 			}
 
 			if (key.return) {
 				if (handleEnter && onEnter) {
-					onEnter(originalValue);
+					onEnter(originalValueRef.current);
 					return;
 				}
 				if (handleEnter && onSubmit) {
-					onSubmit(originalValue);
+					onSubmit(originalValueRef.current);
 					return;
 				}
 				return;
 			}
 
-			let nextCursorOffset = cursorOffset;
-			let nextValue = originalValue;
+			let nextCursorOffset = cursorOffsetRef.current;
+			let nextValue = originalValueRef.current;
 			let nextCursorWidth = 0;
 
 			if (key.ctrl) {
-				// Readline keybinds
-				switch (input) {
-					case 'a': {
-						// Move cursor to start of line
-						nextCursorOffset = 0;
-						break;
+				if (key.leftArrow) {
+					// Ctrl+Left: jump to start of previous word
+					if (showCursor) {
+						nextCursorOffset = moveToPrevWord(
+							originalValueRef.current,
+							cursorOffsetRef.current,
+						);
 					}
-
-					case 'e': {
-						// Move cursor to end of line
-						nextCursorOffset = originalValue.length;
-						break;
+				} else if (key.rightArrow) {
+					// Ctrl+Right: jump to end of next word
+					if (showCursor) {
+						nextCursorOffset = moveToNextWord(
+							originalValueRef.current,
+							cursorOffsetRef.current,
+						);
 					}
-
-					case 'b': {
-						// Move cursor back one character
-						if (showCursor) {
-							nextCursorOffset--;
+				} else {
+					// Readline keybinds
+					switch (input) {
+						case 'a': {
+							// Move cursor to start of line
+							nextCursorOffset = 0;
+							break;
 						}
 
-						break;
-					}
-
-					case 'f': {
-						// Move cursor forward one character
-						if (showCursor) {
-							nextCursorOffset++;
+						case 'e': {
+							// Move cursor to end of line
+							nextCursorOffset = originalValueRef.current.length;
+							break;
 						}
 
-						break;
-					}
-
-					case 'w': {
-						// Delete previous word (backward-kill-word)
-						if (cursorOffset > 0) {
-							let i = cursorOffset;
-
-							// Skip whitespace immediately before cursor
-							while (i > 0 && originalValue[i - 1] === ' ') {
-								i--;
+						case 'b': {
+							// Move cursor back one character
+							if (showCursor) {
+								nextCursorOffset--;
 							}
 
-							// Delete back to next whitespace or start
-							while (i > 0 && originalValue[i - 1] !== ' ') {
-								i--;
-							}
-
-							nextValue =
-								originalValue.slice(0, i) + originalValue.slice(cursorOffset);
-							nextCursorOffset = i;
+							break;
 						}
 
-						break;
-					}
+						case 'f': {
+							// Move cursor forward one character
+							if (showCursor) {
+								nextCursorOffset++;
+							}
 
-					case 'u': {
-						// Delete from cursor to start of line
-						nextValue = originalValue.slice(cursorOffset);
-						nextCursorOffset = 0;
-						break;
-					}
+							break;
+						}
 
-					case 'k': {
-						// Delete from cursor to end of line
-						nextValue = originalValue.slice(0, cursorOffset);
-						break;
-					}
+						case 'w': {
+							// Delete previous word (backward-kill-word, newline-aware)
+							if (cursorOffset > 0) {
+								let i = cursorOffset;
+								while (
+									i > 0 &&
+									(originalValueRef.current[i - 1] === ' ' ||
+										originalValueRef.current[i - 1] === '\n')
+								)
+									i--;
+								while (
+									i > 0 &&
+									originalValueRef.current[i - 1] !== ' ' &&
+									originalValueRef.current[i - 1] !== '\n'
+								)
+									i--;
+								nextValue =
+									originalValueRef.current.slice(0, i) +
+									originalValueRef.current.slice(cursorOffset);
+								nextCursorOffset = i;
+							}
 
-					default:
-						// Ignore all other ctrl combinations (don't insert characters)
-						break;
+							break;
+						}
+
+						case 'u': {
+							// Delete from cursor to start of line
+							nextValue = originalValueRef.current.slice(cursorOffset);
+							nextCursorOffset = 0;
+							break;
+						}
+
+						case 'k': {
+							// Delete from cursor to end of line
+							nextValue = originalValueRef.current.slice(0, cursorOffset);
+							break;
+						}
+
+						default:
+							// Ignore all other ctrl combinations (don't insert characters)
+							break;
+					}
 				}
 			} else if (key.leftArrow) {
 				if (showCursor) {
@@ -197,15 +284,21 @@ function TextInput({
 			} else if (key.backspace || key.delete) {
 				if (cursorOffset > 0) {
 					nextValue =
-						originalValue.slice(0, cursorOffset - 1) +
-						originalValue.slice(cursorOffset, originalValue.length);
+						originalValueRef.current.slice(0, cursorOffset - 1) +
+						originalValueRef.current.slice(
+							cursorOffset,
+							originalValueRef.current.length,
+						);
 					nextCursorOffset--;
 				}
 			} else {
 				nextValue =
-					originalValue.slice(0, cursorOffset) +
+					originalValueRef.current.slice(0, cursorOffset) +
 					input +
-					originalValue.slice(cursorOffset, originalValue.length);
+					originalValueRef.current.slice(
+						cursorOffset,
+						originalValueRef.current.length,
+					);
 				nextCursorOffset += input.length;
 
 				if (input.length > 1) {
@@ -221,12 +314,16 @@ function TextInput({
 				nextCursorOffset = nextValue.length;
 			}
 
+			// Update refs immediately so the next event in the same stdin.read()
+			// block sees the correct values (Ink doesn't re-render between events)
+			cursorOffsetRef.current = nextCursorOffset;
 			setState({
 				cursorOffset: nextCursorOffset,
 				cursorWidth: nextCursorWidth,
 			});
 
-			if (nextValue !== originalValue) {
+			if (nextValue !== originalValueRef.current) {
+				originalValueRef.current = nextValue;
 				onChange(nextValue);
 			}
 		},

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -776,6 +776,8 @@ export default function UserInput({
 
 		// Handle navigation
 		if (key.upArrow) {
+			// In multiline mode, Up/Down navigate lines — let TextInput handle it
+			if (input.includes('\n')) return;
 			// File autocomplete navigation takes priority
 			if (isFileAutocompleteMode && fileCompletions.length > 0) {
 				setSelectedFileIndex(prev =>
@@ -798,6 +800,8 @@ export default function UserInput({
 		}
 
 		if (key.downArrow) {
+			// In multiline mode, Up/Down navigate lines — let TextInput handle it
+			if (input.includes('\n')) return;
 			// File autocomplete navigation takes priority
 			if (isFileAutocompleteMode && fileCompletions.length > 0) {
 				setSelectedFileIndex(prev =>
@@ -914,6 +918,7 @@ export default function UserInput({
 						key={textInputKey}
 						value={input}
 						onChange={updateInput}
+						onEdgeArrow={handleHistoryNavigation}
 						onSubmit={handleSubmit}
 						onEnter={handleSubmit}
 						placeholder="/ commands, ! bash, ↑/↓ history"

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/utils/file-autocomplete';
 import {handleFileMention} from '@/utils/file-mention-handler';
 import {assemblePrompt} from '@/utils/prompt-processor';
+import {getVisualLineSegments} from '@/utils/text-wrapping';
 import type {ActiveEditorState} from '@/vscode/vscode-server';
 
 const MAX_COMMAND_COMPLETION_ROWS = 10;
@@ -101,6 +102,9 @@ export default function UserInput({
 	const inputState = useInputState();
 	const uiState = useUIStateContext();
 	const {boxWidth, isNarrow, actualWidth, truncate} = useResponsiveTerminal();
+	// Must match the wrapWidth passed to TextInput below — both sides use it to
+	// decide whether Up/Down means line navigation or history.
+	const inputWrapWidth = boxWidth - 3;
 	const [textInputKey, setTextInputKey] = useState(0);
 	const completionJustSelectedRef = useRef(false);
 	// Store the full InputState draft when starting history navigation, so it can be restored
@@ -776,8 +780,9 @@ export default function UserInput({
 
 		// Handle navigation
 		if (key.upArrow) {
-			// In multiline mode, Up/Down navigate lines — let TextInput handle it
-			if (input.includes('\n')) return;
+			// In multiline mode (real \n or soft-wrapped visual lines), Up/Down
+			// navigate lines — let TextInput handle it
+			if (getVisualLineSegments(input, inputWrapWidth).length > 1) return;
 			// File autocomplete navigation takes priority
 			if (isFileAutocompleteMode && fileCompletions.length > 0) {
 				setSelectedFileIndex(prev =>
@@ -800,8 +805,9 @@ export default function UserInput({
 		}
 
 		if (key.downArrow) {
-			// In multiline mode, Up/Down navigate lines — let TextInput handle it
-			if (input.includes('\n')) return;
+			// In multiline mode (real \n or soft-wrapped visual lines), Up/Down
+			// navigate lines — let TextInput handle it
+			if (getVisualLineSegments(input, inputWrapWidth).length > 1) return;
 			// File autocomplete navigation takes priority
 			if (isFileAutocompleteMode && fileCompletions.length > 0) {
 				setSelectedFileIndex(prev =>
@@ -923,7 +929,7 @@ export default function UserInput({
 						onEnter={handleSubmit}
 						placeholder="/ commands, ! bash, ↑/↓ history"
 						focus={effectiveFocus}
-						wrapWidth={boxWidth - 3}
+						wrapWidth={inputWrapWidth}
 						handleEnter={false}
 					/>
 				</Box>

--- a/source/utils/text-wrapping.spec.ts
+++ b/source/utils/text-wrapping.spec.ts
@@ -1,5 +1,9 @@
 import test from 'ava';
-import {wrapWithTrimmedContinuations} from './text-wrapping';
+import {
+	getVisualLineSegments,
+	moveCursorToVisualLine,
+	wrapWithTrimmedContinuations,
+} from './text-wrapping';
 
 test('returns text unchanged if width <= 0', t => {
 	t.is(wrapWithTrimmedContinuations('hello world', 0), 'hello world');
@@ -39,4 +43,110 @@ test('handles single character width with hard wrap', t => {
 	const result = wrapWithTrimmedContinuations('ab', 1);
 	const lines = result.split('\n');
 	t.true(lines.length >= 2);
+});
+
+test('keeps the wrap-artifact space when it carries the inverse cursor', t => {
+	// Cursor rendered as inverse space at a wrap boundary must stay visible:
+	// stripping the space would leave an empty inverse span (invisible cursor)
+	const inverseSpace = '\x1b[7m \x1b[27m';
+	const result = wrapWithTrimmedContinuations(`aaa${inverseSpace}bbb`, 4);
+	t.true(result.includes(inverseSpace));
+});
+
+// --- getVisualLineSegments ---
+
+test('single short line is one segment', t => {
+	t.deepEqual(getVisualLineSegments('hello', 80), [{start: 0, length: 5}]);
+});
+
+test('no width falls back to logical lines', t => {
+	t.deepEqual(getVisualLineSegments('ab\ncd', undefined), [
+		{start: 0, length: 2},
+		{start: 3, length: 2},
+	]);
+});
+
+test('long single line with no newline yields multiple segments', t => {
+	// The reported bug: a text-wrapped prompt has no \n but renders as
+	// several visual lines
+	const segments = getVisualLineSegments('aaa bbb ccc', 4);
+	t.true(segments.length > 1);
+	// Segments tile the value exactly: each starts where the previous ended
+	let expectedStart = 0;
+	for (const seg of segments) {
+		t.is(seg.start, expectedStart);
+		expectedStart += seg.length;
+	}
+	t.is(expectedStart, 'aaa bbb ccc'.length);
+});
+
+test('hard-wrapped unbroken word yields fixed-width segments', t => {
+	t.deepEqual(getVisualLineSegments('abcdefghij', 4), [
+		{start: 0, length: 4},
+		{start: 4, length: 4},
+		{start: 8, length: 2},
+	]);
+});
+
+test('mixes logical newlines and soft wraps', t => {
+	const segments = getVisualLineSegments('short\naaaa bbbb', 5);
+	// 'short' fits; 'aaaa bbbb' wraps into at least two segments
+	t.is(segments[0].start, 0);
+	t.is(segments[0].length, 5);
+	t.true(segments.length >= 3);
+	// Second logical line starts after the \n
+	t.is(segments[1].start, 6);
+});
+
+test('empty lines produce zero-length segments', t => {
+	t.deepEqual(getVisualLineSegments('a\n\nb', 80), [
+		{start: 0, length: 1},
+		{start: 2, length: 0},
+		{start: 3, length: 1},
+	]);
+});
+
+// --- moveCursorToVisualLine ---
+
+test('down moves into the next soft-wrapped row preserving column', t => {
+	// 'abcdefghij' at width 4 → rows: abcd | efgh | ij
+	const segments = getVisualLineSegments('abcdefghij', 4);
+	// Cursor on 'b' (offset 1), down → 'f' (offset 5)
+	t.is(moveCursorToVisualLine(segments, 1, 'down'), 5);
+});
+
+test('up moves into the previous soft-wrapped row preserving column', t => {
+	const segments = getVisualLineSegments('abcdefghij', 4);
+	// Cursor on 'g' (offset 6), up → 'c' (offset 2)
+	t.is(moveCursorToVisualLine(segments, 6, 'up'), 2);
+});
+
+test('column is clamped to a shorter target row', t => {
+	const segments = getVisualLineSegments('abcdefghij', 4);
+	// Cursor at col 3 of 'efgh' row (offset 7), down → 'ij' row end (offset 10)
+	t.is(moveCursorToVisualLine(segments, 7, 'down'), 10);
+});
+
+test('up on first visual row returns null (history handoff)', t => {
+	const segments = getVisualLineSegments('abcdefghij', 4);
+	t.is(moveCursorToVisualLine(segments, 2, 'up'), null);
+});
+
+test('down on last visual row returns null (history handoff)', t => {
+	const segments = getVisualLineSegments('abcdefghij', 4);
+	t.is(moveCursorToVisualLine(segments, 9, 'down'), null);
+});
+
+test('navigates across logical newlines too', t => {
+	const segments = getVisualLineSegments('hello\nworld', 80);
+	// Cursor on 'r' (offset 8, col 2), up → 'l' (offset 2)
+	t.is(moveCursorToVisualLine(segments, 8, 'up'), 2);
+	// And back down
+	t.is(moveCursorToVisualLine(segments, 2, 'down'), 8);
+});
+
+test('cursor at end of value navigates up correctly', t => {
+	const segments = getVisualLineSegments('abcdefghij', 4);
+	// Cursor past last char (offset 10, col 2 of 'ij'), up → offset 6
+	t.is(moveCursorToVisualLine(segments, 10, 'up'), 6);
 });

--- a/source/utils/text-wrapping.ts
+++ b/source/utils/text-wrapping.ts
@@ -27,11 +27,113 @@ export function wrapWithTrimmedContinuations(
 		for (let i = 1; i < subLines.length; i++) {
 			// Trim the leading space that is a word-wrap artifact.
 			// Handle ANSI escape codes that may precede the space.
+			// Keep the space when it carries the inverse-video cursor —
+			// stripping it would leave an empty inverse span (invisible cursor).
 			result.push(
-				(subLines[i] ?? '').replace(/^((?:\x1b\[[0-9;]*m)*)\s/, '$1'),
+				(subLines[i] ?? '').replace(
+					/^((?:\x1b\[[0-9;]*m)*)\s/,
+					(match, codes: string) => (codes.includes('\x1b[7m') ? match : codes),
+				),
 			);
 		}
 	}
 
 	return result.join('\n');
+}
+
+export type VisualLineSegment = {
+	/** Offset in the original value of this visual line's first character */
+	start: number;
+	/** Number of characters on this visual line */
+	length: number;
+};
+
+/**
+ * Compute the visual lines an input value renders as: logical lines (split on
+ * \n) further soft-wrapped at `width` the same way the display path wraps them
+ * (wrap-ansi, trim: false, hard: true). A single logical line longer than the
+ * terminal width therefore yields multiple segments — this is what lets cursor
+ * navigation treat text-wrapped prompts as multiline even without any \n.
+ *
+ * Without a positive width, segments are just the logical lines.
+ */
+export function getVisualLineSegments(
+	value: string,
+	width?: number,
+): VisualLineSegment[] {
+	const segments: VisualLineSegment[] = [];
+	let offset = 0;
+
+	for (const line of value.split('\n')) {
+		if (!width || width <= 0 || line.length === 0) {
+			segments.push({start: offset, length: line.length});
+		} else {
+			const wrapped = wrapAnsi(line, width, {trim: false, hard: true});
+			if (wrapped.replaceAll('\n', '') === line) {
+				// Lossless wrap (only \n insertions): sub-line lengths map 1:1
+				// onto consecutive slices of the original line.
+				let subStart = offset;
+				for (const sub of wrapped.split('\n')) {
+					segments.push({start: subStart, length: sub.length});
+					subStart += sub.length;
+				}
+			} else {
+				// Defensive fallback if wrap-ansi ever mutates content:
+				// fixed-width slices so offsets stay valid.
+				for (let i = 0; i < line.length; i += width) {
+					segments.push({
+						start: offset + i,
+						length: Math.min(width, line.length - i),
+					});
+				}
+			}
+		}
+
+		offset += line.length + 1;
+	}
+
+	return segments;
+}
+
+/**
+ * Move a cursor offset one visual line up or down, preserving the column
+ * where possible (clamped to the target line's length).
+ *
+ * Returns the new offset, or null when the cursor is already on the first
+ * (up) / last (down) visual line — the caller falls back to history
+ * navigation in that case.
+ */
+export function moveCursorToVisualLine(
+	segments: VisualLineSegment[],
+	cursorOffset: number,
+	direction: 'up' | 'down',
+): number | null {
+	let row = segments.length - 1;
+	for (let i = 0; i < segments.length; i++) {
+		const end = segments[i].start + segments[i].length;
+		if (cursorOffset < end) {
+			row = i;
+			break;
+		}
+		if (cursorOffset === end) {
+			// At a soft-wrap boundary the same offset is both this row's end and
+			// the next row's start; the renderer shows the cursor at the start of
+			// the next row, so it belongs there. At a \n boundary (gap of 1) the
+			// cursor sits on the newline at this row's end.
+			const next = segments[i + 1];
+			if (!next || next.start > end) {
+				row = i;
+				break;
+			}
+		}
+	}
+
+	const targetRow = direction === 'up' ? row - 1 : row + 1;
+	if (targetRow < 0 || targetRow >= segments.length) {
+		return null;
+	}
+
+	const col = cursorOffset - segments[row].start;
+	const target = segments[targetRow];
+	return target.start + Math.min(col, target.length);
 }


### PR DESCRIPTION
## Description

The multiline text input had no cursor navigation between lines and no word-jump support. Up/Down always triggered history, Ctrl+Left/Right didn't exist, and Ctrl+W didn't respect newlines as word boundaries.

Adds line-aware Up/Down navigation, Ctrl+Left/Right word-jump across newlines, and newline-aware Ctrl+W.

## Type of Change

- [x] New feature

## Testing

46 passing tests in `text-input.spec.ts`. `tsc --noEmit` passes clean.

```
npx ava source/components/text-input.spec.ts
npx tsc --noEmit
```

- [x] New features include passing tests
- [x] All existing tests pass

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes
