### PR TITLE
Add web mode event layer(Phase 2)

### DIFF
--- a/source/web/protocol.ts
+++ b/source/web/protocol.ts
@@ -1,0 +1,75 @@
+export const WEB_PROTOCOL_VERSION = 1;
+
+export type WebClientEvent =
+	| {type: 'hello'; protocolVersion: typeof WEB_PROTOCOL_VERSION}
+	| {type: 'user_message'; id: string; text: string}
+	| {type: 'cancel'; id: string};
+
+export type WebServerEvent =
+	| {type: 'ready'; protocolVersion: typeof WEB_PROTOCOL_VERSION}
+	| {type: 'ack'; id: string}
+	| {type: 'assistant_delta'; id: string; text: string}
+	| {type: 'tool_started'; id: string; name: string}
+	| {type: 'tool_finished'; id: string; name: string; ok: boolean}
+	| {type: 'approval_required'; id: string; reason: string}
+	| {type: 'question_required'; id: string; question: string}
+	| {type: 'turn_completed'; id: string}
+	| {type: 'error'; message: string};
+
+export function parseWebClientEvent(rawMessage: string): WebClientEvent {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawMessage);
+	} catch {
+		throw new Error('Invalid JSON message.');
+	}
+
+	if (!isRecord(parsed) || typeof parsed.type !== 'string') {
+		throw new Error('Invalid web event.');
+	}
+
+	switch (parsed.type) {
+		case 'hello':
+			if (parsed.protocolVersion !== WEB_PROTOCOL_VERSION) {
+				throw new Error('Unsupported web protocol version.');
+			}
+
+			return {
+				type: 'hello',
+				protocolVersion: WEB_PROTOCOL_VERSION,
+			};
+		case 'user_message':
+			if (typeof parsed.id !== 'string' || parsed.id.length === 0) {
+				throw new Error('User message id is required.');
+			}
+
+			if (typeof parsed.text !== 'string') {
+				throw new Error('User message text is required.');
+			}
+
+			return {
+				type: 'user_message',
+				id: parsed.id,
+				text: parsed.text,
+			};
+		case 'cancel':
+			if (typeof parsed.id !== 'string' || parsed.id.length === 0) {
+				throw new Error('Cancel id is required.');
+			}
+
+			return {
+				type: 'cancel',
+				id: parsed.id,
+			};
+		default:
+			throw new Error(`Unsupported web event type: ${parsed.type}.`);
+	}
+}
+
+export function serializeWebServerEvent(event: WebServerEvent): string {
+	return JSON.stringify(event);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/source/web/server.spec.ts
+++ b/source/web/server.spec.ts
@@ -1,4 +1,6 @@
 import test from 'ava';
+import {WebSocket} from 'ws';
+import {WEB_PROTOCOL_VERSION, type WebServerEvent} from './protocol.js';
 import {startLocalWebServer} from './server.js';
 
 async function readText(url: string): Promise<{status: number; body: string}> {
@@ -7,6 +9,31 @@ async function readText(url: string): Promise<{status: number; body: string}> {
 		status: response.status,
 		body: await response.text(),
 	};
+}
+
+async function waitForWebSocketOpen(client: WebSocket): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		client.once('open', resolve);
+		client.once('error', reject);
+	});
+}
+
+async function readWebSocketEvent(client: WebSocket): Promise<WebServerEvent> {
+	const message = await new Promise<string>(resolve => {
+		client.once('message', data => {
+			resolve(data.toString());
+		});
+	});
+	return JSON.parse(message) as WebServerEvent;
+}
+
+function closeWebSocket(client: WebSocket): void {
+	if (
+		client.readyState === WebSocket.OPEN ||
+		client.readyState === WebSocket.CLOSING
+	) {
+		client.close();
+	}
 }
 
 test('local web server binds to localhost and serves token-protected placeholder page', async t => {
@@ -54,4 +81,165 @@ test('local web server exposes health endpoint without token', async t => {
 
 	t.is(response.status, 200);
 	t.deepEqual(body, {ok: true, mode: 'web'});
+});
+
+test('local web server accepts token-protected WebSocket connections', async t => {
+	const webServer = await startLocalWebServer({
+		openBrowser: false,
+		token: 'test-token',
+	});
+	t.teardown(() => {
+		return webServer.close();
+	});
+
+	const client = new WebSocket(webServer.eventsUrl);
+	t.teardown(() => {
+		closeWebSocket(client);
+	});
+	const readyEvent = readWebSocketEvent(client);
+	await waitForWebSocketOpen(client);
+
+	const event = await readyEvent;
+
+	t.deepEqual(event, {
+		type: 'ready',
+		protocolVersion: WEB_PROTOCOL_VERSION,
+	});
+});
+
+test('local web server rejects WebSocket connections without a valid token', async t => {
+	const webServer = await startLocalWebServer({
+		openBrowser: false,
+		token: 'test-token',
+	});
+	t.teardown(() => {
+		return webServer.close();
+	});
+
+	const client = new WebSocket(
+		`ws://127.0.0.1:${webServer.port}/events?token=wrong-token`,
+	);
+	t.teardown(() => {
+		closeWebSocket(client);
+	});
+
+	const statusCode = await new Promise<number | undefined>(resolve => {
+		client.once('unexpected-response', (_request, response) => {
+			resolve(response.statusCode);
+		});
+		client.once('open', () => {
+			resolve(undefined);
+		});
+	});
+
+	t.is(statusCode, 401);
+});
+
+test('local web server acknowledges valid WebSocket client events', async t => {
+	const webServer = await startLocalWebServer({
+		openBrowser: false,
+		token: 'test-token',
+	});
+	t.teardown(() => {
+		return webServer.close();
+	});
+
+	const client = new WebSocket(webServer.eventsUrl);
+	t.teardown(() => {
+		closeWebSocket(client);
+	});
+	const readyEvent = readWebSocketEvent(client);
+	await waitForWebSocketOpen(client);
+	await readyEvent;
+
+	client.send(
+		JSON.stringify({
+			type: 'user_message',
+			id: 'message-1',
+			text: 'hello',
+		}),
+	);
+	const event = await readWebSocketEvent(client);
+
+	t.deepEqual(event, {
+		type: 'ack',
+		id: 'message-1',
+	});
+});
+
+test('local web server reports invalid WebSocket messages without crashing', async t => {
+	const webServer = await startLocalWebServer({
+		openBrowser: false,
+		token: 'test-token',
+	});
+	t.teardown(() => {
+		return webServer.close();
+	});
+
+	const client = new WebSocket(webServer.eventsUrl);
+	t.teardown(() => {
+		closeWebSocket(client);
+	});
+	const readyEvent = readWebSocketEvent(client);
+	await waitForWebSocketOpen(client);
+	await readyEvent;
+
+	client.send('{');
+	const event = await readWebSocketEvent(client);
+
+	t.deepEqual(event, {
+		type: 'error',
+		message: 'Invalid JSON message.',
+	});
+});
+
+test('local web server can broadcast events to connected clients', async t => {
+	const webServer = await startLocalWebServer({
+		openBrowser: false,
+		token: 'test-token',
+	});
+	t.teardown(() => {
+		return webServer.close();
+	});
+
+	const client = new WebSocket(webServer.eventsUrl);
+	t.teardown(() => {
+		closeWebSocket(client);
+	});
+	const readyEvent = readWebSocketEvent(client);
+	await waitForWebSocketOpen(client);
+	await readyEvent;
+
+	webServer.broadcastEvent({
+		type: 'turn_completed',
+		id: 'turn-1',
+	});
+	const event = await readWebSocketEvent(client);
+
+	t.deepEqual(event, {
+		type: 'turn_completed',
+		id: 'turn-1',
+	});
+});
+
+test('local web server closes WebSocket clients during shutdown', async t => {
+	const webServer = await startLocalWebServer({
+		openBrowser: false,
+		token: 'test-token',
+	});
+	const client = new WebSocket(webServer.eventsUrl);
+	const readyEvent = readWebSocketEvent(client);
+	await waitForWebSocketOpen(client);
+	await readyEvent;
+
+	const closePromise = new Promise<void>(resolve => {
+		client.once('close', () => {
+			resolve();
+		});
+	});
+
+	await webServer.close();
+	await closePromise;
+
+	t.is(client.readyState, WebSocket.CLOSED);
 });

--- a/source/web/server.ts
+++ b/source/web/server.ts
@@ -116,7 +116,9 @@ export async function startLocalWebServer(
 
 	const port = address.port;
 	const url = `http://${host}:${port}/?token=${token}`;
-	const eventsUrl = `ws://${host}:${port}/events?token=${token}`;
+	// Local-only WebSocket paired with the localhost HTTP page; using wss:// here
+	// would require local TLS certificate setup that this server does not provide.
+	const eventsUrl = `ws://${host}:${port}/events?token=${token}`; // nosemgrep: javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
 
 	if (options.openBrowser !== false) {
 		openUrl(url);

--- a/source/web/server.ts
+++ b/source/web/server.ts
@@ -1,6 +1,15 @@
 import {spawn} from 'node:child_process';
 import {randomBytes} from 'node:crypto';
 import {createServer, type Server} from 'node:http';
+import type {Duplex} from 'node:stream';
+import {WebSocket, WebSocketServer} from 'ws';
+import {
+	parseWebClientEvent,
+	serializeWebServerEvent,
+	WEB_PROTOCOL_VERSION,
+	type WebClientEvent,
+	type WebServerEvent,
+} from './protocol.js';
 
 export interface LocalWebServerOptions {
 	host?: string;
@@ -15,6 +24,8 @@ export interface LocalWebServer {
 	port: number;
 	token: string;
 	url: string;
+	eventsUrl: string;
+	broadcastEvent: (event: WebServerEvent) => void;
 	close: () => Promise<void>;
 }
 
@@ -55,6 +66,39 @@ export async function startLocalWebServer(
 		response.writeHead(200, {'content-type': 'text/html; charset=utf-8'});
 		response.end(renderPlaceholderPage());
 	});
+	const webSocketServer = new WebSocketServer({noServer: true});
+	const connectedClients = new Set<WebSocket>();
+
+	server.on('upgrade', (request, socket, head) => {
+		const requestUrl = new URL(request.url ?? '/', `http://${host}`);
+		if (
+			requestUrl.pathname !== '/events' ||
+			requestUrl.searchParams.get('token') !== token
+		) {
+			rejectWebSocketUpgrade(socket);
+			return;
+		}
+
+		webSocketServer.handleUpgrade(request, socket, head, clientSocket => {
+			webSocketServer.emit('connection', clientSocket, request);
+		});
+	});
+
+	webSocketServer.on('connection', clientSocket => {
+		connectedClients.add(clientSocket);
+		sendServerEvent(clientSocket, {
+			type: 'ready',
+			protocolVersion: WEB_PROTOCOL_VERSION,
+		});
+
+		clientSocket.on('message', message => {
+			handleClientMessage(clientSocket, message.toString());
+		});
+
+		clientSocket.on('close', () => {
+			connectedClients.delete(clientSocket);
+		});
+	});
 
 	await new Promise<void>((resolve, reject) => {
 		server.once('error', reject);
@@ -72,6 +116,7 @@ export async function startLocalWebServer(
 
 	const port = address.port;
 	const url = `http://${host}:${port}/?token=${token}`;
+	const eventsUrl = `ws://${host}:${port}/events?token=${token}`;
 
 	if (options.openBrowser !== false) {
 		openUrl(url);
@@ -83,8 +128,57 @@ export async function startLocalWebServer(
 		port,
 		token,
 		url,
-		close: () => closeServer(server),
+		eventsUrl,
+		broadcastEvent: event => {
+			for (const clientSocket of connectedClients) {
+				sendServerEvent(clientSocket, event);
+			}
+		},
+		close: () =>
+			closeWebServerWithClients(server, webSocketServer, connectedClients),
 	};
+}
+
+function handleClientMessage(
+	clientSocket: WebSocket,
+	rawMessage: string,
+): void {
+	let event: WebClientEvent;
+	try {
+		event = parseWebClientEvent(rawMessage);
+	} catch (error) {
+		sendServerEvent(clientSocket, {
+			type: 'error',
+			message: error instanceof Error ? error.message : 'Invalid web event.',
+		});
+		return;
+	}
+
+	if (event.type === 'hello') {
+		sendServerEvent(clientSocket, {
+			type: 'ready',
+			protocolVersion: WEB_PROTOCOL_VERSION,
+		});
+		return;
+	}
+
+	sendServerEvent(clientSocket, {
+		type: 'ack',
+		id: event.id,
+	});
+}
+
+function sendServerEvent(clientSocket: WebSocket, event: WebServerEvent): void {
+	if (clientSocket.readyState !== WebSocket.OPEN) {
+		return;
+	}
+
+	clientSocket.send(serializeWebServerEvent(event));
+}
+
+function rejectWebSocketUpgrade(socket: Duplex): void {
+	socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+	socket.destroy();
 }
 
 function openUrl(url: string): void {
@@ -111,6 +205,25 @@ async function closeServer(server: Server): Promise<void> {
 			resolve();
 		});
 	});
+}
+
+async function closeWebServerWithClients(
+	server: Server,
+	webSocketServer: WebSocketServer,
+	connectedClients: Set<WebSocket>,
+): Promise<void> {
+	for (const clientSocket of connectedClients) {
+		clientSocket.close();
+	}
+	connectedClients.clear();
+
+	await new Promise<void>(resolve => {
+		webSocketServer.close(() => {
+			resolve();
+		});
+	});
+
+	await closeServer(server);
 }
 
 function renderPlaceholderPage(): string {
@@ -173,15 +286,63 @@ function renderPlaceholderPage(): string {
 			color: #8f96a3;
 			font-size: 14px;
 		}
+		.events {
+			margin-top: 24px;
+			padding: 14px 16px;
+			border: 1px solid rgba(255, 255, 255, 0.12);
+			border-radius: 8px;
+			background: rgba(255, 255, 255, 0.04);
+			color: #b9c0cc;
+			font-size: 15px;
+			line-height: 1.6;
+		}
 	</style>
 </head>
 <body>
 	<main>
-		<div class="status">Local session ready</div>
+		<div class="status" id="connection-status">Local session starting</div>
 		<h1>Nanocoder web mode</h1>
 		<p>Your browser connection is live. Keep the terminal open for chat, tool approvals, and agent output while the full workspace view is being wired into this page.</p>
+		<div class="events" id="event-log">Preparing the local event channel...</div>
 		<p class="note">This page is served only from your machine and requires the private URL token.</p>
 	</main>
+	<script>
+		const statusElement = document.querySelector('#connection-status');
+		const logElement = document.querySelector('#event-log');
+		const token = new URLSearchParams(window.location.search).get('token');
+		const eventsUrl = new URL('/events', window.location.href);
+		eventsUrl.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+		eventsUrl.searchParams.set('token', token ?? '');
+
+		function setStatus(text) {
+			statusElement.textContent = text;
+		}
+
+		function setEventMessage(text) {
+			logElement.textContent = text;
+		}
+
+		const socket = new WebSocket(eventsUrl);
+		socket.addEventListener('open', () => {
+			setStatus('Local session connected');
+		});
+		socket.addEventListener('message', event => {
+			try {
+				const message = JSON.parse(event.data);
+				if (message.type === 'ready') {
+					setEventMessage('Event channel is ready. Chat UI wiring comes next.');
+					return;
+				}
+			} catch {}
+			setEventMessage('Received a local session update.');
+		});
+		socket.addEventListener('close', () => {
+			setStatus('Local session disconnected');
+		});
+		socket.addEventListener('error', () => {
+			setStatus('Local session connection failed');
+		});
+	</script>
 </body>
 </html>`;
 }


### PR DESCRIPTION

## Description

Adds the Phase 2 event layer for local browser-based web mode.

This introduces a typed browser/server event protocol and a token-protected WebSocket endpoint at `/events`. The browser page now connects back to the localhost-only Nanocoder web server using the same private URL token, receives a `ready` event, and shows a human-readable connection message instead of raw protocol JSON.

This keeps Phase 2 focused on the event foundation only. It does not add the full browser chat UI yet; that remains for the next phase.

Phase 2: #628

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Focused tests run:

- pnpm run test:ava source/web/server.spec.ts source/cli.spec.ts
- pnpm run test:types
- pnpm run test:format
- pnpm run build


Result: `43 tests passed` for the focused AVA run.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)
- [x] Manually launched `nanocoder --web` web shell locally
- [x] Confirmed browser connects to the local event channel and displays a human-readable ready message

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

