### PR TITLE
fix: validate checkpoint name to prevent path traversal

### DIFF
--- a/source/services/checkpoint-manager.spec.ts
+++ b/source/services/checkpoint-manager.spec.ts
@@ -312,6 +312,47 @@ test.serial(
 	},
 );
 
+test.serial(
+	'CheckpointManager rejects path traversal in delete',
+	async t => {
+		const tempDir = await createTempDir();
+		// A file outside the checkpoints dir that a traversal name would target.
+		const outside = path.join(tempDir, 'outside');
+		await fs.mkdir(outside, {recursive: true});
+		try {
+			const manager = new CheckpointManager(tempDir);
+
+			await t.throwsAsync(
+				async () => {
+					await manager.deleteCheckpoint('../../outside');
+				},
+				{message: /Invalid checkpoint name|invalid characters/},
+			);
+
+			// The escape target must still be there.
+			t.true(existsSync(outside));
+		} finally {
+			await cleanupTempDir(tempDir);
+		}
+	},
+);
+
+test.serial('CheckpointManager rejects path traversal in load', async t => {
+	const tempDir = await createTempDir();
+	try {
+		const manager = new CheckpointManager(tempDir);
+
+		await t.throwsAsync(
+			async () => {
+				await manager.loadCheckpoint('../../../etc');
+			},
+			{message: /Invalid checkpoint name|invalid characters/},
+		);
+	} finally {
+		await cleanupTempDir(tempDir);
+	}
+});
+
 test.serial('CheckpointManager validates checkpoint integrity', async t => {
 	const tempDir = await createTempDir();
 	try {

--- a/source/services/checkpoint-manager.ts
+++ b/source/services/checkpoint-manager.ts
@@ -53,11 +53,22 @@ export class CheckpointManager {
 	}
 
 	/**
-	 * Get the directory path for a specific checkpoint
+	 * Get the directory path for a specific checkpoint.
+	 *
+	 * Every read/mutate method routes through here, so this is the single
+	 * place that guards against a name escaping the checkpoints directory
+	 * (e.g. `../../etc`). The name is validated for unsafe characters and the
+	 * resolved path is checked to stay inside checkpointsDir.
 	 */
-	// nosemgrep
 	private getCheckpointDir(name: string): string {
-		return path.join(this.checkpointsDir, name); // nosemgrep
+		this.validateName(name);
+		const dir = path.join(this.checkpointsDir, name);
+		const base = path.resolve(this.checkpointsDir);
+		const resolved = path.resolve(dir);
+		if (resolved !== base && !resolved.startsWith(base + path.sep)) {
+			throw new Error(`Invalid checkpoint name: '${name}'`);
+		}
+		return dir;
 	}
 
 	/**


### PR DESCRIPTION
## Description

Checkpoint names weren't validated on load or delete. `getCheckpointDir` joined the name into a path directly, and every read/delete method goes through it:

```ts
private getCheckpointDir(name: string): string {
	return path.join(this.checkpointsDir, name); // nosemgrep
}
```

`/checkpoint delete` passes raw user input as the name, so `../../foo` points outside `.nanocoder/checkpoints/`. `deleteCheckpoint` runs `fs.rm(..., {recursive: true, force: true})`, so it could delete a directory outside the workspace. Only `saveCheckpoint` validated the name before.

Fix validates the name and checks the resolved path stays inside the checkpoints dir, in `getCheckpointDir` so load/delete/metadata/exists are all covered in one place.

## Type of Change

- [x] Bug fix

## Testing

- [x] New tests in `checkpoint-manager.spec.ts` for traversal in load and delete
- [x] Existing checkpoint tests still pass

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes

Closes #686
