### PR TITLE
feat: implement interactive tool permission and diff management UI

### DIFF
--- a/plugins/vscode/media/chat-panel.css
+++ b/plugins/vscode/media/chat-panel.css
@@ -86,3 +86,73 @@ textarea {
 textarea:focus {
 	border-color: var(--input-focus-border);
 }
+
+/* Tool Cards */
+.tool-card {
+	margin-top: 12px;
+	margin-bottom: 12px;
+	border: 1px solid var(--vscode-widget-border);
+	border-radius: 4px;
+	background-color: var(--vscode-editorWidget-background);
+	overflow: hidden;
+}
+
+.tool-header {
+	padding: 8px 12px;
+	display: flex;
+	align-items: center;
+	background-color: var(--vscode-editorWidget-border);
+	border-bottom: 1px solid var(--vscode-widget-border);
+	gap: 8px;
+}
+
+.tool-title {
+	font-family: var(--vscode-editor-font-family);
+	font-size: 0.9em;
+	font-weight: 600;
+	word-break: break-all;
+}
+
+.tool-body {
+	padding: 8px 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.tool-diff-link {
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+	font-size: 0.9em;
+}
+
+.tool-diff-link:hover {
+	text-decoration: underline;
+}
+
+.tool-actions {
+	display: flex;
+	gap: 8px;
+	margin-top: 8px;
+}
+
+.tool-btn {
+	padding: 4px 12px;
+	border: none;
+	border-radius: 2px;
+	cursor: pointer;
+	font-size: 0.9em;
+	color: var(--vscode-button-foreground);
+}
+
+.tool-btn.approve-btn {
+	background-color: var(--vscode-button-background);
+}
+
+.tool-btn.approve-btn:hover {
+	background-color: var(--vscode-button-hoverBackground);
+}
+
+.tool-btn.deny-btn {
+	background-color: var(--vscode-errorForeground);
+}

--- a/plugins/vscode/media/chat-panel.js
+++ b/plugins/vscode/media/chat-panel.js
@@ -110,6 +110,9 @@
 			case 'acpUpdate':
 				handleAcpUpdate(message.update);
 				break;
+			case 'permissionRequested':
+				handlePermissionRequested(message.toolCallId, message.toolCall);
+				break;
 		}
 	});
 
@@ -126,7 +129,121 @@
 			if (update.content && update.content.text) {
 				appendChunk(update.content.text);
 			}
+		} else if (update.sessionUpdate === 'tool_call' || update.sessionUpdate === 'tool_call_update') {
+			handleToolCallUpdate(update);
 		}
+	}
+
+	function handleToolCallUpdate(update) {
+		const toolCallId = update.toolCallId || (update.toolCall && update.toolCall.toolCallId);
+		if (!toolCallId) return;
+
+		let card = document.getElementById(`tool-card-${toolCallId}`);
+		if (!card) {
+			card = createToolCard(toolCallId, update);
+			messagesContainer.appendChild(card);
+			scrollToBottom();
+		} else {
+			updateToolCard(card, update);
+		}
+	}
+
+	function createToolCard(toolCallId, update) {
+		const card = document.createElement('div');
+		card.className = 'tool-card';
+		card.id = `tool-card-${toolCallId}`;
+		
+		const header = document.createElement('div');
+		header.className = 'tool-header';
+		
+		const title = document.createElement('span');
+		title.className = 'tool-title';
+		title.textContent = update.title || update.name || 'Tool Call';
+		
+		const status = document.createElement('span');
+		status.className = 'tool-status pending';
+		status.textContent = '⏳';
+		
+		header.appendChild(status);
+		header.appendChild(title);
+		card.appendChild(header);
+		
+		const body = document.createElement('div');
+		body.className = 'tool-body';
+		
+		// Add diff link if there's a diff content
+		if (update.content && Array.isArray(update.content)) {
+			const hasDiff = update.content.some(c => c.type === 'diff');
+			if (hasDiff) {
+				const diffLink = document.createElement('a');
+				diffLink.href = '#';
+				diffLink.className = 'tool-diff-link';
+				diffLink.textContent = 'View Changes';
+				diffLink.onclick = (e) => {
+					e.preventDefault();
+					vscode.postMessage({ type: 'showDiff', toolCallId });
+				};
+				body.appendChild(diffLink);
+			}
+		}
+
+		card.appendChild(body);
+		return card;
+	}
+
+	function updateToolCard(card, update) {
+		const statusEl = card.querySelector('.tool-status');
+		const bodyEl = card.querySelector('.tool-body');
+		
+		if (update.status) {
+			statusEl.className = `tool-status ${update.status}`;
+			if (update.status === 'success' || update.status === 'completed') {
+				statusEl.textContent = '✅';
+				const actions = card.querySelector('.tool-actions');
+				if (actions) actions.remove();
+			} else if (update.status === 'error') {
+				statusEl.textContent = '❌';
+				const actions = card.querySelector('.tool-actions');
+				if (actions) actions.remove();
+			} else if (update.status === 'cancelled' || update.status === 'denied') {
+				statusEl.textContent = '🚫';
+				const actions = card.querySelector('.tool-actions');
+				if (actions) actions.remove();
+			}
+		}
+	}
+
+	function handlePermissionRequested(toolCallId, toolCall) {
+		const card = document.getElementById(`tool-card-${toolCallId}`);
+		if (!card) return;
+		
+		// Check if actions already exist
+		if (card.querySelector('.tool-actions')) return;
+
+		const actionsDiv = document.createElement('div');
+		actionsDiv.className = 'tool-actions';
+		
+		const approveBtn = document.createElement('button');
+		approveBtn.className = 'tool-btn approve-btn';
+		approveBtn.textContent = 'Approve';
+		approveBtn.onclick = () => {
+			vscode.postMessage({ type: 'approveTool', toolCallId });
+			actionsDiv.remove();
+		};
+		
+		const denyBtn = document.createElement('button');
+		denyBtn.className = 'tool-btn deny-btn';
+		denyBtn.textContent = 'Deny';
+		denyBtn.onclick = () => {
+			vscode.postMessage({ type: 'denyTool', toolCallId });
+			actionsDiv.remove();
+		};
+		
+		actionsDiv.appendChild(approveBtn);
+		actionsDiv.appendChild(denyBtn);
+		
+		card.appendChild(actionsDiv);
+		scrollToBottom();
 	}
 
 	// Notify extension that webview is ready

--- a/plugins/vscode/src/acp-client.ts
+++ b/plugins/vscode/src/acp-client.ts
@@ -11,6 +11,9 @@ export class NanocoderAcpClient {
 	private stateManager: AcpStateManager;
 	private _sessionId?: string;
 	public onSessionUpdate?: (update: any) => void;
+	public onPermissionRequested?: (toolCallId: string, toolCall: any) => void;
+
+	private pendingPermissions = new Map<string, (response: any) => void>();
 
 	constructor(outputChannel: vscode.OutputChannel, stateManager: AcpStateManager) {
 		this.outputChannel = outputChannel;
@@ -19,6 +22,31 @@ export class NanocoderAcpClient {
 
 	setConnection(conn: ClientSideConnection) {
 		this.connection = conn;
+	}
+
+	async handlePermissionRequest(params: any): Promise<any> {
+		const toolCall = params.toolCall;
+		const toolCallId = toolCall.toolCallId;
+		
+		return new Promise<any>((resolve) => {
+			this.pendingPermissions.set(toolCallId, resolve);
+			if (this.onPermissionRequested) {
+				this.onPermissionRequested(toolCallId, toolCall);
+			}
+		});
+	}
+
+	resolvePermission(toolCallId: string, allow: boolean) {
+		const resolver = this.pendingPermissions.get(toolCallId);
+		if (resolver) {
+			resolver({
+				outcome: {
+					outcome: 'selected',
+					optionId: allow ? 'allow' : 'deny',
+				}
+			});
+			this.pendingPermissions.delete(toolCallId);
+		}
 	}
 
 	async initializeHandshake(): Promise<boolean> {

--- a/plugins/vscode/src/acp-process-manager.ts
+++ b/plugins/vscode/src/acp-process-manager.ts
@@ -87,8 +87,7 @@ export class AcpProcessManager {
 				}
 			},
 			requestPermission: async (params: any) => {
-				// To be implemented in Phase 4
-				return { outcome: 'denied' } as any; 
+				return this.acpClient.handlePermissionRequest(params);
 			}
 		} as any), stream);
 		this.acpClient.setConnection(connection);

--- a/plugins/vscode/src/chat-webview-provider.ts
+++ b/plugins/vscode/src/chat-webview-provider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { WebviewToExtensionMessage, ExtensionToWebviewMessage } from './webview-protocol';
 
 import { NanocoderAcpClient } from './acp-client';
+import { DiffManager } from './diff-manager';
 
 export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 	public static readonly viewType = 'nanocoder.chatView';
@@ -11,15 +12,44 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 	constructor(
 		private readonly _extensionUri: vscode.Uri,
 		private readonly _outputChannel: vscode.OutputChannel,
-		private readonly _acpClient: NanocoderAcpClient
+		private readonly _acpClient: NanocoderAcpClient,
+		private readonly _diffManager: DiffManager
 	) { 
 		// Listen for session updates from ACP
 		this._acpClient.onSessionUpdate = (update: any) => {
+			this.handleDiffs(update);
 			this.postMessage({
 				type: 'acpUpdate',
 				update
 			} as any);
 		};
+
+		this._acpClient.onPermissionRequested = (toolCallId: string, toolCall: any) => {
+			this.handleDiffs(toolCall);
+			this.postMessage({
+				type: 'permissionRequested',
+				toolCallId,
+				toolCall
+			} as any);
+		};
+	}
+
+	private handleDiffs(update: any) {
+		if (update?.content && Array.isArray(update.content)) {
+			for (const block of update.content) {
+				if (block.type === 'diff' && block.path) {
+					this._diffManager.addPendingChange({
+						type: 'file_change',
+						id: update.toolCallId || block.path, // fallback id
+						filePath: block.path,
+						originalContent: block.before || '',
+						newContent: block.after || '',
+						toolName: update.title || update.name || 'edit',
+						toolArgs: update.rawInput || {}
+					});
+				}
+			}
+		}
 	}
 
 	public resolveWebviewView(
@@ -51,6 +81,18 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 					case 'cancel':
 						this._outputChannel.appendLine('[Webview] User cancelled operation.');
 						this._acpClient.cancel();
+						break;
+					case 'approveTool':
+						this._outputChannel.appendLine(`[Webview] User approved tool: ${message.toolCallId}`);
+						this._acpClient.resolvePermission(message.toolCallId, true);
+						break;
+					case 'denyTool':
+						this._outputChannel.appendLine(`[Webview] User denied tool: ${message.toolCallId}`);
+						this._acpClient.resolvePermission(message.toolCallId, false);
+						break;
+					case 'showDiff':
+						this._outputChannel.appendLine(`[Webview] User requested to see diff for: ${message.toolCallId}`);
+						this._diffManager.showDiff(message.toolCallId);
 						break;
 				}
 			}

--- a/plugins/vscode/src/extension.ts
+++ b/plugins/vscode/src/extension.ts
@@ -53,7 +53,7 @@ export function activate(context: vscode.ExtensionContext) {
 	statusBarItem.show();
 
 	// Register Webview Provider
-	const chatProvider = new ChatWebviewProvider(context.extensionUri, outputChannel, acpClient);
+	const chatProvider = new ChatWebviewProvider(context.extensionUri, outputChannel, acpClient, diffManager);
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(ChatWebviewProvider.viewType, chatProvider)
 	);

--- a/plugins/vscode/src/webview-protocol.ts
+++ b/plugins/vscode/src/webview-protocol.ts
@@ -32,12 +32,38 @@ export interface ExtensionMessageAcpUpdate {
 	update: any; // schema.SessionNotification or custom internal payload
 }
 
+export interface ExtensionMessageToolStarted {
+	type: 'toolStarted';
+	toolCall: any;
+}
+
+export interface ExtensionMessageToolUpdated {
+	type: 'toolUpdated';
+	update: any;
+}
+
+export interface ExtensionMessageToolCompleted {
+	type: 'toolCompleted';
+	toolCallId: string;
+	result: any;
+}
+
+export interface ExtensionMessagePermissionRequested {
+	type: 'permissionRequested';
+	toolCallId: string;
+	toolCall: any;
+}
+
 export type ExtensionToWebviewMessage =
 	| ExtensionMessageAppendMessage
 	| ExtensionMessageAppendThought
 	| ExtensionMessageStateUpdate
 	| ExtensionMessageClear
-	| ExtensionMessageAcpUpdate;
+	| ExtensionMessageAcpUpdate
+	| ExtensionMessageToolStarted
+	| ExtensionMessageToolUpdated
+	| ExtensionMessageToolCompleted
+	| ExtensionMessagePermissionRequested;
 
 
 // ---------------------------------------------------------
@@ -57,7 +83,25 @@ export interface WebviewMessageCancel {
 	type: 'cancel';
 }
 
+export interface WebviewMessageApproveTool {
+	type: 'approveTool';
+	toolCallId: string;
+}
+
+export interface WebviewMessageDenyTool {
+	type: 'denyTool';
+	toolCallId: string;
+}
+
+export interface WebviewMessageShowDiff {
+	type: 'showDiff';
+	toolCallId: string;
+}
+
 export type WebviewToExtensionMessage =
 	| WebviewMessageReady
 	| WebviewMessageSubmitMessage
-	| WebviewMessageCancel;
+	| WebviewMessageCancel
+	| WebviewMessageApproveTool
+	| WebviewMessageDenyTool
+	| WebviewMessageShowDiff;


### PR DESCRIPTION
## Description

This PR implements Phase 4 of the native VS Code GUI Extension for Nanocoder (Issue #654). It brings the ACP server's tool execution loop directly into the VS Code sidebar Webview, allowing developers to view streaming tool execution progress, inspect generated file diffs natively, and approve/deny privileged tool calls in real time. 

Crucially, in alignment with the architecture discussed in, this PR strictly adheres to the principle of the extension acting purely as a "thin client." **The VS Code extension does not execute tools, evaluate permissions, or duplicate approval policies.** It merely routes protocol events (like `onRequestPermission`) from the ACP SDK to the Webview UI, and feeds user decisions back to the core CLI engine.

### Key Additions & Changes

#### 1. ACP Client & Protocol (`plugins/vscode/src/acp-client.ts` & `webview-protocol.ts`)
* Implemented the `onRequestPermission` handler in `NanocoderAcpClient` to intercept permission requests from the ACP server and safely pause the execution loop pending user input.
* Added `resolvePermission()` to route the user's `Approve` / `Deny` decisions back to the suspended ACP promise.
* Extended the internal postMessage protocol in `webview-protocol.ts` to support strongly typed tool events: `permissionRequested`, `approveTool`, `denyTool`, and `showDiff`.

#### 2. Chat Webview UI (`plugins/vscode/media/chat-panel.js` & `chat-panel.css`)
* Implemented dynamic **Tool Cards** that automatically render and update in place in response to `tool_call` and `tool_call_update` session notifications. 
* Added UI representations for execution states: Pending (`⏳`), Success (`✅`), Error (`❌`), and Denied (`🚫`).
* Intercepted `permissionRequested` messages to dynamically render inline **Approve** and **Deny** buttons directly on the active tool card. 

#### 3. Diff Integration (`plugins/vscode/src/chat-webview-provider.ts` & `diff-manager.ts`)
* Intercepted `diff` blocks generated by the ACP server (e.g., from `string_replace` or `write_file`) inside the `ChatWebviewProvider`.
* Piped the `before` and `after` blocks directly into the existing VS Code `DiffManager` via `addPendingChange()`.
* Generated a native **"View Changes"** button on the Webview tool card. When clicked, it instructs the Extension Host to pop open the virtual diff URI in the native editor, eliminating the need to duplicate complex diff-rendering logic inside the HTML webview.

## Testing Instructions
1. Run the `plugins/vscode` Extension Development Host.
2. In the Sidebar, ask the agent to execute a basic bash command (`ls -la`). Observe the `execute_bash` tool card appear, execute, and succeed.
3. Prompt the agent to make a file modification (e.g., "Add a comment to `src/index.ts`").
4. Wait for the agent to pause and ask for permission via the inline **Approve/Deny** buttons.
5. Click **View Changes** on the tool card to verify the diff preview opens correctly via the existing VS Code virtual diff infrastructure.
6. Click **Approve** and verify the tool resumes execution and completes successfully.
