### PR TITLE
feat: tabbed settings dialog with searchable categories

### DIFF
--- a/.changeset/tabbed-settings-dialog.md
+++ b/.changeset/tabbed-settings-dialog.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added a tabbed `/settings` dialog with searchable categories, so settings are easier to scan and filter from the TUI. Thanks to @llupRisinglll. Closes #471.

--- a/source/app/components/modal-selectors.tsx
+++ b/source/app/components/modal-selectors.tsx
@@ -7,7 +7,7 @@ import type {ActiveMode} from '@/hooks/useAppState';
 import type {CheckpointListItem, TuneConfig} from '@/types';
 import {McpWizard} from '@/wizards/mcp-wizard';
 import {ProviderWizard} from '@/wizards/provider-wizard';
-import {SettingsSelector} from './settings-selector';
+import {SettingsSelector} from './settings-tabs';
 import {TuneSelector} from './tune-selector';
 
 export interface ModalSelectorsProps {

--- a/source/app/components/settings-selector.spec.tsx
+++ b/source/app/components/settings-selector.spec.tsx
@@ -1,7 +1,19 @@
+import {mkdtempSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import test from 'ava';
 import React from 'react';
-import {renderWithTheme} from '../../test-utils/render-with-theme';
-import {SettingsSelector} from './settings-selector';
+// CRITICAL: redirect preference reads to a temp dir BEFORE settings-tabs (and
+// its @/config/preferences import chain) loads. SettingsSelector now reads
+// preferences at mount to populate the Settings tab's row values.
+process.env.NANOCODER_CONFIG_DIR = mkdtempSync(
+	join(tmpdir(), 'nanocoder-spec-'),
+);
+const {resetPreferencesCache} = await import('@/config/preferences');
+resetPreferencesCache();
+
+const {renderWithTheme} = await import('../../test-utils/render-with-theme');
+const {SettingsSelector} = await import('./settings-tabs');
 
 test('SettingsSelector renders without crashing', t => {
 	const {unmount} = renderWithTheme(<SettingsSelector onCancel={() => {}} />);
@@ -9,17 +21,17 @@ test('SettingsSelector renders without crashing', t => {
 	unmount();
 });
 
-test('SettingsSelector main menu shows settings options', t => {
+test('SettingsSelector shows the tab bar with Appearance tab', t => {
 	const {lastFrame, unmount} = renderWithTheme(
 		<SettingsSelector onCancel={() => {}} />,
 	);
 	const output = lastFrame();
 	t.truthy(output);
-	t.truthy(output!.includes('Settings'));
+	t.truthy(output!.includes('Appearance'));
 	unmount();
 });
 
-test('SettingsSelector main menu shows Theme option', t => {
+test('SettingsSelector shows Theme option', t => {
 	const {lastFrame, unmount} = renderWithTheme(
 		<SettingsSelector onCancel={() => {}} />,
 	);
@@ -29,7 +41,7 @@ test('SettingsSelector main menu shows Theme option', t => {
 	unmount();
 });
 
-test('SettingsSelector main menu shows navigation hints', t => {
+test('SettingsSelector shows navigation hints', t => {
 	const {lastFrame, unmount} = renderWithTheme(
 		<SettingsSelector onCancel={() => {}} />,
 	);
@@ -40,10 +52,17 @@ test('SettingsSelector main menu shows navigation hints', t => {
 	unmount();
 });
 
-test('SettingsSelector main menu shows Display Settings option', t => {
-	const {lastFrame, unmount} = renderWithTheme(
+test('SettingsSelector shows Tool Results and Thinking option on the Display tab', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
 		<SettingsSelector onCancel={() => {}} />,
 	);
+	const tick = () => new Promise(resolve => setTimeout(resolve, 30));
+	await tick();
+	// Appearance -> Input -> Display.
+	stdin.write('[C');
+	await tick();
+	stdin.write('[C');
+	await tick();
 	const output = lastFrame();
 	t.truthy(output);
 	t.truthy(output!.includes('Tool Results and Thinking'));

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -30,152 +30,23 @@ import type {NanocoderShape, ThemePreset} from '@/types/ui';
 import {setNotificationsConfig} from '@/utils/notifications';
 import {DEFAULT_SINGLE_LINE_PASTE_THRESHOLD} from '@/utils/paste-utils';
 
-type SettingsStep =
-	| 'main'
+/**
+ * The set of "managed" settings panels: preserved full-featured sub-UIs that
+ * the tabbed Settings dialog (`settings-tabs.tsx`) opens in place of the old
+ * top-level menu. `main`/`done` no longer exist as panel states — the tab
+ * dialog's own list/header modes replace them.
+ */
+export type ManagedSettingsPanel =
 	| 'theme'
 	| 'title-shape'
 	| 'nanocoder-shape'
 	| 'paste-threshold'
 	| 'notifications'
 	| 'display-settings'
-	| 'privacy'
-	| 'done';
+	| 'privacy';
 
-interface SettingsSelectorProps {
+export interface SettingsSelectorProps {
 	onCancel: () => void;
-}
-
-interface MainMenuItem {
-	label: string;
-	value: SettingsStep;
-	description: string;
-}
-
-// Main settings menu
-function SettingsMainMenu({
-	onSelect,
-	onCancel,
-}: {
-	onSelect: (step: SettingsStep) => void;
-	onCancel: () => void;
-}) {
-	const {colors} = useTheme();
-	const {boxWidth, isNarrow} = useResponsiveTerminal();
-
-	const items: MainMenuItem[] = [
-		{
-			label: 'Theme',
-			value: 'theme',
-			description: 'Change color scheme',
-		},
-		{
-			label: 'Title Shape',
-			value: 'title-shape',
-			description: 'Customize box title styles',
-		},
-		{
-			label: 'Nanocoder Shape',
-			value: 'nanocoder-shape',
-			description: 'Change welcome banner font',
-		},
-		{
-			label: 'Paste Threshold',
-			value: 'paste-threshold',
-			description: 'Set single-line paste character limit',
-		},
-		{
-			label: 'Notifications',
-			value: 'notifications',
-			description: 'Desktop notification preferences',
-		},
-		{
-			label: 'Tool Results and Thinking',
-			value: 'display-settings',
-			description: 'Set defaults for model thoughts and tool results',
-		},
-		{
-			label: 'Privacy',
-			value: 'privacy',
-			description: 'Manage prompt scrubbing and sensitive data',
-		},
-		{
-			label: 'Done',
-			value: 'done',
-			description: 'Exit settings',
-		},
-	];
-
-	useInput((_input, key) => {
-		if (key.escape) {
-			onCancel();
-		}
-	});
-
-	// Narrow terminal: simplified layout (matches Status component pattern)
-	if (isNarrow) {
-		return (
-			<Box
-				flexDirection="column"
-				marginBottom={1}
-				borderStyle="round"
-				borderColor={colors.primary}
-				paddingY={1}
-				paddingX={2}
-				width="100%"
-			>
-				<Text color={colors.primary} bold>
-					Settings
-				</Text>
-				<Text color={colors.text}> </Text>
-				<StyledSelectInput
-					items={items.map(item => ({
-						label: item.label,
-						value: item.value,
-					}))}
-					onSelect={item => {
-						if (item.value === 'done') {
-							onCancel();
-						} else {
-							onSelect(item.value as SettingsStep);
-						}
-					}}
-				/>
-				<Box marginBottom={1}></Box>
-				<Text color={colors.secondary}>Enter/Esc</Text>
-			</Box>
-		);
-	}
-
-	return (
-		<TitledBoxWithPreferences
-			title="Settings"
-			width={boxWidth}
-			borderColor={colors.primary}
-			paddingX={1}
-			paddingY={1}
-			flexDirection="column"
-		>
-			<Box marginBottom={1}>
-				<Text color={colors.secondary}>Select a setting to configure:</Text>
-			</Box>
-			<StyledSelectInput
-				items={items.map(item => ({
-					label: `${item.label} - ${item.description}`,
-					value: item.value,
-				}))}
-				onSelect={item => {
-					if (item.value === 'done') {
-						onCancel();
-					} else {
-						onSelect(item.value as SettingsStep);
-					}
-				}}
-			/>
-			<Box marginTop={1}>
-				<Text color={colors.secondary}>Enter to select, Esc to exit</Text>
-			</Box>
-		</TitledBoxWithPreferences>
-	);
 }
 
 function ThemePreviewMessage({
@@ -290,7 +161,7 @@ function ThemeMiniPreview({
 }
 
 // Theme settings panel
-function SettingsThemePanel({
+export function SettingsThemePanel({
 	onBack,
 	onCancel,
 }: {
@@ -389,7 +260,7 @@ function SettingsThemePanel({
 }
 
 // Title Shape settings panel
-function SettingsTitleShapePanel({
+export function SettingsTitleShapePanel({
 	onBack,
 	onCancel,
 }: {
@@ -561,7 +432,7 @@ function SettingsTitleShapePanel({
 }
 
 // Nanocoder Shape settings panel
-function SettingsNanocoderShapePanel({
+export function SettingsNanocoderShapePanel({
 	onBack,
 	onCancel,
 }: {
@@ -686,7 +557,7 @@ function SettingsNanocoderShapePanel({
 }
 
 // Paste Threshold settings panel
-function SettingsPasteThresholdPanel({
+export function SettingsPasteThresholdPanel({
 	onBack,
 	onCancel,
 }: {
@@ -784,7 +655,7 @@ function SettingsPasteThresholdPanel({
 }
 
 // Notifications settings panel
-function SettingsNotificationsPanel({
+export function SettingsNotificationsPanel({
 	onBack,
 	onCancel,
 }: {
@@ -893,7 +764,7 @@ function SettingsNotificationsPanel({
 }
 
 // Display settings panel
-function SettingsDisplayPanel({
+export function SettingsDisplayPanel({
 	onBack,
 	onCancel,
 }: {
@@ -971,67 +842,8 @@ function SettingsDisplayPanel({
 	);
 }
 
-// Main settings selector with step navigation
-export function SettingsSelector({onCancel}: SettingsSelectorProps) {
-	const [step, setStep] = useState<SettingsStep>('main');
-
-	switch (step) {
-		case 'main':
-			return <SettingsMainMenu onSelect={setStep} onCancel={onCancel} />;
-		case 'theme':
-			return (
-				<SettingsThemePanel
-					onBack={() => setStep('main')}
-					onCancel={onCancel}
-				/>
-			);
-		case 'title-shape':
-			return (
-				<SettingsTitleShapePanel
-					onBack={() => setStep('main')}
-					onCancel={onCancel}
-				/>
-			);
-		case 'nanocoder-shape':
-			return (
-				<SettingsNanocoderShapePanel
-					onBack={() => setStep('main')}
-					onCancel={onCancel}
-				/>
-			);
-		case 'paste-threshold':
-			return (
-				<SettingsPasteThresholdPanel
-					onBack={() => setStep('main')}
-					onCancel={onCancel}
-				/>
-			);
-		case 'notifications':
-			return (
-				<SettingsNotificationsPanel
-					onBack={() => setStep('main')}
-					onCancel={onCancel}
-				/>
-			);
-		case 'display-settings':
-			return (
-				<SettingsDisplayPanel
-					onBack={() => setStep('main')}
-					onCancel={onCancel}
-				/>
-			);
-		case 'privacy':
-			return (
-				<SettingsPrivacyPanel
-					onBack={() => setStep('main')}
-					onCancel={onCancel}
-				/>
-			);
-	}
-}
-
 // Privacy settings panel
-function SettingsPrivacyPanel({
+export function SettingsPrivacyPanel({
 	onBack,
 	onCancel,
 }: {

--- a/source/app/components/settings-tabs.spec.tsx
+++ b/source/app/components/settings-tabs.spec.tsx
@@ -1,0 +1,810 @@
+import {mkdtempSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {render} from 'ink-testing-library';
+import test from 'ava';
+import React from 'react';
+// CRITICAL: force chalk/ink to emit real ANSI escapes (inverse-video cursor
+// etc.) even though this process has no TTY — must be set BEFORE anything
+// transitively imports chalk (chalk resolves its color level at import
+// time), so this has to be the very first statement in the file.
+process.env.FORCE_COLOR = '1';
+// CRITICAL: redirect preference reads to a temp dir BEFORE settings-tabs (and
+// its @/config/preferences import chain) loads.
+process.env.NANOCODER_CONFIG_DIR = mkdtempSync(
+	join(tmpdir(), 'nanocoder-spec-'),
+);
+const {resetPreferencesCache, getAlternateScreen} = await import(
+	'@/config/preferences'
+);
+resetPreferencesCache();
+
+const {renderWithTheme} = await import('../../test-utils/render-with-theme');
+const {defaultTheme, themes} = await import('@/config/themes');
+const {ThemeContext} = await import('@/hooks/useTheme');
+const {TitleShapeContext} = await import('@/hooks/useTitleShape');
+const {UIStateProvider} = await import('@/hooks/useUIState');
+const {SettingsSelector} = await import('./settings-tabs');
+type TitleShape = import('@/components/ui/styled-title').TitleShape;
+
+/**
+ * Renders SettingsSelector with an explicit title shape — renderWithTheme
+ * hardcodes 'pill', but the shape-reuse specs below need to force a
+ * different shape (e.g. 'arrow-double') to prove StyledTitle is really
+ * driving the selected-tab render.
+ */
+function renderWithTitleShape(shape: TitleShape) {
+	const themeValue = {
+		currentTheme: defaultTheme,
+		colors: themes[defaultTheme].colors,
+		setCurrentTheme: () => {},
+	};
+	const titleShapeValue = {
+		currentTitleShape: shape,
+		setCurrentTitleShape: () => {},
+	};
+	return render(
+		<ThemeContext.Provider value={themeValue}>
+			<TitleShapeContext.Provider value={titleShapeValue}>
+				<UIStateProvider>
+					<SettingsSelector onCancel={() => {}} />
+				</UIStateProvider>
+			</TitleShapeContext.Provider>
+		</ThemeContext.Provider>,
+	);
+}
+
+console.log('\nsettings-tabs.spec.tsx');
+
+const DOWN = '[B';
+const LEFT = '[D';
+const RIGHT = '[C';
+const ESC = '';
+const ENTER = '\r';
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 30));
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping real terminal escape codes for text-only assertions.
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (s: string) => s.replace(ANSI_RE, '');
+
+/**
+ * Matches the StyledTitle-rendered filled block for a given label: bold +
+ * a background color escape (standard 4x, bright 10x, or truecolor) + a
+ * foreground color escape, wrapping " label ", closed by the matching
+ * resets. This is what marks the SELECTED tab, regardless of which
+ * borderColor (focused vs unfocused) or theme palette produced the codes.
+ */
+const filledBlockRegex = (label: string) =>
+	new RegExp(
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: matching real terminal escape codes.
+		`\\x1b\\[1m\\x1b\\[[0-9;]*m\\x1b\\[[0-9;]*m ${label} \\x1b\\[39m\\x1b\\[49m\\x1b\\[22m`,
+	);
+
+/**
+ * Count of filled-block background-color escapes anywhere in the raw
+ * output — background-SET codes only (40-47, 100-107, or truecolor 48;2;…),
+ * excluding the background-RESET code (49).
+ */
+const countBackgroundEscapes = (s: string) =>
+	(s.match(/\x1b\[(4[0-7]|10[0-7]|48;2;\d+;\d+;\d+)m/g) ?? []).length;
+
+test.beforeEach(() => {
+	resetPreferencesCache();
+});
+
+test('renders all four category tabs with Appearance selected first', async t => {
+	const {lastFrame, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+	const output = lastFrame();
+	t.truthy(output);
+	t.truthy(output!.includes('Appearance'));
+	t.truthy(output!.includes('Input'));
+	t.truthy(output!.includes('Display'));
+	t.truthy(output!.includes('Advanced'));
+	// The selected tab is marked by the user's TitleShape system, not a
+	// literal bracket string (ANSI escapes also contain '[', so compare
+	// against the stripped text).
+	t.falsy(stripAnsi(output!).includes('['));
+	unmount();
+});
+
+test('left/right arrows move the selected-tab StyledTitle rendering', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	const initial = lastFrame();
+	t.truthy(initial);
+	// Appearance starts selected: it carries the pill's filled background
+	// ANSI sequence (bold + backgroundColor + textColor around the label).
+	t.regex(initial!, filledBlockRegex('Appearance'));
+
+	stdin.write(RIGHT);
+	await tick();
+	let output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, filledBlockRegex('Input'));
+	t.notRegex(output!, filledBlockRegex('Appearance'));
+
+	stdin.write(LEFT);
+	await tick();
+	output = lastFrame();
+	t.regex(output!, filledBlockRegex('Appearance'));
+
+	unmount();
+});
+
+test('selected tab renders through the real StyledTitle pill shape, no bracket characters', async t => {
+	const {lastFrame, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+	const output = lastFrame();
+	t.truthy(output);
+	// Filled block: bold + background + text color wrapped around " Appearance ".
+	t.regex(output!, filledBlockRegex('Appearance'));
+	t.falsy(stripAnsi(output!).includes('['));
+	unmount();
+});
+
+test('selected tab honors a non-pill TitleShape (arrow-double flank glyphs) around the active tab only', async t => {
+	const {lastFrame, unmount} = renderWithTitleShape('arrow-double');
+	await tick();
+	const output = lastFrame();
+	t.truthy(output);
+	const plain = stripAnsi(output!);
+
+	// arrow-double flanks the active tab's label with « ... » in the
+	// visible (ANSI-stripped) text.
+	t.regex(plain, /« Appearance »/);
+	// The flank glyphs belong to Appearance's block only — no other « … »
+	// pair exists in the row, and specifically not around "Input".
+	const flankPairs = plain.match(/«[^»]*»/g) ?? [];
+	t.is(flankPairs.length, 1);
+	t.falsy(flankPairs[0]!.includes('Input'));
+
+	unmount();
+});
+
+test('faux "Settings" label is present but is never selectable via arrow keys', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	let output = lastFrame();
+	t.truthy(output);
+	t.truthy(output!.includes('Settings'));
+	// The faux label never carries the selected tab's filled-background ANSI.
+	t.notRegex(output!, filledBlockRegex('Settings'));
+
+	// Cycle through every tab (4 tabs); "Settings" must never become the
+	// marked tab.
+	for (let i = 0; i < 4; i++) {
+		stdin.write(RIGHT);
+		await tick();
+		output = lastFrame();
+		t.notRegex(output!, filledBlockRegex('Settings'));
+	}
+
+	unmount();
+});
+
+test('unselected tabs carry no background/inverse ANSI', async t => {
+	const {lastFrame, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+	const output = lastFrame();
+	t.truthy(output);
+
+	// No inverse-video escape anywhere — the old bracket implementation used
+	// `inverse` on the selected tab; the new one never does.
+	t.notRegex(output!, /\x1b\[7m/);
+	// Exactly one filled background block on the header row: the selected
+	// tab's StyledTitle. Unselected tabs (and the faux "Settings" label)
+	// contribute zero background escapes.
+	t.is(countBackgroundEscapes(output!), 1);
+
+	unmount();
+});
+
+test('each tab lists its expected setting rows', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	// Search-filters to a single row so presence can be checked regardless
+	// of the visible-row scroll window — each tab's row count varies, and
+	// some tabs have more rows than fit in one page.
+	const expectRow = async (label: string) => {
+		stdin.write(DOWN);
+		await tick();
+		stdin.write(label);
+		await tick();
+		const output = lastFrame();
+		t.truthy(output, `expected a frame while checking "${label}"`);
+		t.truthy(output!.includes(label), `expected to find row "${label}"`);
+		// Clear the query, then return focus to the header — ready for the
+		// next row check (same tab) or a tab switch.
+		stdin.write(ESC); // query non-empty: clears the query
+		await tick();
+		stdin.write(ESC); // query now empty: search -> header
+		await tick();
+	};
+
+	// Appearance (default tab).
+	await expectRow('Theme');
+	await expectRow('Title Shape');
+	await expectRow('Nanocoder Shape');
+	await expectRow('Alternate Screen');
+
+	// Input.
+	stdin.write(RIGHT);
+	await tick();
+	await expectRow('Paste Threshold');
+	await expectRow('Notifications');
+
+	// Display.
+	stdin.write(RIGHT);
+	await tick();
+	await expectRow('Tool Results and Thinking');
+
+	// Advanced.
+	stdin.write(RIGHT);
+	await tick();
+	await expectRow('Privacy');
+
+	unmount();
+});
+
+test('typing in the search box filters the active tab settings list', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	// Enter the Appearance tab's search box.
+	stdin.write(DOWN);
+	await tick();
+
+	stdin.write('theme');
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.truthy(output!.includes('Theme'));
+	// "Alternate Screen" shares no substring with "theme" — it should be filtered out.
+	t.falsy(output!.includes('Alternate Screen'));
+
+	unmount();
+});
+
+// Regression test: Ink parses every keypress out of one stdin chunk and
+// delivers them synchronously in the same tick (ink's App.handleReadable
+// loops over all parsed events and calls each useInput handler before
+// React re-renders between them). A real user pressing the down arrow and
+// then typing fast enough that the terminal/PTY delivers both in the same
+// `data` chunk — not just paste, ordinary fast typing — reproduces this:
+// unlike the test above (which awaits a tick between the arrow and the
+// letters, giving focus state time to commit), this drives both in one
+// `stdin.write` call so the header->search transition and the first typed
+// characters land in the exact same synchronous batch.
+test('typing that arrives in the same stdin chunk as the down-arrow still reaches the search box', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	// One combined write: down arrow immediately followed by the query,
+	// exactly as a real terminal can deliver a fast "press down, then type"
+	// burst in a single stdin `data` event.
+	stdin.write(`${DOWN}theme`);
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	// The label and the typed query render as separate differently-coloured
+	// Text spans, so strip ANSI before checking they're contiguous — a raw
+	// substring check would false-negative on the color-reset codes between
+	// them even when the fix is working correctly.
+	t.truthy(stripAnsi(output!).includes('theme'));
+	// HTML-placeholder semantics: once a query is typed, the placeholder
+	// label disappears entirely — it must not prefix the typed query.
+	t.falsy(stripAnsi(output!).includes('Search settings…'));
+	t.truthy(output!.includes('Theme'));
+	t.falsy(output!.includes('Alternate Screen'));
+
+	unmount();
+});
+
+test('Enter on the Alternate Screen boolean row flips the persisted preference', async t => {
+	t.is(getAlternateScreen(), false);
+
+	const {stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	// Filter down to the single boolean row so index 0 is deterministic.
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('Alternate');
+	await tick();
+	stdin.write(DOWN);
+	await tick();
+	stdin.write(ENTER);
+	await tick();
+
+	t.is(getAlternateScreen(), true);
+
+	unmount();
+});
+
+// Regression coverage for the full Enter contract advertised by the search
+// box's own footer hint ("Enter/↓ select"): Enter in search focus must move
+// into the list with the first filtered row selected, and Enter ON a row
+// must activate it. Includes the coalesced-chunk class from the gotcha
+// above: Ink can fold a typed query and one or more trailing Enters into a
+// SINGLE keypress event (`key.return` false, `input` containing literal
+// `\r` characters) when a real terminal delivers them in one stdin chunk.
+
+test('search + query, Enter moves into the list with the first filtered row selected', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('theme');
+	await tick();
+	stdin.write(ENTER);
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	// The Theme row is now the selected list row ("> " marker + info color),
+	// not still sitting in the search box.
+	t.regex(stripAnsi(output!), /> Theme\b/);
+	t.truthy(output!.includes('Enter change'));
+
+	unmount();
+});
+
+test('a second Enter on the selected row activates it: boolean flips on disk', async t => {
+	// Other serial tests in this file share the same temp preferences file
+	// and may have already flipped this boolean — assert the toggle, not an
+	// assumed starting value.
+	const before = getAlternateScreen();
+
+	const {stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('Alternate');
+	await tick();
+	stdin.write(ENTER); // search -> list, selects the single filtered row
+	await tick();
+	stdin.write(ENTER); // list: activates the selected row
+	await tick();
+
+	t.is(getAlternateScreen(), !before);
+
+	unmount();
+});
+
+test('a second Enter on a managed row opens its sub-panel', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('Theme');
+	await tick();
+	stdin.write(ENTER); // search -> list
+	await tick();
+	stdin.write(ENTER); // list: activates -> opens the Theme sub-panel
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.falsy(output!.includes('Settings'));
+	t.truthy(output!.includes('navigate'));
+
+	unmount();
+});
+
+test('Enter directly on an empty query (no typing) still moves into the list', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write(ENTER);
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.truthy(output!.includes('Enter change'));
+
+	unmount();
+});
+
+test('"↓theme\\r" sent as ONE stdin chunk ends with the list focused and the query intact', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	// Down-arrow, the typed query, and the trailing Enter all in a single
+	// write — reproducing the terminal coalescing a fast "type then hit
+	// Enter" burst into one stdin `data` chunk.
+	stdin.write(`${DOWN}theme${ENTER}`);
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	const plain = stripAnsi(output!);
+	// The query text survived (no stray `\r` got left dangling in it) and
+	// the list is now focused on the Theme row.
+	t.truthy(plain.includes('theme'));
+	// HTML-placeholder semantics: an unfocused-with-query row shows only the
+	// query, never the placeholder label prefixed in front of it.
+	t.falsy(plain.includes('Search settings…'));
+	t.regex(plain, /> Theme\b/);
+	t.truthy(plain.includes('Enter change'));
+
+	unmount();
+});
+
+// Regression test for the stale-closure bug: activateRow (replayed from the
+// coalesced-chunk split above) read `filteredRows[clampedIndex]` from the
+// render-time closure, which hadn't recomputed yet because the replayed
+// typed segment's `setQuery` is async. "theme" is a false-positive target
+// for this bug — Theme is ALSO the unfiltered index-0 row, so the stale
+// (unfiltered) list and the correctly-filtered list agree by coincidence.
+// "alternate" is not index 0 unfiltered (Alternate Screen is the LAST
+// appearance row), so it actually distinguishes stale-unfiltered-index-0
+// (would open the Theme sub-panel) from correctly-filtered (activates the
+// Alternate Screen boolean row) behavior.
+test('"↓alternate\\r\\r" sent as ONE stdin chunk flips the Alternate Screen preference, not the Theme panel', async t => {
+	// Other serial tests in this file share the same temp preferences file —
+	// assert the toggle, never an assumed starting value.
+	const before = getAlternateScreen();
+
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(`${DOWN}alternate${ENTER}${ENTER}`);
+	await tick();
+
+	t.is(getAlternateScreen(), !before);
+
+	const output = lastFrame();
+	t.truthy(output);
+	// The Theme sub-panel did NOT open: the tab bar/list frame is still
+	// showing (the sub-panel view hides "Settings" and shows "navigate").
+	t.truthy(output!.includes('Settings'));
+	t.falsy(output!.includes('navigate'));
+
+	unmount();
+});
+
+// Same stale-closure class, one Enter short of activation: proves the
+// search->list transition itself lands on the correctly-filtered row (not
+// just that the final activation happens to be right).
+test('"↓alternate\\r" sent as ONE stdin chunk ends with the list focused and Alternate Screen selected', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(`${DOWN}alternate${ENTER}`);
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	const plain = stripAnsi(output!);
+	t.regex(plain, /> Alternate Screen\b/);
+	t.truthy(plain.includes('Enter change'));
+
+	unmount();
+});
+
+test('Enter on the Theme managed row opens the sub-panel, Esc returns to the list', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('Theme');
+	await tick();
+	stdin.write(DOWN);
+	await tick();
+	stdin.write(ENTER);
+	await tick();
+
+	let output = lastFrame();
+	t.truthy(output);
+	// The tab bar (including the faux "Settings" label) is hidden while the
+	// sub-panel is open.
+	t.falsy(output!.includes('Settings'));
+	t.truthy(output!.includes('navigate'));
+
+	stdin.write(ESC);
+	await tick();
+
+	output = lastFrame();
+	t.truthy(output!.includes('Settings'));
+	t.regex(output!, filledBlockRegex('Appearance'));
+
+	unmount();
+});
+
+// On this branch the Appearance tab (the tab with the most rows) has exactly
+// MAX_VISIBLE_ROWS (4) entries — Status Line lives on a separate, not-yet-
+// upstream fork feature and is out of scope for this branch, so no tab
+// currently overflows the visible window and the indicator can't be
+// organically triggered here. Skipped rather than deleted: restore once any
+// tab exceeds 4 rows (e.g. when Status Line lands on main).
+test.skip('scroll indicator appears when items exceed the visible window', async t => {
+	const {lastFrame, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.truthy(output!.includes('more below'));
+
+	unmount();
+});
+
+// Regression coverage for the real-text-field cursor (upstream PR 684 style
+// "Filter: query_"): the search row must carry an inverse-video ANSI
+// sequence, not just plain text — the search box previously echoed the
+// query with no cursor glyph at all, so typing felt like invisible hotkey
+// filtering rather than a focused text field.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching a real terminal inverse-video escape.
+const INVERSE_RE = /\x1b\[7m/;
+
+test('search-focused row renders an inverse-video cursor at the end of the query', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('theme');
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	// The inverse escape appears immediately after the typed query, not
+	// merely somewhere in the frame (e.g. from an unrelated selected-tab
+	// pill) — anchor on "theme" followed by the inverse-on code.
+	t.regex(output!, /theme\x1b\[7m/);
+	t.regex(output!, INVERSE_RE);
+
+	unmount();
+});
+
+// HTML-placeholder semantics: once the query is non-empty, the placeholder
+// label must disappear entirely, leaving only the glyph, the query, and the
+// trailing inverse cursor — matching openclaude's SearchBox (focused
+// non-empty branch renders ONLY query + cursor) and this repo's own
+// text-input.tsx placeholder idiom.
+test('search-focused row with a typed query does not render the placeholder label', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('the');
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	const plain = stripAnsi(output!);
+	t.falsy(plain.includes('Search settings…'));
+	t.truthy(plain.includes('the'));
+	t.regex(output!, INVERSE_RE);
+
+	unmount();
+});
+
+test('search-focused row with an empty query shows the placeholder with its first character inverse', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, INVERSE_RE);
+	t.truthy(stripAnsi(output!).includes('Search settings…'));
+
+	unmount();
+});
+
+test('unfocused search row carries no inverse-video ANSI', async t => {
+	const {lastFrame, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	// Header is focused by default — the search row is unfocused.
+	const output = lastFrame();
+	t.truthy(output);
+	t.notRegex(output!, INVERSE_RE);
+
+	unmount();
+});
+
+// Regression coverage for ranked (not just substring) fuzzy filtering,
+// matching upstream PR 684's ranked "Filter:" behavior: a prefix match must
+// outrank a mere fuzzy/subsequence match for the same query, even though
+// both survive the filter.
+test('fuzzy ranking: a prefix match outranks a weaker subsequence match for the same query', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	// Appearance tab (default): "Theme" starts with "the" (prefix, score
+	// 850); "Title Shape" only matches "the" as a scattered subsequence
+	// (t...h...e, score well below 700) — both survive the filter, but
+	// Theme must render first.
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('the');
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	const plain = stripAnsi(output!);
+	t.truthy(plain.includes('Theme'));
+	t.truthy(plain.includes('Title Shape'));
+	const themeIndex = plain.indexOf('Theme');
+	const titleShapeIndex = plain.indexOf('Title Shape');
+	t.true(themeIndex >= 0 && titleShapeIndex >= 0);
+	t.true(themeIndex < titleShapeIndex);
+
+	unmount();
+});
+
+// Ctrl+U (readline "clear to start of line") clears the whole query — this
+// row's cursor is always at the end, so there's nothing after it to keep.
+test('Ctrl+U in search focus clears the whole query', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('theme');
+	await tick();
+	t.truthy(stripAnsi(lastFrame()!).includes('theme'));
+
+	stdin.write('\x15'); // Ctrl+U
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	const plain = stripAnsi(output!);
+	t.falsy(plain.includes('theme'));
+	t.truthy(plain.includes('Search settings…'));
+	// Back to an empty query: every Appearance row is visible again.
+	t.truthy(plain.includes('Alternate Screen'));
+
+	unmount();
+});
+
+// The list view now deliberately draws TWO rounded-border boxes: the outer
+// dialog panel, and the search box nested inside it (ported from
+// openclaude's SearchBox — src/components/SearchBox.tsx). A managed
+// sub-panel replaces this entire view (its own TitledBoxWithPreferences is
+// the only border on screen at that point), so this spec only covers the
+// list view.
+test('the list view frame has exactly two rounded-border boxes: outer panel + search box', async t => {
+	const {lastFrame, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	const lines = output!.split('\n');
+
+	// One top-border line for the outer panel, one for the search box.
+	const topBorderLines = lines.filter(line => line.includes('╭'));
+	t.is(topBorderLines.length, 2);
+
+	// Likewise two bottom-border lines.
+	const bottomBorderLines = lines.filter(line => line.includes('╰'));
+	t.is(bottomBorderLines.length, 2);
+
+	unmount();
+});
+
+// Regression coverage for the openclaude-styled search box port: the
+// magnifier prefix glyph must be present in the search row, and the search
+// box's border color must key on focus (a different ANSI color escape when
+// focused vs unfocused), exactly like openclaude's
+// `borderColor={isFocused ? "suggestion" : undefined}` /
+// `borderDimColor={!isFocused}` pair.
+
+test('search row renders the magnifier glyph prefix', async t => {
+	const {lastFrame, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.truthy(stripAnsi(output!).includes('⌕ '));
+
+	unmount();
+});
+
+test('search box border color differs between focused and unfocused states', async t => {
+	const {lastFrame, stdin, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	await tick();
+
+	// Header focused by default — the search box border is unfocused.
+	const unfocusedOutput = lastFrame();
+	t.truthy(unfocusedOutput);
+	// The search box's top-border line is the second "╭" line (the outer
+	// panel's top border is the first).
+	const unfocusedTopBorder = unfocusedOutput!
+		.split('\n')
+		.filter(line => line.includes('╭'))[1];
+	t.truthy(unfocusedTopBorder);
+	const unfocusedColorCodes = unfocusedTopBorder!.match(/\x1b\[[0-9;]*m/g);
+	t.truthy(unfocusedColorCodes && unfocusedColorCodes.length > 0);
+
+	// Move focus into the search box.
+	stdin.write(DOWN);
+	await tick();
+
+	const focusedOutput = lastFrame();
+	t.truthy(focusedOutput);
+	const focusedTopBorder = focusedOutput!
+		.split('\n')
+		.filter(line => line.includes('╭'))[1];
+	t.truthy(focusedTopBorder);
+	const focusedColorCodes = focusedTopBorder!.match(/\x1b\[[0-9;]*m/g);
+	t.truthy(focusedColorCodes && focusedColorCodes.length > 0);
+
+	// The two border-color ANSI sequences differ — focused and unfocused
+	// use different color tokens (colors.info vs colors.secondary).
+	t.notDeepEqual(unfocusedColorCodes, focusedColorCodes);
+
+	unmount();
+});

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -1,0 +1,661 @@
+import chalk from 'chalk';
+import {Box, Text, useInput} from 'ink';
+import type {ReactElement} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
+import {StyledTitle} from '@/components/ui/styled-title';
+import {
+	getAlternateScreen,
+	getNanocoderShape,
+	getNotificationsPreference,
+	getPasteThreshold,
+	getPrivacyPreference,
+	updateAlternateScreen,
+} from '@/config/preferences';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+import {useTitleShape} from '@/hooks/useTitleShape';
+import {fuzzyScore} from '@/utils/fuzzy-matching';
+import {DEFAULT_SINGLE_LINE_PASTE_THRESHOLD} from '@/utils/paste-utils';
+import type {
+	ManagedSettingsPanel,
+	SettingsSelectorProps,
+} from './settings-selector';
+import {
+	SettingsDisplayPanel,
+	SettingsNanocoderShapePanel,
+	SettingsNotificationsPanel,
+	SettingsPasteThresholdPanel,
+	SettingsPrivacyPanel,
+	SettingsThemePanel,
+	SettingsTitleShapePanel,
+} from './settings-selector';
+
+/**
+ * Tab categories are our own settings, grouped for browsability — not the
+ * Status/Config/Usage read-only surfaces (those live at /status and /usage).
+ * Every existing preference must be reachable from exactly one of these
+ * four tabs.
+ */
+export type SettingsTabId = 'appearance' | 'input' | 'display' | 'advanced';
+
+interface TabDefinition {
+	id: SettingsTabId;
+	label: string;
+}
+
+const TABS: TabDefinition[] = [
+	{id: 'appearance', label: 'Appearance'},
+	{id: 'input', label: 'Input'},
+	{id: 'display', label: 'Display'},
+	{id: 'advanced', label: 'Advanced'},
+];
+
+type SettingRow =
+	| {
+			kind: 'boolean';
+			id: string;
+			label: string;
+			value: boolean;
+			onToggle: () => void;
+	  }
+	| {
+			kind: 'number';
+			id: string;
+			label: string;
+			value: number;
+			panel: ManagedSettingsPanel;
+	  }
+	| {
+			kind: 'managed';
+			id: string;
+			label: string;
+			value: string;
+			panel: ManagedSettingsPanel;
+	  };
+
+const MAX_VISIBLE_ROWS = 4;
+const SEARCH_PLACEHOLDER = 'Search settings…';
+
+function buildRowsForTab(
+	tabId: SettingsTabId,
+	currentTheme: string,
+	currentTitleShape: string,
+): SettingRow[] {
+	switch (tabId) {
+		case 'appearance': {
+			return [
+				{
+					kind: 'managed',
+					id: 'theme',
+					label: 'Theme',
+					value: currentTheme,
+					panel: 'theme',
+				},
+				{
+					kind: 'managed',
+					id: 'title-shape',
+					label: 'Title Shape',
+					value: currentTitleShape,
+					panel: 'title-shape',
+				},
+				{
+					kind: 'managed',
+					id: 'nanocoder-shape',
+					label: 'Nanocoder Shape',
+					value: getNanocoderShape() ?? 'tiny',
+					panel: 'nanocoder-shape',
+				},
+				{
+					kind: 'boolean',
+					id: 'alternate-screen',
+					label: 'Alternate Screen',
+					value: getAlternateScreen(),
+					onToggle: () => updateAlternateScreen(!getAlternateScreen()),
+				},
+			];
+		}
+		case 'input': {
+			const pasteThreshold =
+				getPasteThreshold() ?? DEFAULT_SINGLE_LINE_PASTE_THRESHOLD;
+			const notifications = getNotificationsPreference();
+			return [
+				{
+					kind: 'number',
+					id: 'paste-threshold',
+					label: 'Paste Threshold',
+					value: pasteThreshold,
+					panel: 'paste-threshold',
+				},
+				{
+					kind: 'managed',
+					id: 'notifications',
+					label: 'Notifications',
+					value: notifications?.enabled ? 'on' : 'off',
+					panel: 'notifications',
+				},
+			];
+		}
+		case 'display':
+			return [
+				{
+					kind: 'managed',
+					id: 'display-settings',
+					label: 'Tool Results and Thinking',
+					value: 'configure',
+					panel: 'display-settings',
+				},
+			];
+		case 'advanced':
+			return [
+				{
+					kind: 'managed',
+					id: 'privacy',
+					label: 'Privacy',
+					value: getPrivacyPreference() ? 'on' : 'off',
+					panel: 'privacy',
+				},
+			];
+	}
+}
+
+/**
+ * Pure row filter, shared between the render-time `filteredRows` memo and
+ * the `handleKey` replay path — the replay reads this from `queryRef`
+ * (synchronous) instead of the `query` state (async), see the coalesced-
+ * chunk gotcha on `queryRef` below.
+ *
+ * Ranked like upstream PR 684's "Filter:" box: score each row against both
+ * its label and id with `fuzzyScore` (exact=1000 > startsWith=850 >
+ * contains=700 > subsequence), keep only score > 0, sort descending with an
+ * alphabetical tie-break. Empty query is a no-op — natural tab order.
+ */
+function filterRows(rows: SettingRow[], query: string): SettingRow[] {
+	const q = query.trim();
+	if (!q) return rows;
+	return rows
+		.map(row => ({
+			row,
+			score: Math.max(fuzzyScore(row.label, q), fuzzyScore(row.id, q)),
+		}))
+		.filter(({score}) => score > 0)
+		.sort((a, b) => {
+			if (b.score !== a.score) return b.score - a.score;
+			return a.row.label.localeCompare(b.row.label);
+		})
+		.map(({row}) => row);
+}
+
+/**
+ * Builds the flat row list for the active tab from the preferences getters.
+ * `version` is a manual refresh trigger — bump it after any mutation this
+ * hook can't otherwise observe (a managed sub-panel writes preferences.json
+ * directly, outside this component's React state).
+ */
+function useTabRows(tabId: SettingsTabId, version: number): SettingRow[] {
+	const {currentTheme} = useTheme();
+	const {currentTitleShape} = useTitleShape();
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: version deliberately drives a full recompute — see doc comment above.
+	return useMemo(
+		() => buildRowsForTab(tabId, currentTheme, currentTitleShape ?? 'pill'),
+		[version, tabId, currentTheme, currentTitleShape],
+	);
+}
+
+function SettingRowLine({
+	row,
+	selected,
+	labelWidth,
+	isNarrow,
+}: {
+	row: SettingRow;
+	selected: boolean;
+	labelWidth: number;
+	isNarrow: boolean;
+}) {
+	const {colors} = useTheme();
+	const valueText =
+		row.kind === 'boolean' ? (row.value ? 'true' : 'false') : String(row.value);
+	const rowColor = selected ? colors.info : colors.text;
+
+	return (
+		<Box flexDirection="row">
+			<Text color={rowColor}>{selected ? '> ' : '  '}</Text>
+			<Box width={labelWidth}>
+				<Text color={rowColor} wrap={isNarrow ? 'truncate' : undefined}>
+					{row.label}
+				</Text>
+			</Box>
+			<Text color={colors.secondary} wrap={isNarrow ? 'truncate' : undefined}>
+				{valueText}
+			</Text>
+		</Box>
+	);
+}
+
+function renderManagedPanel(
+	panel: ManagedSettingsPanel,
+	onBack: () => void,
+): ReactElement {
+	switch (panel) {
+		case 'theme':
+			return <SettingsThemePanel onBack={onBack} onCancel={onBack} />;
+		case 'title-shape':
+			return <SettingsTitleShapePanel onBack={onBack} onCancel={onBack} />;
+		case 'nanocoder-shape':
+			return <SettingsNanocoderShapePanel onBack={onBack} onCancel={onBack} />;
+		case 'paste-threshold':
+			return <SettingsPasteThresholdPanel onBack={onBack} onCancel={onBack} />;
+		case 'notifications':
+			return <SettingsNotificationsPanel onBack={onBack} onCancel={onBack} />;
+		case 'display-settings':
+			return <SettingsDisplayPanel onBack={onBack} onCancel={onBack} />;
+		case 'privacy':
+			return <SettingsPrivacyPanel onBack={onBack} onCancel={onBack} />;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tab shell: outer panel — tab bar, search box, rows, scroll indicator,
+// footer hints. Two bordered boxes are on screen while the row list is
+// showing: this outer panel, and the search box nested inside it (styled
+// after openclaude's SearchBox — see the search box's own comment below).
+// When a managed sub-panel is open, it replaces this entire return value
+// (its own TitledBoxWithPreferences is the only border on screen at that
+// point) — the tab bar and this frame (including the search box) are not
+// rendered underneath it.
+// ---------------------------------------------------------------------------
+
+type TabFocus = 'header' | 'search' | 'list';
+
+function TabBar({
+	activeTab,
+	headerFocused,
+}: {
+	activeTab: SettingsTabId;
+	headerFocused: boolean;
+}) {
+	const {colors} = useTheme();
+	const {currentTitleShape} = useTitleShape();
+	const shape = currentTitleShape ?? 'pill';
+
+	return (
+		<Box
+			key={`${activeTab}-${headerFocused}`}
+			flexDirection="row"
+			gap={1}
+			marginBottom={1}
+		>
+			<Text bold color={colors.primary}>
+				Settings
+			</Text>
+			{TABS.map(tab => {
+				const isActive = tab.id === activeTab;
+				if (isActive) {
+					return (
+						<StyledTitle
+							key={tab.id}
+							title={tab.label}
+							shape={shape}
+							borderColor={headerFocused ? colors.primary : colors.secondary}
+							textColor={colors.base}
+						/>
+					);
+				}
+				return <Text key={tab.id}> {tab.label} </Text>;
+			})}
+		</Box>
+	);
+}
+
+export function SettingsSelector({onCancel}: SettingsSelectorProps) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+
+	const [activeTab, setActiveTab] = useState<SettingsTabId>('appearance');
+	const [focus, setFocus] = useState<TabFocus>('header');
+	const [openPanel, setOpenPanel] = useState<ManagedSettingsPanel | null>(null);
+
+	const [version, setVersion] = useState(0);
+	const [query, setQuery] = useState('');
+	const [selectedIndex, setSelectedIndex] = useState(0);
+	const [scrollOffset, setScrollOffset] = useState(0);
+
+	// Ink delivers every keypress event parsed out of one stdin chunk
+	// synchronously in the same tick (see ink's `App.handleReadable`), so a
+	// down-arrow immediately followed by typed characters (a very ordinary
+	// "press down then type" burst, not just paste) can arrive as two
+	// separate `useInput` calls before React re-renders between them. The
+	// `focus` state read via closure in the second call would still be
+	// 'header', silently dropping the keystrokes into the header branch's
+	// no-op path. Mirror `focus` into a ref that's written synchronously
+	// wherever the state is, and branch on the ref inside the handler so the
+	// second event in the same batch sees the first event's transition.
+	const focusRef = useRef<TabFocus>(focus);
+	const updateFocus = (next: TabFocus) => {
+		focusRef.current = next;
+		setFocus(next);
+	};
+
+	// Same gotcha as focusRef, applied to the search query and selection
+	// index: the coalesced-chunk replay in the useInput wrapper below can
+	// fire a typed segment (which calls setQuery) immediately followed by
+	// one or more synthetic Enter replays in the SAME synchronous batch. The
+	// `filteredRows`/`clampedIndex` below are derived from `query`/
+	// `selectedIndex` STATE, which hasn't re-rendered yet when the replayed
+	// Enters run — so activateRow would read a stale, unfiltered row list
+	// (e.g. always index 0) instead of the just-typed filter. Mirror both
+	// into refs written synchronously wherever the state is, and have
+	// `handleKey` derive its effective rows/index from the refs (via
+	// `filterRows`, the same pure helper the render-time memo below uses)
+	// instead of closing over the state-derived `filteredRows`/`clampedIndex`.
+	const queryRef = useRef(query);
+	const updateQuery = (next: string) => {
+		queryRef.current = next;
+		setQuery(next);
+	};
+	const selectedIndexRef = useRef(selectedIndex);
+
+	// Switching tabs resets the per-tab search/selection/scroll state and
+	// returns focus to the header — the search box always filters within
+	// the currently active tab only.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: activeTab is the trigger, not read in the body — resets per-tab state whenever the active tab changes.
+	useEffect(() => {
+		updateQuery('');
+		selectedIndexRef.current = 0;
+		setSelectedIndex(0);
+		setScrollOffset(0);
+		updateFocus('header');
+	}, [activeTab]);
+
+	const allRows = useTabRows(activeTab, version);
+	const filteredRows = useMemo(
+		() => filterRows(allRows, query),
+		[allRows, query],
+	);
+
+	const clampedIndex = Math.min(
+		selectedIndex,
+		Math.max(0, filteredRows.length - 1),
+	);
+
+	// `rowsLength` is passed explicitly by the caller (handleKey) rather than
+	// closed over, so a replayed call can pass the ref-derived effective
+	// rows length instead of the stale state-derived `filteredRows.length`.
+	const moveSelection = (nextIndex: number, rowsLength: number) => {
+		const clamped = Math.max(0, Math.min(nextIndex, rowsLength - 1));
+		selectedIndexRef.current = clamped;
+		setSelectedIndex(clamped);
+		setScrollOffset(prevOffset => {
+			if (clamped < prevOffset) return clamped;
+			if (clamped >= prevOffset + MAX_VISIBLE_ROWS) {
+				return clamped - MAX_VISIBLE_ROWS + 1;
+			}
+			return prevOffset;
+		});
+	};
+
+	const goToTab = (direction: 1 | -1) => {
+		const idx = TABS.findIndex(t => t.id === activeTab);
+		const next = TABS[(idx + direction + TABS.length) % TABS.length];
+		if (next) setActiveTab(next.id);
+	};
+
+	const activateRow = (row: SettingRow) => {
+		if (row.kind === 'boolean') {
+			row.onToggle();
+			setVersion(v => v + 1);
+			return;
+		}
+		setOpenPanel(row.panel);
+	};
+
+	// Handles ONE logical keypress (a real key.return, or a synthetic one
+	// replayed from a coalesced chunk — see the useInput wrapper below).
+	// Reads/branches on focusRef so replayed events in the same synchronous
+	// batch see each other's transitions, exactly like the down-arrow +
+	// fast-typing case this pattern already handles.
+	const handleKey = (
+		input: string,
+		key: Parameters<Parameters<typeof useInput>[0]>[1],
+	) => {
+		if (openPanel) {
+			// The preserved sub-panel owns input while it's open.
+			return;
+		}
+
+		if (focusRef.current === 'header') {
+			if (key.escape) {
+				onCancel();
+				return;
+			}
+			if (key.leftArrow) {
+				goToTab(-1);
+				return;
+			}
+			if (key.rightArrow) {
+				goToTab(1);
+				return;
+			}
+			if (key.downArrow) {
+				updateFocus('search');
+			}
+			return;
+		}
+
+		if (focusRef.current === 'search') {
+			if (key.escape) {
+				if (queryRef.current.length > 0) {
+					updateQuery('');
+				} else {
+					updateFocus('header');
+				}
+				return;
+			}
+			if (key.upArrow) {
+				updateFocus('header');
+				return;
+			}
+			if (key.ctrl && input === 'u') {
+				// Readline idiom: Ctrl+U clears from cursor to start of line — our
+				// cursor is always at the end, so this clears the whole query.
+				updateQuery('');
+				return;
+			}
+			if (key.downArrow || key.return) {
+				const effectiveRows = filterRows(allRows, queryRef.current);
+				if (effectiveRows.length > 0) {
+					updateFocus('list');
+					moveSelection(0, effectiveRows.length);
+				}
+				return;
+			}
+			if (key.backspace || key.delete) {
+				updateQuery(queryRef.current.slice(0, -1));
+				return;
+			}
+			if (input && !key.ctrl && !key.meta) {
+				updateQuery(queryRef.current + input);
+			}
+			return;
+		}
+
+		// focus === 'list'
+		const effectiveRows = filterRows(allRows, queryRef.current);
+		const effectiveClampedIndex = Math.min(
+			selectedIndexRef.current,
+			Math.max(0, effectiveRows.length - 1),
+		);
+
+		if (key.escape || input === '/') {
+			updateFocus('search');
+			return;
+		}
+		if (key.upArrow) {
+			if (effectiveClampedIndex === 0) {
+				updateFocus('search');
+			} else {
+				moveSelection(effectiveClampedIndex - 1, effectiveRows.length);
+			}
+			return;
+		}
+		if (key.downArrow) {
+			moveSelection(effectiveClampedIndex + 1, effectiveRows.length);
+			return;
+		}
+		if (key.return || input === ' ') {
+			const row = effectiveRows[effectiveClampedIndex];
+			if (row) activateRow(row);
+		}
+	};
+
+	useInput(
+		(input, key) => {
+			// Ink coalesces a run of plain characters immediately followed by
+			// one or more Enters — arriving from a real terminal in a single
+			// stdin chunk (fast typing capped off with Enter, or a fast
+			// double-Enter) — into ONE keypress event: `key.return` is false
+			// and `input` is the whole run including the literal `\r`
+			// character(s) (e.g. "theme\r" or "theme\r\r", even bare "\r\r").
+			// Handled naively, that string falls through to the search box's
+			// printable-text branch and gets appended to the query verbatim —
+			// the Enter is swallowed, never reaching the select/activate
+			// branches at all. Split the run on `\r` and replay each piece
+			// through `handleKey` as its own logical keypress: the typed text
+			// first, then a synthetic `key.return` event per `\r`. Each
+			// replayed call reads/writes `focusRef` synchronously, so a
+			// replayed Enter that transitions search -> list is immediately
+			// visible to the next replayed Enter in the same batch — the same
+			// mechanism that already keeps down-arrow + fast-typing in sync.
+			if (!key.return && input.includes('\r')) {
+				const segments = input.split('\r');
+				segments.forEach((segment, i) => {
+					if (segment) handleKey(segment, {...key, return: false});
+					if (i < segments.length - 1) handleKey('', {...key, return: true});
+				});
+				return;
+			}
+			handleKey(input, key);
+		},
+		{isActive: true},
+	);
+
+	if (openPanel) {
+		const onBack = () => {
+			setVersion(v => v + 1);
+			setOpenPanel(null);
+		};
+		return renderManagedPanel(openPanel, onBack);
+	}
+
+	const width = isNarrow ? '100%' : boxWidth;
+	const labelWidth = Math.min(44, Math.max(18, Math.floor(boxWidth * 0.5)));
+	const visibleRows = filteredRows.slice(
+		scrollOffset,
+		scrollOffset + MAX_VISIBLE_ROWS,
+	);
+	const moreAbove = scrollOffset;
+	const moreBelow = Math.max(
+		0,
+		filteredRows.length - scrollOffset - MAX_VISIBLE_ROWS,
+	);
+
+	const footerHint =
+		focus === 'header'
+			? '←/→ tabs · ↓ enter · Esc close'
+			: focus === 'search'
+				? 'Type to filter · Enter/↓ select · ^U clear · ↑ tabs · Esc clear'
+				: 'Enter change · / search · Esc back';
+
+	return (
+		<Box
+			flexDirection="column"
+			borderStyle="round"
+			borderColor={colors.primary}
+			paddingX={isNarrow ? 1 : 2}
+			paddingY={1}
+			width={width}
+			marginBottom={1}
+		>
+			<TabBar activeTab={activeTab} headerFocused={focus === 'header'} />
+
+			{/*
+			 * Search box: rounded-border row matching openclaude's SearchBox
+			 * (src/components/SearchBox.tsx) — magnifier prefix, border color
+			 * keyed on focus (focused: colors.info, undimmed; unfocused:
+			 * colors.secondary, dimmed via borderDimColor, mirroring
+			 * openclaude's `borderColor={isFocused ? "suggestion" : undefined}` /
+			 * `borderDimColor={!isFocused}`). No explicit width: like
+			 * openclaude's SearchBox, this Box relies on the parent column
+			 * flex container's default `alignItems: stretch` to fill the full
+			 * interior width — the row list below is a sibling Box with its
+			 * own independent width, unaffected by this border/padding.
+			 */}
+			<Box
+				flexShrink={0}
+				borderStyle="round"
+				borderColor={focus === 'search' ? colors.info : colors.secondary}
+				borderDimColor={focus !== 'search'}
+				paddingX={1}
+			>
+				<Text color={colors.secondary}>{'⌕ '}</Text>
+				{focus === 'search' ? (
+					<Text>
+						{query.length === 0
+							? // Empty query: the placeholder itself carries the cursor —
+								// its first character renders inverse-video, mirroring
+								// text-input.tsx's `renderedPlaceholder` idiom exactly.
+								chalk.inverse(SEARCH_PLACEHOLDER[0]) +
+								chalk.hex(colors.info)(SEARCH_PLACEHOLDER.slice(1)) +
+								' '
+							: // Non-empty query: HTML-placeholder semantics — the
+								// placeholder text disappears entirely once typing
+								// starts (matches openclaude's SearchBox and this
+								// file's own text-input.tsx placeholder idiom). The
+								// cursor is always at the end (this row has no
+								// interior cursor movement), so append an
+								// inverse-video space — text-input.tsx's
+								// `cursorOffset === value.length` end-of-value cursor.
+								query + chalk.inverse(' ')}
+					</Text>
+				) : (
+					<>
+						{query.length === 0 ? (
+							<Text color={colors.secondary}>{SEARCH_PLACEHOLDER} </Text>
+						) : (
+							<Text color={colors.text}>{query}</Text>
+						)}
+					</>
+				)}
+			</Box>
+			<Box marginTop={1} flexDirection="column">
+				{moreAbove > 0 && (
+					<Text color={colors.secondary} dimColor>
+						↑ {moreAbove} more above
+					</Text>
+				)}
+				{visibleRows.length === 0 && (
+					<Text color={colors.secondary}>No settings match "{query}"</Text>
+				)}
+				{visibleRows.map((row, i) => (
+					<SettingRowLine
+						key={row.id}
+						row={row}
+						selected={focus === 'list' && scrollOffset + i === clampedIndex}
+						labelWidth={labelWidth}
+						isNarrow={isNarrow}
+					/>
+				))}
+				{moreBelow > 0 && (
+					<Text color={colors.secondary} dimColor>
+						↓ {moreBelow} more below
+					</Text>
+				)}
+			</Box>
+
+			<Box marginTop={1}>
+				<Text color={colors.secondary}>{footerHint}</Text>
+			</Box>
+		</Box>
+	);
+}

--- a/source/config/preferences.ts
+++ b/source/config/preferences.ts
@@ -192,3 +192,21 @@ export function updatePrivacyPreference(value: boolean): void {
 	preferences.enablePromptScrubbing = value;
 	savePreferences(preferences);
 }
+
+/**
+ * Get the alternate-screen (fullscreen) preference. Also settable via
+ * --alt-screen/--no-alt-screen at launch; this is the persisted default.
+ */
+export function getAlternateScreen(): boolean {
+	const preferences = loadPreferences();
+	return preferences.alternateScreen ?? false;
+}
+
+/**
+ * Save the alternate-screen preference
+ */
+export function updateAlternateScreen(value: boolean): void {
+	const preferences = loadPreferences();
+	preferences.alternateScreen = value;
+	savePreferences(preferences);
+}


### PR DESCRIPTION
## Description

Resolves #471.

- `/settings` is now a tabbed dialog: Appearance, Input, Display, and Advanced tabs group the existing settings, with the active tab rendered in the user's configured title shape.
- A bordered search field with a magnifier icon, a real cursor, and placeholder behavior fuzzy-filters the active tab's settings; Ctrl+U clears the query.
- Booleans toggle in place, other settings open their existing sub-panels, and Esc always steps back one level (sub-panel to list, search to tabs, tabs to close) so navigation never gets lost.
- Fast key bursts (an arrow, typed characters, and Enter arriving together) are handled correctly.

<img width="842" height="273" alt="Screenshot_20260720_042813" src="https://github.com/user-attachments/assets/0b035619-a868-4782-b885-89845892bec3" />


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files

`source/app/components/settings-tabs.spec.tsx` has 27 passing specs (plus 1 deliberately skipped) covering: tab rendering and left/right navigation through the title-shape-aware tab bar, the search field's cursor and placeholder rendering, fuzzy ranking of search results, on-disk persistence of boolean toggles, sub-panel open/close navigation, and coalesced-keystroke regressions (an arrow, typed characters, and Enter arriving in a single stdin chunk).

- [ ] All existing tests pass (`pnpm test:all` completes successfully)

Ran the touched-area suites (`settings-tabs`, `settings-selector`, `modal-selectors`, `interactive-app`) on this branch and all pass. Also ran the full `pnpm test:all`; it does not pass clean on this machine, so leaving the box unchecked: known machine-dependent failures unrelated to this change — a handful of specs read the machine's real on-disk theme preference instead of an isolated config dir and crash under it, and a couple of CLI/path-display specs assume a built `dist/` or a short working-directory path that this checkout doesn't have.

- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Manually exercised end to end in the interactive TUI (tab navigation, search, toggles, sub-panel round trips).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

