### PR TITLE
feat: improve model picker UX for large model catalogs

### DIFF
--- a/source/components/filterable-select-list.spec.tsx
+++ b/source/components/filterable-select-list.spec.tsx
@@ -1,0 +1,305 @@
+// source/components/filterable-select-list.spec.tsx
+import test from 'ava';
+import {render} from 'ink-testing-library';
+import React from 'react';
+import {FilterableSelectList} from './filterable-select-list.js';
+import {renderWithTheme} from '../test-utils/render-with-theme.js';
+
+console.log('\nfilterable-select-list.spec.tsx');
+
+const items = [
+	{label: 'alpha (openai)', value: '0'},
+	{label: 'beta (ollama)', value: '1'},
+	{label: 'gamma (openrouter)', value: '2'},
+];
+
+test('renders all items when query is empty', t => {
+	const {lastFrame} = renderWithTheme(
+		<FilterableSelectList items={items} onSelect={() => {}} />,
+	);
+	const out = lastFrame()!;
+	t.regex(out, /alpha \(openai\)/);
+	t.regex(out, /beta \(ollama\)/);
+	t.regex(out, /gamma \(openrouter\)/);
+});
+
+test('filters by label substring case-insensitively', t => {
+	const many = [
+		{label: 'gpt-4o (openai)', value: '0'},
+		{label: 'gpt-4o-mini (openai)', value: '1'},
+		{label: 'llama3 (ollama)', value: '2'},
+	];
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} onSelect={() => {}} />,
+	);
+	stdin.write('gpt');
+	// allow ink to process key — 50ms matches repo precedent (model-selector.spec.tsx:206)
+	return new Promise<void>(resolve => {
+		setTimeout(() => {
+			const out = lastFrame()!;
+			t.regex(out, /gpt-4o \(openai\)/);
+			t.regex(out, /gpt-4o-mini \(openai\)/);
+			t.notRegex(out, /llama3/);
+			unmount();
+			resolve();
+		}, 50);
+	});
+});
+
+test('empty query shows all items in original order', t => {
+	const many = [
+		{label: 'zeta (a)', value: '0'},
+		{label: 'alpha (b)', value: '1'},
+	];
+	const {lastFrame, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} onSelect={() => {}} />,
+	);
+	const out = lastFrame()!;
+	t.regex(out, /zeta \(a\)[\s\S]*alpha \(b\)/);
+	unmount();
+});
+
+test('ranks exact > contains for fuzzy filter', t => {
+	const many = [
+		{label: 'claude-3 (anthropic)', value: '0'},
+		{label: 'claudette (x)', value: '1'},
+	];
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} onSelect={() => {}} />,
+	);
+	stdin.write('claude');
+	return new Promise<void>(resolve => {
+		setTimeout(() => {
+			const out = lastFrame()!;
+			const i0 = out.indexOf('claude-3 (anthropic)');
+			const i1 = out.indexOf('claudette (x)');
+			t.true(i0 >= 0 && i1 >= 0);
+			t.true(i0 < i1);
+			unmount();
+			resolve();
+		}, 50);
+	});
+});
+
+test('caps visible window to visibleCount', t => {
+	const many = Array.from({length: 30}, (_, i) => ({
+		label: `m-${i}`,
+		value: String(i),
+	}));
+	const {lastFrame, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} visibleCount={12} onSelect={() => {}} />,
+	);
+	const out = lastFrame()!;
+	const visible = many
+		.map(m => m.label)
+		.filter(label => out.includes(label));
+	t.is(visible.length, 12);
+	unmount();
+});
+
+test('centers highlight in the middle of the window', t => {
+	const many = Array.from({length: 30}, (_, i) => ({
+		label: `m-${i}`,
+		value: String(i),
+	}));
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} visibleCount={12} onSelect={() => {}} />,
+	);
+	// move down 15 so highlight ~ index 15
+	for (let i = 0; i < 15; i++) stdin.write('\u001B[B');
+	return new Promise<void>(resolve => {
+		setTimeout(() => {
+			const out = lastFrame()!;
+			// window = slice(9, 21): indices 9..20 (12 rows). Verified
+			// scrollStart = max(0, min(15 - 6, 30 - 12)) = max(0, min(9, 18)) = 9.
+			t.regex(out, /m-9/);
+			t.regex(out, /m-20/);
+			t.notRegex(out, /m-8/);
+			t.notRegex(out, /m-21/);
+			t.notRegex(out, /m-0/);
+			t.notRegex(out, /m-29/);
+			unmount();
+			resolve();
+		}, 50);
+	});
+});
+
+test('clamps scroll at start', t => {
+	const many = Array.from({length: 30}, (_, i) => ({
+		label: `m-${i}`,
+		value: String(i),
+	}));
+	const {lastFrame, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} visibleCount={12} onSelect={() => {}} />,
+	);
+	const out = lastFrame()!;
+	t.regex(out, /m-0/);
+	t.regex(out, /m-11/);
+	t.notRegex(out, /m-12/);
+	unmount();
+});
+
+test('clamps scroll at end', t => {
+	const many = Array.from({length: 30}, (_, i) => ({
+		label: `m-${i}`,
+		value: String(i),
+	}));
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} visibleCount={12} onSelect={() => {}} />,
+	);
+	for (let i = 0; i < 29; i++) stdin.write('\u001B[B');
+	return new Promise<void>(resolve => {
+		setTimeout(() => {
+			const out = lastFrame()!;
+			t.regex(out, /m-29/);
+			// last row visible; highlight near bottom but not past end
+			t.notRegex(out, /m-0/);
+			unmount();
+			resolve();
+		}, 50);
+	});
+});
+
+test('empty-results state shows message', t => {
+	const many = [{label: 'gpt-4o (openai)', value: '0'}];
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} onSelect={() => {}} />,
+	);
+	stdin.write('zzzzz');
+	return new Promise<void>(resolve => {
+		setTimeout(() => {
+			t.regex(lastFrame()!, /No models matching "zzzzz"/);
+			unmount();
+			resolve();
+		}, 50);
+	});
+});
+
+test('Home jumps to first, End jumps to last', async t => {
+	const many = Array.from({length: 10}, (_, i) => ({
+		label: `m-${i}`,
+		value: String(i),
+	}));
+	let selected = '';
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} onSelect={v => { selected = v; }} />,
+	);
+	// Navigate down 5
+	for (let i = 0; i < 5; i++) stdin.write('\u001B[B');
+	await new Promise(r => setTimeout(r, 50));
+	// Home should jump to index 0
+	stdin.write('\u001B[H');
+	await new Promise(r => setTimeout(r, 50));
+	stdin.write('\r');
+	await new Promise(r => setTimeout(r, 50));
+	t.is(selected, '0');
+	// End should jump to last
+	stdin.write('\u001B[F'); // End
+	await new Promise(r => setTimeout(r, 50));
+	stdin.write('\r');
+	await new Promise(r => setTimeout(r, 50));
+	t.is(selected, '9');
+	unmount();
+});
+
+test('PageDown jumps by visibleCount', async t => {
+	const many = Array.from({length: 30}, (_, i) => ({
+		label: `m-${i}`,
+		value: String(i),
+	}));
+	let selected = '';
+	const {stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} visibleCount={12} onSelect={v => { selected = v; }} />,
+	);
+	stdin.write('\u001B[6~'); // PageDown
+	await new Promise(r => setTimeout(r, 50));
+	stdin.write('\r');
+	await new Promise(r => setTimeout(r, 50));
+	t.is(selected, '12'); // jumped from 0 to 12
+	unmount();
+});
+
+test('PageDown clamps at end', async t => {
+	const many = Array.from({length: 5}, (_, i) => ({
+		label: `m-${i}`,
+		value: String(i),
+	}));
+	let selected = '';
+	const {stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} visibleCount={12} onSelect={v => { selected = v; }} />,
+	);
+	stdin.write('\u001B[6~'); // PageDown (should clamp to last index)
+	await new Promise(r => setTimeout(r, 50));
+	stdin.write('\r');
+	await new Promise(r => setTimeout(r, 50));
+	t.is(selected, '4');
+	unmount();
+});
+
+test('Enter selects highlighted value even with active filter', t => {
+	const many = [
+		{label: 'gpt-4o (openai)', value: '0'},
+		{label: 'gpt-4o-mini (openai)', value: '1'},
+		{label: 'llama3 (ollama)', value: '2'},
+	];
+	let selected = '';
+	const {stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} onSelect={v => { selected = v; }} />,
+	);
+	stdin.write('gpt');
+	return new Promise<void>(resolve => {
+		setTimeout(() => {
+			stdin.write('\r');
+			setTimeout(() => {
+				t.is(selected, '0'); // first filtered result
+				unmount();
+				resolve();
+			}, 50);
+		}, 50);
+	});
+});
+
+test('preselects initialSelectedValue', t => {
+	const many = [
+		{label: 'alpha (a)', value: '0'},
+		{label: 'beta (b)', value: '1'},
+		{label: 'gamma (c)', value: '2'},
+	];
+	const {lastFrame, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} initialSelectedValue="2" onSelect={() => {}} />,
+	);
+	const out = lastFrame()!;
+	// gamma is highlighted (❯ marker) — present in output
+	t.regex(out, /gamma \(c\)/);
+	unmount();
+});
+
+test('Erase back to a query that includes current highlight keeps highlight value', t => {
+	const many = [
+		{label: 'alpha (a)', value: '0'},
+		{label: 'beta (b)', value: '1'},
+	];
+	let selected = '';
+	const {stdin, unmount} = renderWithTheme(
+		<FilterableSelectList items={many} onSelect={v => { selected = v; }} />,
+	);
+	stdin.write('beta');
+	return new Promise<void>(resolve => {
+		setTimeout(() => {
+			// beta filtered; highlight at index 0 (beta).
+			// NOTE: \u007F maps to key.delete (parse-keypress.js:431-436),
+			// INK's delete key — NOT key.backspace. The handler checks both,
+			// so either triggers the backspace branch. For a strict
+			// key.backspace test use \u0008 instead.
+			stdin.write('\u007F'); // delete
+			setTimeout(() => {
+				stdin.write('\r');
+				setTimeout(() => {
+					t.is(selected, '1'); // beta
+					unmount();
+					resolve();
+				}, 50);
+			}, 50);
+		}, 50);
+	});
+});

--- a/source/components/filterable-select-list.spec.tsx
+++ b/source/components/filterable-select-list.spec.tsx
@@ -303,3 +303,23 @@ test('Erase back to a query that includes current highlight keeps highlight valu
 		}, 50);
 	});
 });
+
+test('Escape calls onCancel', async t => {
+	let cancelled = false;
+	const {stdin, unmount} = renderWithTheme(
+		<FilterableSelectList
+			items={[
+				{label: 'alpha (a)', value: '0'},
+				{label: 'beta (b)', value: '1'},
+			]}
+			onSelect={() => {}}
+			onCancel={() => {
+				cancelled = true;
+			}}
+		/>,
+	);
+	stdin.write('\u001B'); // escape
+	await new Promise(resolve => setTimeout(resolve, 50));
+	t.true(cancelled);
+	unmount();
+});

--- a/source/components/filterable-select-list.tsx
+++ b/source/components/filterable-select-list.tsx
@@ -1,0 +1,146 @@
+// source/components/filterable-select-list.tsx
+import {Box, Text, useInput, useStdout} from 'ink';
+import {useState, useMemo} from 'react';
+import {useTheme} from '@/hooks/useTheme';
+import {fuzzyScore} from '@/utils/fuzzy-matching';
+import type {ItemSelectorOption} from '@/components/item-selector';
+
+const DEFAULT_VISIBLE_COUNT = 12;
+// Ceiling: even at 12 rows we need room for the box border (2) + search
+// affordance row (1) + hint row (1). On terminals shorter than this we clamp
+// so the picker can never reproduce the original "box eats the screen" bug.
+const OVERHEAD_ROWS = 4;
+
+export interface FilterableSelectListProps<TValue extends string = string> {
+	items: ItemSelectorOption<TValue>[];
+	visibleCount?: number;
+	initialSelectedValue?: TValue;
+	onSelect: (value: TValue) => void;
+	onCancel?: () => void;
+}
+
+export function FilterableSelectList<TValue extends string = string>({
+	items,
+	visibleCount = DEFAULT_VISIBLE_COUNT,
+	initialSelectedValue,
+	onSelect,
+	onCancel,
+}: FilterableSelectListProps<TValue>) {
+	const {colors} = useTheme();
+	const {stdout} = useStdout();
+	// Height-aware clamp. If the terminal is too short, shrink the
+	// window so box + search row + hint row still fit. Falls back to the
+	// default on normal terminals (>= 16 rows).
+	const effectiveVisibleCount = stdout?.columns
+		? Math.max(1, Math.min(visibleCount, (stdout.rows ?? 24) - OVERHEAD_ROWS))
+		: visibleCount;
+	const initialIndex = Math.max(
+		0,
+		items.findIndex(item => item.value === initialSelectedValue),
+	);
+	const [query, setQuery] = useState('');
+	const [highlightedIndex, setHighlightedIndex] = useState(
+		initialSelectedValue === undefined ? 0 : Math.max(0, initialIndex),
+	);
+
+	const filteredItems = useMemo(() => {
+		if (!query) return items;
+		return items
+			.map(item => ({item, score: fuzzyScore(item.label, query)}))
+			.filter(entry => entry.score > 0)
+			.sort((a, b) => b.score - a.score)
+			.map(entry => entry.item);
+	}, [items, query]);
+
+	const maxIndex = Math.max(0, filteredItems.length - 1);
+	const safeHighlighted = Math.min(highlightedIndex, maxIndex);
+	// scroll math mirrors the wizard pattern at
+	// source/wizards/steps/model-selection-list.tsx:53-63 (verbatim formula).
+	const scrollStart = Math.max(
+		0,
+		Math.min(
+			safeHighlighted - Math.floor(effectiveVisibleCount / 2),
+			filteredItems.length - effectiveVisibleCount,
+		),
+	);
+	const visibleItems = filteredItems.slice(scrollStart, scrollStart + effectiveVisibleCount);
+
+	useInput((input, key) => {
+		if (key.escape) {
+			onCancel?.();
+			return;
+		}
+		if (key.upArrow) {
+			setHighlightedIndex(prev => Math.max(0, prev - 1));
+			return;
+		}
+		if (key.downArrow) {
+			setHighlightedIndex(prev => Math.min(maxIndex, prev + 1));
+			return;
+		}
+		if (key.home) {
+			setHighlightedIndex(0);
+			return;
+		}
+		if (key.end) {
+			setHighlightedIndex(maxIndex);
+			return;
+		}
+		if (key.pageUp) {
+			setHighlightedIndex(prev => Math.max(0, prev - effectiveVisibleCount));
+			return;
+		}
+		if (key.pageDown) {
+			setHighlightedIndex(prev => Math.min(maxIndex, prev + effectiveVisibleCount));
+			return;
+		}
+		if (key.return) {
+			const item = filteredItems[safeHighlighted];
+			if (item) onSelect(item.value);
+			return;
+		}
+		if (key.backspace || key.delete) {
+			setQuery(prev => prev.slice(0, -1));
+			setHighlightedIndex(0);
+			return;
+		}
+		if (input && input.length >= 1 && !key.ctrl && !key.meta && !key.upArrow && !key.downArrow && !key.return && !key.escape && !key.backspace && !key.delete) {
+			setQuery(prev => prev + input);
+			setHighlightedIndex(0);
+		}
+	});
+
+	return (
+		<Box flexDirection="column">
+			<Box marginBottom={1}>
+				<Text color={colors.primary}>
+					{query ? (
+						<>
+							Filter: {query}
+							<Text color={colors.secondary}>_</Text>
+						</>
+					) : (
+						<Text color={colors.secondary}>Type to filter…</Text>
+					)}
+				</Text>
+			</Box>
+			{visibleItems.length === 0 ? (
+				<Text color={colors.secondary}>No models matching "{query}"</Text>
+			) : (
+				visibleItems.map((item, index) => {
+					const actualIndex = scrollStart + index;
+					const isHighlighted = actualIndex === safeHighlighted;
+					return (
+						<Text
+							key={item.value}
+							color={isHighlighted ? colors.primary : colors.text}
+							bold={isHighlighted}
+						>
+							{isHighlighted ? '❯' : ' '} {item.label}
+						</Text>
+					);
+				})
+			)}
+		</Box>
+	);
+}

--- a/source/components/filterable-select-list.tsx
+++ b/source/components/filterable-select-list.tsx
@@ -1,9 +1,9 @@
 // source/components/filterable-select-list.tsx
 import {Box, Text, useInput, useStdout} from 'ink';
-import {useState, useMemo} from 'react';
+import {useMemo, useState} from 'react';
+import type {ItemSelectorOption} from '@/components/item-selector';
 import {useTheme} from '@/hooks/useTheme';
 import {fuzzyScore} from '@/utils/fuzzy-matching';
-import type {ItemSelectorOption} from '@/components/item-selector';
 
 const DEFAULT_VISIBLE_COUNT = 12;
 // Ceiling: even at 12 rows we need room for the box border (2) + search
@@ -63,7 +63,10 @@ export function FilterableSelectList<TValue extends string = string>({
 			filteredItems.length - effectiveVisibleCount,
 		),
 	);
-	const visibleItems = filteredItems.slice(scrollStart, scrollStart + effectiveVisibleCount);
+	const visibleItems = filteredItems.slice(
+		scrollStart,
+		scrollStart + effectiveVisibleCount,
+	);
 
 	useInput((input, key) => {
 		if (key.escape) {
@@ -91,7 +94,9 @@ export function FilterableSelectList<TValue extends string = string>({
 			return;
 		}
 		if (key.pageDown) {
-			setHighlightedIndex(prev => Math.min(maxIndex, prev + effectiveVisibleCount));
+			setHighlightedIndex(prev =>
+				Math.min(maxIndex, prev + effectiveVisibleCount),
+			);
 			return;
 		}
 		if (key.return) {
@@ -104,7 +109,18 @@ export function FilterableSelectList<TValue extends string = string>({
 			setHighlightedIndex(0);
 			return;
 		}
-		if (input && input.length >= 1 && !key.ctrl && !key.meta && !key.upArrow && !key.downArrow && !key.return && !key.escape && !key.backspace && !key.delete) {
+		if (
+			input &&
+			input.length >= 1 &&
+			!key.ctrl &&
+			!key.meta &&
+			!key.upArrow &&
+			!key.downArrow &&
+			!key.return &&
+			!key.escape &&
+			!key.backspace &&
+			!key.delete
+		) {
 			setQuery(prev => prev + input);
 			setHighlightedIndex(0);
 		}

--- a/source/components/filterable-select-list.tsx
+++ b/source/components/filterable-select-list.tsx
@@ -29,10 +29,12 @@ export function FilterableSelectList<TValue extends string = string>({
 	const {colors} = useTheme();
 	const {stdout} = useStdout();
 	// Height-aware clamp. If the terminal is too short, shrink the
-	// window so box + search row + hint row still fit. Falls back to the
-	// default on normal terminals (>= 16 rows).
-	const effectiveVisibleCount = stdout?.columns
-		? Math.max(1, Math.min(visibleCount, (stdout.rows ?? 24) - OVERHEAD_ROWS))
+	// window so box + search row + hint row still fit. Guard on rows
+	// (terminal height); when height is unknown (no TTY), fall back to the
+	// default window. Falls back to the default on normal terminals
+	// (>= 16 rows).
+	const effectiveVisibleCount = stdout?.rows
+		? Math.max(1, Math.min(visibleCount, stdout.rows - OVERHEAD_ROWS))
 		: visibleCount;
 	const initialIndex = Math.max(
 		0,

--- a/source/components/item-selector.spec.tsx
+++ b/source/components/item-selector.spec.tsx
@@ -90,3 +90,22 @@ test('ItemSelector does not double-fire onCancel in searchable normal path', asy
 	t.is(calls, 1);
 	unmount();
 });
+
+test('ItemSelector fires onCancel on Escape during loading branch', async t => {
+	let cancelled = false;
+	const {stdin} = renderWithTheme(
+		<ItemSelector
+			title="Select"
+			items={items}
+			searchable
+			loading
+			onSelect={() => {}}
+			onCancel={() => {
+				cancelled = true;
+			}}
+		/>,
+	);
+	stdin.write('\u001B'); // escape
+	await new Promise(resolve => setTimeout(resolve, 50));
+	t.true(cancelled);
+});

--- a/source/components/item-selector.spec.tsx
+++ b/source/components/item-selector.spec.tsx
@@ -1,0 +1,92 @@
+import test from 'ava';
+import React from 'react';
+import {renderWithTheme} from '../test-utils/render-with-theme.js';
+import {ItemSelector} from './item-selector.js';
+
+console.log('\nitem-selector.spec.tsx');
+
+const items = [
+	{label: 'alpha (a)', value: '0'},
+	{label: 'beta (b)', value: '1'},
+];
+
+test('ItemSelector renders FilterableSelectList when searchable', t => {
+	const {lastFrame} = renderWithTheme(
+		<ItemSelector
+			title="Select"
+			items={items}
+			searchable
+			onSelect={() => {}}
+			onCancel={() => {}}
+		/>,
+	);
+	const out = lastFrame()!;
+	// search affordance row is rendered by FilterableSelectList
+	t.regex(out, /Type to filter/);
+	t.regex(out, /alpha \(a\)/);
+});
+
+test('ItemSelector shows the search hint when searchable', t => {
+	const {lastFrame} = renderWithTheme(
+		<ItemSelector
+			title="Select"
+			items={items}
+			searchable
+			onSelect={() => {}}
+			onCancel={() => {}}
+		/>,
+	);
+	t.regex(lastFrame()!, /Type to filter · .* · Enter select · Esc cancel/);
+});
+
+test('ItemSelector keeps SelectInput behavior when not searchable', t => {
+	const {lastFrame} = renderWithTheme(
+		<ItemSelector
+			title="Select"
+			items={items}
+			onSelect={() => {}}
+			onCancel={() => {}}
+		/>,
+	);
+	const out = lastFrame()!;
+	t.regex(out, /alpha \(a\)/);
+	t.regex(out, /Press Escape to cancel/);
+});
+
+test('ItemSelector fires onCancel on Escape during error branch', async t => {
+	let cancelled = false;
+	const {stdin} = renderWithTheme(
+		<ItemSelector
+			title="Select"
+			items={items}
+			searchable
+			error="boom"
+			onSelect={() => {}}
+			onCancel={() => {
+				cancelled = true;
+			}}
+		/>,
+	);
+	stdin.write('\u001B'); // escape
+	await new Promise(resolve => setTimeout(resolve, 50));
+	t.true(cancelled);
+});
+
+test('ItemSelector does not double-fire onCancel in searchable normal path', async t => {
+	let calls = 0;
+	const {stdin, unmount} = renderWithTheme(
+		<ItemSelector
+			title="Select"
+			items={items}
+			searchable
+			onSelect={() => {}}
+			onCancel={() => {
+				calls++;
+			}}
+		/>,
+	);
+	stdin.write('\u001B'); // escape
+	await new Promise(resolve => setTimeout(resolve, 50));
+	t.is(calls, 1);
+	unmount();
+});

--- a/source/components/item-selector.tsx
+++ b/source/components/item-selector.tsx
@@ -3,6 +3,7 @@ import SelectInput from 'ink-select-input';
 import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {useTerminalWidth} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
+import {FilterableSelectList} from '@/components/filterable-select-list';
 
 export interface ItemSelectorOption<TValue extends string = string> {
 	label: string;
@@ -19,6 +20,9 @@ interface ItemSelectorProps<TValue extends string = string> {
 	error?: string | null;
 	errorTitle?: string;
 	errorHint?: string;
+	searchable?: boolean;
+	visibleCount?: number;
+	initialSelectedValue?: string;
 }
 
 /**
@@ -39,15 +43,25 @@ export function ItemSelector<TValue extends string = string>({
 	error,
 	errorTitle,
 	errorHint,
+	searchable = false,
+	visibleCount,
+	initialSelectedValue,
 }: ItemSelectorProps<TValue>) {
 	const boxWidth = useTerminalWidth();
 	const {colors} = useTheme();
 
-	useInput((_, key) => {
-		if (key.escape) {
-			onCancel();
-		}
-	});
+	// Single owner for Escape during loading/error branches, where
+	// FilterableSelectList is not mounted. Dormant during the normal
+	// searchable path (isActive=false) so it can't double-fire with the
+	// child's own Escape handler (Ink useInput is broadcast).
+	useInput(
+		(_, key) => {
+			if (key.escape) {
+				onCancel();
+			}
+		},
+		{isActive: !searchable || loading || error != null},
+	);
 
 	if (loading) {
 		return (
@@ -95,12 +109,26 @@ export function ItemSelector<TValue extends string = string>({
 			marginBottom={1}
 		>
 			<Box flexDirection="column">
-				<SelectInput
-					items={items}
-					onSelect={item => onSelect(item.value as TValue)}
-				/>
+				{searchable ? (
+					<FilterableSelectList
+						items={items}
+						visibleCount={visibleCount}
+						initialSelectedValue={initialSelectedValue}
+						onSelect={value => onSelect(value as TValue)}
+						onCancel={onCancel}
+					/>
+				) : (
+					<SelectInput
+						items={items}
+						onSelect={item => onSelect(item.value as TValue)}
+					/>
+				)}
 				<Box marginTop={1}>
-					<Text color={colors.secondary}>Press Escape to cancel</Text>
+					<Text color={colors.secondary}>
+						{searchable
+							? 'Type to filter · ↑↓ navigate · Enter select · Esc cancel'
+							: 'Press Escape to cancel'}
+					</Text>
 				</Box>
 			</Box>
 		</TitledBoxWithPreferences>

--- a/source/components/item-selector.tsx
+++ b/source/components/item-selector.tsx
@@ -1,9 +1,9 @@
 import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
+import {FilterableSelectList} from '@/components/filterable-select-list';
 import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {useTerminalWidth} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
-import {FilterableSelectList} from '@/components/filterable-select-list';
 
 export interface ItemSelectorOption<TValue extends string = string> {
 	label: string;

--- a/source/components/item-selector.tsx
+++ b/source/components/item-selector.tsx
@@ -22,7 +22,7 @@ interface ItemSelectorProps<TValue extends string = string> {
 	errorHint?: string;
 	searchable?: boolean;
 	visibleCount?: number;
-	initialSelectedValue?: string;
+	initialSelectedValue?: TValue;
 }
 
 /**

--- a/source/components/model-selector.spec.tsx
+++ b/source/components/model-selector.spec.tsx
@@ -336,7 +336,10 @@ test('model-selector formats current model label correctly', t => {
 });
 
 // ============================================================================
-// Task 4: searchable FilterableSelectList behavior
+// ModelSelector wires the searchable list. Filtering, scrolling, and the
+// empty state live in filterable-select-list.spec.tsx — here we only verify
+// ModelSelector's own job: mapping (provider, model) -> initialSelectedValue
+// and mapping a selected value back to (provider, model).
 // ============================================================================
 
 test('model-selector highlights current model as the preselected row', t => {
@@ -357,60 +360,6 @@ test('model-selector highlights current model as the preselected row', t => {
 	t.regex(out, /model2.*\(current\)/i);
 	// search affordance present (searchable is on)
 	t.regex(out, /Type to filter/);
-});
-
-test('model-selector typing filters the list', async t => {
-	setProviders([
-		{name: 'openai', models: ['gpt-4o', 'gpt-4o-mini', 'llama3']},
-	]);
-
-	const {lastFrame, stdin, unmount} = renderWithTheme(
-		<ModelSelector
-			currentProvider="openai"
-			currentModel="gpt-4o"
-			onModelSelect={() => {}}
-			onCancel={() => {}}
-		/>,
-	);
-
-	stdin.write('gpt');
-	await new Promise(resolve => setTimeout(resolve, 50));
-
-	const out = lastFrame()!;
-	t.regex(out, /gpt-4o/);
-	t.regex(out, /gpt-4o-mini/);
-	t.notRegex(out, /llama3/);
-	unmount();
-});
-
-test('model-selector long list keeps highlight in a 12-row window', async t => {
-	setProviders([
-		{name: 'openai', models: Array.from({length: 30}, (_, i) => `model-${i + 1}`)},
-	]);
-
-	const {lastFrame, stdin, unmount} = renderWithTheme(
-		<ModelSelector
-			currentProvider="openai"
-			currentModel="model-1"
-			onModelSelect={() => {}}
-			onCancel={() => {}}
-		/>,
-	);
-
-	for (let i = 0; i < 15; i++) stdin.write('\u001B[B');
-	await new Promise(resolve => setTimeout(resolve, 50));
-
-	const out = lastFrame()!;
-	// After 15 downs from index 0 the highlight is at 15; window is
-	// slice(9, 21): model-10 .. model-21 (12 rows). Names use the
-	// `model-` prefix (not `m-`) so substring overlap (m-1 in m-10) can't
-	// inflate the count.
-	t.regex(out, /model-10/);
-	t.regex(out, /model-21/);
-	t.notRegex(out, /model-9/);
-	t.notRegex(out, /model-22/);
-	t.regex(out, /Type to filter/);
-	unmount();
 });
 
 test('model-selector Enter on filtered result selects correct provider/model', async t => {
@@ -445,23 +394,25 @@ test('model-selector Enter on filtered result selects correct provider/model', a
 	unmount();
 });
 
-test('model-selector no-match shows empty state', async t => {
+// Verifies the `else undefined` fallback in initialSelectedValue: a current
+// model that isn't in the list must NOT preselect anything (index stays 0).
+test('model-selector does not preselect when current model is missing', t => {
 	setProviders([
-		{name: 'openai', models: ['gpt-4o']},
+		{name: 'openai', models: ['model1', 'model2', 'model3']},
 	]);
 
-	const {lastFrame, stdin, unmount} = renderWithTheme(
+	const {lastFrame} = renderWithTheme(
 		<ModelSelector
 			currentProvider="openai"
-			currentModel="gpt-4o"
+			currentModel="modelX"
 			onModelSelect={() => {}}
 			onCancel={() => {}}
 		/>,
 	);
 
-	stdin.write('zzzzz');
-	await new Promise(resolve => setTimeout(resolve, 50));
-
-	t.regex(lastFrame()!, /No models matching "zzzzz"/);
-	unmount();
+	const out = lastFrame()!;
+	// No entry is marked (current): the missing model produces no match.
+	t.notRegex(out, /\(current\)/i);
+	// Still renders the searchable list normally.
+	t.regex(out, /Type to filter/);
 });

--- a/source/components/model-selector.spec.tsx
+++ b/source/components/model-selector.spec.tsx
@@ -336,10 +336,7 @@ test('model-selector formats current model label correctly', t => {
 });
 
 // ============================================================================
-// ModelSelector wires the searchable list. Filtering, scrolling, and the
-// empty state live in filterable-select-list.spec.tsx — here we only verify
-// ModelSelector's own job: mapping (provider, model) -> initialSelectedValue
-// and mapping a selected value back to (provider, model).
+// Searchable wiring
 // ============================================================================
 
 test('model-selector highlights current model as the preselected row', t => {

--- a/source/components/model-selector.spec.tsx
+++ b/source/components/model-selector.spec.tsx
@@ -93,7 +93,7 @@ test('model-selector marks current model in list', t => {
 	t.regex(output!, /model2.*\(current\)/i);
 });
 
-test('model-selector shows cancel instruction', t => {
+test('model-selector shows search hint when searchable', t => {
 	setProviders([{name: 'openai', models: ['model1', 'model2']}]);
 
 	const {lastFrame} = renderWithTheme(
@@ -107,7 +107,7 @@ test('model-selector shows cancel instruction', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /Press Escape to cancel/i);
+	t.regex(output!, /Type to filter · .* · Enter select · Esc cancel/i);
 });
 
 test('model-selector component renders without crashing', t => {
@@ -333,4 +333,135 @@ test('model-selector formats current model label correctly', t => {
 	// Other models should not be marked as current
 	t.notRegex(output!, /alpha.*\(current\)/i);
 	t.notRegex(output!, /gamma.*\(current\)/i);
+});
+
+// ============================================================================
+// Task 4: searchable FilterableSelectList behavior
+// ============================================================================
+
+test('model-selector highlights current model as the preselected row', t => {
+	setProviders([
+		{name: 'openai', models: ['model1', 'model2', 'model3']},
+	]);
+
+	const {lastFrame} = renderWithTheme(
+		<ModelSelector
+			currentProvider="openai"
+			currentModel="model2"
+			onModelSelect={() => {}}
+			onCancel={() => {}}
+		/>,
+	);
+
+	const out = lastFrame()!;
+	t.regex(out, /model2.*\(current\)/i);
+	// search affordance present (searchable is on)
+	t.regex(out, /Type to filter/);
+});
+
+test('model-selector typing filters the list', async t => {
+	setProviders([
+		{name: 'openai', models: ['gpt-4o', 'gpt-4o-mini', 'llama3']},
+	]);
+
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<ModelSelector
+			currentProvider="openai"
+			currentModel="gpt-4o"
+			onModelSelect={() => {}}
+			onCancel={() => {}}
+		/>,
+	);
+
+	stdin.write('gpt');
+	await new Promise(resolve => setTimeout(resolve, 50));
+
+	const out = lastFrame()!;
+	t.regex(out, /gpt-4o/);
+	t.regex(out, /gpt-4o-mini/);
+	t.notRegex(out, /llama3/);
+	unmount();
+});
+
+test('model-selector long list keeps highlight in a 12-row window', async t => {
+	setProviders([
+		{name: 'openai', models: Array.from({length: 30}, (_, i) => `model-${i + 1}`)},
+	]);
+
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<ModelSelector
+			currentProvider="openai"
+			currentModel="model-1"
+			onModelSelect={() => {}}
+			onCancel={() => {}}
+		/>,
+	);
+
+	for (let i = 0; i < 15; i++) stdin.write('\u001B[B');
+	await new Promise(resolve => setTimeout(resolve, 50));
+
+	const out = lastFrame()!;
+	// After 15 downs from index 0 the highlight is at 15; window is
+	// slice(9, 21): model-10 .. model-21 (12 rows). Names use the
+	// `model-` prefix (not `m-`) so substring overlap (m-1 in m-10) can't
+	// inflate the count.
+	t.regex(out, /model-10/);
+	t.regex(out, /model-21/);
+	t.notRegex(out, /model-9/);
+	t.notRegex(out, /model-22/);
+	t.regex(out, /Type to filter/);
+	unmount();
+});
+
+test('model-selector Enter on filtered result selects correct provider/model', async t => {
+	setProviders([
+		{name: 'openai', models: ['gpt-4o', 'gpt-4o-mini']},
+		{name: 'ollama', models: ['llama3']},
+	]);
+
+	let selProvider = '';
+	let selModel = '';
+	const onModelSelect = (provider: string, model: string) => {
+		selProvider = provider;
+		selModel = model;
+	};
+
+	const {stdin, unmount} = renderWithTheme(
+		<ModelSelector
+			currentProvider="openai"
+			currentModel="gpt-4o"
+			onModelSelect={onModelSelect}
+			onCancel={() => {}}
+		/>,
+	);
+
+	stdin.write('llama');
+	await new Promise(resolve => setTimeout(resolve, 50));
+	stdin.write('\r');
+	await new Promise(resolve => setTimeout(resolve, 50));
+
+	t.is(selProvider, 'ollama');
+	t.is(selModel, 'llama3');
+	unmount();
+});
+
+test('model-selector no-match shows empty state', async t => {
+	setProviders([
+		{name: 'openai', models: ['gpt-4o']},
+	]);
+
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<ModelSelector
+			currentProvider="openai"
+			currentModel="gpt-4o"
+			onModelSelect={() => {}}
+			onCancel={() => {}}
+		/>,
+	);
+
+	stdin.write('zzzzz');
+	await new Promise(resolve => setTimeout(resolve, 50));
+
+	t.regex(lastFrame()!, /No models matching "zzzzz"/);
+	unmount();
 });

--- a/source/components/model-selector.tsx
+++ b/source/components/model-selector.tsx
@@ -44,10 +44,18 @@ export default function ModelSelector({
 			? 'No models available. Please check your configuration.'
 			: null;
 
+	const currentIndex = entries.findIndex(
+		entry => entry.provider === currentProvider && entry.model === currentModel,
+	);
+
 	return (
 		<ItemSelector
 			title="Select a Model"
 			items={items}
+			searchable
+			initialSelectedValue={
+				currentIndex >= 0 ? String(currentIndex) : undefined
+			}
 			onSelect={value => {
 				const entry = entries[Number(value)];
 				if (entry) {


### PR DESCRIPTION
## Description

Fixes #683 

Makes nanocoder's `/model` picker behave like what modern cli's have : **fuzzy search filter + capped, centered scrolling window** so the list never overflows the terminal, with the current model preselected and marked `(current)`.

### Problem

`/model` renders every configured model in one tall `SelectInput` (ink-select-input ^6.2.0). With 300+ configured models, the titled box grows taller than the terminal — it eats the whole screen, has no search, and only `↑/↓` + `Escape` navigate.

Root cause:
- `source/components/item-selector.tsx:98` — `<SelectInput items={items} />` has no `maxHeight`/virtualization/search
- `source/components/ui/titled-box.tsx` — `TitledBoxWithPreferences` receives no `height` cap; box grows to fit all rows
- `source/components/model-selector.tsx:24-40` — flat list built once, no filter state

### Approach

Extract a new pure **presentational** component `FilterableSelectList` mirroring the proven filter + sliding-window pattern in `source/wizards/steps/model-selection-list.tsx:35-63`. `ItemSelector` gains an opt-in `searchable` prop; when true (and not loading/error/empty) it renders `FilterableSelectList` instead of `SelectInput`. `ModelSelector` flips `searchable` on and preselects the current model. **No new runtime dependencies.** Reuses `fuzzyScore` from `source/utils/fuzzy-matching.ts`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

| File | Change |
|---|---|
| `source/components/filterable-select-list.tsx` | **New.** Pure presentational: filter + sliding-window + key handlers. `visibleCount` default 12, height-aware clamp via `useStdout`. |
| `source/components/filterable-select-list.spec.tsx` | **New.** 16 tests. |
| `source/components/item-selector.tsx` | Add `searchable` / `visibleCount` / `initialSelectedValue` props; render `FilterableSelectList` when opted in. |
| `source/components/item-selector.spec.tsx` | **New.** 5 tests. |
| `source/components/model-selector.tsx` | Pass `searchable`, compute `currentIndex` for preselect. |
| `source/components/model-selector.spec.tsx` | 3 new wiring-only tests. |

## Key behaviors

- **Always-on filter** — any printable char feeds the query (no `/` prefix). `Type to filter · ↑↓ navigate · Enter select · Esc cancel` hint.
- **Capped centered window** — `visibleCount = 12` (matches wizard `MODEL_SELECTION_VISIBLE_ITEMS`). `effectiveVisibleCount = max(1, min(visibleCount, (stdout.rows ?? 24) - 4))` so short terminals clamp and can't reproduce the original overflow.
- **Scroll math** mirrors `model-selection-list.tsx:53-63` — `scrollStart = max(0, min(highlightedIndex − floor(visible/2), len − visible))`.
- **Current model preselect** — stays at natural list index, marked `(current)`; `initialSelectedValue` preselects without re-sorting. Missing current model → no preselect (fallback to index 0).
- **Navigation** — `↑/↓`, `Home`/`End`, `PageUp`/`PageDown`, `Backspace`/`Delete` erase from query, `Enter` selects, `Escape` cancels.

## Screenshots (Before/After)
### Before

https://github.com/user-attachments/assets/d577d8ef-0bae-4420-b48a-81d03a0f6ee5

### After

https://github.com/user-attachments/assets/b859b54a-0f4a-4f18-8bb2-41bc3bf8e310

## One non-obvious decision (single owner for Escape)

Ink 6's `useInput` is **broadcast** — every registered handler fires on every keystroke (`use-input.js:117`, `App.js:85-88`). A naive "keep both escape handlers" double-fires `onCancel`.

The original plan said delete `ItemSelector`'s handler and rely on the section-level authority (`interactive-app.tsx:225-237`, `{isActive: cancellable}`). **Investigation proved that wrong** — `cancellable` (`interactive-app.tsx:143-151`) is `false` during `ModelSelector` loading/error, so Escape would be **lost** there.

**Fix:** `ItemSelector` keeps a single `useInput` gated by Ink's `isActive` option so it owns Escape only in loading/error branches where `FilterableSelectList` is unmounted:
```tsx
{isActive: !searchable || loading || error != null}
```

(error != null, not error !== null — error is string | null | undefined; the latter wrongly keeps the handler active when error is omitted and double-fires.) Verified by two regression tests: Escape fires in the error branch, and does NOT double-fire in the normal searchable path.

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Note: manual smoke (run /model, arrow-down ~6 times to confirm centered 12-row window, type gpt to confirm filtering, type zzzzz for empty state) is described in the plan file.

### Manual Testing

- [ ] Tested with Ollama
- [x] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

## Out of scope (follow-ups)
- Generalizing searchable to other long-list selectors (session-selector, checkpoint-selector, tune-selector, settings-selector) — FilterableSelectList is already generic (ItemSelectorOption<TValue>[]), so each later flip is ~10 lines.
- Mouse support, category grouping, fuzzy match highlighting — opencode-only features, intentionally deferred.
