### PR TITLE
Fix CI model context and coverage checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
 	},
 	"c8": {
 		"exclude": [
-			"source/app/App.tsx"
+			"source/app/App.tsx",
+			"source/web/page.ts"
 		],
 		"reporter": [
 			"text",

--- a/source/models/models-dev-client.ts
+++ b/source/models/models-dev-client.ts
@@ -81,6 +81,7 @@ const OLLAMA_MODEL_CONTEXT_LIMITS: Record<string, number> = {
 	// DeepSeek models (base matches wrong model on models.dev)
 	'deepseek-coder': 16000,
 	'deepseek-coder-v2': 128000,
+	'deepseek-v3.1': 128000,
 
 	// Phi models (not on models.dev)
 	phi3: 128000,
@@ -88,7 +89,11 @@ const OLLAMA_MODEL_CONTEXT_LIMITS: Record<string, number> = {
 	'phi3:medium': 128000,
 
 	// Moonshot AI models (kimi-for-coding is a provider, not a model ID)
+	'kimi-k2': 128000,
 	'kimi-for-coding': 256000,
+
+	// Mistral cloud aliases
+	'devstral-small-2': 128000,
 };
 
 /**

--- a/source/vscode/extension-installer.spec.ts
+++ b/source/vscode/extension-installer.spec.ts
@@ -143,8 +143,8 @@ test('installExtension with VSIX missing returns appropriate error', async t => 
 			result.message.includes('Failed') || result.message.includes('not found'),
 		);
 	} else {
-		// If it succeeded, the extension was installed
-		t.true(result.message.includes('success'));
+		t.true(result.results.some(cliResult => cliResult.success));
+		t.true(result.message.includes('installed'));
 	}
 });
 


### PR DESCRIPTION

## Description

Fixes CI failures seen after the web mode work.

This adds fallback context limits for model aliases that currently do not resolve to a numeric context limit through `models.dev`, updates a brittle VS Code extension installer test assertion, and excludes the static web mode page template from c8 coverage.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Focused checks run:

```bash
./node_modules/.bin/biome check package.json source/models/models-dev-client.ts source/vscode/extension-installer.spec.ts
./node_modules/.bin/tsc
./node_modules/.bin/ava source/models/models-dev-client.spec.ts source/vscode/extension-installer.spec.ts
```

Result: `80 tests passed`

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))


## FIxes 
<img width="1059" height="907" alt="Screenshot 2026-07-17 at 12 17 02 PM" src="https://github.com/user-attachments/assets/55b6d1f4-4b3d-4b04-8a40-a0774f0ae47c" />