### PR TITLE
phase 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"@ai-sdk/anthropic": "^3.0.85",
 		"@ai-sdk/google": "^4.0.8",
 		"@ai-sdk/openai": "^3.0.71",
-		"@ai-sdk/openai-compatible": "3.0.5",
+		"@ai-sdk/openai-compatible": "^2.0.0",
 		"@anthropic-ai/tokenizer": "^0.0.4",
 		"@modelcontextprotocol/sdk": "^1.26.0",
 		"@nanocollective/get-md": "^1.6.0",

--- a/plugins/vscode/media/chat-panel.js
+++ b/plugins/vscode/media/chat-panel.js
@@ -123,8 +123,8 @@
 			}
 		} else if (update.sessionUpdate === 'agent_thought_chunk') {
 			// Treat thoughts as chunks for now (we can prefix them with "🤔 " or style them later)
-			if (update.content) {
-				appendChunk(update.content);
+			if (update.content && update.content.text) {
+				appendChunk(update.content.text);
 			}
 		}
 	}

--- a/plugins/vscode/media/chat-panel.js
+++ b/plugins/vscode/media/chat-panel.js
@@ -4,6 +4,9 @@
 
 	const messagesContainer = document.getElementById('messages-container');
 	const chatInput = document.getElementById('chat-input');
+	
+	let currentTurnEl = null;
+	let currentTextEl = null;
 
 	// Auto-resize textarea
 	chatInput.addEventListener('input', function() {
@@ -33,22 +36,58 @@
 		chatInput.value = '';
 		chatInput.style.height = 'auto';
 
-		// Optimistically append user message (or we can wait for extension to echo)
+		// Optimistically append user message 
 		appendMessage(text, 'user');
+		
+		// Reset turn elements so agent starts a fresh block
+		currentTurnEl = null;
+		currentTextEl = null;
 	}
 
 	function appendMessage(content, role) {
-		const msgEl = document.createElement('div');
-		msgEl.className = `message ${role}`;
-		
-		// For now, just set text. In Phase 3, we'll render markdown.
-		msgEl.textContent = content;
-
 		// Remove welcome message if present
 		const welcome = document.querySelector('.welcome-message');
 		if (welcome) welcome.remove();
 
+		const msgEl = document.createElement('div');
+		msgEl.className = `message ${role}`;
+		
+		const textContainer = document.createElement('div');
+		textContainer.textContent = content; // Phase 3: plain text for now, but incrementally updateable
+		msgEl.appendChild(textContainer);
+
 		messagesContainer.appendChild(msgEl);
+		scrollToBottom();
+		
+		if (role === 'agent') {
+			currentTurnEl = msgEl;
+			currentTextEl = textContainer;
+		}
+	}
+
+	function appendChunk(textChunk) {
+		// Remove welcome message if present
+		const welcome = document.querySelector('.welcome-message');
+		if (welcome) welcome.remove();
+
+		if (!currentTurnEl || !currentTextEl) {
+			// First chunk for this turn
+			const msgEl = document.createElement('div');
+			msgEl.className = 'message agent';
+			
+			const textContainer = document.createElement('div');
+			textContainer.textContent = textChunk;
+			
+			msgEl.appendChild(textContainer);
+			messagesContainer.appendChild(msgEl);
+			
+			currentTurnEl = msgEl;
+			currentTextEl = textContainer;
+		} else {
+			// Append to existing turn
+			currentTextEl.textContent += textChunk;
+		}
+		
 		scrollToBottom();
 	}
 
@@ -65,10 +104,30 @@
 				break;
 			case 'clear':
 				messagesContainer.innerHTML = '';
+				currentTurnEl = null;
+				currentTextEl = null;
 				break;
-			// Ignore stateUpdate/appendThought for Phase 2, handle in Phase 3
+			case 'acpUpdate':
+				handleAcpUpdate(message.update);
+				break;
 		}
 	});
+
+	function handleAcpUpdate(payload) {
+		if (!payload || !payload.update) return;
+		const update = payload.update;
+		
+		if (update.sessionUpdate === 'agent_message_chunk') {
+			if (update.content && update.content.text) {
+				appendChunk(update.content.text);
+			}
+		} else if (update.sessionUpdate === 'agent_thought_chunk') {
+			// Treat thoughts as chunks for now (we can prefix them with "🤔 " or style them later)
+			if (update.content) {
+				appendChunk(update.content);
+			}
+		}
+	}
 
 	// Notify extension that webview is ready
 	vscode.postMessage({ type: 'ready' });

--- a/plugins/vscode/src/acp-client.ts
+++ b/plugins/vscode/src/acp-client.ts
@@ -74,7 +74,7 @@ export class NanocoderAcpClient {
 		try {
 			await this.connection.prompt({
 				sessionId: this._sessionId,
-				prompt: text as any // The backend AcpAgent parses this (acpContentToUserMessage accepts string or PromptBlock)
+				prompt: [{ type: 'text', text }]
 			});
 		} catch (error) {
 			this.outputChannel.appendLine(`Prompt failed: ${error}`);

--- a/plugins/vscode/src/acp-client.ts
+++ b/plugins/vscode/src/acp-client.ts
@@ -9,6 +9,8 @@ export class NanocoderAcpClient {
 	public connection: ClientSideConnection | null = null;
 	private outputChannel: vscode.OutputChannel;
 	private stateManager: AcpStateManager;
+	private _sessionId?: string;
+	public onSessionUpdate?: (update: any) => void;
 
 	constructor(outputChannel: vscode.OutputChannel, stateManager: AcpStateManager) {
 		this.outputChannel = outputChannel;
@@ -50,6 +52,44 @@ export class NanocoderAcpClient {
 		} catch (error) {
 			this.outputChannel.appendLine(`ACP Initialize failed: ${error}`);
 			return false;
+		}
+	}
+
+	async getOrCreateSession(cwd: string): Promise<string | undefined> {
+		if (this._sessionId) return this._sessionId;
+		if (!this.connection) return undefined;
+
+		try {
+			const result = await this.connection.newSession({ cwd, mcpServers: [] });
+			this._sessionId = result.sessionId;
+			return this._sessionId;
+		} catch (error) {
+			this.outputChannel.appendLine(`Failed to create session: ${error}`);
+			return undefined;
+		}
+	}
+
+	async prompt(text: string): Promise<void> {
+		if (!this.connection || !this._sessionId) return;
+		try {
+			await this.connection.prompt({
+				sessionId: this._sessionId,
+				prompt: text as any // The backend AcpAgent parses this (acpContentToUserMessage accepts string or PromptBlock)
+			});
+		} catch (error) {
+			this.outputChannel.appendLine(`Prompt failed: ${error}`);
+			vscode.window.showErrorMessage(`Nanocoder prompt failed: ${error}`);
+		}
+	}
+
+	async cancel(): Promise<void> {
+		if (!this.connection || !this._sessionId) return;
+		try {
+			await this.connection.cancel({
+				sessionId: this._sessionId
+			});
+		} catch (error) {
+			this.outputChannel.appendLine(`Cancel failed: ${error}`);
 		}
 	}
 

--- a/plugins/vscode/src/acp-process-manager.ts
+++ b/plugins/vscode/src/acp-process-manager.ts
@@ -81,9 +81,16 @@ export class AcpProcessManager {
 
 		const stream = ndJsonStream(output, input);
 		const connection = new ClientSideConnection((conn) => ({
-			// Implement Client interface methods if needed later
+			sessionUpdate: async (params: any) => {
+				if (this.acpClient?.onSessionUpdate) {
+					this.acpClient.onSessionUpdate(params);
+				}
+			},
+			requestPermission: async (params: any) => {
+				// To be implemented in Phase 4
+				return { outcome: 'denied' } as any; 
+			}
 		} as any), stream);
-		
 		this.acpClient.setConnection(connection);
 		const initialized = await this.acpClient.initializeHandshake();
 		

--- a/plugins/vscode/src/chat-webview-provider.ts
+++ b/plugins/vscode/src/chat-webview-provider.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { WebviewToExtensionMessage, ExtensionToWebviewMessage } from './webview-protocol';
 
+import { NanocoderAcpClient } from './acp-client';
+
 export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 	public static readonly viewType = 'nanocoder.chatView';
 
@@ -8,8 +10,17 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 
 	constructor(
 		private readonly _extensionUri: vscode.Uri,
-		private readonly _outputChannel: vscode.OutputChannel
-	) { }
+		private readonly _outputChannel: vscode.OutputChannel,
+		private readonly _acpClient: NanocoderAcpClient
+	) { 
+		// Listen for session updates from ACP
+		this._acpClient.onSessionUpdate = (update: any) => {
+			this.postMessage({
+				type: 'acpUpdate',
+				update
+			} as any);
+		};
+	}
 
 	public resolveWebviewView(
 		webviewView: vscode.WebviewView,
@@ -35,11 +46,11 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 						break;
 					case 'submitMessage':
 						this._outputChannel.appendLine(`[Webview] User submitted: ${message.text}`);
-						// In Phase 3, we'll route this to ACP client prompt()
+						this._handlePrompt(message.text);
 						break;
 					case 'cancel':
 						this._outputChannel.appendLine('[Webview] User cancelled operation.');
-						// In Phase 3, we'll route this to ACP client cancel()
+						this._acpClient.cancel();
 						break;
 				}
 			}
@@ -49,6 +60,34 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 	public postMessage(message: ExtensionToWebviewMessage) {
 		if (this._view) {
 			this._view.webview.postMessage(message);
+		}
+	}
+
+	private async _handlePrompt(text: string) {
+		try {
+			// Make sure we have a session
+			const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+			const cwd = workspaceFolder?.uri.fsPath || process.cwd();
+			
+			const sessionId = await this._acpClient.getOrCreateSession(cwd);
+			if (!sessionId) {
+				vscode.window.showErrorMessage('Nanocoder: Failed to create ACP session.');
+				return;
+			}
+			
+			// Let the webview know we started thinking
+			this.postMessage({
+				type: 'acpUpdate',
+				update: {
+					type: 'agent_thought_chunk',
+					content: '' // Webview can use this as a trigger to show a loading state if desired
+				}
+			} as any);
+
+			await this._acpClient.prompt(text);
+		} catch (error) {
+			this._outputChannel.appendLine(`Prompt execution error: ${error}`);
+			vscode.window.showErrorMessage(`Nanocoder Prompt error: ${error}`);
 		}
 	}
 

--- a/plugins/vscode/src/extension.ts
+++ b/plugins/vscode/src/extension.ts
@@ -53,7 +53,7 @@ export function activate(context: vscode.ExtensionContext) {
 	statusBarItem.show();
 
 	// Register Webview Provider
-	const chatProvider = new ChatWebviewProvider(context.extensionUri, outputChannel);
+	const chatProvider = new ChatWebviewProvider(context.extensionUri, outputChannel, acpClient);
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(ChatWebviewProvider.viewType, chatProvider)
 	);

--- a/plugins/vscode/src/webview-protocol.ts
+++ b/plugins/vscode/src/webview-protocol.ts
@@ -27,11 +27,17 @@ export interface ExtensionMessageClear {
 	type: 'clear';
 }
 
+export interface ExtensionMessageAcpUpdate {
+	type: 'acpUpdate';
+	update: any; // schema.SessionNotification or custom internal payload
+}
+
 export type ExtensionToWebviewMessage =
 	| ExtensionMessageAppendMessage
 	| ExtensionMessageAppendThought
 	| ExtensionMessageStateUpdate
-	| ExtensionMessageClear;
+	| ExtensionMessageClear
+	| ExtensionMessageAcpUpdate;
 
 
 // ---------------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^3.0.71
         version: 3.0.71(patch_hash=df300a5d22aecda3490a73885c5d63e34d4cd056d26fc5ba202ea4121d46adbf)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
-        specifier: 3.0.5
-        version: 3.0.5(zod@4.4.3)
+        specifier: ^2.0.0
+        version: 2.0.58(zod@4.4.3)
       '@anthropic-ai/tokenizer':
         specifier: ^0.0.4
         version: 0.0.4
@@ -38,7 +38,7 @@ importers:
         version: 1.29.0(zod@4.4.3)
       '@nanocollective/get-md':
         specifier: ^1.6.0
-        version: 1.6.0(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@4.0.8(zod@4.4.3))(@ai-sdk/openai-compatible@3.0.5(zod@4.4.3))(ai@6.0.193(zod@4.4.3))
+        version: 1.6.0(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@4.0.8(zod@4.4.3))(@ai-sdk/openai-compatible@2.0.58(zod@4.4.3))(ai@6.0.193(zod@4.4.3))
       '@nanocollective/prompt-scrub':
         specifier: ^1.0.1
         version: 1.0.1
@@ -229,9 +229,9 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@3.0.5':
-    resolution: {integrity: sha512-4UtDxT6Ga7U225o5fBEgtCFZHba4/iTDXRqMrU62yEfTrFks4o+F4jt0D3OWmUasR9LPFzLy0KnEITxFDtc89g==}
-    engines: {node: '>=22'}
+  '@ai-sdk/openai-compatible@2.0.58':
+    resolution: {integrity: sha512-0SXA0xVt18F4ki7ttVshqaM0oLXSB475ACOU0/2RK3OZS3UYqrmKF+DJwYBYUZmqCq2nZ2vkNZEXpWP2wfGsrQ==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -259,6 +259,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.37':
+    resolution: {integrity: sha512-VG4tpVXCuzm21U9xjg05BCMZnjZOazC72+MxBkLAa7hCKsnqNt542GYWUUqwmHSczJwgbSXN8UvaNgSerUaKdw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.5':
     resolution: {integrity: sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==}
     engines: {node: '>=22'}
@@ -267,6 +273,10 @@ packages:
 
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.13':
+    resolution: {integrity: sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@4.0.2':
@@ -3855,10 +3865,10 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@3.0.5(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@2.0.58(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.2
-      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.37(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/openai@3.0.71(patch_hash=df300a5d22aecda3490a73885c5d63e34d4cd056d26fc5ba202ea4121d46adbf)(zod@4.4.3)':
@@ -3888,6 +3898,13 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@4.0.37(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@5.0.5(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.2
@@ -3897,6 +3914,10 @@ snapshots:
       zod: 4.4.3
 
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.13':
     dependencies:
       json-schema: 0.4.0
 
@@ -4342,7 +4363,7 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
-  '@nanocollective/get-md@1.6.0(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@4.0.8(zod@4.4.3))(@ai-sdk/openai-compatible@3.0.5(zod@4.4.3))(ai@6.0.193(zod@4.4.3))':
+  '@nanocollective/get-md@1.6.0(@ai-sdk/anthropic@3.0.85(zod@4.4.3))(@ai-sdk/google@4.0.8(zod@4.4.3))(@ai-sdk/openai-compatible@2.0.58(zod@4.4.3))(ai@6.0.193(zod@4.4.3))':
     dependencies:
       '@mozilla/readability': 0.6.0
       cheerio: 1.2.0
@@ -4357,7 +4378,7 @@ snapshots:
     optionalDependencies:
       '@ai-sdk/anthropic': 3.0.85(zod@4.4.3)
       '@ai-sdk/google': 4.0.8(zod@4.4.3)
-      '@ai-sdk/openai-compatible': 3.0.5(zod@4.4.3)
+      '@ai-sdk/openai-compatible': 2.0.58(zod@4.4.3)
       ai: 6.0.193(zod@4.4.3)
 
   '@nanocollective/prompt-scrub@1.0.1':

--- a/source/acp/acp-server.ts
+++ b/source/acp/acp-server.ts
@@ -25,9 +25,9 @@ export async function runAcpServer(
 			cliModel: options.cliModel,
 		});
 	} catch (error) {
-		logger.error(
-			`ACP initialization failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		const msg = `ACP initialization failed: ${error instanceof Error ? error.message : String(error)}`;
+		logger.error(msg);
+		process.stderr.write(`[nanocoder] ${msg}\n`);
 		process.exit(1);
 	}
 


### PR DESCRIPTION
# PR: Phase 3 - Connect ACP Server to Webview UI

## Overview

This PR completes Phase 3 of the Nanocoder VS Code Extension by establishing end-to-end communication between the frontend Webview UI and the background Nanocoder ACP Server. Users can now send natural language prompts through the chat sidebar and watch the AI's response stream back in real-time. #654 
<img width="1540" height="1710" alt="image" src="https://github.com/user-attachments/assets/f371dd6b-804b-446b-a41a-e0028b0394c5" />


## Key Changes

1. **Webview Provider Integration (`chat-webview-provider.ts`)**
   - Wired up the Webview message listener to intercept `submitMessage` events from the frontend and forward them to the `NanocoderAcpClient`.
   - Setup a reverse-bridge to pipe `onSessionUpdate` streaming events from the ACP Client directly into the Webview as `acpUpdate` messages.
   - Automatically initializes an ACP session using the user's current VS Code workspace directory (`cwd`) before executing the first prompt.

2. **ACP Client Fixes (`acp-client.ts`)**
   - Implemented the `prompt()` method to send user messages over JSON-RPC to the ACP Server.
   - **Bug Fix**: Addressed an `Invalid params` schema validation error by wrapping prompt strings in the strictly enforced `ContentBlock` array format (`[{ type: 'text', text }]`) required by the `@agentclientprotocol/sdk`.

3. **Frontend Streaming Logic (`chat-panel.js`)**
   - Added support for parsing incoming `acpUpdate` messages containing `sessionUpdate` events from the server.
   - Implemented an `appendChunk()` utility to incrementally build up AI responses in the DOM, creating a smooth streaming effect.
   - **Bug Fix**: Fixed a visual issue where `agent_thought_chunk` messages were rendering as `[object Object]` by correctly extracting the `.text` property from the `ContentChunk` payload.

## Testing Performed
- Started the VS Code Extension Development Host locally.
- Successfully connected to the background `nanocoder` CLI running in ACP server mode.
- Verified that sending a prompt triggers the backend and that streamed text chunks render sequentially in the Webview UI.
