### PR TITLE
feat: add --resume/--continue CLI session flags

### DIFF
--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -37,7 +37,7 @@ Type `/` in the chat input to see available commands. All commands start with `/
 | `/lsp` | List connected LSP servers |
 | `/schedule` | Read-only view of cron subscriptions declared by skills (see [Skills → Event subscriptions](skills.md#event-subscriptions)) |
 | `/skills` | List and inspect loaded skills; scaffold new bundle skills with AI assistance (see [Skills](skills.md)) |
-| `/resume` | Resume a previous chat session (aliases: `/sessions`, `/history`). See [Session Management](session-management.md) |
+| `/resume` | Resume a previous chat session (aliases: `/sessions`, `/history`). Also available at launch via the `--resume`/`--continue` CLI flags. See [Session Management](session-management.md) |
 | `/retry` | Re-run the last user turn. Use `/retry --model <id>` or `/retry --provider <name> --model <id>` to switch models first |
 | `/rename` | Rename the current session. Name must be non-empty and 100 characters or less. See [Session Management](session-management.md) |
 | `/explorer` | Interactive file browser to navigate, preview, and select files for context |

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -138,6 +138,10 @@ Nanocoder [automatically saves your sessions](session-management.md) so you can 
 /resume last    # jump back into the most recent one
 ```
 
+```bash
+nanocoder --continue    # or resume from your shell at launch
+```
+
 Sessions are saved every 30 seconds by default and kept for 30 days.
 
 ## Tracking Complex Work

--- a/docs/features/session-management.md
+++ b/docs/features/session-management.md
@@ -19,6 +19,19 @@ Nanocoder automatically saves your conversations so you can close the terminal a
 
 You can also use the aliases `/sessions` or `/history`.
 
+### From the Command Line
+
+You can resume a session directly at launch instead of using a slash command:
+
+```bash
+nanocoder --continue      # resume the most recent session for this directory (-c)
+nanocoder --resume        # open the session picker at startup (-r)
+nanocoder --resume last   # jump straight into the most recent session
+nanocoder --resume {id}   # resume a specific session by ID or list index
+```
+
+`--continue` silently starts a fresh session if no previous session exists for the current directory, while `--resume` exits with an error if the requested session is not found. The two flags are mutually exclusive, and both are interactive-only — they cannot be combined with `run`. See the [CLI Options Reference](../getting-started/index.md#cli-options) for the full flag list.
+
 ## Renaming a Session
 
 ```bash

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -55,6 +55,8 @@ nanocoder -h
 | `--trust-directory` | | Skip the first-run directory trust prompt for this run only. Only valid with `run`; ignored (with a warning) in interactive mode. The trust is ephemeral — `trustedDirectories` in your preferences file is not modified. |
 | `--alt-screen` | | Start in fullscreen mode: a fixed-height layout on the alternate screen buffer with in-app scrolling. Overrides the `alternateScreen` preference for this run. |
 | `--no-alt-screen` | | Force inline mode (the default), even if `alternateScreen: true` is set in your preferences file. |
+| `--continue` | `-c` | Resume the most recent [saved session](../features/session-management.md) for the current directory; starts a fresh session if none exists. Interactive only — errors with `run`. Mutually exclusive with `--resume`. |
+| `--resume [id]` | `-r` | Resume a [saved session](../features/session-management.md) by session ID, 1-based list index, or `last`. With no ID, opens the session picker at startup. Errors if the session is not found. Interactive only — errors with `run`. |
 | `run` | | Run in non-interactive mode |
 
 **Provider/Model Flags:**

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -60,6 +60,8 @@ export default function App({
 	cliMode,
 	trustDirectory = false,
 	altScreenActive = false,
+	initialSession,
+	openSessionSelectorOnStart = false,
 }: AppProps) {
 	// Resolve the initial development mode with this precedence:
 	// 1. --mode CLI flag (highest priority)
@@ -487,6 +489,25 @@ export default function App({
 		handleChatMessage: chatHandler.handleChatMessage,
 		dismissActiveEditor: vscodeServer.dismissActiveEditor,
 	});
+
+	// Apply a session resolved by cli.tsx from --continue/--resume <id> (or open
+	// the picker for a bare --resume), once on mount. Reuses the exact same
+	// applySession path as the in-app /resume command so messages, provider,
+	// model, sessionId, key-generator reseed, and scrollback replay all stay
+	// in sync. Guarded by a ref (not an empty dep array) so a re-render before
+	// the effect fires — e.g. from the vscode-prompt-dispatcher bind above —
+	// can't apply it twice.
+	const startupSessionAppliedRef = React.useRef(false);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: startup-only effect, guarded by the ref above
+	React.useEffect(() => {
+		if (startupSessionAppliedRef.current) return;
+		startupSessionAppliedRef.current = true;
+		if (initialSession) {
+			appHandlers.applySession(initialSession);
+		} else if (openSessionSelectorOnStart) {
+			appState.setActiveMode('sessionSelector');
+		}
+	}, []);
 
 	// Bind the chat-input submit handler into the VS Code prompt dispatcher
 	// now that appHandlers exists. The dispatcher was created earlier (before

--- a/source/app/types.ts
+++ b/source/app/types.ts
@@ -1,3 +1,4 @@
+import type {Session} from '@/session/session-manager';
 import type {DevelopmentMode} from '@/types/core';
 
 /**
@@ -42,6 +43,17 @@ export interface AppProps {
 	 * the terminal's native scrollback.
 	 */
 	altScreenActive?: boolean;
+	/**
+	 * A session resolved by `cli.tsx` from `--continue`/`--resume <id>` before
+	 * render. Applied once on mount via the same `applySession` path used by
+	 * `/resume` (see App.tsx).
+	 */
+	initialSession?: Session;
+	/**
+	 * Set when `--resume` was passed with no id: opens the session picker
+	 * (activeMode `'sessionSelector'`) as soon as the app mounts.
+	 */
+	openSessionSelectorOnStart?: boolean;
 }
 
 /**

--- a/source/app/utils/handlers/session-handler.ts
+++ b/source/app/utils/handlers/session-handler.ts
@@ -1,3 +1,4 @@
+import {resolveSession} from '@/session/resolve-session';
 import {sessionManager} from '@/session/session-manager';
 import type {MessageSubmissionOptions} from '@/types/index';
 import {formatError} from '@/utils/error-formatter';
@@ -68,41 +69,21 @@ export async function handleResumeCommand(
 
 	const sessionIdOrSpecial = args[0];
 	try {
-		const listOptions = showAll ? undefined : {workingDirectory: process.cwd()};
-		const sessions = await sessionManager.listSessions(listOptions);
-		const sorted = [...sessions].sort(
-			(a, b) =>
-				new Date(b.lastAccessedAt).getTime() -
-				new Date(a.lastAccessedAt).getTime(),
-		);
+		const result = await resolveSession(sessionIdOrSpecial, process.cwd(), {
+			all: showAll,
+		});
 
-		let sessionId: string | null = null;
-
-		if (sessionIdOrSpecial.toLowerCase() === 'last') {
-			if (sorted.length > 0) sessionId = sorted[0].id;
-		} else {
-			const index = Number.parseInt(sessionIdOrSpecial, 10);
-			if (!Number.isNaN(index) && index >= 1 && index <= sorted.length) {
-				sessionId = sorted[index - 1].id;
-			} else {
-				sessionId = sessionIdOrSpecial;
-			}
-		}
-
-		if (!sessionId) {
-			onAddToChatQueue(infoMsg('No sessions found.', 'resume-info'));
+		if (!result.ok) {
+			const msg =
+				result.reason === 'empty'
+					? infoMsg(result.message, 'resume-info')
+					: errorMsg(result.message, 'resume-error');
+			onAddToChatQueue(msg);
 			onCommandComplete?.();
 			return true;
 		}
 
-		const session = await sessionManager.loadSession(sessionId);
-		if (session) {
-			onResumeSession(session);
-		} else {
-			onAddToChatQueue(
-				errorMsg(`Session not found: ${sessionId}`, 'resume-error'),
-			);
-		}
+		onResumeSession(result.session);
 	} catch (error) {
 		onAddToChatQueue(
 			errorMsg(

--- a/source/cli.spec.ts
+++ b/source/cli.spec.ts
@@ -445,3 +445,135 @@ test('alt-screen: flag and preference both true is not double-negated', t => {
 	});
 	t.true(useAltScreen);
 });
+
+// --continue / -c and --resume / -r flag parsing tests. Mirrors the logic in
+// cli.tsx: mutual exclusion, optional id/index after --resume, and rejection
+// when combined with the `run` command.
+function resolveResumeFlags(args: string[]): {
+	continueRequested: boolean;
+	resumeRequested: boolean;
+	resumeArg: string | undefined;
+	mutuallyExclusiveError: boolean;
+	nonInteractiveError: boolean;
+} {
+	const runCommandIndex = args.findIndex(arg => arg === 'run');
+	const nonInteractiveMode = runCommandIndex !== -1;
+
+	const continueRequested =
+		args.includes('--continue') || args.includes('-c');
+	const resumeFlagIndex = args.findIndex(
+		arg => arg === '--resume' || arg === '-r',
+	);
+	const resumeRequested = resumeFlagIndex !== -1;
+
+	const mutuallyExclusiveError = continueRequested && resumeRequested;
+
+	let resumeArg: string | undefined;
+	if (resumeRequested) {
+		const next = args[resumeFlagIndex + 1];
+		if (next && !next.startsWith('-') && next !== 'run') {
+			resumeArg = next;
+		}
+	}
+
+	const nonInteractiveError =
+		(continueRequested || resumeRequested) &&
+		nonInteractiveMode &&
+		!mutuallyExclusiveError;
+
+	return {
+		continueRequested,
+		resumeRequested,
+		resumeArg,
+		mutuallyExclusiveError,
+		nonInteractiveError,
+	};
+}
+
+test('resume flags: detects --continue', t => {
+	const {continueRequested} = resolveResumeFlags(['--continue']);
+	t.true(continueRequested);
+});
+
+test('resume flags: detects -c shorthand', t => {
+	const {continueRequested} = resolveResumeFlags(['-c']);
+	t.true(continueRequested);
+});
+
+test('resume flags: detects --resume with no id', t => {
+	const {resumeRequested, resumeArg} = resolveResumeFlags(['--resume']);
+	t.true(resumeRequested);
+	t.is(resumeArg, undefined);
+});
+
+test('resume flags: detects -r shorthand with no id', t => {
+	const {resumeRequested, resumeArg} = resolveResumeFlags(['-r']);
+	t.true(resumeRequested);
+	t.is(resumeArg, undefined);
+});
+
+test('resume flags: captures an id after --resume', t => {
+	const {resumeRequested, resumeArg} = resolveResumeFlags([
+		'--resume',
+		'last',
+	]);
+	t.true(resumeRequested);
+	t.is(resumeArg, 'last');
+});
+
+test('resume flags: captures a numeric index after -r', t => {
+	const {resumeArg} = resolveResumeFlags(['-r', '2']);
+	t.is(resumeArg, '2');
+});
+
+test('resume flags: captures a raw uuid after --resume', t => {
+	const {resumeArg} = resolveResumeFlags([
+		'--resume',
+		'123e4567-e89b-42d3-a456-426614174000',
+	]);
+	t.is(resumeArg, '123e4567-e89b-42d3-a456-426614174000');
+});
+
+test('resume flags: does not treat a following flag as the resume id', t => {
+	const {resumeArg} = resolveResumeFlags(['--resume', '--alt-screen']);
+	t.is(resumeArg, undefined);
+});
+
+test('resume flags: does not treat a following `run` as the resume id', t => {
+	const {resumeArg} = resolveResumeFlags(['--resume', 'run', 'do a thing']);
+	t.is(resumeArg, undefined);
+});
+
+test('resume flags: --continue and --resume together is an error', t => {
+	const {mutuallyExclusiveError} = resolveResumeFlags([
+		'--continue',
+		'--resume',
+	]);
+	t.true(mutuallyExclusiveError);
+});
+
+test('resume flags: -c and -r together is an error', t => {
+	const {mutuallyExclusiveError} = resolveResumeFlags(['-c', '-r']);
+	t.true(mutuallyExclusiveError);
+});
+
+test('resume flags: neither flag alone is not a mutual-exclusion error', t => {
+	t.false(resolveResumeFlags(['--continue']).mutuallyExclusiveError);
+	t.false(resolveResumeFlags(['--resume']).mutuallyExclusiveError);
+	t.false(resolveResumeFlags([]).mutuallyExclusiveError);
+});
+
+test('resume flags: --continue combined with `run` is an error', t => {
+	const {nonInteractiveError} = resolveResumeFlags(['--continue', 'run', 'hi']);
+	t.true(nonInteractiveError);
+});
+
+test('resume flags: --resume combined with `run` is an error', t => {
+	const {nonInteractiveError} = resolveResumeFlags(['--resume', 'run', 'hi']);
+	t.true(nonInteractiveError);
+});
+
+test('resume flags: --continue without `run` is not a non-interactive error', t => {
+	const {nonInteractiveError} = resolveResumeFlags(['--continue']);
+	t.false(nonInteractiveError);
+});

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -94,6 +94,11 @@ Options:
   --output-format     Specify stdout format ('text' or 'json'). Synonym for --json.
   --acp               Run as an ACP (Agent Client Protocol) server for editor integration.
                       Communicates via JSON-RPC over stdin/stdout.
+  -c, --continue      Resume the most recent session for the current directory, silently.
+                      Starts a fresh session if none exists. Interactive mode only.
+  -r, --resume [id]   Resume a session by id or 1-based list index (e.g. "last", "2",
+                      or a session uuid). With no id, opens the session picker at
+                      startup. Mutually exclusive with --continue. Interactive mode only.
   run                 Run in non-interactive mode
 
 Examples:
@@ -106,6 +111,9 @@ Examples:
   nanocoder --trust-directory run "analyze src/app.ts"
   nanocoder --plain run "summarize README.md"
   nanocoder --plain --json run "summarize README.md" | jq .finalText
+  nanocoder --continue
+  nanocoder --resume last
+  nanocoder --resume
   `);
 	process.exit(0);
 }
@@ -316,6 +324,36 @@ async function main(): Promise<void> {
 
 	const nonInteractiveMode = runCommandIndex !== -1;
 
+	// --continue/-c and --resume/-r: session resume flags for the interactive
+	// TUI only (mirrors Claude Code's -c/-r). Mutually exclusive.
+	const continueRequested = args.includes('--continue') || args.includes('-c');
+	const resumeFlagIndex = args.findIndex(
+		arg => arg === '--resume' || arg === '-r',
+	);
+	const resumeRequested = resumeFlagIndex !== -1;
+
+	if (continueRequested && resumeRequested) {
+		console.error('Cannot pass both --continue and --resume.');
+		process.exit(1);
+	}
+
+	// A bare --resume (no id) opens the session picker at startup. Only treat
+	// the next token as an id/index if it isn't another flag or `run`.
+	let resumeArg: string | undefined;
+	if (resumeRequested) {
+		const next = args[resumeFlagIndex + 1];
+		if (next && !next.startsWith('-') && next !== 'run') {
+			resumeArg = next;
+		}
+	}
+
+	if ((continueRequested || resumeRequested) && nonInteractiveMode) {
+		console.error(
+			'--continue/-c and --resume/-r are only supported for the interactive session (not with `run`).',
+		);
+		process.exit(1);
+	}
+
 	// Validate execution constraints for --json rules
 	if (outputFormat === 'json' && !nonInteractiveMode) {
 		console.error("Error: --json can only be used with the 'run' command.");
@@ -454,6 +492,45 @@ async function main(): Promise<void> {
 		const {installPerfBufferGuard} = await import('@/utils/perf-buffer');
 		installPerfBufferGuard();
 
+		// Resolve --continue/--resume <id> into a Session BEFORE rendering, so
+		// the app can apply it on first mount (see App's initialSession prop).
+		// A bare --resume (no id) instead opens the picker at startup — no
+		// resolution needed here.
+		let initialSession: import('@/session/session-manager').Session | undefined;
+		const openSessionSelectorOnStart = resumeRequested && !resumeArg;
+		if (continueRequested || resumeRequested) {
+			const {sessionManager} = await import('@/session/session-manager');
+			try {
+				await sessionManager.initialize();
+			} catch (error) {
+				console.error(
+					`Failed to initialize sessions: ${error instanceof Error ? error.message : error}`,
+				);
+				process.exit(1);
+			}
+		}
+		if (continueRequested || (resumeRequested && resumeArg)) {
+			const {resolveSession} = await import('@/session/resolve-session');
+
+			if (continueRequested) {
+				const outcome = await resolveSession('last', process.cwd());
+				if (outcome.ok) {
+					initialSession = outcome.session;
+				} else {
+					console.log(
+						'No previous session found for this directory — starting fresh.',
+					);
+				}
+			} else {
+				const outcome = await resolveSession(resumeArg, process.cwd());
+				if (!outcome.ok) {
+					console.error(outcome.message);
+					process.exit(1);
+				}
+				initialSession = outcome.session;
+			}
+		}
+
 		// Switch to alternate screen buffer (like vim/less/htop) for the
 		// interactive TUI only. Run mode (`nanocoder run …`) prints a
 		// transcript the user needs to keep after exit — the alt screen
@@ -539,6 +616,8 @@ async function main(): Promise<void> {
 				cliMode={cliMode}
 				trustDirectory={trustDirectory}
 				altScreenActive={useAltScreen}
+				initialSession={initialSession}
+				openSessionSelectorOnStart={openSessionSelectorOnStart}
 			/>,
 			{
 				// Ctrl+C is handled inside App (routed through the shutdown

--- a/source/hooks/useAppHandlers.tsx
+++ b/source/hooks/useAppHandlers.tsx
@@ -137,6 +137,7 @@ export interface AppHandlers {
 	) => Promise<void>;
 	handleCheckpointCancel: () => void;
 	enterSessionSelectorMode: (showAll?: boolean) => void;
+	applySession: (session: Session) => void;
 	handleSessionSelect: (sessionId: string) => Promise<void>;
 	handleSessionCancel: () => void;
 	enterCheckpointLoadMode: (
@@ -746,6 +747,7 @@ export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 		handleCheckpointCancel,
 		enterCheckpointLoadMode,
 		enterSessionSelectorMode,
+		applySession,
 		handleSessionSelect,
 		handleSessionCancel,
 		handleMessageSubmit,

--- a/source/hooks/useSessionAutosave.ts
+++ b/source/hooks/useSessionAutosave.ts
@@ -1,9 +1,10 @@
-import {useEffect, useRef} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import {getAppConfig} from '@/config/index';
 import {sessionManager} from '@/session/session-manager';
 import type {Message} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
 import {logWarning} from '@/utils/message-queue';
+import {getShutdownManager} from '@/utils/shutdown';
 
 interface UseSessionAutosaveProps {
 	messages: Message[];
@@ -13,6 +14,8 @@ interface UseSessionAutosaveProps {
 	setCurrentSessionId: (id: string | null) => void;
 }
 
+const SHUTDOWN_HANDLER_NAME = 'session-autosave-flush';
+
 /**
  * Hook to handle automatic session saving.
  * Updates the current session when currentSessionId is set; otherwise creates a new session.
@@ -20,7 +23,7 @@ interface UseSessionAutosaveProps {
  *
  * Race safety: saves are serialised through a single chained promise stored in
  * saveChainRef. A new save does not start until the previous one resolves.
- * Critically, doSave reads currentSessionIdRef.current AFTER the
+ * Critically, runSave reads currentSessionIdRef.current AFTER the
  * initPromiseRef await so it sees the value set by any prior save in the same
  * chain - not the stale captured value from effect-fire time. This guarantees
  * at most one createSession() call per conversation even when the effect fires
@@ -30,6 +33,12 @@ interface UseSessionAutosaveProps {
  * maxMessages bounds only what is sent to the model (enforced in the
  * conversation loop before the LLM call), not what is stored in the
  * session file.
+ *
+ * Flush-on-exit: the debounced save (default 30s) means a quit right after
+ * the last message could lose the tail. A shutdown handler (registered once
+ * below, priority -10 so it runs before cli.tsx's terminal-teardown handler)
+ * chains one final save with the live messages/provider/model onto the same
+ * saveChainRef the debounced path uses, so it can never race a pending save.
  */
 export function useSessionAutosave({
 	messages,
@@ -45,13 +54,29 @@ export function useSessionAutosave({
 	// Serialises saves: each new save is chained onto the tail of this promise.
 	const saveChainRef = useRef<Promise<void>>(Promise.resolve());
 
-	// Live mirror of currentSessionId. doSave reads this ref after the
+	// Live mirror of currentSessionId. runSave reads this ref after the
 	// initPromiseRef await (i.e. at execution time, not effect-fire time) so
 	// it sees the ID written by any prior save in the same chain.
 	const currentSessionIdRef = useRef<string | null>(currentSessionId);
 	useEffect(() => {
 		currentSessionIdRef.current = currentSessionId;
 	}, [currentSessionId]);
+
+	// Live mirrors of messages/provider/model for flush(), which runs at exit
+	// time (not from the messages-changed effect below) and needs whatever was
+	// most recently rendered, not a value captured at some earlier effect fire.
+	const messagesRef = useRef<Message[]>(messages);
+	const providerRef = useRef<string>(currentProvider);
+	const modelRef = useRef<string>(currentModel);
+	useEffect(() => {
+		messagesRef.current = messages;
+	}, [messages]);
+	useEffect(() => {
+		providerRef.current = currentProvider;
+	}, [currentProvider]);
+	useEffect(() => {
+		modelRef.current = currentModel;
+	}, [currentModel]);
 
 	// Clear current session when conversation is cleared
 	useEffect(() => {
@@ -89,37 +114,17 @@ export function useSessionAutosave({
 		};
 	}, []);
 
-	// Auto-save when messages change (debounced by saveInterval)
-	useEffect(() => {
-		const config = getAppConfig();
-		const sessionConfig = config.sessions;
-		const autoSave = sessionConfig?.autoSave ?? true;
-		const saveInterval = sessionConfig?.saveInterval ?? 30000;
-
-		if (!autoSave || !initPromiseRef.current || messages.length === 0) {
-			return;
-		}
-
-		if (timeoutRef.current) {
-			clearTimeout(timeoutRef.current);
-		}
-
-		const now = Date.now();
-		const timeSinceLastSave = now - lastSaveRef.current;
-
-		// Capture message content at effect-fire time. Provider/model are also
-		// captured here since they describe this particular save slot.
-		// Note: we do NOT capture currentSessionId here - doSave reads the live
-		// ref at execution time so it sees any ID set by a prior save in the chain.
-		const capturedMessages = messages;
-		const capturedProvider = currentProvider;
-		const capturedModel = currentModel;
-
-		const doSave = async () => {
+	// Core save routine, shared by the debounced auto-save effect and flush().
+	const runSave = useCallback(
+		async (
+			capturedMessages: Message[],
+			capturedProvider: string,
+			capturedModel: string,
+		) => {
 			try {
 				// Wait for initialization to complete before saving
 				const initialized = await initPromiseRef.current;
-				if (!initialized) return;
+				if (!initialized || capturedMessages.length === 0) return;
 
 				// Read the live session ID AFTER the await above. Any prior save
 				// in this chain has already called setCurrentSessionId (and updated
@@ -161,16 +166,16 @@ export function useSessionAutosave({
 							workingDirectory: process.cwd(),
 							messages: capturedMessages,
 						});
-						// Update the ref immediately so any subsequent doSave in this
+						// Update the ref immediately so any subsequent save in this
 						// chain takes the update path, not another createSession().
 						currentSessionIdRef.current = newSession.id;
 						setCurrentSessionId(newSession.id);
 					}
 				} else {
 					// No session yet for this conversation — create one.
-					// Because doSave() runs serially inside saveChainRef and reads
+					// Because runSave() runs serially inside saveChainRef and reads
 					// the live ref, at most one createSession() call executes per
-					// conversation even if the effect fired several times.
+					// conversation even if it's invoked several times in a row.
 					const newSession = await sessionManager.createSession({
 						title,
 						messageCount: capturedMessages.length,
@@ -179,7 +184,7 @@ export function useSessionAutosave({
 						workingDirectory: process.cwd(),
 						messages: capturedMessages,
 					});
-					// Update the ref immediately so any subsequent doSave in this
+					// Update the ref immediately so any subsequent save in this
 					// chain takes the update path, not another createSession().
 					currentSessionIdRef.current = newSession.id;
 					setCurrentSessionId(newSession.id);
@@ -189,12 +194,42 @@ export function useSessionAutosave({
 			} catch (error) {
 				console.warn('Failed to auto-save session:', error);
 			}
-		};
+		},
+		[setCurrentSessionId],
+	);
+
+	// Auto-save when messages change (debounced by saveInterval)
+	useEffect(() => {
+		const config = getAppConfig();
+		const sessionConfig = config.sessions;
+		const autoSave = sessionConfig?.autoSave ?? true;
+		const saveInterval = sessionConfig?.saveInterval ?? 30000;
+
+		if (!autoSave || !initPromiseRef.current || messages.length === 0) {
+			return;
+		}
+
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current);
+		}
+
+		const now = Date.now();
+		const timeSinceLastSave = now - lastSaveRef.current;
+
+		// Capture message content at effect-fire time. Provider/model are also
+		// captured here since they describe this particular save slot.
+		// Note: we do NOT capture currentSessionId here - runSave reads the live
+		// ref at execution time so it sees any ID set by a prior save in the chain.
+		const capturedMessages = messages;
+		const capturedProvider = currentProvider;
+		const capturedModel = currentModel;
 
 		const schedule = () => {
 			// Chain onto the tail of any in-flight save so saves are never
-			// concurrent. Errors inside doSave() are swallowed there; the chain
+			// concurrent. Errors inside runSave() are swallowed there; the chain
 			// itself must not reject so future saves are not blocked.
+			const doSave = () =>
+				runSave(capturedMessages, capturedProvider, capturedModel);
 			saveChainRef.current = saveChainRef.current.then(doSave, doSave);
 		};
 
@@ -204,5 +239,38 @@ export function useSessionAutosave({
 			const delay = saveInterval - timeSinceLastSave;
 			timeoutRef.current = setTimeout(schedule, delay);
 		}
-	}, [messages, currentProvider, currentModel, setCurrentSessionId]);
+	}, [messages, currentProvider, currentModel, runSave]);
+
+	// Final synchronous-ish flush on exit: cancels any pending debounced timer
+	// and chains one last save with the live (ref) messages onto the same
+	// saveChainRef the debounced path uses, so it can't race a save already
+	// in flight. No-ops if autosave was never initialized (disabled) or there
+	// are no messages to persist.
+	const flush = useCallback(async () => {
+		if (!initPromiseRef.current) return;
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current);
+			timeoutRef.current = null;
+		}
+		const capturedMessages = messagesRef.current;
+		const capturedProvider = providerRef.current;
+		const capturedModel = modelRef.current;
+		const finalSave = () =>
+			runSave(capturedMessages, capturedProvider, capturedModel);
+		saveChainRef.current = saveChainRef.current.then(finalSave, finalSave);
+		await saveChainRef.current;
+	}, [runSave]);
+
+	// Register the flush as a shutdown handler once. Priority -10 runs it
+	// before cli.tsx's 'tui-exit-render' handler (priority 0), so the save
+	// completes while the process is still fully alive.
+	useEffect(() => {
+		const manager = getShutdownManager();
+		manager.register({
+			name: SHUTDOWN_HANDLER_NAME,
+			priority: -10,
+			handler: flush,
+		});
+		return () => manager.unregister(SHUTDOWN_HANDLER_NAME);
+	}, [flush]);
 }

--- a/source/session/resolve-session.spec.ts
+++ b/source/session/resolve-session.spec.ts
@@ -1,0 +1,154 @@
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import {resolveSession} from './resolve-session.js';
+import {SessionManager} from './session-manager.js';
+
+let testDir: string;
+let manager: SessionManager;
+
+const CWD_A = '/projects/a';
+const CWD_B = '/projects/b';
+
+test.beforeEach(async () => {
+	testDir = await mkdtemp(join(tmpdir(), 'resolve-session-test-'));
+	manager = new SessionManager(join(testDir, 'sessions'));
+	await manager.initialize();
+});
+
+test.afterEach(async () => {
+	if (testDir) {
+		await rm(testDir, {recursive: true, force: true});
+	}
+});
+
+async function createSession(
+	workingDirectory: string,
+	title: string,
+	lastAccessedAtOffsetMs = 0,
+) {
+	const session = await manager.createSession({
+		title,
+		messageCount: 1,
+		provider: 'openai',
+		model: 'gpt-4',
+		workingDirectory,
+		messages: [{role: 'user', content: title}],
+	});
+	if (lastAccessedAtOffsetMs !== 0) {
+		await manager.saveSession({
+			...session,
+			lastAccessedAt: new Date(
+				Date.now() + lastAccessedAtOffsetMs,
+			).toISOString(),
+		});
+	}
+	return session;
+}
+
+test.serial('resolves "last" to the most recently accessed session in scope', async t => {
+	await createSession(CWD_A, 'older', -10_000);
+	const newer = await createSession(CWD_A, 'newer');
+
+	const result = await resolveSession('last', CWD_A, {manager});
+
+	t.true(result.ok);
+	if (result.ok) t.is(result.session.id, newer.id);
+});
+
+test.serial('treats an undefined arg the same as "last"', async t => {
+	const only = await createSession(CWD_A, 'only');
+
+	const result = await resolveSession(undefined, CWD_A, {manager});
+
+	t.true(result.ok);
+	if (result.ok) t.is(result.session.id, only.id);
+});
+
+test.serial('resolves a 1-based index into the scoped, most-recent-first list', async t => {
+	const newer = await createSession(CWD_A, 'newer');
+	const older = await createSession(CWD_A, 'older', -10_000);
+
+	const first = await resolveSession('1', CWD_A, {manager});
+	const second = await resolveSession('2', CWD_A, {manager});
+
+	t.true(first.ok);
+	t.true(second.ok);
+	if (first.ok) t.is(first.session.id, newer.id);
+	if (second.ok) t.is(second.session.id, older.id);
+});
+
+test.serial('resolves a raw session uuid directly, even from a different cwd', async t => {
+	const session = await createSession(CWD_B, 'other-project-session');
+
+	// Scoped to CWD_A (not CWD_B), yet the raw uuid still resolves — loadSession
+	// isn't filtered by workingDirectory, matching pre-refactor /resume behavior.
+	const result = await resolveSession(session.id, CWD_A, {manager});
+
+	t.true(result.ok);
+	if (result.ok) t.is(result.session.id, session.id);
+});
+
+test.serial('returns not-found for an id that does not exist', async t => {
+	const result = await resolveSession(
+		'00000000-0000-4000-8000-000000000000',
+		CWD_A,
+		{manager},
+	);
+
+	t.false(result.ok);
+	if (!result.ok) t.is(result.reason, 'not-found');
+});
+
+test.serial('returns not-found for an out-of-range index', async t => {
+	await createSession(CWD_A, 'only');
+
+	const result = await resolveSession('99', CWD_A, {manager});
+
+	t.false(result.ok);
+	if (!result.ok) t.is(result.reason, 'not-found');
+});
+
+test.serial('returns empty when resolving "last" against an empty scoped list', async t => {
+	// Session exists, but in a different cwd than we're scoping to.
+	await createSession(CWD_B, 'unrelated');
+
+	const result = await resolveSession('last', CWD_A, {manager});
+
+	t.false(result.ok);
+	if (!result.ok) t.is(result.reason, 'empty');
+});
+
+test.serial('returns empty when resolving "last" against a fully empty list', async t => {
+	const result = await resolveSession('last', CWD_A, {manager});
+
+	t.false(result.ok);
+	if (!result.ok) t.is(result.reason, 'empty');
+});
+
+test.serial('the `all` option resolves "last" across every cwd', async t => {
+	await createSession(CWD_A, 'a-session', -10_000);
+	const newestOverall = await createSession(CWD_B, 'b-session');
+
+	const result = await resolveSession('last', CWD_A, {manager, all: true});
+
+	t.true(result.ok);
+	if (result.ok) t.is(result.session.id, newestOverall.id);
+});
+
+test.serial('a digit-prefixed uuid is treated as a raw id, not an index', async t => {
+	// 6 sessions so parseInt('5e4b…') === 5 would be an in-range index.
+	for (let i = 0; i < 6; i++) {
+		await createSession(CWD_A, `session-${i}`, -i * 1000);
+	}
+
+	const result = await resolveSession(
+		'5e4b0000-0000-4000-8000-000000000000',
+		CWD_A,
+		{manager},
+	);
+
+	t.false(result.ok);
+	if (!result.ok) t.is(result.reason, 'not-found');
+});

--- a/source/session/resolve-session.ts
+++ b/source/session/resolve-session.ts
@@ -1,0 +1,80 @@
+import type {Session, SessionManager} from './session-manager';
+import {sessionManager} from './session-manager';
+
+export type ResolveSessionFailureReason = 'not-found' | 'empty';
+
+export type ResolveSessionResult =
+	| {ok: true; session: Session}
+	| {ok: false; reason: ResolveSessionFailureReason; message: string};
+
+export interface ResolveSessionOptions {
+	/** When true, resolves "last" / index against every session, not just this cwd's. */
+	all?: boolean;
+	/** Injectable manager for tests; defaults to the app singleton. Caller must have already called `initialize()`. */
+	manager?: SessionManager;
+}
+
+/**
+ * Resolves a /resume-style argument ("last" / 1-based index / raw session id)
+ * against sessionManager.listSessions, then loads and returns the full Session.
+ *
+ * This mirrors the resolution logic that used to live inline in
+ * handleResumeCommand — behavior is intentionally unchanged:
+ *  - undefined arg is treated as "last" (session-handler.ts itself only calls
+ *    this when an arg is present; the CLI entry points rely on this default).
+ *  - "last" (case-insensitive): most recent session (by lastAccessedAt) in
+ *    the scoped list. Empty scoped list -> {ok:false, reason:'empty'}.
+ *  - an all-digit string that is an in-range 1-based index into the scoped,
+ *    lastAccessedAt-desc-sorted list: resolves to that entry. Only pure-digit
+ *    args are index candidates — a uuid like "5e4b…" must not parseInt to 5.
+ *  - anything else: treated as a raw session id and loaded directly via
+ *    sessionManager.loadSession, which is NOT scoped by workingDirectory —
+ *    so a raw uuid resolves correctly even when `all` is false and the
+ *    session belongs to a different cwd. This matches the pre-refactor
+ *    behavior of handleResumeCommand.
+ */
+export async function resolveSession(
+	arg: string | undefined,
+	workingDirectory: string,
+	opts?: ResolveSessionOptions,
+): Promise<ResolveSessionResult> {
+	const manager = opts?.manager ?? sessionManager;
+	const listOptions = opts?.all ? undefined : {workingDirectory};
+	const sessions = await manager.listSessions(listOptions);
+	const sorted = [...sessions].sort(
+		(a, b) =>
+			new Date(b.lastAccessedAt).getTime() -
+			new Date(a.lastAccessedAt).getTime(),
+	);
+
+	const specialArg = arg === undefined ? 'last' : arg;
+
+	let sessionId: string | null = null;
+
+	if (specialArg.toLowerCase() === 'last') {
+		if (sorted.length === 0) {
+			return {ok: false, reason: 'empty', message: 'No sessions found.'};
+		}
+		sessionId = sorted[0].id;
+	} else {
+		const index = /^\d+$/.test(specialArg)
+			? Number.parseInt(specialArg, 10)
+			: Number.NaN;
+		if (!Number.isNaN(index) && index >= 1 && index <= sorted.length) {
+			sessionId = sorted[index - 1].id;
+		} else {
+			sessionId = specialArg;
+		}
+	}
+
+	const session = await manager.loadSession(sessionId);
+	if (!session) {
+		return {
+			ok: false,
+			reason: 'not-found',
+			message: `Session not found: ${sessionId}`,
+		};
+	}
+
+	return {ok: true, session};
+}


### PR DESCRIPTION
## Description

- Adds `--continue` / `-c` — resume the most recent session for the current directory (starts fresh with a notice if none exists).
- Adds `--resume [id]` / `-r [id]` — resume a session by id, 1-based list index, or `last`; a bare `--resume` opens the session picker at startup. Both flags are interactive-only and mutually exclusive.
- Sessions saved by the existing autosave are now reachable directly from the shell; `--help` text and docs updated.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

25 new tests: 10 specs for `resolveSession` (`source/session/resolve-session.spec.ts` — `last`, undefined-arg default, index resolution, raw uuid from another cwd, not-found, out-of-range index, empty scoped list, empty global list, the `all` option, and the digit-prefixed-uuid-vs-index case) and 15 specs for CLI flag parsing (`source/cli.spec.ts` — flag/shorthand detection, id capture, flag/`run` tokens not swallowed as ids, mutual exclusion, and non-interactive rejection).

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Used as a daily driver: `--continue` and `--resume` (bare, by index, by id, and `last`) exercised across real multi-day sessions, including the fresh-start path in a directory with no sessions and quit-then-`--continue` round trips confirming the exit flush preserves the conversation tail.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

`--help` text and examples updated for both flags. New surface area is additive only — running with neither flag is byte-identical to before, and pre-render failures use plain `console.error` + exit like the surrounding CLI validation code.

