### PR TITLE
feat: dual TUI screen modes, reliable /clear, and graceful exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,19 @@ nanocoder run --provider openrouter "refactor database module"
 # Boot directly into a development mode (normal, auto-accept, yolo, plan)
 nanocoder --mode yolo
 nanocoder --mode plan run "audit the auth module"
+
+# Fullscreen mode with in-app scrolling instead of the inline default
+nanocoder --alt-screen
 ```
+
+### Screen Modes
+
+Nanocoder supports two rendering modes, mirroring what Claude Code and Codex ship:
+
+- **Inline (default)** — renders on the main screen; finished messages print once into the terminal's native scrollback, so your terminal's scrollbar, mouse wheel, and search work as usual. The transcript stays in the terminal after you exit.
+- **Fullscreen** (`--alt-screen` flag, or `"alternateScreen": true` in preferences) — a fixed-height layout on the alternate screen buffer with in-app scrolling: mouse wheel and PgUp/PgDn, with a scroll indicator and automatic snap-back to bottom on new output. `--no-alt-screen` forces inline mode even if the preference is set.
+
+In both modes, `/clear` fully resets the terminal to a fresh welcome banner, and exiting (Ctrl+C or `/exit`) erases the input UI cleanly, leaving the transcript and a farewell instead of a dead input box.
 
 ## Documentation
 

--- a/docs/configuration/preferences.md
+++ b/docs/configuration/preferences.md
@@ -30,6 +30,7 @@ Preferences follow the same location hierarchy as configuration files:
 | `nanocoderShape` | The nanocoder ASCII art shape |
 | `trustedDirectories` | Directories you've approved through the first-run security disclaimer |
 | `lastUpdateCheck` | Timestamp of the last update check (used to avoid checking too frequently) |
+| `alternateScreen` | When `true`, starts in fullscreen mode (alternate screen buffer with in-app scrolling) by default. The `--alt-screen`/`--no-alt-screen` CLI flags override this for a single run. See [CLI Options](../getting-started/index.md#cli-options). |
 
 ### Paste Configuration
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -53,6 +53,8 @@ nanocoder -h
 | `--context-max` | | Set maximum context length in tokens (supports k/K suffix, e.g. `128k`) |
 | `--mode` | | Start in a specific [development mode](../features/development-modes.md) — `normal`, `auto-accept`, `yolo`, or `plan`. Defaults to `normal` for interactive sessions and `auto-accept` for `run` mode. |
 | `--trust-directory` | | Skip the first-run directory trust prompt for this run only. Only valid with `run`; ignored (with a warning) in interactive mode. The trust is ephemeral — `trustedDirectories` in your preferences file is not modified. |
+| `--alt-screen` | | Start in fullscreen mode: a fixed-height layout on the alternate screen buffer with in-app scrolling. Overrides the `alternateScreen` preference for this run. |
+| `--no-alt-screen` | | Force inline mode (the default), even if `alternateScreen: true` is set in your preferences file. |
 | `run` | | Run in non-interactive mode |
 
 **Provider/Model Flags:**

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -1,4 +1,4 @@
-import {Box, Text, useApp} from 'ink';
+import {Box, Text, useApp, useInput} from 'ink';
 import Spinner from 'ink-spinner';
 import React, {useMemo} from 'react';
 import {createStaticComponents} from '@/app/components/app-container';
@@ -59,6 +59,7 @@ export default function App({
 	cliModel,
 	cliMode,
 	trustDirectory = false,
+	altScreenActive = false,
 }: AppProps) {
 	// Resolve the initial development mode with this precedence:
 	// 1. --mode CLI flag (highest priority)
@@ -103,10 +104,35 @@ export default function App({
 	const [extensionPromptComplete, setExtensionPromptComplete] =
 		React.useState(false);
 
+	// Conversation ID to force re-render of all content on /clear
+	const [conversationId, setConversationId] = React.useState(() =>
+		crypto.randomUUID(),
+	);
+
+	// Track whether we should show welcome (reset on /clear to clear banner)
+	const [showWelcome, setShowWelcome] = React.useState(true);
+
+	// Exit WITHOUT unmounting Ink first: the shutdown manager's
+	// 'tui-exit-render' handler (cli.tsx) erases the live region and prints
+	// the farewell — ink's clear() only works while still mounted. A second
+	// Ctrl+C while shutdown is in flight force-quits immediately.
+	const isExitingRef = React.useRef(false);
 	const handleExit = () => {
-		exit();
+		if (isExitingRef.current) {
+			exit();
+			process.exit(0);
+		}
+		isExitingRef.current = true;
 		void getShutdownManager().gracefulShutdown(0);
 	};
+
+	// Ink's built-in exitOnCtrlC is disabled (cli.tsx) so Ctrl+C can run
+	// the same graceful path as /exit instead of abandoning the last frame.
+	useInput((input, key) => {
+		if (key.ctrl && input === 'c') {
+			handleExit();
+		}
+	});
 
 	// VS Code → chat plumbing. The dispatcher is created up front because
 	// useVSCodeServer needs `onPrompt` immediately, and `handleUserSubmit`
@@ -123,24 +149,30 @@ export default function App({
 		onPrompt: vscodePromptDispatcher.handleVSCodePrompt,
 	});
 
-	// Create theme context value
-	const themeContextValue = {
-		currentTheme: appState.currentTheme,
-		colors: getThemeColors(appState.currentTheme),
-		setCurrentTheme: (theme: ThemePreset) => {
-			appState.setCurrentTheme(theme);
-			updateSelectedTheme(theme);
-		},
-	};
+	// Create theme context value (memoized to prevent unnecessary re-renders)
+	const themeContextValue = React.useMemo(
+		() => ({
+			currentTheme: appState.currentTheme,
+			colors: getThemeColors(appState.currentTheme),
+			setCurrentTheme: (theme: ThemePreset) => {
+				appState.setCurrentTheme(theme);
+				updateSelectedTheme(theme);
+			},
+		}),
+		[appState.currentTheme, appState.setCurrentTheme],
+	);
 
-	// Create title shape context value
-	const titleShapeContextValue = {
-		currentTitleShape: appState.currentTitleShape,
-		setCurrentTitleShape: (shape: TitleShape) => {
-			appState.setCurrentTitleShape(shape);
-			updateTitleShape(shape);
-		},
-	};
+	// Create title shape context value (memoized to prevent unnecessary re-renders)
+	const titleShapeContextValue = React.useMemo(
+		() => ({
+			currentTitleShape: appState.currentTitleShape,
+			setCurrentTitleShape: (shape: TitleShape) => {
+				appState.setCurrentTitleShape(shape);
+				updateTitleShape(shape);
+			},
+		}),
+		[appState.currentTitleShape, appState.setCurrentTitleShape],
+	);
 
 	// Initialize global message queue on component mount
 	React.useEffect(() => {
@@ -412,6 +444,17 @@ export default function App({
 		customCommandCache: appState.customCommandCache,
 		customCommandLoader: appState.customCommandLoader,
 		customCommandExecutor: appState.customCommandExecutor,
+		onClearCounterIncrement: () => {
+			// Inline mode: /clear must wipe the real terminal (screen +
+			// native scrollback + home) like Claude Code's classic renderer,
+			// otherwise the old transcript stays above the fresh banner. The
+			// fullscreen path repaints its whole fixed-height frame anyway.
+			if (!altScreenActive && process.stdout.isTTY) {
+				process.stdout.write('\x1B[2J\x1B[3J\x1B[H');
+			}
+			setConversationId(crypto.randomUUID());
+			setShowWelcome(true);
+		},
 		updateMessages: appState.updateMessages,
 		setIsCancelling: appState.setIsCancelling,
 		setDevelopmentMode: appState.setDevelopmentMode,
@@ -490,29 +533,21 @@ export default function App({
 		setCurrentSessionId: appState.setCurrentSessionId,
 	});
 
-	const shouldShowWelcome = !nonInteractiveMode;
-
 	// Memoize static components. We pin the run-mode header to the
 	// initial development mode so it never changes during the run — the
 	// boot line represents what the agent *started* under, not a live
 	// indicator.
-	const staticComponents = React.useMemo(
-		() =>
-			createStaticComponents({
-				shouldShowWelcome,
-				currentProvider: appState.currentProvider,
-				currentModel: appState.currentModel,
-				nonInteractiveMode,
-				developmentMode: initialDevelopmentMode,
-			}),
-		[
-			shouldShowWelcome,
-			appState.currentProvider,
-			appState.currentModel,
+	const initialProvider = React.useRef(appState.currentProvider);
+	const initialModel = React.useRef(appState.currentModel);
+	const staticComponents = React.useMemo(() => {
+		return createStaticComponents({
+			shouldShowWelcome: showWelcome && !nonInteractiveMode,
+			currentProvider: initialProvider.current,
+			currentModel: initialModel.current,
 			nonInteractiveMode,
-			initialDevelopmentMode,
-		],
-	);
+			developmentMode: initialDevelopmentMode,
+		});
+	}, [showWelcome, nonInteractiveMode, initialDevelopmentMode]);
 
 	// Handle loading state for directory trust check
 	if (isTrustLoading) {
@@ -650,32 +685,32 @@ export default function App({
 	return (
 		<ThemeContext.Provider value={themeContextValue}>
 			<TitleShapeContext.Provider value={titleShapeContextValue}>
-				<UIStateProvider>
-					<PrivacyContext.Provider
-						value={{
-							privacyEnabled: getPrivacyPreference(),
-							privacySessionMapRef: appState.privacySessionMapRef,
-						}}
-					>
-						<InteractiveApp
-							appState={appState}
-							chatHandler={chatHandler}
-							modeHandlers={modeHandlers}
-							appHandlers={appHandlers}
-							vscodeServer={vscodeServer}
-							staticComponents={staticComponents}
-							liveComponent={liveComponent}
-							pendingSubagentApproval={pendingSubagentApproval}
-							handleSubagentToolApproval={handleSubagentToolApproval}
-							pendingToolConfirmation={pendingToolConfirmation}
-							handleToolConfirmation={handleToolConfirmation}
-							handleQuestionAnswer={handleQuestionAnswer}
-							handleUserSubmit={handleUserSubmit}
-							userMessageQueue={userMessageQueue}
-							handleIdeSelect={handleIdeSelect}
-						/>
-					</PrivacyContext.Provider>
-				</UIStateProvider>
+				<PrivacyContext.Provider
+					value={{
+						privacyEnabled: getPrivacyPreference(),
+						privacySessionMapRef: appState.privacySessionMapRef,
+					}}
+				>
+					<InteractiveApp
+						altScreenActive={altScreenActive}
+						appState={appState}
+						chatHandler={chatHandler}
+						modeHandlers={modeHandlers}
+						appHandlers={appHandlers}
+						vscodeServer={vscodeServer}
+						staticComponents={staticComponents}
+						clearKey={conversationId}
+						liveComponent={liveComponent}
+						pendingSubagentApproval={pendingSubagentApproval}
+						handleSubagentToolApproval={handleSubagentToolApproval}
+						pendingToolConfirmation={pendingToolConfirmation}
+						handleToolConfirmation={handleToolConfirmation}
+						handleQuestionAnswer={handleQuestionAnswer}
+						handleUserSubmit={handleUserSubmit}
+						userMessageQueue={userMessageQueue}
+						handleIdeSelect={handleIdeSelect}
+					/>
+				</PrivacyContext.Provider>
 			</TitleShapeContext.Provider>
 		</ThemeContext.Provider>
 	);

--- a/source/app/components/chat-history.spec.tsx
+++ b/source/app/components/chat-history.spec.tsx
@@ -1,8 +1,11 @@
 import test from 'ava';
 import React from 'react';
+import {wheelEvents} from '@/utils/terminal-mouse';
 import {renderWithTheme} from '../../test-utils/render-with-theme';
 import {ChatHistory} from './chat-history';
 import type {ChatHistoryProps} from './chat-history';
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 30));
 
 function createDefaultProps(
 	overrides: Partial<ChatHistoryProps> = {},
@@ -56,4 +59,149 @@ test('ChatHistory does not render content when startChat is false', t => {
 	// Content should not include the static component text
 	t.false(output?.includes('Should Not Show'));
 	unmount();
+});
+
+// ============================================================================
+// Fullscreen mode: banner splitting, scroll gating (PageUp/PageDown, mouse
+// wheel), and the /clear reset key.
+// ============================================================================
+
+test('fullscreen mode splits the first static component out as the banner', t => {
+	const props = createDefaultProps({
+		fullscreen: true,
+		staticComponents: [
+			<div key="banner">BANNER-MARKER</div>,
+			<div key="rest">REST-MARKER</div>,
+		],
+	});
+	const {lastFrame, unmount} = renderWithTheme(<ChatHistory {...props} />);
+	const output = lastFrame() ?? '';
+	t.regex(output, /BANNER-MARKER/);
+	t.regex(output, /REST-MARKER/);
+	unmount();
+});
+
+test('inline mode keeps the banner as part of staticComponents (not split out)', t => {
+	const props = createDefaultProps({
+		fullscreen: false,
+		staticComponents: [<div key="banner">BANNER-MARKER</div>],
+	});
+	const {lastFrame, unmount} = renderWithTheme(<ChatHistory {...props} />);
+	t.regex(lastFrame() ?? '', /BANNER-MARKER/);
+	unmount();
+});
+
+test('fullscreen + scrollActive does not crash on PageUp/PageDown and stays stable when nothing overflows', t => {
+	const props = createDefaultProps({
+		fullscreen: true,
+		scrollActive: true,
+		staticComponents: [<div key="only">short content</div>],
+	});
+	const {stdin, lastFrame, unmount} = renderWithTheme(
+		<ChatHistory {...props} />,
+	);
+	const before = lastFrame();
+	t.notThrows(() => stdin.write('[5~')); // PageUp
+	t.notThrows(() => stdin.write('[6~')); // PageDown
+	t.truthy(before);
+	unmount();
+});
+
+test('PageUp is ignored (no crash, no indicator) when scrollActive is false, even in fullscreen', async t => {
+	const props = createDefaultProps({
+		fullscreen: true,
+		scrollActive: false,
+		staticComponents: Array.from({length: 5}, (_, i) => (
+			<div key={i}>{`line-${i}`}</div>
+		)),
+	});
+	const {stdin, lastFrame, unmount} = renderWithTheme(
+		<ChatHistory {...props} />,
+	);
+	const before = lastFrame();
+	stdin.write('[5~'); // PageUp
+	await tick();
+	const after = lastFrame();
+	// No scroll-position indicator text should ever appear — the useInput
+	// handler is inactive (isActive: fullscreen && scrollActive).
+	t.notRegex(after ?? '', /PgUp\/PgDn/);
+	t.is(before, after);
+	unmount();
+});
+
+test('PageUp is ignored (no crash) when fullscreen is false, even if scrollActive is true', async t => {
+	const props = createDefaultProps({
+		fullscreen: false,
+		scrollActive: true,
+		staticComponents: [<div key="only">inline content</div>],
+	});
+	const {stdin, lastFrame, unmount} = renderWithTheme(
+		<ChatHistory {...props} />,
+	);
+	stdin.write('[5~');
+	await tick();
+	t.notRegex(lastFrame() ?? '', /PgUp\/PgDn/);
+	unmount();
+});
+
+test('mouse wheel ticks are ignored when scrollActive is false (no subscription side effects)', async t => {
+	const props = createDefaultProps({
+		fullscreen: true,
+		scrollActive: false,
+		staticComponents: [<div key="only">content</div>],
+	});
+	const {lastFrame, unmount} = renderWithTheme(<ChatHistory {...props} />);
+	const before = lastFrame();
+	t.notThrows(() => {
+		wheelEvents.emit('wheel', 'up');
+		wheelEvents.emit('wheel', 'down');
+	});
+	await tick();
+	t.is(lastFrame(), before);
+	unmount();
+});
+
+test('mouse wheel ticks do not throw when active in fullscreen mode', async t => {
+	const props = createDefaultProps({
+		fullscreen: true,
+		scrollActive: true,
+		staticComponents: [<div key="only">content</div>],
+	});
+	const {unmount} = renderWithTheme(<ChatHistory {...props} />);
+	t.notThrows(() => {
+		wheelEvents.emit('wheel', 'up');
+		wheelEvents.emit('wheel', 'down');
+	});
+	await tick();
+	unmount();
+});
+
+test('unmounting a fullscreen+scrollActive instance detaches its wheel listener (no leak across instances)', async t => {
+	const propsA = createDefaultProps({
+		fullscreen: true,
+		scrollActive: true,
+		staticComponents: [<div key="a">A</div>],
+	});
+	const before = wheelEvents.listenerCount('wheel');
+	const {unmount} = renderWithTheme(<ChatHistory {...propsA} />);
+	t.true(wheelEvents.listenerCount('wheel') > before);
+	unmount();
+	await tick();
+	t.is(wheelEvents.listenerCount('wheel'), before);
+});
+
+test('clearKey prop is accepted and does not change output for equal transcripts', t => {
+	const propsA = createDefaultProps({
+		clearKey: 'session-1',
+		staticComponents: [<div key="s">same content</div>],
+	});
+	const propsB = createDefaultProps({
+		clearKey: 'session-2',
+		staticComponents: [<div key="s">same content</div>],
+	});
+	const a = renderWithTheme(<ChatHistory {...propsA} />);
+	const b = renderWithTheme(<ChatHistory {...propsB} />);
+	t.is(a.lastFrame(), b.lastFrame());
+	a.unmount();
+	b.unmount();
 });

--- a/source/app/components/chat-history.tsx
+++ b/source/app/components/chat-history.tsx
@@ -1,7 +1,10 @@
-import {Box} from 'ink';
+import {Box, measureElement, Text, useInput} from 'ink';
 import React from 'react';
 import ChatQueue from '@/components/chat-queue';
 import {RenderErrorBoundary} from '@/components/render-error-boundary';
+import {useTerminalRows} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+import {wheelEvents} from '@/utils/terminal-mouse';
 
 export interface ChatHistoryProps {
 	/** Whether the chat has started (ready to display) */
@@ -10,38 +13,151 @@ export interface ChatHistoryProps {
 	staticComponents: React.ReactNode[];
 	/** Dynamic components added during the chat session */
 	queuedComponents: React.ReactNode[];
-	/** Live component that renders outside Static (for real-time updates) */
+	/** Live component rendered below the transcript (streaming updates) */
 	liveComponent?: React.ReactNode;
 	renderLastQueuedComponentLive?: boolean;
+	/** Key to force a full transcript reset (e.g., on /clear) */
+	clearKey?: string;
+	/**
+	 * Fullscreen (alternate-screen) mode: render a bottom-anchored viewport
+	 * that clips overflowing history at the top, instead of an append-only
+	 * Static transcript. Ink's Static is useless on the alternate screen —
+	 * the alt buffer has no scrollback for it to print into.
+	 */
+	fullscreen?: boolean;
+	/**
+	 * Whether PageUp/PageDown scrolling is active. Off while a modal
+	 * (model selector, wizard, explorer) is open so those keys reach the
+	 * modal instead — Ink runs ALL useInput handlers for every keypress.
+	 */
+	scrollActive?: boolean;
 }
 
 /**
- * Chat history component that displays frozen and dynamic chat content.
+ * Chat history for two rendering worlds:
  *
- * IMPORTANT: This component should NEVER be conditionally unmounted.
- * It contains ink's Static component which holds frozen terminal output.
- * Unmounting causes the Static content to be destroyed and recreated,
- * leading to memory issues and visual glitches.
+ * - Fullscreen (interactive TUI on the alt screen): a fixed-height viewport.
+ *   Content is bottom-anchored via justifyContent="flex-end"; when it grows
+ *   taller than the viewport, the top (banner, oldest messages) clips away —
+ *   the same model OpenClaude/Codex use for their fullscreen modes. The
+ *   inner wrapper MUST keep flexShrink={0}: without it Yoga shrinks each
+ *   child to fit and every other line disappears. PageUp/PageDown scroll
+ *   the viewport by applying a negative marginBottom to the content, which
+ *   pushes it down past the clip edge and reveals older rows at the top.
  *
- * Use ChatInput separately for the input area, which can mount/unmount freely.
+ * - Transcript (non-interactive `run` mode, main screen buffer): the classic
+ *   Ink Static append-only flow, which prints finished turns into the
+ *   terminal's native scrollback.
  */
-export function ChatHistory({
+export const ChatHistory = React.memo(function ChatHistory({
 	startChat,
 	staticComponents,
 	queuedComponents,
 	liveComponent,
 	renderLastQueuedComponentLive,
+	clearKey,
+	fullscreen = false,
+	scrollActive = false,
 }: ChatHistoryProps): React.ReactElement {
-	return (
-		<Box flexGrow={1} flexDirection="column" minHeight={0}>
-			{startChat && (
-				<ChatQueue
-					staticComponents={staticComponents}
-					queuedComponents={queuedComponents}
-					renderLastQueuedComponentLive={renderLastQueuedComponentLive}
-				/>
+	const {colors} = useTheme();
+	const terminalRows = useTerminalRows();
+	const viewportRef = React.useRef(null);
+	const contentRef = React.useRef(null);
+	const [scrollOffset, setScrollOffset] = React.useState(0);
+
+	// New content or a vertical resize snaps the view back to the bottom
+	// (sticky scroll) — matching every chat TUI's behavior.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: the deps are intentional TRIGGERS (new chat content / resize), not values read inside the effect.
+	React.useEffect(() => {
+		setScrollOffset(0);
+	}, [queuedComponents, liveComponent, terminalRows]);
+
+	// Scroll by `delta` rows (positive = towards older content), clamped to
+	// the measured content extent. Shared by PageUp/PageDown and the mouse
+	// wheel. `halfPage: true` scales the step to half the viewport height.
+	const scrollBy = React.useCallback((delta: number, halfPage = false) => {
+		const viewport = viewportRef.current
+			? measureElement(viewportRef.current)
+			: undefined;
+		const content = contentRef.current
+			? measureElement(contentRef.current)
+			: undefined;
+		const viewportHeight = viewport?.height ?? 0;
+		const contentHeight = content?.height ?? 0;
+		const maxOffset = Math.max(0, contentHeight - viewportHeight);
+		const step = halfPage
+			? Math.max(1, Math.floor(viewportHeight / 2)) * Math.sign(delta)
+			: delta;
+
+		setScrollOffset(current => {
+			if (step > 0) return Math.min(current + step, maxOffset);
+			// The indicator row shifts the viewport height by 1 between
+			// scrolled/unscrolled states, so clamping can strand the view
+			// a couple of rows above the bottom — snap those to 0.
+			const next = Math.max(current + step, 0);
+			return next <= 2 ? 0 : next;
+		});
+	}, []);
+
+	useInput(
+		(_input, key) => {
+			if (key.pageUp) scrollBy(1, true);
+			else if (key.pageDown) scrollBy(-1, true);
+		},
+		{isActive: fullscreen && scrollActive},
+	);
+
+	// Mouse wheel (SGR mouse reporting, stripped from stdin in cli.tsx and
+	// re-emitted on this bus). Three rows per tick, like most pagers.
+	React.useEffect(() => {
+		if (!fullscreen || !scrollActive) return;
+		const onWheel = (direction: 'up' | 'down') => {
+			scrollBy(direction === 'up' ? 3 : -3);
+		};
+		wheelEvents.on('wheel', onWheel);
+		return () => {
+			wheelEvents.off('wheel', onWheel);
+		};
+	}, [fullscreen, scrollActive, scrollBy]);
+
+	// Fullscreen: the banner renders in regular flow as the first row of the
+	// scrolling content (it clips away with old history, like OpenClaude).
+	// Inline: the banner stays INSIDE Static so it prints exactly once into
+	// the terminal's native scrollback — rendering it in the live region was
+	// the original "banner disappears" bug: Ink erases and rewrites the
+	// whole non-Static region on every keystroke, and clips its top first
+	// once it outgrows the terminal.
+	const banner = fullscreen ? staticComponents[0] : undefined;
+	const frozenComponents = React.useMemo(
+		() => (fullscreen ? staticComponents.slice(1) : staticComponents),
+		[fullscreen, staticComponents],
+	);
+
+	const chatQueueProps = React.useMemo(
+		() => ({
+			staticComponents: frozenComponents,
+			queuedComponents,
+			renderLastQueuedComponentLive,
+			clearKey,
+			disableStatic: fullscreen,
+		}),
+		[
+			frozenComponents,
+			queuedComponents,
+			renderLastQueuedComponentLive,
+			clearKey,
+			fullscreen,
+		],
+	);
+
+	const content = (
+		<>
+			{startChat && banner && (
+				<RenderErrorBoundary label="banner">{banner}</RenderErrorBoundary>
 			)}
-			{/* Live component renders outside Static for real-time updates */}
+
+			{startChat && <ChatQueue {...chatQueueProps} />}
+
 			{liveComponent && (
 				<Box marginLeft={-1} flexDirection="column">
 					<RenderErrorBoundary label="live">
@@ -49,6 +165,49 @@ export function ChatHistory({
 					</RenderErrorBoundary>
 				</Box>
 			)}
+		</>
+	);
+
+	if (!fullscreen) {
+		return (
+			<Box flexGrow={1} flexDirection="column" minHeight={0}>
+				{content}
+			</Box>
+		);
+	}
+
+	return (
+		// flexBasis={0} is load-bearing: without it the flex basis is the
+		// full transcript height, so Yoga shrinks the input/status footer
+		// proportionally along with the chat area and crushes it. Basis 0 +
+		// grow 1 means this box only ever receives the space left over
+		// after the (flexShrink=0) footer takes its natural height.
+		<Box flexGrow={1} flexBasis={0} flexDirection="column" minHeight={0}>
+			{scrollOffset > 0 && (
+				<Box flexShrink={0}>
+					<Text color={colors.secondary}>
+						{`── ↑ ${scrollOffset} rows · PgUp/PgDn · new output returns to bottom ──`}
+					</Text>
+				</Box>
+			)}
+			<Box
+				ref={viewportRef}
+				flexGrow={1}
+				flexBasis={0}
+				flexDirection="column"
+				minHeight={0}
+				overflow="hidden"
+				justifyContent="flex-end"
+			>
+				<Box
+					ref={contentRef}
+					flexDirection="column"
+					flexShrink={0}
+					marginBottom={-scrollOffset}
+				>
+					{content}
+				</Box>
+			</Box>
 		</Box>
 	);
-}
+});

--- a/source/app/components/chat-history.tsx
+++ b/source/app/components/chat-history.tsx
@@ -159,7 +159,10 @@ export const ChatHistory = React.memo(function ChatHistory({
 			{startChat && <ChatQueue {...chatQueueProps} />}
 
 			{liveComponent && (
-				<Box marginLeft={-1} flexDirection="column">
+				// Inline: Static renders at column 0, so live content shifts -1 to
+				// match. Fullscreen: viewport already starts at column 1 (Static
+				// disabled), so no compensation is needed.
+				<Box marginLeft={fullscreen ? 0 : -1} flexDirection="column">
 					<RenderErrorBoundary label="live">
 						{liveComponent}
 					</RenderErrorBoundary>

--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -10,6 +10,8 @@ import type {useChatHandler} from '@/hooks/chat-handler';
 import type {AppHandlers} from '@/hooks/useAppHandlers';
 import type {useAppState} from '@/hooks/useAppState';
 import type {useModeHandlers} from '@/hooks/useModeHandlers';
+import {useTerminalRows} from '@/hooks/useTerminalWidth';
+import {UIStateProvider} from '@/hooks/useUIState';
 import type {useUserMessageQueue} from '@/hooks/useUserMessageQueue';
 import type {useVSCodeServer} from '@/hooks/useVSCodeServer';
 import type {ImageAttachment} from '@/types/core';
@@ -38,6 +40,13 @@ interface InteractiveAppProps {
 	) => Promise<void>;
 	userMessageQueue: ReturnType<typeof useUserMessageQueue>;
 	handleIdeSelect: (ide: string) => void;
+	clearKey?: string;
+	/**
+	 * Whether the terminal is on the alternate screen buffer (set by
+	 * cli.tsx). Drives the fullscreen fixed-height layout; false renders
+	 * the inline Static-based flow with native scrollback.
+	 */
+	altScreenActive?: boolean;
 }
 
 /**
@@ -62,6 +71,8 @@ export function InteractiveApp({
 	handleUserSubmit,
 	userMessageQueue,
 	handleIdeSelect,
+	clearKey,
+	altScreenActive = false,
 }: InteractiveAppProps): React.ReactElement {
 	const nextRestoredDraftIdRef = React.useRef(1);
 	const [submittedDraft, setSubmittedDraft] =
@@ -236,114 +247,146 @@ export function InteractiveApp({
 		{isActive: cancellable},
 	);
 
+	// Fullscreen layout if and only if cli.tsx put us on the alternate
+	// screen. Inline mode (--no-alt-screen / alternateScreen:false pref),
+	// test renderers, and piped stdout all use the classic flow layout
+	// with Static + native scrollback.
+	const fullscreen = altScreenActive;
+	const terminalRows = useTerminalRows();
+
 	return (
-		<Box flexDirection="column" padding={1} width="100%">
-			{/* Chat History - ALWAYS rendered to keep Static content stable */}
+		// Fullscreen layout on the alternate screen buffer: the root Box is
+		// pinned to the exact terminal height so the frame can never exceed
+		// the viewport. The chat area (ChatHistory) flexes and clips at the
+		// top; everything below it (modals, status line, input) keeps its
+		// natural height, so Yoga shrinks the chat area to make room — the
+		// input can never be pushed off-screen.
+		<Box
+			flexDirection="column"
+			padding={1}
+			width="100%"
+			height={fullscreen ? terminalRows : undefined}
+		>
+			{/* Chat area — fullscreen bottom-anchored viewport */}
 			<ChatHistory
 				startChat={appState.startChat}
 				staticComponents={staticComponents}
 				queuedComponents={appState.chatComponents}
 				liveComponent={liveComponent}
 				renderLastQueuedComponentLive={recallableSubmittedDraft}
+				clearKey={clearKey}
+				fullscreen={fullscreen}
+				scrollActive={
+					!showModalSelectors &&
+					!appState.isExplorerMode &&
+					!appState.isIdeSelectionMode
+				}
 			/>
 
-			{appState.planReviewState?.show && (
-				<PlanReviewPrompt
-					onProceed={appHandlers.handlePlanProceed}
-					onAskMore={() => void appHandlers.handlePlanAskMore()}
-					onModify={appHandlers.handlePlanModify}
-					onDismiss={appHandlers.handlePlanModify}
-				/>
-			)}
-
-			{appState.isExplorerMode && (
-				<Box marginLeft={-1} flexDirection="column">
-					<FileExplorer onClose={modeHandlers.handleExplorerCancel} />
-				</Box>
-			)}
-
-			{appState.isIdeSelectionMode && (
-				<Box marginLeft={-1} flexDirection="column">
-					<IdeSelector
-						onSelect={handleIdeSelect}
-						onCancel={modeHandlers.handleIdeSelectionCancel}
-					/>
-				</Box>
-			)}
-
-			{showModalSelectors && (
-				<Box marginLeft={-1} flexDirection="column">
-					<ModalSelectors
-						activeMode={appState.activeMode}
-						isSettingsMode={appState.isSettingsMode}
-						showAllSessions={appState.showAllSessions}
-						currentModel={appState.currentModel}
-						currentProvider={appState.currentProvider}
-						checkpointLoadData={appState.checkpointLoadData}
-						onModelSelect={modeHandlers.handleModelSelect}
-						onModelSelectionCancel={modeHandlers.handleModelSelectionCancel}
-						onModelDatabaseCancel={modeHandlers.handleModelDatabaseCancel}
-						onConfigWizardComplete={modeHandlers.handleConfigWizardComplete}
-						onConfigWizardCancel={modeHandlers.handleConfigWizardCancel}
-						onMcpWizardComplete={modeHandlers.handleMcpWizardComplete}
-						onMcpWizardCancel={modeHandlers.handleMcpWizardCancel}
-						onSettingsCancel={modeHandlers.handleSettingsCancel}
-						tuneConfig={appState.tune}
-						onTuneSelect={modeHandlers.handleTuneSelect}
-						onTuneCancel={modeHandlers.handleTuneCancel}
-						onCheckpointSelect={appHandlers.handleCheckpointSelect}
-						onCheckpointCancel={appHandlers.handleCheckpointCancel}
-						onSessionSelect={sessionId =>
-							void appHandlers.handleSessionSelect(sessionId)
-						}
-						onSessionCancel={appHandlers.handleSessionCancel}
-					/>
-				</Box>
-			)}
-
-			{appState.startChat &&
-				appState.activeMode === null &&
-				!appState.isSettingsMode &&
-				!appState.planReviewState?.show && (
-					<ChatInput
-						isCancelling={appState.isCancelling}
-						isToolExecuting={appState.isToolExecuting}
-						isQuestionMode={appState.isQuestionMode}
-						pendingToolCalls={appState.pendingToolCalls}
-						currentToolIndex={appState.currentToolIndex}
-						pendingQuestion={appState.pendingQuestion}
-						onQuestionAnswer={handleQuestionAnswer}
-						mcpInitialized={appState.mcpInitialized}
-						client={appState.client}
-						customCommands={Array.from(appState.customCommandCache.keys())}
-						inputDisabled={false}
-						onSubmittedDraft={handleSubmittedDraft}
-						restoreSubmittedDraft={restoredDraft}
-						queuedMessages={userMessageQueue.queuedMessages}
-						onQueueMessage={userMessageQueue.enqueueMessage}
-						onRemoveQueuedMessage={userMessageQueue.removeMessage}
-						isBusy={cancellable}
-						developmentMode={appState.developmentMode}
-						contextPercentUsed={appState.contextPercentUsed}
-						contextSource={appState.contextSource}
-						sessionName={appState.sessionName || undefined}
-						compactToolCounts={appState.compactToolCounts}
-						compactToolDisplay={appState.compactToolDisplay}
-						liveTaskList={appState.liveTaskList}
-						onToggleCompactDisplay={handleToggleCompactDisplay}
-						pendingSubagentApproval={pendingSubagentApproval}
-						onSubagentToolApproval={handleSubagentToolApproval}
-						pendingToolConfirmation={pendingToolConfirmation}
-						onToolConfirmation={handleToolConfirmation}
-						onSubmit={handleUserSubmit}
-						activeEditor={vscodeServer.activeEditor}
-						onDismissActiveEditor={vscodeServer.dismissActiveEditor}
-						onToggleMode={appHandlers.handleToggleDevelopmentMode}
-						onToggleReasoningExpanded={handleToggleReasoningExpanded}
-						tune={appState.tune}
-						currentModel={appState.currentModel}
+			{/* Footer: modals, input. flexShrink=0 so the chat viewport above
+			    absorbs ALL vertical shrink — without it Yoga crushes the
+			    input box when the transcript is tall. */}
+			<Box flexDirection="column" flexShrink={0}>
+				{appState.planReviewState?.show && (
+					<PlanReviewPrompt
+						onProceed={appHandlers.handlePlanProceed}
+						onAskMore={() => void appHandlers.handlePlanAskMore()}
+						onModify={appHandlers.handlePlanModify}
+						onDismiss={appHandlers.handlePlanModify}
 					/>
 				)}
+
+				{appState.isExplorerMode && (
+					<Box marginLeft={-1} flexDirection="column">
+						<FileExplorer onClose={modeHandlers.handleExplorerCancel} />
+					</Box>
+				)}
+
+				{appState.isIdeSelectionMode && (
+					<Box marginLeft={-1} flexDirection="column">
+						<IdeSelector
+							onSelect={handleIdeSelect}
+							onCancel={modeHandlers.handleIdeSelectionCancel}
+						/>
+					</Box>
+				)}
+
+				{showModalSelectors && (
+					<Box marginLeft={-1} flexDirection="column">
+						<ModalSelectors
+							activeMode={appState.activeMode}
+							isSettingsMode={appState.isSettingsMode}
+							showAllSessions={appState.showAllSessions}
+							currentModel={appState.currentModel}
+							currentProvider={appState.currentProvider}
+							checkpointLoadData={appState.checkpointLoadData}
+							onModelSelect={modeHandlers.handleModelSelect}
+							onModelSelectionCancel={modeHandlers.handleModelSelectionCancel}
+							onModelDatabaseCancel={modeHandlers.handleModelDatabaseCancel}
+							onConfigWizardComplete={modeHandlers.handleConfigWizardComplete}
+							onConfigWizardCancel={modeHandlers.handleConfigWizardCancel}
+							onMcpWizardComplete={modeHandlers.handleMcpWizardComplete}
+							onMcpWizardCancel={modeHandlers.handleMcpWizardCancel}
+							onSettingsCancel={modeHandlers.handleSettingsCancel}
+							tuneConfig={appState.tune}
+							onTuneSelect={modeHandlers.handleTuneSelect}
+							onTuneCancel={modeHandlers.handleTuneCancel}
+							onCheckpointSelect={appHandlers.handleCheckpointSelect}
+							onCheckpointCancel={appHandlers.handleCheckpointCancel}
+							onSessionSelect={sessionId =>
+								void appHandlers.handleSessionSelect(sessionId)
+							}
+							onSessionCancel={appHandlers.handleSessionCancel}
+						/>
+					</Box>
+				)}
+
+				{appState.startChat &&
+					appState.activeMode === null &&
+					!appState.isSettingsMode &&
+					!appState.planReviewState?.show && (
+						<UIStateProvider>
+							<ChatInput
+								isCancelling={appState.isCancelling}
+								isToolExecuting={appState.isToolExecuting}
+								isQuestionMode={appState.isQuestionMode}
+								pendingToolCalls={appState.pendingToolCalls}
+								currentToolIndex={appState.currentToolIndex}
+								pendingQuestion={appState.pendingQuestion}
+								onQuestionAnswer={handleQuestionAnswer}
+								mcpInitialized={appState.mcpInitialized}
+								client={appState.client}
+								customCommands={Array.from(appState.customCommandCache.keys())}
+								inputDisabled={false}
+								onSubmittedDraft={handleSubmittedDraft}
+								restoreSubmittedDraft={restoredDraft}
+								queuedMessages={userMessageQueue.queuedMessages}
+								onQueueMessage={userMessageQueue.enqueueMessage}
+								onRemoveQueuedMessage={userMessageQueue.removeMessage}
+								isBusy={cancellable}
+								developmentMode={appState.developmentMode}
+								contextPercentUsed={appState.contextPercentUsed}
+								contextSource={appState.contextSource}
+								sessionName={appState.sessionName || undefined}
+								compactToolCounts={appState.compactToolCounts}
+								compactToolDisplay={appState.compactToolDisplay}
+								liveTaskList={appState.liveTaskList}
+								onToggleCompactDisplay={handleToggleCompactDisplay}
+								pendingSubagentApproval={pendingSubagentApproval}
+								onSubagentToolApproval={handleSubagentToolApproval}
+								pendingToolConfirmation={pendingToolConfirmation}
+								onToolConfirmation={handleToolConfirmation}
+								onSubmit={handleUserSubmit}
+								activeEditor={vscodeServer.activeEditor}
+								onDismissActiveEditor={vscodeServer.dismissActiveEditor}
+								onToggleMode={appHandlers.handleToggleDevelopmentMode}
+								onToggleReasoningExpanded={handleToggleReasoningExpanded}
+								tune={appState.tune}
+								currentModel={appState.currentModel}
+							/>
+						</UIStateProvider>
+					)}
+			</Box>
 		</Box>
 	);
 }

--- a/source/app/types.ts
+++ b/source/app/types.ts
@@ -35,6 +35,13 @@ export interface AppProps {
 	 * is ephemeral — preferences are not modified.
 	 */
 	trustDirectory?: boolean;
+	/**
+	 * Whether cli.tsx put the terminal on the alternate screen buffer for
+	 * this run. Drives the fullscreen (fixed-height, in-app scroll) layout;
+	 * when false the interactive UI renders inline with Ink's Static and
+	 * the terminal's native scrollback.
+	 */
+	altScreenActive?: boolean;
 }
 
 /**

--- a/source/app/utils/app-util.ts
+++ b/source/app/utils/app-util.ts
@@ -274,7 +274,8 @@ async function handleSpecialCommand(
 		case SPECIAL_COMMANDS.CLEAR:
 			await onClearMessages();
 			await clearAllTasks();
-			onAddToChatQueue(successMsg('Chat and tasks cleared.', 'clear-success'));
+			// Increment clear counter to force re-render of static components
+			options.onClearCounterIncrement?.();
 			setTimeout(() => onCommandComplete?.(), DELAY_COMMAND_COMPLETE_MS);
 			return true;
 

--- a/source/cli.spec.ts
+++ b/source/cli.spec.ts
@@ -346,3 +346,102 @@ test('plain mode: --vscode suppresses auto-detection', t => {
 	t.false(plainMode);
 	t.true(vscodeMode);
 });
+
+// --alt-screen / --no-alt-screen flag tests. The resolution rule mirrors
+// the logic in cli.tsx: --no-alt-screen always wins (forces inline), then
+// --alt-screen or the "alternateScreen" preference opt in, and the whole
+// thing is gated on being an interactive TTY session (never in
+// nonInteractiveMode, e.g. `run`, and never off a real TTY).
+function resolveAltScreenMode(opts: {
+	args: string[];
+	stdoutIsTTY: boolean;
+	nonInteractiveMode: boolean;
+	preferenceAlternateScreen: boolean;
+}): boolean {
+	const {args, stdoutIsTTY, nonInteractiveMode, preferenceAlternateScreen} =
+		opts;
+	const altScreenAllowed =
+		!args.includes('--no-alt-screen') &&
+		(args.includes('--alt-screen') || preferenceAlternateScreen === true);
+	return stdoutIsTTY && !nonInteractiveMode && altScreenAllowed;
+}
+
+test('alt-screen: off by default (no flag, no preference)', t => {
+	const useAltScreen = resolveAltScreenMode({
+		args: [],
+		stdoutIsTTY: true,
+		nonInteractiveMode: false,
+		preferenceAlternateScreen: false,
+	});
+	t.false(useAltScreen);
+});
+
+test('alt-screen: --alt-screen flag turns it on over a TTY', t => {
+	const useAltScreen = resolveAltScreenMode({
+		args: ['--alt-screen'],
+		stdoutIsTTY: true,
+		nonInteractiveMode: false,
+		preferenceAlternateScreen: false,
+	});
+	t.true(useAltScreen);
+});
+
+test('alt-screen: "alternateScreen" preference turns it on without the flag', t => {
+	const useAltScreen = resolveAltScreenMode({
+		args: [],
+		stdoutIsTTY: true,
+		nonInteractiveMode: false,
+		preferenceAlternateScreen: true,
+	});
+	t.true(useAltScreen);
+});
+
+test('alt-screen: --no-alt-screen overrides the flag', t => {
+	const useAltScreen = resolveAltScreenMode({
+		args: ['--alt-screen', '--no-alt-screen'],
+		stdoutIsTTY: true,
+		nonInteractiveMode: false,
+		preferenceAlternateScreen: false,
+	});
+	t.false(useAltScreen);
+});
+
+test('alt-screen: --no-alt-screen overrides the persisted preference', t => {
+	const useAltScreen = resolveAltScreenMode({
+		args: ['--no-alt-screen'],
+		stdoutIsTTY: true,
+		nonInteractiveMode: false,
+		preferenceAlternateScreen: true,
+	});
+	t.false(useAltScreen);
+});
+
+test('alt-screen: never enabled off a non-TTY, even with the flag', t => {
+	const useAltScreen = resolveAltScreenMode({
+		args: ['--alt-screen'],
+		stdoutIsTTY: false,
+		nonInteractiveMode: false,
+		preferenceAlternateScreen: false,
+	});
+	t.false(useAltScreen);
+});
+
+test('alt-screen: never enabled for non-interactive `run` mode, even with the flag', t => {
+	const useAltScreen = resolveAltScreenMode({
+		args: ['--alt-screen'],
+		stdoutIsTTY: true,
+		nonInteractiveMode: true,
+		preferenceAlternateScreen: false,
+	});
+	t.false(useAltScreen);
+});
+
+test('alt-screen: flag and preference both true is not double-negated', t => {
+	const useAltScreen = resolveAltScreenMode({
+		args: ['--alt-screen'],
+		stdoutIsTTY: true,
+		nonInteractiveMode: false,
+		preferenceAlternateScreen: true,
+	});
+	t.true(useAltScreen);
+});

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -84,6 +84,11 @@ Options:
   --plain             Use a lightweight, Ink-free runtime for non-interactive runs.
                       Only valid with the "run" command. Auto-enables in CI / non-TTY.
   --no-plain          Force the Ink runtime even in CI / non-TTY environments.
+  --alt-screen        Fullscreen TUI on the alternate screen buffer with in-app
+                      scrolling (mouse wheel / PgUp / PgDn). Persistent version:
+                      "alternateScreen": true in preferences.json.
+  --no-alt-screen     Force the default inline mode (main screen, chat history in
+                      the terminal's native scrollback), overriding the preference.
   --json              Output execution results as a single well-formed JSON object to stdout.
                       Only valid with the "run" command.
   --output-format     Specify stdout format ('text' or 'json'). Synonym for --json.
@@ -298,6 +303,8 @@ async function main(): Promise<void> {
 				continue; // skip this flag
 			} else if (arg === '--plain' || arg === '--no-plain') {
 				continue; // skip this flag
+			} else if (arg === '--no-alt-screen' || arg === '--alt-screen') {
+				continue; // skip this flag
 			} else if (arg === '--web' || arg === '--gui') {
 				continue; // skip this flag
 			} else {
@@ -446,7 +453,82 @@ async function main(): Promise<void> {
 		// bound during long Ink sessions. See issue #521.
 		const {installPerfBufferGuard} = await import('@/utils/perf-buffer');
 		installPerfBufferGuard();
-		render(
+
+		// Switch to alternate screen buffer (like vim/less/htop) for the
+		// interactive TUI only. Run mode (`nanocoder run …`) prints a
+		// transcript the user needs to keep after exit — the alt screen
+		// would discard it when restoring the original buffer.
+		// Screen mode: inline (main screen + native scrollback) by DEFAULT —
+		// the terminal's own scrollbar, wheel, and search work there.
+		// Fullscreen (alt screen + in-app scroll) is opt-in via --alt-screen
+		// or the alternateScreen:true preference; --no-alt-screen forces
+		// inline regardless of the preference.
+		const {loadPreferences} = await import('@/config/preferences');
+		const altScreenAllowed =
+			!args.includes('--no-alt-screen') &&
+			(args.includes('--alt-screen') ||
+				loadPreferences().alternateScreen === true);
+		const useAltScreen =
+			process.stdout.isTTY && !nonInteractiveMode && altScreenAllowed;
+		let inkStdin: NodeJS.ReadStream | undefined;
+		let stopInputForwarding: (() => void) | undefined;
+		if (useAltScreen) {
+			process.stdout.write('\x1B[?1049h'); // Enter alternate screen
+			// SGR mouse reporting so wheel scrolling reaches the app. The alt
+			// screen has no native scrollback, so the terminal's own wheel /
+			// scrollbar can't work — the app must receive wheel events itself.
+			// (Text selection needs Shift+drag while mouse reporting is on.)
+			process.stdout.write('\x1B[?1000h\x1B[?1006h');
+
+			// Wipe the screen on resize BEFORE Ink repaints (this listener is
+			// registered first, so it runs first). When the terminal GROWS,
+			// Ink's diff path only erases the old smaller frame and rewrites
+			// from a misaligned cursor, leaving stale rows on screen. A clear
+			// + home makes the next full-frame paint land on a clean buffer.
+			process.stdout.on('resize', () => {
+				process.stdout.write('\x1B[2J\x1B[H');
+			});
+
+			// Ink must never see the raw mouse sequences (its keypress parser
+			// would leak them into the chat input as text), so it reads from a
+			// filtered proxy stream: mouse reports are stripped, wheel ticks
+			// are re-emitted on the wheelEvents bus for the chat viewport.
+			const {PassThrough} = await import('node:stream');
+			const {stripMouseSequences, wheelEvents} = await import(
+				'@/utils/terminal-mouse'
+			);
+			const filtered = new PassThrough();
+			let carry = '';
+			const forwardInput = (chunk: Buffer | string) => {
+				const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+				const result = stripMouseSequences(text, carry);
+				carry = result.carry;
+				for (const direction of result.wheel) {
+					wheelEvents.emit('wheel', direction);
+				}
+				if (result.clean) {
+					filtered.write(result.clean);
+				}
+			};
+			process.stdin.on('data', forwardInput);
+			stopInputForwarding = () => {
+				process.stdin.off('data', forwardInput);
+				process.stdin.pause();
+			};
+			// TTY facade: Ink checks isTTY for raw-mode support and calls
+			// setRawMode/ref/unref — delegate those to the real stdin.
+			inkStdin = Object.assign(filtered, {
+				isTTY: true,
+				setRawMode: (mode: boolean) => {
+					process.stdin.setRawMode?.(mode);
+					return inkStdin;
+				},
+				ref: () => process.stdin.ref(),
+				unref: () => process.stdin.unref(),
+			}) as unknown as NodeJS.ReadStream;
+		}
+
+		const result = render(
 			<App
 				vscodeMode={vscodeMode}
 				vscodePort={vscodePort}
@@ -456,8 +538,54 @@ async function main(): Promise<void> {
 				cliModel={cliModel}
 				cliMode={cliMode}
 				trustDirectory={trustDirectory}
+				altScreenActive={useAltScreen}
 			/>,
+			{
+				// Ctrl+C is handled inside App (routed through the shutdown
+				// manager) so the exit-render handler below can paint the
+				// farewell frame before the process dies.
+				exitOnCtrlC: false,
+				...(inkStdin ? {stdin: inkStdin} : {}),
+			},
 		);
+
+		let terminalRestored = false;
+		const restoreTerminal = () => {
+			if (terminalRestored) return;
+			terminalRestored = true;
+			stopInputForwarding?.();
+			if (useAltScreen) {
+				// Mouse reporting off, then back to the main screen buffer.
+				process.stdout.write('\x1B[?1006l\x1B[?1000l\x1B[?1049l');
+			}
+		};
+
+		// On ANY graceful shutdown (Ctrl+C, /exit, fatal error): erase the
+		// live Ink region (input box, status lines — the Static transcript
+		// stays in the terminal), stop Ink from repainting, restore the
+		// screen mode, and leave a simple farewell. clear() BEFORE unmount()
+		// is deliberate: clear syncs the erased frame as current so
+		// unmount's final render skips rewriting it, and unmount prevents
+		// any late React state update (e.g. /exit's Goodbye message) from
+		// repainting over the farewell. Priority 0 = runs before other
+		// teardown.
+		const {getShutdownManager} = await import('@/utils/shutdown');
+		getShutdownManager().register({
+			name: 'tui-exit-render',
+			priority: 0,
+			handler: async () => {
+				result.clear();
+				result.unmount();
+				restoreTerminal();
+				process.stdout.write('Exiting...\n');
+			},
+		});
+
+		// Fallback restore for exit paths that bypass the shutdown manager
+		// (idempotent — the shutdown handler above usually runs first).
+		result.waitUntilExit().then(() => {
+			restoreTerminal();
+		});
 	}
 }
 

--- a/source/components/chat-queue.spec.tsx
+++ b/source/components/chat-queue.spec.tsx
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {Box} from 'ink';
+import {Box, Text} from 'ink';
 import {render} from 'ink-testing-library';
 import React from 'react';
 import ChatQueue from './chat-queue';
@@ -116,4 +116,162 @@ test('ChatQueue generates default key for component without key prop', t => {
 	t.notThrows(() => {
 		render(<ChatQueue staticComponents={components} queuedComponents={[]} />);
 	});
+});
+
+// ============================================================================
+// Fullscreen (disableStatic) path — used on the alt screen where Ink's
+// <Static> has no native scrollback to print into.
+// ============================================================================
+
+test('disableStatic renders staticComponents in regular flow instead of Static', t => {
+	const {lastFrame} = render(
+		<ChatQueue
+			staticComponents={[<Box key="1">Flow message</Box>]}
+			queuedComponents={[]}
+			disableStatic
+		/>,
+	);
+	t.regex(lastFrame() ?? '', /Flow message/);
+});
+
+test('disableStatic still renders the live (last-queued) component below the flow', t => {
+	const {lastFrame} = render(
+		<ChatQueue
+			staticComponents={[]}
+			queuedComponents={[
+				<Box key="frozen">Frozen part</Box>,
+				<Box key="live">Live part</Box>,
+			]}
+			renderLastQueuedComponentLive
+			disableStatic
+		/>,
+	);
+	const output = lastFrame() ?? '';
+	t.regex(output, /Frozen part/);
+	t.regex(output, /Live part/);
+});
+
+test('disableStatic caps the rendered tail at FULLSCREEN_TAIL_CAP (60) components', t => {
+	// 70 numbered items; only the last 60 (indices 10..69) should survive.
+	const components = Array.from({length: 70}, (_, i) => (
+		<Box key={`item-${i}`}>{`item-${i}`}</Box>
+	));
+
+	const {lastFrame} = render(
+		<ChatQueue
+			staticComponents={components}
+			queuedComponents={[]}
+			disableStatic
+		/>,
+	);
+	const output = lastFrame() ?? '';
+
+	t.false(output.includes('item-9\n') || /item-9$/.test(output));
+	t.notRegex(output, /\bitem-0\b/);
+	t.notRegex(output, /\bitem-9\b/);
+	t.regex(output, /\bitem-10\b/);
+	t.regex(output, /\bitem-69\b/);
+});
+
+test('disableStatic with fewer than 60 components renders all of them untouched', t => {
+	const components = Array.from({length: 5}, (_, i) => (
+		<Box key={`short-${i}`}>{`short-${i}`}</Box>
+	));
+	const {lastFrame} = render(
+		<ChatQueue
+			staticComponents={components}
+			queuedComponents={[]}
+			disableStatic
+		/>,
+	);
+	const output = lastFrame() ?? '';
+	for (let i = 0; i < 5; i++) {
+		t.regex(output, new RegExp(`\\bshort-${i}\\b`));
+	}
+});
+
+test('disableStatic falls back to `flow-${index}` key for components without a key', t => {
+	const NoKeyComponent = () => <Box>anonymous flow item</Box>;
+	t.notThrows(() => {
+		render(
+			<ChatQueue
+				staticComponents={[<NoKeyComponent />]}
+				queuedComponents={[]}
+				disableStatic
+			/>,
+		);
+	});
+});
+
+test('disableStatic renders nothing extra when both component lists are empty', t => {
+	const {lastFrame} = render(
+		<ChatQueue staticComponents={[]} queuedComponents={[]} disableStatic />,
+	);
+	t.is(lastFrame(), '');
+});
+
+// ============================================================================
+// clearKey — forces a fresh Ink <Static> instance on /clear
+// ============================================================================
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 30));
+
+test('changing clearKey remounts the Static-backed content (component key changes across renders)', async t => {
+	let mountCount = 0;
+	const TrackMount = () => {
+		React.useEffect(() => {
+			mountCount++;
+		}, []);
+		return <Text>tracked</Text>;
+	};
+
+	const {rerender} = render(
+		<ChatQueue
+			staticComponents={[<TrackMount key="tracked" />]}
+			queuedComponents={[]}
+			clearKey="session-1"
+		/>,
+	);
+	await tick();
+	t.is(mountCount, 1);
+
+	rerender(
+		<ChatQueue
+			staticComponents={[<TrackMount key="tracked" />]}
+			queuedComponents={[]}
+			clearKey="session-2"
+		/>,
+	);
+	await tick();
+	t.is(mountCount, 2);
+});
+
+test('same clearKey across rerenders does not remount the Static content', async t => {
+	let mountCount = 0;
+	const TrackMount = () => {
+		React.useEffect(() => {
+			mountCount++;
+		}, []);
+		return <Text>tracked</Text>;
+	};
+
+	const {rerender} = render(
+		<ChatQueue
+			staticComponents={[<TrackMount key="tracked" />]}
+			queuedComponents={[]}
+			clearKey="stable"
+		/>,
+	);
+	await tick();
+	t.is(mountCount, 1);
+
+	rerender(
+		<ChatQueue
+			staticComponents={[<TrackMount key="tracked" />]}
+			queuedComponents={[]}
+			clearKey="stable"
+		/>,
+	);
+	await tick();
+	t.is(mountCount, 1);
 });

--- a/source/components/chat-queue.tsx
+++ b/source/components/chat-queue.tsx
@@ -67,7 +67,7 @@ export default memo(function ChatQueue({
 					</RenderErrorBoundary>
 				))}
 				{liveQueuedComponents.length > 0 && (
-					<Box marginLeft={-1} flexDirection="column">
+					<Box flexDirection="column">
 						{liveQueuedComponents.map((component, index) => (
 							<RenderErrorBoundary
 								key={componentKey(component, `live-${index}`)}

--- a/source/components/chat-queue.tsx
+++ b/source/components/chat-queue.tsx
@@ -1,12 +1,35 @@
 import {Box, Static} from 'ink';
-import {memo, useMemo} from 'react';
+import {type Key, memo, type ReactNode, useMemo} from 'react';
 import {RenderErrorBoundary} from '@/components/render-error-boundary';
 import type {ChatQueueProps} from '@/types/index';
+
+/**
+ * In fullscreen mode only the visible bottom slice of the transcript can
+ * ever be seen (the viewport clips the rest), but Yoga still lays out every
+ * mounted component. Cap the rendered tail so layout cost stays bounded in
+ * long sessions. 60 components is comfortably more than any terminal is
+ * tall.
+ */
+const FULLSCREEN_TAIL_CAP = 60;
+
+const componentKey = (component: ReactNode, fallback: string): Key => {
+	if (
+		component &&
+		typeof component === 'object' &&
+		'key' in component &&
+		component.key
+	) {
+		return component.key;
+	}
+	return fallback;
+};
 
 export default memo(function ChatQueue({
 	staticComponents = [],
 	queuedComponents = [],
 	renderLastQueuedComponentLive = false,
+	clearKey,
+	disableStatic = false,
 }: ChatQueueProps) {
 	const {staticQueuedComponents, liveQueuedComponents} = useMemo(() => {
 		if (!renderLastQueuedComponentLive) {
@@ -22,56 +45,64 @@ export default memo(function ChatQueue({
 		};
 	}, [queuedComponents, renderLastQueuedComponentLive]);
 
-	// Move ALL messages to static - prevents any re-renders
-	// All messages are now immutable once rendered
+	// Combine static and queued components for Static rendering
 	const allStaticComponents = useMemo(
 		() => [...staticComponents, ...staticQueuedComponents],
 		[staticComponents, staticQueuedComponents],
 	);
 
+	// Fullscreen path: no Static — render a bounded tail in regular flow so
+	// the bottom-anchored viewport in ChatHistory can clip it at the top.
+	const flowComponents = useMemo(() => {
+		if (!disableStatic) return [];
+		return allStaticComponents.slice(-FULLSCREEN_TAIL_CAP);
+	}, [disableStatic, allStaticComponents]);
+
+	if (disableStatic) {
+		return (
+			<Box flexDirection="column">
+				{flowComponents.map((component, index) => (
+					<RenderErrorBoundary key={componentKey(component, `flow-${index}`)}>
+						{component}
+					</RenderErrorBoundary>
+				))}
+				{liveQueuedComponents.length > 0 && (
+					<Box marginLeft={-1} flexDirection="column">
+						{liveQueuedComponents.map((component, index) => (
+							<RenderErrorBoundary
+								key={componentKey(component, `live-${index}`)}
+							>
+								{component}
+							</RenderErrorBoundary>
+						))}
+					</Box>
+				)}
+			</Box>
+		);
+	}
+
 	return (
 		<Box flexDirection="column">
-			{/* All content is static to prevent re-renders */}
+			{/* Static content renders at top and persists */}
 			{allStaticComponents.length > 0 && (
-				<Static items={allStaticComponents}>
-					{(component, index) => {
-						const key =
-							component &&
-							typeof component === 'object' &&
-							'key' in component &&
-							component.key
-								? component.key
-								: `static-${index}`;
-
-						return (
-							<RenderErrorBoundary key={key}>{component}</RenderErrorBoundary>
-						);
-					}}
+				<Static key={clearKey} items={allStaticComponents}>
+					{(component, index) => (
+						<RenderErrorBoundary
+							key={componentKey(component, `static-${index}`)}
+						>
+							{component}
+						</RenderErrorBoundary>
+					)}
 				</Static>
 			)}
-			{/*
-			 * Live-queued components render in the normal flex layout, which is
-			 * inset by the parent's padding={1}. Ink's <Static> above renders
-			 * outside that layout (flush at column 0), so without this
-			 * compensating marginLeft={-1} these messages sit one column to the
-			 * right of the static queue. Keep in sync with ChatHistory's
-			 * liveComponent wrapper.
-			 */}
+			{/* Live content renders below */}
 			{liveQueuedComponents.length > 0 && (
 				<Box marginLeft={-1} flexDirection="column">
-					{liveQueuedComponents.map((component, index) => {
-						const key =
-							component &&
-							typeof component === 'object' &&
-							'key' in component &&
-							component.key
-								? component.key
-								: `live-${index}`;
-
-						return (
-							<RenderErrorBoundary key={key}>{component}</RenderErrorBoundary>
-						);
-					})}
+					{liveQueuedComponents.map((component, index) => (
+						<RenderErrorBoundary key={componentKey(component, `live-${index}`)}>
+							{component}
+						</RenderErrorBoundary>
+					))}
 				</Box>
 			)}
 		</Box>

--- a/source/hooks/useAppHandlers.tsx
+++ b/source/hooks/useAppHandlers.tsx
@@ -66,6 +66,9 @@ interface UseAppHandlersProps {
 	customCommandLoader: CustomCommandLoader | null;
 	customCommandExecutor: CustomCommandExecutor | null;
 
+	// Callbacks
+	onClearCounterIncrement?: () => void;
+
 	// State setters
 	updateMessages: (newMessages: Message[]) => void;
 	setIsCancelling: (value: boolean) => void;
@@ -657,6 +660,7 @@ export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 					customCommandLoader: props.customCommandLoader,
 					customCommandExecutor: props.customCommandExecutor,
 					onClearMessages: clearMessages,
+					onClearCounterIncrement: props.onClearCounterIncrement,
 					onRenameSession: props.setSessionName,
 					commandArgs,
 					onEnterModelSelectionMode: props.enterModelSelectionMode,

--- a/source/hooks/useTerminalWidth.tsx
+++ b/source/hooks/useTerminalWidth.tsx
@@ -42,6 +42,53 @@ function subscribe(onChange: (width: number) => void): () => void {
 	};
 }
 
+const DEFAULT_TERMINAL_ROWS = 24;
+
+const computeRows = () => process.stdout.rows || DEFAULT_TERMINAL_ROWS;
+
+// Same shared-listener pattern as width, but for rows. Kept as a separate
+// subscriber set so width consumers don't re-render on height-only changes.
+const rowSubscribers = new Set<(rows: number) => void>();
+let sharedRowListener: (() => void) | null = null;
+
+function subscribeRows(onChange: (rows: number) => void): () => void {
+	rowSubscribers.add(onChange);
+
+	if (!sharedRowListener) {
+		sharedRowListener = () => {
+			const newRows = computeRows();
+			for (const notify of rowSubscribers) {
+				notify(newRows);
+			}
+		};
+		process.stdout.on('resize', sharedRowListener);
+	}
+
+	return () => {
+		rowSubscribers.delete(onChange);
+		if (rowSubscribers.size === 0 && sharedRowListener) {
+			process.stdout.off('resize', sharedRowListener);
+			sharedRowListener = null;
+		}
+	};
+}
+
+/**
+ * Reactive terminal height in rows. Drives the fixed-height fullscreen
+ * layout: the interactive app sizes its root Box to exactly this many rows
+ * so the frame never exceeds the alternate-screen viewport.
+ */
+export const useTerminalRows = () => {
+	const [rows, setRows] = useState(computeRows);
+
+	useEffect(() => {
+		setRows(computeRows());
+		return subscribeRows(setRows);
+	}, []);
+
+	return rows;
+};
+
 export const useTerminalWidth = () => {
 	const [boxWidth, setBoxWidth] = useState(computeWidth);
 

--- a/source/mcp/mcp-client.ts
+++ b/source/mcp/mcp-client.ts
@@ -127,6 +127,23 @@ export class MCPClient {
 
 				await client.connect(transport);
 
+				// Stdio transports are created with stderr:'pipe' (see
+				// TransportFactory) so server children can't write to the
+				// user's terminal. Drain the pipe into the logger — an
+				// unconsumed pipe would fill up and block the child.
+				if ('stderr' in transport && transport.stderr) {
+					const serverName = normalizedServer.name;
+					transport.stderr.on('data', (chunk: Buffer) => {
+						const text = chunk.toString('utf8').trimEnd();
+						if (text) {
+							this.logger.debug(`MCP server stderr [${serverName}]`, {
+								serverName,
+								stderr: text,
+							});
+						}
+					});
+				}
+
 				this.logger.info('MCP server connected successfully', {
 					serverName: normalizedServer.name,
 					transport: normalizedServer.transport,

--- a/source/mcp/transport-factory.ts
+++ b/source/mcp/transport-factory.ts
@@ -129,6 +129,12 @@ export class TransportFactory {
 			env: server.env
 				? ({...process.env, ...server.env} as Record<string, string>)
 				: undefined,
+			// Default 'inherit' lets server children write straight to the
+			// user's terminal — including crash dumps that land AFTER
+			// nanocoder exits (e.g. an EPIPE stack trace when a server dies
+			// writing to the closed pipe during shutdown). Pipe it instead;
+			// mcp-client drains it into the logger.
+			stderr: 'pipe',
 		});
 	}
 

--- a/source/types/app.ts
+++ b/source/types/app.ts
@@ -19,6 +19,7 @@ export interface MessageSubmissionOptions {
 	customCommandLoader: CustomCommandLoader | null;
 	customCommandExecutor: CustomCommandExecutor | null;
 	onClearMessages: () => Promise<void>;
+	onClearCounterIncrement?: () => void;
 	onRenameSession: (name: string) => void;
 	commandArgs?: string[];
 	onEnterModelSelectionMode: () => void;

--- a/source/types/components.ts
+++ b/source/types/components.ts
@@ -14,6 +14,13 @@ export interface ChatQueueProps {
 	staticComponents?: ReactNode[];
 	queuedComponents?: ReactNode[];
 	renderLastQueuedComponentLive?: boolean;
+	clearKey?: string;
+	/**
+	 * Render everything in regular flow instead of Ink's Static. Used by the
+	 * fullscreen (alternate-screen) layout, where Static has no scrollback
+	 * to print into. Only a bounded tail of components is rendered.
+	 */
+	disableStatic?: boolean;
 }
 
 export type Completion = {name: string; isCustom: boolean};

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -418,4 +418,13 @@ export interface UserPreferences {
 	reasoningExpanded?: boolean;
 	compactToolDisplay?: boolean;
 	enablePromptScrubbing?: boolean;
+	/**
+	 * Interactive TUI screen mode. true (default): fullscreen on the
+	 * alternate screen buffer with in-app scrolling (wheel / PgUp / PgDn).
+	 * false: inline mode on the main screen — finished messages print into
+	 * the terminal's native scrollback, so the terminal's own scrollbar,
+	 * wheel, and search work, but the TUI cannot clip or re-layout old
+	 * content. Also switchable per-run with the --no-alt-screen flag.
+	 */
+	alternateScreen?: boolean;
 }

--- a/source/utils/terminal-mouse.spec.ts
+++ b/source/utils/terminal-mouse.spec.ts
@@ -1,0 +1,49 @@
+import test from 'ava';
+import {stripMouseSequences} from './terminal-mouse.js';
+
+test('passes plain text through untouched', t => {
+	const r = stripMouseSequences('hello world');
+	t.is(r.clean, 'hello world');
+	t.deepEqual(r.wheel, []);
+	t.is(r.carry, '');
+});
+
+test('strips wheel events and reports direction', t => {
+	const r = stripMouseSequences('\x1b[<64;10;5Mabc\x1b[<65;10;5M');
+	t.is(r.clean, 'abc');
+	t.deepEqual(r.wheel, ['up', 'down']);
+});
+
+test('strips click press/release without emitting wheel', t => {
+	const r = stripMouseSequences('\x1b[<0;3;4M\x1b[<0;3;4mtyped');
+	t.is(r.clean, 'typed');
+	t.deepEqual(r.wheel, []);
+});
+
+test('wheel with modifier bits still detected', t => {
+	// 64 | 4 (shift) = 68 up; 65 | 8 (alt) = 73 down
+	const r = stripMouseSequences('\x1b[<68;1;1M\x1b[<73;1;1M');
+	t.deepEqual(r.wheel, ['up', 'down']);
+});
+
+test('lone ESC (the Escape key) is NOT held back', t => {
+	const r = stripMouseSequences('\x1b');
+	t.is(r.clean, '\x1b');
+	t.is(r.carry, '');
+});
+
+test('arrow keys are NOT held back or stripped', t => {
+	const r = stripMouseSequences('\x1b[A\x1b[B');
+	t.is(r.clean, '\x1b[A\x1b[B');
+	t.is(r.carry, '');
+});
+
+test('partial mouse sequence is carried and completed next chunk', t => {
+	const first = stripMouseSequences('abc\x1b[<64;1');
+	t.is(first.clean, 'abc');
+	t.is(first.carry, '\x1b[<64;1');
+	const second = stripMouseSequences(';5M', first.carry);
+	t.is(second.clean, '');
+	t.deepEqual(second.wheel, ['up']);
+	t.is(second.carry, '');
+});

--- a/source/utils/terminal-mouse.spec.ts
+++ b/source/utils/terminal-mouse.spec.ts
@@ -47,3 +47,99 @@ test('partial mouse sequence is carried and completed next chunk', t => {
 	t.deepEqual(second.wheel, ['up']);
 	t.is(second.carry, '');
 });
+
+// ============================================================================
+// Error / edge scenarios beyond the happy path
+// ============================================================================
+
+test('empty chunk with no prefix returns empty result', t => {
+	const r = stripMouseSequences('');
+	t.is(r.clean, '');
+	t.deepEqual(r.wheel, []);
+	t.is(r.carry, '');
+});
+
+test('malformed sequence missing the M/m terminator is NOT stripped mid-chunk', t => {
+	// No terminator anywhere in the chunk and it's followed by more text,
+	// so it can't be a genuine split-at-boundary partial (that case only
+	// holds back a TRAILING run). It must pass through untouched rather
+	// than being silently dropped as if it were a valid mouse report.
+	const r = stripMouseSequences('\x1b[<64;10;5 not-a-terminator');
+	t.is(r.clean, '\x1b[<64;10;5 not-a-terminator');
+	t.deepEqual(r.wheel, []);
+	t.is(r.carry, '');
+});
+
+test('malformed sequence with wrong terminator character is left intact', t => {
+	const r = stripMouseSequences('\x1b[<64;10;5Xtyped');
+	t.is(r.clean, '\x1b[<64;10;5Xtyped');
+	t.deepEqual(r.wheel, []);
+});
+
+test('non-numeric button field does not match and is left intact', t => {
+	const r = stripMouseSequences('\x1b[<ab;10;5Mtyped');
+	t.is(r.clean, '\x1b[<ab;10;5Mtyped');
+	t.deepEqual(r.wheel, []);
+});
+
+test('button field 0 (no bits set) is dropped without emitting wheel', t => {
+	const r = stripMouseSequences('\x1b[<0;1;1M');
+	t.is(r.clean, '');
+	t.deepEqual(r.wheel, []);
+});
+
+test('a trailing partial longer than MAX_PARTIAL is let through, not swallowed', t => {
+	// Comment in terminal-mouse.ts: "longer means it's not a mouse sequence,
+	// so let it through rather than swallowing user input." Build a tail
+	// that matches PARTIAL_TAIL_RE's shape but exceeds the 20-char cap.
+	const longTail = '\x1b[<64;123456789012345';
+	t.true(longTail.length > 20);
+	const r = stripMouseSequences(longTail);
+	t.is(r.clean, longTail);
+	t.is(r.carry, '');
+});
+
+test('carry chains correctly across three chunks split at different points', t => {
+	const first = stripMouseSequences('start\x1b[<6');
+	t.is(first.clean, 'start');
+	t.is(first.carry, '\x1b[<6');
+
+	const second = stripMouseSequences('4;10', first.carry);
+	t.is(second.clean, '');
+	t.is(second.carry, '\x1b[<64;10');
+
+	const third = stripMouseSequences(';5Mend', second.carry);
+	t.is(third.clean, 'end');
+	t.deepEqual(third.wheel, ['up']);
+	t.is(third.carry, '');
+});
+
+test('carry with no matching completion this chunk still strips other sequences', t => {
+	// Previous carry never resolves into a full sequence (chunk has
+	// unrelated content); the carried prefix should not corrupt handling of
+	// a distinct, complete sequence later in the same chunk.
+	const r = stripMouseSequences(
+		'unrelated text\x1b[<0;2;2m',
+		'\x1b[<64;1',
+	);
+	// The prior carry + this chunk's leading text no longer matches the
+	// mouse regex (there's no M/m right after the carried digits), so it
+	// passes through as plain text, while the later complete
+	// (non-wheel) release sequence is still stripped.
+	t.is(r.clean, '\x1b[<64;1unrelated text');
+	t.deepEqual(r.wheel, []);
+});
+
+test('multiple wheel ticks in one chunk preserve order (down, down, up)', t => {
+	const r = stripMouseSequences(
+		'\x1b[<65;1;1M\x1b[<65;1;1M\x1b[<64;1;1M',
+	);
+	t.deepEqual(r.wheel, ['down', 'down', 'up']);
+	t.is(r.clean, '');
+});
+
+test('release (lowercase m) wheel event is still classified by direction bit', t => {
+	const r = stripMouseSequences('\x1b[<64;1;1m');
+	t.deepEqual(r.wheel, ['up']);
+	t.is(r.clean, '');
+});

--- a/source/utils/terminal-mouse.ts
+++ b/source/utils/terminal-mouse.ts
@@ -1,0 +1,72 @@
+import {EventEmitter} from 'node:events';
+
+/**
+ * SGR mouse reporting (DECSET 1000 + 1006) support for the fullscreen TUI.
+ *
+ * The terminal reports mouse activity as `ESC [ < B ; x ; y (M|m)`
+ * sequences on stdin. Ink's keypress parser doesn't understand them, so
+ * they must be stripped before Ink reads stdin — otherwise clicks and
+ * wheel ticks leak into the chat input as garbage text. Wheel events
+ * (button bit 64) are re-emitted on {@link wheelEvents} for the chat
+ * viewport to consume; every other mouse event is silently dropped.
+ */
+
+export type WheelDirection = 'up' | 'down';
+
+/** Singleton bus: cli.tsx publishes wheel ticks, ChatHistory subscribes. */
+export const wheelEvents = new EventEmitter();
+
+// ESC [ < button ; column ; row, terminated by M (press) or m (release).
+const SGR_MOUSE_RE = /\x1b\[<(\d+);\d+;\d+[Mm]/g;
+
+// Trailing partial mouse sequence cut off at a chunk boundary. Requires
+// the full "ESC [ <" prefix: a lone ESC is the Escape KEY and a bare
+// "ESC [" starts arrow keys — holding those back would break real input.
+// Terminals write mouse sequences atomically, so a split before the "<"
+// is not a realistic case.
+const MAX_PARTIAL = 20;
+const PARTIAL_TAIL_RE = /\x1b\[<(?:\d+(?:;\d+(?:;\d+)?)?)?$/;
+
+export interface StripResult {
+	/** Input with all SGR mouse sequences removed. */
+	clean: string;
+	/** Wheel ticks found, in order. */
+	wheel: WheelDirection[];
+	/**
+	 * Trailing bytes that might be the start of a mouse sequence split
+	 * across chunks — prepend to the next chunk before stripping again.
+	 */
+	carry: string;
+}
+
+/**
+ * Remove SGR mouse sequences from a stdin chunk, extracting wheel ticks.
+ * Pass the previous call's `carry` as `prefix` so sequences split across
+ * chunk boundaries are still recognized.
+ */
+export function stripMouseSequences(chunk: string, prefix = ''): StripResult {
+	const input = prefix + chunk;
+	const wheel: WheelDirection[] = [];
+
+	let clean = input.replace(SGR_MOUSE_RE, (_match, buttonStr: string) => {
+		const button = Number(buttonStr);
+		// Bit 64 marks wheel events; low two bits pick the direction.
+		if (button & 64) {
+			const direction = button & 1 ? 'down' : 'up';
+			wheel.push(direction);
+		}
+		return '';
+	});
+
+	// Hold back a trailing partial sequence for the next chunk. Only a
+	// short tail can be a genuine partial — longer means it's not a mouse
+	// sequence, so let it through rather than swallowing user input.
+	let carry = '';
+	const partial = clean.match(PARTIAL_TAIL_RE);
+	if (partial && partial[0].length > 0 && partial[0].length <= MAX_PARTIAL) {
+		carry = partial[0];
+		clean = clean.slice(0, clean.length - carry.length);
+	}
+
+	return {clean, wheel, carry};
+}


### PR DESCRIPTION
## Description

Adds a second rendering mode and fixes two long-standing TUI paint issues:

- **Fullscreen mode** (`--alt-screen` flag, or `"alternateScreen": true` in preferences) — a fixed-height layout on the alternate screen buffer, like Codex and other CLI coding tools that isolate their TUI from the terminal's native scrollback. In-app scrolling via mouse wheel (3 rows/tick) and PgUp/PgDn, with a scroll indicator and snap-back to bottom on new output. `--no-alt-screen` forces inline mode over the preference.
- **Inline mode stays the default** and keeps native terminal scrollback; finished messages print once so the terminal's scrollbar, search, and selection work as usual.
- **`/clear` actually clears** — previously it just appended a fresh welcome message on top of the old transcript instead of resetting the terminal. It now fully resets to a clean welcome banner in both modes.
- **Graceful exit** — exiting (Ctrl+C or `/exit`) could fail or leave a dead input box on screen, typically when MCP servers were still attached. Exit now erases the input UI cleanly and leaves the transcript with a farewell.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files (`terminal-mouse.spec.ts`, `interactive-app.spec.tsx`, `chat-queue.spec.tsx`, `chat-history.spec.tsx`, `cli.spec.ts` — 126 passing, incl. 36 edge-case tests: malformed mouse sequences, alt-screen flag/preference precedence, fullscreen tail cap, clear-key remount, scroll gating)
- [x] All existing tests pass
- [x] Tests cover both success and error scenarios

```
pnpm run test:ava source/utils/terminal-mouse.spec.ts source/app/sections/interactive-app.spec.tsx
npx tsc --noEmit
```

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [x] Tested MCP integration (exit path with MCP servers attached)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (README section on screen modes)
- [x] No breaking changes (inline mode remains the default; fullscreen is opt-in)
- [ ] Appropriate logging added using structured logging
