### PR TITLE
feat: implement phase 2 protocol and ux correctness fixes for acp gui

### DIFF
--- a/plugins/vscode/src/acp-client.ts
+++ b/plugins/vscode/src/acp-client.ts
@@ -3,7 +3,7 @@ import {ClientSideConnection} from '@agentclientprotocol/sdk';
 import {AcpStateManager, ACPStatus} from './acp-state';
 
 // We expect at least the version of the CLI where ACP was introduced
-const MINIMUM_CLI_VERSION = '0.4.0'; // Example baseline
+const MINIMUM_CLI_VERSION = '0.4.0';
 
 export class NanocoderAcpClient {
 	public connection: ClientSideConnection | null = null;
@@ -42,25 +42,25 @@ export class NanocoderAcpClient {
 			}
 		});
 
-		// Workspace context: notify the backend when the user switches active file.
-		vscode.window.onDidChangeActiveTextEditor((editor) => {
-			if (editor && this.connection && this._sessionId) {
-				const uri = editor.document.uri.toString();
-				const cursorPos = editor.selection.active;
-				const visibleRange = editor.visibleRanges[0];
-				const range = visibleRange ?? new vscode.Range(cursorPos, cursorPos);
-				this.connection.unstable_didFocusDocument({
-					sessionId: this._sessionId,
-					uri,
-					version: editor.document.version,
-					position: { line: cursorPos.line, character: cursorPos.character },
-					visibleRange: {
-						start: { line: range.start.line, character: range.start.character },
-						end: { line: range.end.line, character: range.end.character },
-					},
-				}).catch(() => { /* best-effort */ });
-			}
-		});
+	}
+
+	notifyActiveEditorChanged(editor: vscode.TextEditor | undefined) {
+		if (editor && this.connection && this._sessionId) {
+			const uri = editor.document.uri.toString();
+			const cursorPos = editor.selection.active;
+			const visibleRange = editor.visibleRanges[0];
+			const range = visibleRange ?? new vscode.Range(cursorPos, cursorPos);
+			this.connection.unstable_didFocusDocument({
+				sessionId: this._sessionId,
+				uri,
+				version: editor.document.version,
+				position: { line: cursorPos.line, character: cursorPos.character },
+				visibleRange: {
+					start: { line: range.start.line, character: range.start.character },
+					end: { line: range.end.line, character: range.end.character },
+				},
+			}).catch(() => { /* best-effort */ });
+		}
 	}
 
 	hasPendingPermissions(): boolean {
@@ -161,9 +161,16 @@ export class NanocoderAcpClient {
 				if (modelOpt) {
 					this.currentModel = modelOpt.currentValue;
 					
-					// modelOpt.options is either Array<Option> or Array<Group>. We assume Option here for simplicity.
-					// If it's a flat array of Options, they have a 'value'.
-					this.availableModels = (modelOpt.options || []).map((opt: any) => opt.value || opt);
+					this.availableModels = [];
+					for (const opt of modelOpt.options || []) {
+						if (opt.options && Array.isArray(opt.options)) {
+							// It's a group
+							this.availableModels.push(...opt.options.map((o: any) => o.value || o));
+						} else {
+							// It's a flat option
+							this.availableModels.push(opt.value || opt);
+						}
+					}
 				}
 			}
 
@@ -185,7 +192,7 @@ export class NanocoderAcpClient {
 	}
 
 	notifyStateSync() {
-		if (this.onStateSync && this.currentMode && this.currentModel) {
+		if (this.onStateSync && (this.currentMode || this.currentModel)) {
 			this.onStateSync({
 				mode: this.currentMode,
 				availableModes: this.availableModes,
@@ -260,9 +267,14 @@ export class NanocoderAcpClient {
 	}
 
 	private isVersionIncompatible(serverVersion: string): boolean {
-		// A simple semver check could go here. For now, if they have an ACP-capable CLI,
-		// it's likely compatible with the basic initialize(). If we need stricter checks,
-		// we can parse the x.y.z format here.
+		const parseVersion = (v: string) => v.split('.').map(n => parseInt(n, 10) || 0);
+		const [sMajor, sMinor, sPatch] = parseVersion(serverVersion);
+		const [rMajor, rMinor, rPatch] = parseVersion(MINIMUM_CLI_VERSION);
+
+		if (sMajor < rMajor) return true;
+		if (sMajor === rMajor && sMinor < rMinor) return true;
+		if (sMajor === rMajor && sMinor === rMinor && sPatch < rPatch) return true;
+		
 		return false; 
 	}
 

--- a/plugins/vscode/src/extension.ts
+++ b/plugins/vscode/src/extension.ts
@@ -333,11 +333,19 @@ function scheduleActiveEditorSend(): void {
 // Push the current active editor + selection to the CLI. When no editor is
 // active or the document isn't a file on disk, clear the CLI-side state.
 function sendActiveEditor(): void {
+	const editor = vscode.window.activeTextEditor;
+	
+	// 1. Notify the local ACP GUI backend
+	if (acpClient) {
+		acpClient.notifyActiveEditorChanged(editor);
+	}
+
+	// 2. Notify the legacy CLI WebSocket backend
+	// The WebSocket Companion handles editor synchronization for the interactive CLI 'nanocoder'
 	if (!wsClient.isConnected()) {
 		return;
 	}
 
-	const editor = vscode.window.activeTextEditor;
 	const doc = editor?.document;
 	const isFile = doc?.uri.scheme === 'file';
 

--- a/source/acp/acp-agent.ts
+++ b/source/acp/acp-agent.ts
@@ -359,8 +359,6 @@ export class AcpAgent implements Agent {
 		const session = this.sessions.get(params.sessionId);
 		if (!session) return;
 		session.activeFile = params.uri;
-		// Store the cursor line as a lightweight context hint.
-		session.activeSelection = `line ${params.position.line}`;
 		logger.info(
 			`ACP didFocusDocument: session=${params.sessionId} uri=${params.uri}`,
 		);


### PR DESCRIPTION
#654

## Summary of Changes

* **Restored and Implemented Version Validation**
  * **Problem:** The CLI compatibility check scaffolding (`isVersionIncompatible`) was effectively dead code returning `false`, meaning the GUI would never warn users about outdated, incompatible CLI versions.
  * **Fix:** Implemented a proper semantic version parsing comparison in `acp-client.ts`. The extension now accurately warns users if their background CLI is older than the `MINIMUM_CLI_VERSION` (`0.4.0`), properly blocking initialization to prevent silent feature failures.

* **Fixed Model Configuration Parsing**
  * **Problem:** `getOrCreateSession` was using a naive `.map(opt => opt.value || opt)` approach to parse available models, which broke when ACP providers grouped models, rendering them as `[object Object]` in the UI.
  * **Fix:** Rewrote the model extraction logic to recurse through `Array<Group>` structures. Nested options arrays are now explicitly unwrapped into a flat list, guaranteeing proper rendering in the mode/model dropdowns regardless of the provider's grouping structure.

* **Fixed Partial State Synchronization Hangs**
  * **Problem:** `notifyStateSync` required both `currentMode` AND `currentModel` to be present before notifying the UI. If a provider exposed modes but no configurable models, the UI dropdowns remained disabled and stuck on "Loading...".
  * **Fix:** Updated the sync logic to trigger if *either* parameter is available (`this.currentMode || this.currentModel`), gracefully handling providers with partial configuration options.

* **Removed Misleading Context Injection**
  * **Problem:** `unstable_didFocusDocument` in `acp-agent.ts` was naively mapping the user's cursor position to a fake `session.activeSelection = "line N"`. This caused the model prompt builder to frame the literal string "line 5" inside a "Selected text" block, confusing the LLM.
  * **Fix:** Removed the `activeSelection` overwrite. The ACP agent now exclusively tracks the active file URI (`params.uri`) from focus events without masquerading cursor position as selected text.

* **Isolated Companion Mode Coexistence**
  * **Problem:** Both the ACP extension client and the WebSocket Companion logic had overlapping `onDidChangeActiveTextEditor` listeners injecting document focus events redundantly.
  * **Fix:** Consolidated the active-editor synchronization pipeline within `extension.ts`. A single debounced listener now cleanly delegates the event to the local ACP process (`acpClient.notifyActiveEditorChanged`) while preserving the legacy WebSocket `sendActiveEditor()` pipeline for interactive CLI users.
