### PR TITLE
feat: inject semantic memories into prompts(Phase 3)

### DIFF
--- a/source/hooks/chat-handler/types.ts
+++ b/source/hooks/chat-handler/types.ts
@@ -1,5 +1,9 @@
 import type React from 'react';
 import type {CustomCommandLoader} from '@/custom-commands/loader';
+import type {
+	MemoryFinder,
+	ProjectContextOptions,
+} from '@/memory/project-context';
 import type {Task} from '@/tools/tasks/types';
 import type {ToolManager} from '@/tools/tool-manager';
 import type {TuneConfig} from '@/types/config';
@@ -49,6 +53,8 @@ export interface UseChatHandlerProps {
 	subagentsReady?: boolean;
 	privacySessionMapRef?: React.MutableRefObject<Record<string, string>>;
 	privacyEnabled?: boolean;
+	memoryFinder?: MemoryFinder;
+	projectContextOptions?: ProjectContextOptions;
 }
 
 export interface ChatHandlerReturn {

--- a/source/hooks/chat-handler/useChatHandler.spec.tsx
+++ b/source/hooks/chat-handler/useChatHandler.spec.tsx
@@ -416,6 +416,67 @@ test('useChatHandler - drains queued message when setup fails before conversatio
 	rendered.unmount();
 });
 
+test('useChatHandler - injects project context from memory finder', async t => {
+	let hookResult: ChatHandlerReturn | null = null;
+	let sentMessages: Message[] = [];
+	const client: LLMClient = {
+		...createMockClient(),
+		chat: async (messages, _tools, callbacks) => {
+			sentMessages = messages;
+			callbacks.onFinish?.();
+			return {
+				choices: [
+					{
+						message: {
+							role: 'assistant',
+							content: 'ok',
+						},
+					},
+				],
+			};
+		},
+	};
+
+	const props = createMockProps({
+		client,
+		toolManager: createMockToolManager(),
+		memoryFinder: {
+			findRelevantMemories: async (query, limit) => {
+				t.is(query, 'refactor auth');
+				t.is(limit, 8);
+				return [
+					{
+						id: 'memory-1',
+						content: 'Auth uses Clerk and avoids middleware.',
+						category: 'architecture',
+						timestamp: '2026-07-17T00:00:00.000Z',
+					},
+				];
+			},
+		},
+	});
+
+	const rendered = render(
+		<TestHookComponent
+			{...props}
+			onResult={result => {
+				hookResult = result;
+			}}
+		/>,
+	);
+
+	await waitForCondition(() => hookResult !== null);
+	await hookResult!.handleChatMessage('refactor auth');
+
+	t.true(sentMessages[0].content.includes('## Project Context'));
+	t.true(
+		sentMessages[0].content.includes(
+			'- Auth uses Clerk and avoids middleware.',
+		),
+	);
+	rendered.unmount();
+});
+
 test('useChatHandler - streaming state types are correct', t => {
 	let hookResult: ChatHandlerReturn | null = null;
 

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -4,6 +4,7 @@ import {ConversationStateManager} from '@/app/utils/conversation-state';
 import UserMessage from '@/components/user-message';
 import {getAppConfig} from '@/config/index';
 import {CommandIntegration} from '@/custom-commands/command-integration';
+import {appendRelevantProjectContext} from '@/memory/project-context';
 import {generateKey} from '@/session/key-generator';
 import {getTuneToolMode} from '@/types/config';
 import type {ImageAttachment, Message} from '@/types/core';
@@ -357,6 +358,8 @@ export function useChatHandler({
 					message,
 				);
 			}
+
+			systemPrompt = await appendRelevantProjectContext(systemPrompt, message);
 
 			// Create stream request
 			const systemMessage: Message = {

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -5,6 +5,7 @@ import UserMessage from '@/components/user-message';
 import {getAppConfig} from '@/config/index';
 import {CommandIntegration} from '@/custom-commands/command-integration';
 import {appendRelevantProjectContext} from '@/memory/project-context';
+import {SemanticMemoryManager} from '@/memory/semantic-memory-manager';
 import {generateKey} from '@/session/key-generator';
 import {getTuneToolMode} from '@/types/config';
 import type {ImageAttachment, Message} from '@/types/core';
@@ -91,9 +92,16 @@ export function useChatHandler({
 	subagentsReady,
 	privacySessionMapRef,
 	privacyEnabled,
+	memoryFinder,
+	projectContextOptions,
 }: UseChatHandlerProps): ChatHandlerReturn {
 	// Conversation state manager for enhanced context
 	const conversationStateManager = React.useRef(new ConversationStateManager());
+
+	const projectMemoryFinder = React.useMemo(
+		() => memoryFinder ?? new SemanticMemoryManager(),
+		[memoryFinder],
+	);
 
 	// Resolve the active fallback format when native tools are disabled. When
 	// native is on, this value is unused. The tune override takes priority over
@@ -359,7 +367,13 @@ export function useChatHandler({
 				);
 			}
 
-			systemPrompt = await appendRelevantProjectContext(systemPrompt, message);
+			systemPrompt = await appendRelevantProjectContext(
+				systemPrompt,
+				message,
+				projectMemoryFinder,
+				projectContextOptions,
+			);
+			setLastBuiltPrompt(systemPrompt);
 
 			// Create stream request
 			const systemMessage: Message = {

--- a/source/memory/project-context.spec.ts
+++ b/source/memory/project-context.spec.ts
@@ -27,6 +27,40 @@ test('formatProjectContext formats memories as project context', t => {
 	);
 });
 
+test('formatProjectContext respects token budget', t => {
+	t.is(
+		formatProjectContext(
+			[
+				memory('Use existing hooks.'),
+				memory(
+					'This second memory is intentionally long enough to exceed the tiny test budget.',
+				),
+			],
+			{tokenBudget: 12},
+		),
+		'## Project Context\n\n- Use existing hooks.',
+	);
+});
+
+test('formatProjectContext returns empty string when budget is too small', t => {
+	t.is(formatProjectContext([memory('Use existing hooks.')], {tokenBudget: 1}), '');
+});
+
+test('formatProjectContext skips oversized memories within budget', t => {
+	t.is(
+		formatProjectContext(
+			[
+				memory(
+					'This first memory is intentionally too long for the small budget.',
+				),
+				memory('Use adapters.'),
+			],
+			{tokenBudget: 10},
+		),
+		'## Project Context\n\n- Use adapters.',
+	);
+});
+
 test('appendProjectContext returns original prompt without memories', t => {
 	t.is(appendProjectContext('base prompt', []), 'base prompt');
 });
@@ -42,12 +76,29 @@ test('appendRelevantProjectContext appends relevant memories', async t => {
 	const prompt = await appendRelevantProjectContext('base prompt', 'auth', {
 		findRelevantMemories: async (query, limit) => {
 			t.is(query, 'auth');
-			t.is(limit, 3);
+			t.is(limit, 8);
 			return [memory('Auth uses Clerk.')];
 		},
 	});
 
 	t.is(prompt, 'base prompt\n\n## Project Context\n\n- Auth uses Clerk.');
+});
+
+test('appendRelevantProjectContext passes configured memory limit', async t => {
+	const prompt = await appendRelevantProjectContext(
+		'base prompt',
+		'auth',
+		{
+			findRelevantMemories: async (query, limit) => {
+				t.is(query, 'auth');
+				t.is(limit, 2);
+				return [memory('Auth uses Clerk.')];
+			},
+		},
+		{memoryLimit: 2},
+	);
+
+	t.true(prompt.includes('Auth uses Clerk.'));
 });
 
 test('appendRelevantProjectContext returns original prompt when lookup fails', async t => {

--- a/source/memory/project-context.spec.ts
+++ b/source/memory/project-context.spec.ts
@@ -1,0 +1,61 @@
+import test from 'ava';
+import {
+	appendProjectContext,
+	appendRelevantProjectContext,
+	formatProjectContext,
+} from './project-context.js';
+import type {SemanticMemory} from './semantic-memory-manager.js';
+
+const memory = (content: string): SemanticMemory => ({
+	id: content,
+	content,
+	category: 'project',
+	timestamp: '2026-07-17T00:00:00.000Z',
+});
+
+test('formatProjectContext returns empty string for no memories', t => {
+	t.is(formatProjectContext([]), '');
+});
+
+test('formatProjectContext formats memories as project context', t => {
+	t.is(
+		formatProjectContext([
+			memory('Auth uses Clerk.'),
+			memory('Avoid middleware.\nUse adapters.'),
+		]),
+		'## Project Context\n\n- Auth uses Clerk.\n- Avoid middleware. Use adapters.',
+	);
+});
+
+test('appendProjectContext returns original prompt without memories', t => {
+	t.is(appendProjectContext('base prompt', []), 'base prompt');
+});
+
+test('appendProjectContext appends formatted memories', t => {
+	t.is(
+		appendProjectContext('base prompt', [memory('Use existing provider.')]),
+		'base prompt\n\n## Project Context\n\n- Use existing provider.',
+	);
+});
+
+test('appendRelevantProjectContext appends relevant memories', async t => {
+	const prompt = await appendRelevantProjectContext('base prompt', 'auth', {
+		findRelevantMemories: async (query, limit) => {
+			t.is(query, 'auth');
+			t.is(limit, 3);
+			return [memory('Auth uses Clerk.')];
+		},
+	});
+
+	t.is(prompt, 'base prompt\n\n## Project Context\n\n- Auth uses Clerk.');
+});
+
+test('appendRelevantProjectContext returns original prompt when lookup fails', async t => {
+	const prompt = await appendRelevantProjectContext('base prompt', 'auth', {
+		findRelevantMemories: async () => {
+			throw new Error('memory unavailable');
+		},
+	});
+
+	t.is(prompt, 'base prompt');
+});

--- a/source/memory/project-context.ts
+++ b/source/memory/project-context.ts
@@ -1,0 +1,41 @@
+import type {SemanticMemory} from './semantic-memory-manager';
+import {SemanticMemoryManager} from './semantic-memory-manager';
+
+type MemoryFinder = Pick<SemanticMemoryManager, 'findRelevantMemories'>;
+
+const PROJECT_CONTEXT_LIMIT = 3;
+
+export function formatProjectContext(memories: SemanticMemory[]): string {
+	if (memories.length === 0) return '';
+
+	const bullets = memories.map(
+		memory => `- ${memory.content.replaceAll(/\s+/gu, ' ').trim()}`,
+	);
+
+	return `## Project Context\n\n${bullets.join('\n')}`;
+}
+
+export function appendProjectContext(
+	systemPrompt: string,
+	memories: SemanticMemory[],
+): string {
+	const projectContext = formatProjectContext(memories);
+	if (!projectContext) return systemPrompt;
+
+	return `${systemPrompt}\n\n${projectContext}`;
+}
+
+export async function appendRelevantProjectContext(
+	systemPrompt: string,
+	query: string,
+	memoryFinder: MemoryFinder = new SemanticMemoryManager(),
+): Promise<string> {
+	try {
+		return appendProjectContext(
+			systemPrompt,
+			await memoryFinder.findRelevantMemories(query, PROJECT_CONTEXT_LIMIT),
+		);
+	} catch {
+		return systemPrompt;
+	}
+}

--- a/source/memory/project-context.ts
+++ b/source/memory/project-context.ts
@@ -1,16 +1,40 @@
 import type {SemanticMemory} from './semantic-memory-manager';
 import {SemanticMemoryManager} from './semantic-memory-manager';
 
-type MemoryFinder = Pick<SemanticMemoryManager, 'findRelevantMemories'>;
+export type MemoryFinder = Pick<SemanticMemoryManager, 'findRelevantMemories'>;
 
-const PROJECT_CONTEXT_LIMIT = 3;
+export interface ProjectContextOptions {
+	memoryLimit?: number;
+	tokenBudget?: number;
+}
 
-export function formatProjectContext(memories: SemanticMemory[]): string {
+const DEFAULT_MEMORY_LIMIT = 8;
+const DEFAULT_TOKEN_BUDGET = 240;
+
+function estimateTokens(value: string): number {
+	return Math.ceil(value.length / 4);
+}
+
+export function formatProjectContext(
+	memories: SemanticMemory[],
+	options: ProjectContextOptions = {},
+): string {
 	if (memories.length === 0) return '';
 
-	const bullets = memories.map(
-		memory => `- ${memory.content.replaceAll(/\s+/gu, ' ').trim()}`,
-	);
+	const tokenBudget = options.tokenBudget ?? DEFAULT_TOKEN_BUDGET;
+	const bullets: string[] = [];
+	let usedTokens = estimateTokens('## Project Context\n\n');
+
+	for (const memory of memories) {
+		const bullet = `- ${memory.content.replaceAll(/\s+/gu, ' ').trim()}`;
+		const bulletTokens = estimateTokens(`${bullet}\n`);
+		if (usedTokens + bulletTokens > tokenBudget) continue;
+
+		bullets.push(bullet);
+		usedTokens += bulletTokens;
+	}
+
+	if (bullets.length === 0) return '';
 
 	return `## Project Context\n\n${bullets.join('\n')}`;
 }
@@ -18,8 +42,9 @@ export function formatProjectContext(memories: SemanticMemory[]): string {
 export function appendProjectContext(
 	systemPrompt: string,
 	memories: SemanticMemory[],
+	options?: ProjectContextOptions,
 ): string {
-	const projectContext = formatProjectContext(memories);
+	const projectContext = formatProjectContext(memories, options);
 	if (!projectContext) return systemPrompt;
 
 	return `${systemPrompt}\n\n${projectContext}`;
@@ -29,11 +54,16 @@ export async function appendRelevantProjectContext(
 	systemPrompt: string,
 	query: string,
 	memoryFinder: MemoryFinder = new SemanticMemoryManager(),
+	options: ProjectContextOptions = {},
 ): Promise<string> {
 	try {
 		return appendProjectContext(
 			systemPrompt,
-			await memoryFinder.findRelevantMemories(query, PROJECT_CONTEXT_LIMIT),
+			await memoryFinder.findRelevantMemories(
+				query,
+				options.memoryLimit ?? DEFAULT_MEMORY_LIMIT,
+			),
+			options,
 		);
 	} catch {
 		return systemPrompt;

--- a/source/memory/semantic-memory-manager.spec.ts
+++ b/source/memory/semantic-memory-manager.spec.ts
@@ -93,6 +93,26 @@ test('SemanticMemoryManager returns relevant memories before unrelated ones', as
 	]);
 });
 
+test('SemanticMemoryManager includes category matches in relevance ranking', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+
+	const architecture = await manager.addMemory({
+		content: 'Use the service layer for persistence changes.',
+		category: 'architecture',
+	});
+	await manager.addMemory({
+		content: 'Release notes are generated from contributor history.',
+		category: 'workflow',
+	});
+
+	t.deepEqual(await manager.findRelevantMemories('architecture', 3), [
+		architecture,
+	]);
+});
+
 test('SemanticMemoryManager rejects empty memory content', async t => {
 	const dir = await createTempDir();
 	const cwd = path.join(dir, 'repo');

--- a/source/memory/semantic-memory-manager.ts
+++ b/source/memory/semantic-memory-manager.ts
@@ -147,9 +147,11 @@ export class SemanticMemoryManager {
 		return (await this.listMemories())
 			.map(memory => {
 				const memoryTerms = tokenize(memory.content);
+				const categoryTerms = tokenize(memory.category);
 				let score = 0;
 				for (const term of queryTerms) {
 					if (memoryTerms.has(term)) score++;
+					if (categoryTerms.has(term)) score++;
 				}
 				return {memory, score};
 			})


### PR DESCRIPTION
## Description

Adds Phase 3 of semantic memory: retrieves relevant repo-scoped memories and appends them to the system prompt as `Project Context` before the model call. This uses the existing `SemanticMemoryManager.findRelevantMemories()` path and keeps injection limited to the top relevant memories.

Phase 3: #619

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))