### PR TITLE
feat: add mode and model selectors to chat UI with workspace configuration synchronization

### DIFF
--- a/plugins/vscode/media/chat-panel.css
+++ b/plugins/vscode/media/chat-panel.css
@@ -26,6 +26,31 @@ html, body {
 	height: 100%;
 }
 
+.chat-header {
+	display: flex;
+	gap: 8px;
+	padding: 8px var(--container-padding);
+	border-bottom: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.2));
+	background-color: var(--vscode-editor-background);
+}
+
+.header-dropdown {
+	flex: 1;
+	background-color: var(--vscode-dropdown-background);
+	color: var(--vscode-dropdown-foreground);
+	border: 1px solid var(--vscode-dropdown-border, transparent);
+	padding: 4px;
+	border-radius: 2px;
+	font-family: var(--font-family);
+	font-size: 0.9em;
+	outline: none;
+	width: 50%;
+}
+
+.header-dropdown:focus {
+	border-color: var(--vscode-focusBorder);
+}
+
 .messages {
 	flex: 1;
 	overflow-y: auto;

--- a/plugins/vscode/media/chat-panel.html
+++ b/plugins/vscode/media/chat-panel.html
@@ -13,6 +13,14 @@
 </head>
 <body>
 	<div class="chat-container">
+		<div class="chat-header">
+			<select id="mode-selector" class="header-dropdown" disabled>
+				<option value="">Loading modes...</option>
+			</select>
+			<select id="model-selector" class="header-dropdown" disabled>
+				<option value="">Loading models...</option>
+			</select>
+		</div>
 		<div id="messages-container" class="messages">
 			<!-- Messages will be injected here -->
 			<div class="welcome-message">

--- a/plugins/vscode/media/chat-panel.js
+++ b/plugins/vscode/media/chat-panel.js
@@ -4,6 +4,8 @@
 
 	const messagesContainer = document.getElementById('messages-container');
 	const chatInput = document.getElementById('chat-input');
+	const modeSelector = document.getElementById('mode-selector');
+	const modelSelector = document.getElementById('model-selector');
 	
 	let currentTurnEl = null;
 	let currentTextEl = null;
@@ -116,8 +118,43 @@
 			case 'showPlanReview':
 				handlePlanReview(message);
 				break;
+			case 'syncState':
+				handleSyncState(message);
+				break;
 		}
 	});
+
+	modeSelector.addEventListener('change', () => {
+		vscode.postMessage({ type: 'setMode', mode: modeSelector.value });
+	});
+
+	modelSelector.addEventListener('change', () => {
+		vscode.postMessage({ type: 'setModel', model: modelSelector.value });
+	});
+
+	function handleSyncState(message) {
+		// Update Mode Selector
+		modeSelector.innerHTML = '';
+		message.availableModes.forEach(mode => {
+			const option = document.createElement('option');
+			option.value = mode;
+			option.textContent = mode;
+			modeSelector.appendChild(option);
+		});
+		modeSelector.value = message.mode;
+		modeSelector.disabled = false;
+
+		// Update Model Selector
+		modelSelector.innerHTML = '';
+		message.availableModels.forEach(model => {
+			const option = document.createElement('option');
+			option.value = model;
+			option.textContent = model;
+			modelSelector.appendChild(option);
+		});
+		modelSelector.value = message.model;
+		modelSelector.disabled = false;
+	}
 
 	function handleAcpUpdate(payload) {
 		if (!payload || !payload.update) return;

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -88,6 +88,18 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Show diff preview before applying file changes"
+				},
+				"nanocoder.mode": {
+					"type": "string",
+					"default": "auto-accept",
+					"scope": "resource",
+					"description": "The current operating mode for the Nanocoder assistant (e.g. chat, auto-accept)"
+				},
+				"nanocoder.model": {
+					"type": "string",
+					"default": "google/gemini-3.5-flash",
+					"scope": "machine",
+					"description": "The AI model to use for Nanocoder sessions"
 				}
 			}
 		}

--- a/plugins/vscode/src/acp-client.ts
+++ b/plugins/vscode/src/acp-client.ts
@@ -12,20 +12,44 @@ export class NanocoderAcpClient {
 	private _sessionId?: string;
 	public onSessionUpdate?: (update: any) => void;
 	public onPermissionRequested?: (toolCallId: string, toolCall: any) => void;
+	public onStateSync?: (state: any) => void;
+	public onConnectionReady?: () => void;
+
+	public currentMode?: string;
+	public availableModes: string[] = [];
+	public currentModel?: string;
+	public availableModels: string[] = [];
 
 	private pendingPermissions = new Map<string, (response: any) => void>();
 
 	constructor(outputChannel: vscode.OutputChannel, stateManager: AcpStateManager) {
 		this.outputChannel = outputChannel;
 		this.stateManager = stateManager;
+
+		// Settings Bridge: Listen for configuration changes
+		vscode.workspace.onDidChangeConfiguration((e) => {
+			if (e.affectsConfiguration('nanocoder.mode')) {
+				const newMode = vscode.workspace.getConfiguration('nanocoder').get<string>('mode');
+				if (newMode && newMode !== this.currentMode) {
+					this.setSessionMode(newMode, false);
+				}
+			}
+			if (e.affectsConfiguration('nanocoder.model')) {
+				const newModel = vscode.workspace.getConfiguration('nanocoder').get<string>('model');
+				if (newModel && newModel !== this.currentModel) {
+					this.setSessionModel(newModel, false);
+				}
+			}
+		});
 	}
 
 	hasPendingPermissions(): boolean {
 		return this.pendingPermissions.size > 0;
 	}
 
-	setConnection(conn: ClientSideConnection) {
-		this.connection = conn;
+	setConnection(connection: ClientSideConnection): void {
+		this.connection = connection;
+		this._sessionId = undefined; // Clear any stale session to force re-creation
 	}
 
 	async handlePermissionRequest(params: any): Promise<any> {
@@ -80,6 +104,9 @@ export class NanocoderAcpClient {
 
 			// Complete handshake
 			this.stateManager.setStatus(ACPStatus.Connected);
+			if (this.onConnectionReady) {
+				this.onConnectionReady();
+			}
 			return true;
 		} catch (error) {
 			this.outputChannel.appendLine(`ACP Initialize failed: ${error}`);
@@ -88,16 +115,103 @@ export class NanocoderAcpClient {
 	}
 
 	async getOrCreateSession(cwd: string): Promise<string | undefined> {
-		if (this._sessionId) return this._sessionId;
+		if (this._sessionId) {
+			this.notifyStateSync();
+			return this._sessionId;
+		}
 		if (!this.connection) return undefined;
 
 		try {
+			// Get VS Code settings for initial preferences
+			const config = vscode.workspace.getConfiguration('nanocoder');
+			const initialMode = config.get<string>('mode') || 'auto-accept';
+			const initialModel = config.get<string>('model') || 'google/gemini-3.5-flash';
+
 			const result = await this.connection.newSession({ cwd, mcpServers: [] });
 			this._sessionId = result.sessionId;
+			
+			// Parse modes and configOptions
+			if (result.modes) {
+				this.currentMode = result.modes.currentModeId;
+				this.availableModes = result.modes.availableModes.map((m: any) => m.id);
+			}
+			
+			if (result.configOptions) {
+				const modelOpt = result.configOptions.find((o: any) => o.id === 'model') as any;
+				if (modelOpt) {
+					this.currentModel = modelOpt.currentValue;
+					
+					// modelOpt.options is either Array<Option> or Array<Group>. We assume Option here for simplicity.
+					// If it's a flat array of Options, they have a 'value'.
+					this.availableModels = (modelOpt.options || []).map((opt: any) => opt.value || opt);
+				}
+			}
+
+			// Force initial preferences if they differ
+			if (this.currentMode && this.currentMode !== initialMode && this.availableModes.includes(initialMode)) {
+				await this.setSessionMode(initialMode, false);
+			}
+			if (this.currentModel && this.currentModel !== initialModel && this.availableModels.includes(initialModel)) {
+				await this.setSessionModel(initialModel, false);
+			}
+
+			this.notifyStateSync();
+
 			return this._sessionId;
 		} catch (error) {
 			this.outputChannel.appendLine(`Failed to create session: ${error}`);
 			return undefined;
+		}
+	}
+
+	notifyStateSync() {
+		if (this.onStateSync && this.currentMode && this.currentModel) {
+			this.onStateSync({
+				mode: this.currentMode,
+				availableModes: this.availableModes,
+				model: this.currentModel,
+				availableModels: this.availableModels
+			});
+		}
+	}
+
+	async setSessionMode(modeId: string, persist = true): Promise<void> {
+		if (!this.connection || !this._sessionId) return;
+		try {
+			await this.connection.setSessionMode({
+				sessionId: this._sessionId,
+				modeId
+			});
+			this.currentMode = modeId;
+			this.notifyStateSync();
+
+			if (persist) {
+				const config = vscode.workspace.getConfiguration('nanocoder');
+				// User setting scope
+				await config.update('mode', modeId, vscode.ConfigurationTarget.Global);
+			}
+		} catch (error) {
+			this.outputChannel.appendLine(`Failed to set mode: ${error}`);
+		}
+	}
+
+	async setSessionModel(modelId: string, persist = true): Promise<void> {
+		if (!this.connection || !this._sessionId) return;
+		try {
+			const result = await this.connection.setSessionConfigOption({
+				sessionId: this._sessionId,
+				configId: 'model',
+				value: modelId
+			});
+			this.currentModel = modelId;
+			this.notifyStateSync();
+
+			if (persist) {
+				const config = vscode.workspace.getConfiguration('nanocoder');
+				await config.update('model', modelId, vscode.ConfigurationTarget.Global);
+			}
+		} catch (error) {
+			this.outputChannel.appendLine(`Failed to set model: ${error}`);
 		}
 	}
 

--- a/plugins/vscode/src/chat-webview-provider.ts
+++ b/plugins/vscode/src/chat-webview-provider.ts
@@ -8,6 +8,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 	public static readonly viewType = 'nanocoder.chatView';
 
 	private _view?: vscode.WebviewView;
+	private _isWebviewReady = false;
 
 	constructor(
 		private readonly _extensionUri: vscode.Uri,
@@ -31,6 +32,17 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 				toolCallId,
 				toolCall
 			} as any);
+		};
+
+		this._acpClient.onStateSync = (state: any) => {
+			this.postMessage({
+				type: 'syncState',
+				...state
+			} as any);
+		};
+
+		this._acpClient.onConnectionReady = () => {
+			this._initializeSessionIfReady();
 		};
 	}
 
@@ -74,6 +86,8 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 				switch (message.type) {
 					case 'ready':
 						this._outputChannel.appendLine('[Webview] Chat shell is ready.');
+						this._isWebviewReady = true;
+						this._initializeSessionIfReady();
 						break;
 					case 'submitMessage':
 						this._outputChannel.appendLine(`[Webview] User submitted: ${message.text}`);
@@ -107,6 +121,16 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 						this._outputChannel.appendLine('[Webview] User clicked Cancel on plan review.');
 						this._acpClient.cancelPlan();
 						break;
+					case 'setMode':
+						this._outputChannel.appendLine(`[Webview] User selected mode: ${message.mode}`);
+						this._acpClient.setSessionMode(message.mode);
+						break;
+					case 'setModel':
+						this._outputChannel.appendLine(`[Webview] User selected model: ${message.model}`);
+						this._acpClient.setSessionModel(message.model).then(() => {
+							vscode.window.showInformationMessage(`Nanocoder: Model switched to ${message.model}`);
+						});
+						break;
 				}
 			}
 		);
@@ -115,6 +139,22 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 	public postMessage(message: ExtensionToWebviewMessage) {
 		if (this._view) {
 			this._view.webview.postMessage(message);
+		}
+	}
+
+	private async _initializeSessionIfReady() {
+		if (!this._isWebviewReady || !this._acpClient.connection) {
+			return;
+		}
+		try {
+			const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+			const cwd = workspaceFolder?.uri.fsPath || process.cwd();
+			const sessionId = await this._acpClient.getOrCreateSession(cwd);
+			if (sessionId) {
+				this._outputChannel.appendLine(`[Extension] Session initialized automatically: ${sessionId}`);
+			}
+		} catch (error) {
+			this._outputChannel.appendLine(`Failed to initialize session on ready: ${error}`);
 		}
 	}
 

--- a/plugins/vscode/src/webview-protocol.ts
+++ b/plugins/vscode/src/webview-protocol.ts
@@ -54,6 +54,19 @@ export interface ExtensionMessagePermissionRequested {
 	toolCall: any;
 }
 
+export interface ExtensionMessageShowPlanReview {
+	type: 'showPlanReview';
+	description?: string;
+}
+
+export interface ExtensionMessageSyncState {
+	type: 'syncState';
+	mode: string;
+	availableModes: string[];
+	model: string;
+	availableModels: string[];
+}
+
 export type ExtensionToWebviewMessage =
 	| ExtensionMessageAppendMessage
 	| ExtensionMessageAppendThought
@@ -64,7 +77,8 @@ export type ExtensionToWebviewMessage =
 	| ExtensionMessageToolUpdated
 	| ExtensionMessageToolCompleted
 	| ExtensionMessagePermissionRequested
-	| ExtensionMessageShowPlanReview;
+	| ExtensionMessageShowPlanReview
+	| ExtensionMessageSyncState;
 
 
 // ---------------------------------------------------------
@@ -116,6 +130,16 @@ export interface ExtensionMessageShowPlanReview {
 	description?: string;
 }
 
+export interface WebviewMessageSetMode {
+	type: 'setMode';
+	mode: string;
+}
+
+export interface WebviewMessageSetModel {
+	type: 'setModel';
+	model: string;
+}
+
 export type WebviewToExtensionMessage =
 	| WebviewMessageReady
 	| WebviewMessageSubmitMessage
@@ -125,4 +149,6 @@ export type WebviewToExtensionMessage =
 	| WebviewMessageShowDiff
 	| WebviewMessageProceedPlan
 	| WebviewMessageModifyPlan
-	| WebviewMessageCancelPlan;
+	| WebviewMessageCancelPlan
+	| WebviewMessageSetMode
+	| WebviewMessageSetModel;


### PR DESCRIPTION
This PR introduces the final major UI components for the VS Code extension's chat interface: the ability to select the active mode and model directly from the Webview sidebar, fully synchronized with the local CLI backend via the Agent Client Protocol (ACP). #654 

## Key Features

1. **Webview UI Updates (`chat-panel.html`, `chat-panel.css`, `chat-panel.js`)**:
   - Added a new `.chat-header` container pinned to the top of the chat view.
   - Introduced native-styled `<select>` dropdowns for "Mode" and "Model".
   - Styled the dropdowns using VS Code's standard CSS variables (`--vscode-dropdown-background`, `--vscode-dropdown-border`, etc.) to ensure visual consistency with the rest of the editor.
   - Added event listeners that dispatch `setMode` and `setModel` messages to the extension host.

2. **ACP State Synchronization (`acp-client.ts`, `chat-webview-provider.ts`)**:
   - **Settings Bridge**: Implemented logic in `NanocoderAcpClient` to observe `vscode.workspace.onDidChangeConfiguration`. This ensures that if a user changes their preferred mode or model in their VS Code settings, the change is instantly propagated to the CLI backend.
   - **Session Initialization**: The Webview now receives a `syncState` message upon connection initialization, carrying the arrays of `availableModes` and `availableModels` returned by the backend's `newSession` response.
   - **Protocol Extensions**: Added `setSessionMode` and `setSessionConfigOption` wrappers around the underlying `@agentclientprotocol/sdk` to securely request state mutations on the backend.

3. **Resilience & Bug Fixes**:
   - **Stale Session Fix**: Resolved a critical bug where the CLI restarting (due to API provider failures) caused the extension to hold onto a stale `sessionId`. By resetting `this._sessionId = undefined` on connection drop, the extension now correctly re-negotiates a fresh session and recovers automatically without throwing `RequestError: Internal error`.
   - **Race Condition Fix**: Fixed an initialization timing issue where the UI would permanently display "Loading..." if the Webview loaded slightly faster than the CLI handshake.
   - **User Feedback**: Added `vscode.window.showInformationMessage` success toasts to provide positive visual confirmation when the model is successfully updated on the backend.

## Technical Notes
- The model switching strictly uses `setSessionConfigOption` (targeting the `model` config ID) to align with standard ACP configurations, mapping the `currentValue` property directly to the active selection.
- All Webview updates are communicated via the bidirectional `webview-protocol.ts` typed interfaces.
