### PR TITLE
fix: provider wizard data loss and startup provider fallback

### DIFF
--- a/.changeset/provider-robustness.md
+++ b/.changeset/provider-robustness.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed provider configuration loading so existing providers are preserved and startup falls back to a working provider instead of freezing. Thanks to @llupRisinglll.

--- a/source/hooks/startup-provider.spec.ts
+++ b/source/hooks/startup-provider.spec.ts
@@ -1,0 +1,82 @@
+import test from 'ava';
+import {resolveStartupProvider} from './startup-provider';
+
+test('stale saved provider falls back to undefined with staleName set', t => {
+	const result = resolveStartupProvider(
+		undefined,
+		undefined,
+		'ghost-provider',
+		['openai', 'anthropic'],
+	);
+
+	t.deepEqual(result, {provider: undefined, staleName: 'ghost-provider'});
+});
+
+test('valid saved provider passes through unchanged', t => {
+	const result = resolveStartupProvider(undefined, undefined, 'openai', [
+		'openai',
+		'anthropic',
+	]);
+
+	t.deepEqual(result, {provider: 'openai'});
+});
+
+test('cliProvider is strict passthrough even when unknown', t => {
+	const result = resolveStartupProvider(
+		'totally-unknown',
+		undefined,
+		'openai',
+		['openai', 'anthropic'],
+	);
+
+	t.deepEqual(result, {provider: 'totally-unknown'});
+});
+
+test('cliProvider takes precedence over modeProvider and lastProvider', t => {
+	const result = resolveStartupProvider('cli-provider', 'mode-provider', 'last-provider', [
+		'cli-provider',
+		'mode-provider',
+		'last-provider',
+	]);
+
+	t.deepEqual(result, {provider: 'cli-provider'});
+});
+
+test('modeProvider takes precedence over lastProvider when no cliProvider', t => {
+	const result = resolveStartupProvider(undefined, 'mode-provider', 'last-provider', [
+		'mode-provider',
+		'last-provider',
+	]);
+
+	t.deepEqual(result, {provider: 'mode-provider'});
+});
+
+test('match is case-insensitive', t => {
+	const result = resolveStartupProvider(undefined, undefined, 'OpenAI', [
+		'openai',
+	]);
+
+	t.deepEqual(result, {provider: 'OpenAI'});
+});
+
+test('stale mode provider (not cli) also falls back with staleName set', t => {
+	const result = resolveStartupProvider(undefined, 'stale-mode', 'openai', [
+		'openai',
+	]);
+
+	t.deepEqual(result, {provider: undefined, staleName: 'stale-mode'});
+});
+
+test('no configured providers and a saved provider is always stale', t => {
+	const result = resolveStartupProvider(undefined, undefined, 'openai', []);
+
+	t.deepEqual(result, {provider: undefined, staleName: 'openai'});
+});
+
+test('no provider anywhere resolves to undefined with no staleName', t => {
+	const result = resolveStartupProvider(undefined, undefined, undefined, [
+		'openai',
+	]);
+
+	t.deepEqual(result, {provider: undefined});
+});

--- a/source/hooks/startup-provider.ts
+++ b/source/hooks/startup-provider.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure decision logic for resolving which provider name should be used at
+ * startup, and whether the resolved name is "stale" (saved/mode provider no
+ * longer present in the configured provider list).
+ *
+ * Kept side-effect free on purpose: the caller owns loading the configured
+ * provider names (`loadAllProviderConfigs()`) and any UI side effects (e.g.
+ * queuing a warning message) triggered by a stale result.
+ */
+export interface ResolvedStartupProvider {
+	/** The provider name to pass through, or undefined to use the default. */
+	provider: string | undefined;
+	/**
+	 * Set to the original (stale) name when a saved/mode provider was
+	 * rejected because it isn't in the configured provider list. Absent when
+	 * no fallback occurred (including the strict `cliProvider` path, which
+	 * never triggers a fallback).
+	 */
+	staleName?: string;
+}
+
+/**
+ * Resolve the startup provider name from CLI args, mode config, and saved
+ * preferences, applying the "unknown saved/mode provider falls back to the
+ * default provider" rule.
+ *
+ * An explicit `cliProvider` is always passed through unchanged, even if it
+ * isn't in `configuredNames` — the user asked for that provider by name, so
+ * a hard error downstream (in `createLLMClient`) is the honest response.
+ */
+export function resolveStartupProvider(
+	cliProvider: string | undefined,
+	modeProvider: string | undefined,
+	lastProvider: string | undefined,
+	configuredNames: readonly string[],
+): ResolvedStartupProvider {
+	const provider = cliProvider || modeProvider || lastProvider;
+
+	if (!cliProvider && provider) {
+		const staleName = provider;
+		const known = configuredNames.some(
+			name => name.toLowerCase() === staleName.toLowerCase(),
+		);
+		if (!known) {
+			return {provider: undefined, staleName};
+		}
+	}
+
+	return {provider};
+}

--- a/source/hooks/useAppInitialization.tsx
+++ b/source/hooks/useAppInitialization.tsx
@@ -22,6 +22,7 @@ import {validateProjectConfigSecurity} from '@/config/validation';
 import {TIMEOUT_OUTPUT_FLUSH_MS} from '@/constants';
 import {CustomCommandExecutor} from '@/custom-commands/executor';
 import {CustomCommandLoader} from '@/custom-commands/loader';
+import {resolveStartupProvider} from '@/hooks/startup-provider';
 import {getLSPManager, type LSPInitResult} from '@/lsp/index';
 import {
 	setCommandLoaderGetter,
@@ -367,29 +368,27 @@ export function useAppInitialization({
 
 			// Use CLI provider/model if provided, otherwise mode-specific, otherwise preferences
 			const isProgrammatic = !(cliProvider || cliModel) && !!modeConfig;
-			let provider =
-				cliProvider || modeConfig?.provider || preferences.lastProvider;
 			// A saved/mode provider can go stale (renamed or removed from
 			// agents.config.json). Passing it through would make createLLMClient
 			// throw and strand the app on an error screen with no client. Fall
 			// back to the default-provider path with a warning instead. An
 			// explicit --provider CLI arg stays strict: the user asked for that
 			// provider by name, so a hard error is the honest response.
-			if (!cliProvider && provider) {
-				const staleName = provider;
-				const known = loadAllProviderConfigs().some(
-					p => p.name.toLowerCase() === staleName.toLowerCase(),
+			const configuredNames = loadAllProviderConfigs().map(p => p.name);
+			const {provider, staleName} = resolveStartupProvider(
+				cliProvider,
+				modeConfig?.provider,
+				preferences.lastProvider,
+				configuredNames,
+			);
+			if (staleName) {
+				addToChatQueue(
+					<WarningMessage
+						key={generateKey('stale-provider')}
+						message={`Saved provider '${staleName}' is not in agents.config.json — falling back to the first configured provider.`}
+						hideBox={true}
+					/>,
 				);
-				if (!known) {
-					addToChatQueue(
-						<WarningMessage
-							key={generateKey('stale-provider')}
-							message={`Saved provider '${staleName}' is not in agents.config.json — falling back to the first configured provider.`}
-							hideBox={true}
-						/>,
-					);
-					provider = undefined;
-				}
 			}
 			const model = cliModel || modeConfig?.model || undefined;
 			const client = await initializeClient(provider, model, isProgrammatic);

--- a/source/hooks/useAppInitialization.tsx
+++ b/source/hooks/useAppInitialization.tsx
@@ -367,8 +367,30 @@ export function useAppInitialization({
 
 			// Use CLI provider/model if provided, otherwise mode-specific, otherwise preferences
 			const isProgrammatic = !(cliProvider || cliModel) && !!modeConfig;
-			const provider =
+			let provider =
 				cliProvider || modeConfig?.provider || preferences.lastProvider;
+			// A saved/mode provider can go stale (renamed or removed from
+			// agents.config.json). Passing it through would make createLLMClient
+			// throw and strand the app on an error screen with no client. Fall
+			// back to the default-provider path with a warning instead. An
+			// explicit --provider CLI arg stays strict: the user asked for that
+			// provider by name, so a hard error is the honest response.
+			if (!cliProvider && provider) {
+				const staleName = provider;
+				const known = loadAllProviderConfigs().some(
+					p => p.name.toLowerCase() === staleName.toLowerCase(),
+				);
+				if (!known) {
+					addToChatQueue(
+						<WarningMessage
+							key={generateKey('stale-provider')}
+							message={`Saved provider '${staleName}' is not in agents.config.json — falling back to the first configured provider.`}
+							hideBox={true}
+						/>,
+					);
+					provider = undefined;
+				}
+			}
 			const model = cliModel || modeConfig?.model || undefined;
 			const client = await initializeClient(provider, model, isProgrammatic);
 
@@ -423,6 +445,26 @@ export function useAppInitialization({
 							hideBox={true}
 						/>,
 					);
+				}
+			} else if (
+				error instanceof Error &&
+				error.message.includes('All configured providers failed')
+			) {
+				// Every configured provider failed to initialize. Without a
+				// client the app is unusable, so surface the per-provider
+				// errors and open the provider wizard — the user has to fix
+				// or re-enter a provider either way.
+				addToChatQueue(
+					<ErrorMessage
+						key={generateKey('init-error')}
+						message={error.message}
+						hideBox={true}
+					/>,
+				);
+				if (!nonInteractiveMode) {
+					setTimeout(() => {
+						setActiveMode('configWizard');
+					}, 100);
 				}
 			} else {
 				// Regular error - show simple error message

--- a/source/wizards/base-config-wizard.spec.tsx
+++ b/source/wizards/base-config-wizard.spec.tsx
@@ -1,9 +1,21 @@
-import {existsSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
 import {Box, Text} from 'ink';
 import React from 'react';
+// CRITICAL: redirect config reads to a temp dir BEFORE any @/config import.
+// BaseConfigWizard calls getColors() -> loadPreferences() directly (not
+// through ThemeContext), which otherwise reads this machine's real global
+// preferences file. A fork-only `selectedTheme` value there (not present in
+// upstream's themes.json) makes getThemeColors() throw, crashing every test
+// in this file before it can render anything.
+process.env.NANOCODER_CONFIG_DIR = mkdtempSync(
+	join(tmpdir(), 'nanocoder-wizard-spec-'),
+);
+const {resetPreferencesCache} = await import('@/config/preferences');
+resetPreferencesCache();
+
 import {renderWithTheme} from '../test-utils/render-with-theme.js';
 import {BaseConfigWizard} from './base-config-wizard.js';
 
@@ -273,5 +285,91 @@ test.serial('deleting corrupted config clears corruption state', async t => {
 	t.false(existsSync(configPath));
 	t.is(completedPath, configPath);
 });
+
+test.serial(
+	'configure step receives pre-existing config entries synchronously on entering configure (regression: deferred load lost entries)',
+	async t => {
+		const testDir = join(
+			tmpdir(),
+			`nanocoder-wizard-test-preload-${Date.now()}`,
+		);
+		mkdirSync(testDir, {recursive: true});
+		t.teardown(() => rmSync(testDir, {recursive: true, force: true}));
+
+		const configFileName = 'agents.config.json';
+		const configPath = join(testDir, configFileName);
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				providers: [{name: 'openai'}, {name: 'anthropic'}],
+			}),
+			'utf-8',
+		);
+
+		// Records the `items` the configure step actually received the moment
+		// it first renders. Before the fix (deferred useEffect load, firing
+		// after `setStep('configure')` had already committed), this step's
+		// own useState initializer would capture the wizard's still-empty
+		// `initialItems` — a real config-file with entries would render here
+		// as if it were empty, silently discarding the user's existing
+		// providers on next save.
+		const receivedOnFirstRender: string[][] = [];
+
+		// A real component (not a function called inline by BaseConfigWizard's
+		// switch statement) so its `useState` initializer runs as ITS OWN
+		// hook, exactly matching how the real configure steps this bug
+		// affected are structured — a plain function reference invoked
+		// directly would attach the hook to BaseConfigWizard itself instead.
+		function ConfigureCapture({items}: {items: FakeItems}) {
+			const [captured] = React.useState(items.entries);
+			receivedOnFirstRender.push(captured);
+			return (
+				<Box flexDirection="column">
+					<Text>configure step</Text>
+					<Text>entries: {captured.join(',')}</Text>
+				</Box>
+			);
+		}
+
+		const {lastFrame, stdin} = renderWithTheme(
+			<BaseConfigWizard<FakeItems>
+				title="Title"
+				focusId="preload-wizard"
+				configFileName={configFileName}
+				initialItems={{entries: []}}
+				parseConfig={raw => ({
+					entries: (raw as {providers: {name: string}[]}).providers.map(
+						p => p.name,
+					),
+				})}
+				buildConfig={items => ({
+					providers: items.entries.map(name => ({name})),
+				})}
+				hasItems={items => items.entries.length > 0}
+				renderConfigureStep={({items}) => <ConfigureCapture items={items} />}
+				renderSummaryItems={noopRenderSummary}
+				projectDir={testDir}
+				onComplete={() => {}}
+			/>,
+		);
+
+		// Project config exists, so the location step opens in
+		// "existing-config" mode; the first (default-selected) option is
+		// "Edit this configuration" — select it with Enter.
+		stdin.write('\r');
+		await new Promise(r => setTimeout(r, 100));
+
+		t.true(receivedOnFirstRender.length >= 1);
+		// The captured value comes from a useState initializer, so every
+		// render (even re-renders after the initial mount) must report the
+		// same first-mount snapshot. Before the fix, this would be `[]`.
+		for (const captured of receivedOnFirstRender) {
+			t.deepEqual(captured, ['openai', 'anthropic']);
+		}
+
+		const output = lastFrame()!;
+		t.regex(output, /entries: openai,anthropic/);
+	},
+);
 
 

--- a/source/wizards/base-config-wizard.tsx
+++ b/source/wizards/base-config-wizard.tsx
@@ -10,7 +10,7 @@ import {dirname, join} from 'node:path';
 import {Box, Text, useFocus, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 import Spinner from 'ink-spinner';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {getColors} from '@/config/index';
 import {getConfigPath} from '@/config/paths';
@@ -99,38 +99,47 @@ export function BaseConfigWizard<T>({
 
 	useFocus({autoFocus: true, id: focusId});
 
-	useEffect(() => {
-		if (!configPath) return;
-
-		void Promise.resolve().then(() => {
+	// Loads the existing config at `path` into wizard state. MUST run before
+	// entering the configure step: its child steps capture `items` in useState
+	// initializers at mount, so a load that lands after mount is silently
+	// ignored — and a later save would then REPLACE the file with only the
+	// newly-added entries, destroying the user's existing ones.
+	const loadExistingConfig = useCallback(
+		(path: string) => {
 			try {
-				if (existsSync(configPath)) {
+				if (existsSync(path)) {
 					try {
-						const content = readFileSync(configPath, 'utf-8');
+						const content = readFileSync(path, 'utf-8');
 						const raw = JSON.parse(content) as unknown;
 						setItems(parseConfig(raw));
 						setConfigCorrupted(false);
 					} catch (err) {
 						logError('Failed to load configuration', true, {
-							context: {configPath},
+							context: {configPath: path},
 							error: formatError(err),
 						});
 						setConfigCorrupted(true);
 						setError(
 							`Configuration file has invalid JSON and cannot be loaded. ` +
 								`Fix the syntax error or delete the file before proceeding. ` +
-								`File: ${configPath}`,
+								`File: ${path}`,
 						);
 					}
 				}
 			} catch (err) {
 				logError('Failed to load existing configuration', true, {
-					context: {configPath},
+					context: {configPath: path},
 					error: formatError(err),
 				});
 			}
-		});
-	}, [configPath, parseConfig]);
+		},
+		[parseConfig],
+	);
+
+	useEffect(() => {
+		if (!configPath) return;
+		loadExistingConfig(configPath);
+	}, [configPath, loadExistingConfig]);
 
 	const writeConfigToDisk = (data: T): void => {
 		if (!hasItems(data)) return;
@@ -150,7 +159,11 @@ export function BaseConfigWizard<T>({
 
 	const handleLocationComplete = (location: ConfigLocation) => {
 		const baseDir = location === 'project' ? projectDir : getConfigPath();
-		setConfigPath(join(baseDir, configFileName));
+		const nextPath = join(baseDir, configFileName);
+		setConfigPath(nextPath);
+		// Synchronous load before the configure step mounts — see
+		// loadExistingConfig for why deferring this loses existing entries.
+		loadExistingConfig(nextPath);
 		setStep('configure');
 	};
 


### PR DESCRIPTION
## Description

- The provider wizard no longer deletes existing providers when adding a new one — new providers are appended to `agents.config.json`.
- Startup no longer freezes when the saved provider is missing from `agents.config.json` — it warns and falls back to the first configured provider (an explicit `--provider` CLI arg stays strict and still errors).
- If every configured provider fails to load, the per-provider errors are shown and the provider wizard opens instead of a dead screen.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`useAppInitialization` spec, `tsc --noEmit`, build — all clean; no behavior removed, only new guard paths added)
- [ ] Tests cover both success and error scenarios

### Manual Testing

Verified across four scenarios on a real multi-provider config:
1. Stale saved provider + valid providers → warning + boots on first provider.
2. Stale saved provider + broken first provider → provider-order chain skips it, boots on next valid one.
3. Zero providers configured → setup wizard opens (pre-existing path, confirmed unaffected).
4. All providers broken → per-provider error list + wizard opens (previously froze on a dead screen).

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes
- [ ] Appropriate logging added using structured logging
