### PR TITLE
feat: semantic memory (Phase 2)

### DIFF
--- a/source/commands/lazy-registry.ts
+++ b/source/commands/lazy-registry.ts
@@ -177,6 +177,11 @@ export const lazyCommands: LazyCommand[] = [
 		load: () => import('@/commands/retry').then(m => m.retryCommand),
 	},
 	{
+		name: 'remember',
+		description: 'Save a durable project memory',
+		load: () => import('@/commands/remember').then(m => m.rememberCommand),
+	},
+	{
 		name: 'tasks',
 		description: 'Manage your task list',
 		load: () => import('@/commands/tasks').then(m => m.tasksCommand),

--- a/source/commands/remember.spec.tsx
+++ b/source/commands/remember.spec.tsx
@@ -1,0 +1,111 @@
+import test from 'ava';
+import React from 'react';
+import type {SemanticMemory} from '@/memory/semantic-memory-manager';
+import {SummarizerService} from '@/memory/summarizer-service';
+import {renderWithTheme} from '@/test-utils/render-with-theme';
+import type {Message} from '@/types/core';
+import {lazyCommands} from './lazy-registry.js';
+import {createRememberCommand, rememberCommand} from './remember.js';
+
+const testMetadata = {
+	provider: 'test-provider',
+	model: 'test-model',
+	tokens: 0,
+	getMessageTokens: (message: Message) => message.content.length,
+};
+
+class FakeSummarizerService extends SummarizerService {
+	rememberedInput?: {
+		content: string;
+		category?: string;
+		sourceSessionId?: string;
+	};
+
+	constructor(private readonly memory: SemanticMemory) {
+		super();
+	}
+
+	override async remember(input: {
+		content: string;
+		category?: string;
+		sourceSessionId?: string;
+	}): Promise<SemanticMemory> {
+		this.rememberedInput = input;
+		return this.memory;
+	}
+}
+
+test('rememberCommand has correct name and description', t => {
+	t.is(rememberCommand.name, 'remember');
+	t.is(rememberCommand.description, 'Save a durable project memory');
+});
+
+test('remember command returns usage when content is missing', async t => {
+	const result = await rememberCommand.handler([], [], testMetadata);
+	t.truthy(React.isValidElement(result));
+
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() ?? '';
+
+	t.true(output.includes('Usage: /remember'));
+});
+
+test('remember command saves a manual memory', async t => {
+	const service = new FakeSummarizerService({
+		id: 'memory-1',
+		content: 'Use the existing auth adapter.',
+		category: 'architecture',
+		timestamp: '2026-07-15T00:00:00.000Z',
+	});
+	const command = createRememberCommand({summarizerService: service});
+
+	const result = await command.handler(
+		['Use', 'the', 'existing', 'auth', 'adapter.'],
+		[],
+		testMetadata,
+	);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.deepEqual(service.rememberedInput, {
+		content: 'Use the existing auth adapter.',
+		category: undefined,
+	});
+	t.true((lastFrame() ?? '').includes('Remembered architecture memory.'));
+});
+
+test('remember command forwards explicit category', async t => {
+	const service = new FakeSummarizerService({
+		id: 'memory-1',
+		content: 'Keep generated files out of review.',
+		category: 'codingStyle',
+		timestamp: '2026-07-15T00:00:00.000Z',
+	});
+	const command = createRememberCommand({summarizerService: service});
+
+	await command.handler(
+		[
+			'--category',
+			'coding-style',
+			'Keep',
+			'generated',
+			'files',
+			'out',
+			'of',
+			'review.',
+		],
+		[],
+		testMetadata,
+	);
+
+	t.deepEqual(service.rememberedInput, {
+		content: 'Keep generated files out of review.',
+		category: 'coding-style',
+	});
+});
+
+test('lazy registry exposes /remember', t => {
+	const remember = lazyCommands.find(command => command.name === 'remember');
+
+	t.truthy(remember);
+	t.is(remember?.description, 'Save a durable project memory');
+});

--- a/source/commands/remember.spec.tsx
+++ b/source/commands/remember.spec.tsx
@@ -21,7 +21,10 @@ class FakeSummarizerService extends SummarizerService {
 		sourceSessionId?: string;
 	};
 
-	constructor(private readonly memory: SemanticMemory) {
+	constructor(
+		private readonly memory: SemanticMemory,
+		private readonly error?: Error,
+	) {
 		super();
 	}
 
@@ -31,6 +34,7 @@ class FakeSummarizerService extends SummarizerService {
 		sourceSessionId?: string;
 	}): Promise<SemanticMemory> {
 		this.rememberedInput = input;
+		if (this.error) throw this.error;
 		return this.memory;
 	}
 }
@@ -101,6 +105,28 @@ test('remember command forwards explicit category', async t => {
 		content: 'Keep generated files out of review.',
 		category: 'coding-style',
 	});
+});
+
+test('remember command reports save failures', async t => {
+	const service = new FakeSummarizerService(
+		{
+			id: 'memory-1',
+			content: 'Use the existing auth adapter.',
+			category: 'architecture',
+			timestamp: '2026-07-15T00:00:00.000Z',
+		},
+		new Error('disk full'),
+	);
+	const command = createRememberCommand({summarizerService: service});
+
+	const result = await command.handler(
+		['Use', 'the', 'existing', 'auth', 'adapter.'],
+		[],
+		testMetadata,
+	);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true((lastFrame() ?? '').includes('Failed to save memory: disk full'));
 });
 
 test('lazy registry exposes /remember', t => {

--- a/source/commands/remember.ts
+++ b/source/commands/remember.ts
@@ -1,0 +1,79 @@
+import {SummarizerService} from '@/memory/summarizer-service';
+import type {Command} from '@/types/commands';
+import {formatError} from '@/utils/error-formatter';
+import {errorMsg, successMsg} from '@/utils/message-factory';
+
+interface RememberCommandOptions {
+	summarizerService?: SummarizerService;
+}
+
+interface ParsedRememberArgs {
+	content: string;
+	category?: string;
+	error?: string;
+}
+
+const USAGE = 'Usage: /remember [--category <name>] <project memory>';
+
+export function createRememberCommand(
+	options: RememberCommandOptions = {},
+): Command {
+	const summarizerService =
+		options.summarizerService ?? new SummarizerService();
+
+	return {
+		name: 'remember',
+		description: 'Save a durable project memory',
+		handler: async (args: string[]) => {
+			const parsed = parseRememberArgs(args);
+			if (parsed.error) {
+				return errorMsg(parsed.error, 'remember-error');
+			}
+
+			try {
+				const memory = await summarizerService.remember({
+					content: parsed.content,
+					category: parsed.category,
+				});
+
+				return successMsg(
+					`Remembered ${memory.category} memory.`,
+					'remember-success',
+				);
+			} catch (error) {
+				return errorMsg(
+					`Failed to save memory: ${formatError(error)}`,
+					'remember-error',
+				);
+			}
+		},
+	};
+}
+
+export const rememberCommand: Command = createRememberCommand();
+
+function parseRememberArgs(args: string[]): ParsedRememberArgs {
+	let category: string | undefined;
+	const contentParts: string[] = [];
+
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (arg === '--category' || arg === '-c') {
+			const value = args[index + 1];
+			if (!value) {
+				return {content: '', error: USAGE};
+			}
+
+			category = value;
+			index++;
+			continue;
+		}
+
+		contentParts.push(arg);
+	}
+
+	const content = contentParts.join(' ').trim();
+	if (!content) return {content: '', error: USAGE};
+
+	return {content, category};
+}

--- a/source/memory/summarizer-service.spec.ts
+++ b/source/memory/summarizer-service.spec.ts
@@ -32,7 +32,12 @@ test('SummarizerService stores a manual memory', async t => {
 });
 
 test('SummarizerService rejects empty manual memory content', async t => {
-	const service = new SummarizerService();
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const service = new SummarizerService(
+		new SemanticMemoryManager({memoryDir: dir, cwd}),
+	);
 
 	await t.throwsAsync(service.remember({content: '   '}), {
 		message: 'Memory content cannot be empty',

--- a/source/memory/summarizer-service.spec.ts
+++ b/source/memory/summarizer-service.spec.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'ava';
+import {SemanticMemoryManager} from './semantic-memory-manager.js';
+import {
+	inferMemoryCategory,
+	SummarizerService,
+	toCamelCaseCategory,
+} from './summarizer-service.js';
+
+async function createTempDir(): Promise<string> {
+	return fs.mkdtemp(path.join(os.tmpdir(), 'nanocoder-memory-'));
+}
+
+test('SummarizerService stores a manual memory', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+	const service = new SummarizerService(manager);
+
+	const memory = await service.remember({
+		content: '  Use the existing provider abstraction for model changes.  ',
+		sourceSessionId: 'session-1',
+	});
+
+	t.is(memory.content, 'Use the existing provider abstraction for model changes.');
+	t.is(memory.category, 'architecture');
+	t.is(memory.sourceSessionId, 'session-1');
+	t.deepEqual(await manager.listMemories(), [memory]);
+});
+
+test('SummarizerService rejects empty manual memory content', async t => {
+	const service = new SummarizerService();
+
+	await t.throwsAsync(service.remember({content: '   '}), {
+		message: 'Memory content cannot be empty',
+	});
+});
+
+test('SummarizerService uses explicit camelCase category', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const service = new SummarizerService(
+		new SemanticMemoryManager({memoryDir: dir, cwd}),
+	);
+
+	const memory = await service.remember({
+		content: 'Keep generated files out of review unless needed.',
+		category: 'coding style',
+	});
+
+	t.is(memory.category, 'codingStyle');
+});
+
+test('inferMemoryCategory maps durable facts to stable categories', t => {
+	t.is(
+		inferMemoryCategory('Avoid middleware in the auth architecture.'),
+		'architecture',
+	);
+	t.is(
+		inferMemoryCategory('Use camel case for new command variables.'),
+		'codingStyle',
+	);
+	t.is(inferMemoryCategory('This fixes the queued input regression.'), 'bugFix');
+	t.is(inferMemoryCategory('Refactor the old storage path later.'), 'refactor');
+	t.is(inferMemoryCategory('TODO delete obsolete project memory.'), 'todo');
+	t.is(inferMemoryCategory('The project name is Nanocoder.'), 'project');
+});
+
+test('toCamelCaseCategory normalizes category names', t => {
+	t.is(toCamelCaseCategory('coding style'), 'codingStyle');
+	t.is(toCamelCaseCategory('BUG-FIX'), 'bugFix');
+	t.is(toCamelCaseCategory(''), 'project');
+});

--- a/source/memory/summarizer-service.ts
+++ b/source/memory/summarizer-service.ts
@@ -1,0 +1,77 @@
+import {
+	type SemanticMemory,
+	SemanticMemoryManager,
+} from './semantic-memory-manager';
+
+export interface RememberMemoryInput {
+	content: string;
+	category?: string;
+	sourceSessionId?: string;
+}
+
+const CATEGORY_RULES: Array<{category: string; pattern: RegExp}> = [
+	{
+		category: 'bugFix',
+		pattern: /\b(bug|fix|fixed|regression|failure|failed|failing|flake)\b/i,
+	},
+	{
+		category: 'refactor',
+		pattern: /\b(refactor|migration|migrate|migrated|rewrite)\b/i,
+	},
+	{
+		category: 'todo',
+		pattern: /\b(todo|follow up|later|defer|deferred|unresolved)\b/i,
+	},
+	{
+		category: 'architecture',
+		pattern:
+			/\b(architecture|architectural|adapter|middleware|provider|database|storage|schema|abstraction)\b/i,
+	},
+	{
+		category: 'codingStyle',
+		pattern: /\b(style|convention|format|formatting|naming|camel case|lint)\b/i,
+	},
+];
+
+export class SummarizerService {
+	constructor(private readonly memoryManager = new SemanticMemoryManager()) {}
+
+	async remember(input: RememberMemoryInput): Promise<SemanticMemory> {
+		const content = input.content.trim();
+		if (!content) {
+			throw new Error('Memory content cannot be empty');
+		}
+
+		return this.memoryManager.addMemory({
+			content,
+			category: input.category
+				? toCamelCaseCategory(input.category)
+				: inferMemoryCategory(content),
+			sourceSessionId: input.sourceSessionId,
+		});
+	}
+}
+
+export function inferMemoryCategory(content: string): string {
+	for (const rule of CATEGORY_RULES) {
+		if (rule.pattern.test(content)) return rule.category;
+	}
+
+	return 'project';
+}
+
+export function toCamelCaseCategory(value: string): string {
+	const parts = value
+		.trim()
+		.toLowerCase()
+		.split(/[^a-z0-9]+/u)
+		.filter(Boolean);
+
+	if (parts.length === 0) return 'project';
+
+	return parts
+		.map((part, index) =>
+			index === 0 ? part : `${part[0]?.toUpperCase() ?? ''}${part.slice(1)}`,
+		)
+		.join('');
+}


### PR DESCRIPTION
## Description

Adds Phase 2 of semantic memory: manual memory creation through `/remember`, backed by a `SummarizerService` that validates content, normalizes/infer categories, and saves through the existing `SemanticMemoryManager`.

Phase 2 : #619

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))