### PR TITLE
feat: add semantic memory management(Phase 4 & 5)

### DIFF
--- a/source/commands/lazy-registry.ts
+++ b/source/commands/lazy-registry.ts
@@ -182,6 +182,11 @@ export const lazyCommands: LazyCommand[] = [
 		load: () => import('@/commands/remember').then(m => m.rememberCommand),
 	},
 	{
+		name: 'memory',
+		description: 'Manage project memories',
+		load: () => import('@/commands/memory').then(m => m.memoryCommand),
+	},
+	{
 		name: 'tasks',
 		description: 'Manage your task list',
 		load: () => import('@/commands/tasks').then(m => m.tasksCommand),

--- a/source/commands/memory.spec.tsx
+++ b/source/commands/memory.spec.tsx
@@ -1,0 +1,186 @@
+import test from 'ava';
+import React from 'react';
+import type {SemanticMemory} from '@/memory/semantic-memory-manager';
+import type {MemoryProposal} from '@/memory/summarizer-service';
+import {renderWithTheme} from '@/test-utils/render-with-theme';
+import type {Message} from '@/types/core';
+import {lazyCommands} from './lazy-registry.js';
+import {createMemoryCommand, memoryCommand} from './memory.js';
+
+const testMetadata = {
+	provider: 'test-provider',
+	model: 'test-model',
+	tokens: 0,
+	getMessageTokens: (message: Message) => message.content.length,
+};
+
+class FakeMemoryManager {
+	memories: SemanticMemory[] = [];
+	cleared = false;
+
+	async listMemories(): Promise<SemanticMemory[]> {
+		return this.memories;
+	}
+
+	async deleteMemory(id: string): Promise<boolean> {
+		const before = this.memories.length;
+		this.memories = this.memories.filter(memory => memory.id !== id);
+		return this.memories.length !== before;
+	}
+
+	async clearMemories(): Promise<void> {
+		this.cleared = true;
+		this.memories = [];
+	}
+}
+
+class FakeSummarizerService {
+	constructor(private readonly proposals: MemoryProposal[]) {}
+
+	proposeMemoriesFromMessages(messages: Message[]): MemoryProposal[] {
+		return messages.length === 0 ? [] : this.proposals;
+	}
+}
+
+test('memoryCommand has correct name and description', t => {
+	t.is(memoryCommand.name, 'memory');
+	t.is(memoryCommand.description, 'Manage project memories');
+});
+
+test('memory command lists empty state', async t => {
+	const manager = new FakeMemoryManager();
+	const command = createMemoryCommand({memoryManager: manager});
+
+	const result = await command.handler(['list'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true((lastFrame() ?? '').includes('No project memories saved.'));
+});
+
+test('memory command lists saved memories', async t => {
+	const manager = new FakeMemoryManager();
+	manager.memories = [
+		{
+			id: 'memory-1',
+			content: 'Auth uses Clerk.',
+			category: 'architecture',
+			timestamp: '2026-07-21T00:00:00.000Z',
+		},
+	];
+	const command = createMemoryCommand({memoryManager: manager});
+
+	const result = await command.handler(['list'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() ?? '';
+
+	t.true(output.includes('memory-1'));
+	t.true(output.includes('[architecture]'));
+	t.true(output.includes('Auth uses Clerk.'));
+});
+
+test('memory command deletes a memory', async t => {
+	const manager = new FakeMemoryManager();
+	manager.memories = [
+		{
+			id: 'memory-1',
+			content: 'Auth uses Clerk.',
+			category: 'architecture',
+			timestamp: '2026-07-21T00:00:00.000Z',
+		},
+	];
+	const command = createMemoryCommand({memoryManager: manager});
+
+	const result = await command.handler(['delete', 'memory-1'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true((lastFrame() ?? '').includes('Deleted memory: memory-1'));
+	t.deepEqual(manager.memories, []);
+});
+
+test('memory command reports missing memory delete', async t => {
+	const manager = new FakeMemoryManager();
+	const command = createMemoryCommand({memoryManager: manager});
+
+	const result = await command.handler(['delete', 'missing'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true((lastFrame() ?? '').includes('Memory not found: missing'));
+});
+
+test('memory command clears memories', async t => {
+	const manager = new FakeMemoryManager();
+	manager.memories = [
+		{
+			id: 'memory-1',
+			content: 'Auth uses Clerk.',
+			category: 'architecture',
+			timestamp: '2026-07-21T00:00:00.000Z',
+		},
+	];
+	const command = createMemoryCommand({memoryManager: manager});
+
+	const result = await command.handler(['clear'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true(manager.cleared);
+	t.true((lastFrame() ?? '').includes('Cleared project memories.'));
+});
+
+test('memory command shows usage for unknown subcommand', async t => {
+	const manager = new FakeMemoryManager();
+	const command = createMemoryCommand({memoryManager: manager});
+
+	const result = await command.handler(['unknown'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true((lastFrame() ?? '').includes('Usage: /memory'));
+});
+
+test('memory command proposes durable memories from current messages', async t => {
+	const manager = new FakeMemoryManager();
+	const command = createMemoryCommand({
+		memoryManager: manager,
+		summarizerService: new FakeSummarizerService([
+			{
+				content: 'Auth uses Clerk.',
+				category: 'architecture',
+			},
+		]),
+	});
+
+	const result = await command.handler(
+		['propose'],
+		[
+			{
+				role: 'user',
+				content: 'Refactor auth.',
+			},
+		],
+		testMetadata,
+	);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() ?? '';
+
+	t.true(output.includes('[architecture]'));
+	t.true(output.includes('Auth uses Clerk.'));
+});
+
+test('memory command reports when no proposals are found', async t => {
+	const manager = new FakeMemoryManager();
+	const command = createMemoryCommand({
+		memoryManager: manager,
+		summarizerService: new FakeSummarizerService([]),
+	});
+
+	const result = await command.handler(['propose'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true((lastFrame() ?? '').includes('No durable memory proposals found.'));
+});
+
+test('lazy registry exposes /memory', t => {
+	const memory = lazyCommands.find(command => command.name === 'memory');
+
+	t.truthy(memory);
+	t.is(memory?.description, 'Manage project memories');
+});

--- a/source/commands/memory.ts
+++ b/source/commands/memory.ts
@@ -1,0 +1,94 @@
+import {SemanticMemoryManager} from '@/memory/semantic-memory-manager';
+import {SummarizerService} from '@/memory/summarizer-service';
+import type {Command} from '@/types/commands';
+import {formatError} from '@/utils/error-formatter';
+import {errorMsg, infoMsg, successMsg} from '@/utils/message-factory';
+
+interface MemoryCommandOptions {
+	memoryManager?: Pick<
+		SemanticMemoryManager,
+		'listMemories' | 'deleteMemory' | 'clearMemories'
+	>;
+	summarizerService?: Pick<SummarizerService, 'proposeMemoriesFromMessages'>;
+}
+
+const USAGE =
+	'Usage: /memory list | /memory delete <id> | /memory clear | /memory propose';
+
+export function createMemoryCommand(
+	options: MemoryCommandOptions = {},
+): Command {
+	const memoryManager = options.memoryManager ?? new SemanticMemoryManager();
+	const summarizerService =
+		options.summarizerService ?? new SummarizerService();
+
+	return {
+		name: 'memory',
+		description: 'Manage project memories',
+		handler: async (args, messages) => {
+			const subcommand = args[0]?.toLowerCase() ?? 'list';
+
+			try {
+				if (subcommand === 'list' || subcommand === 'ls') {
+					const memories = await memoryManager.listMemories();
+					if (memories.length === 0) {
+						return infoMsg('No project memories saved.', 'memory-list');
+					}
+
+					return infoMsg(
+						memories
+							.map(
+								memory => `${memory.id} [${memory.category}] ${memory.content}`,
+							)
+							.join('\n'),
+						'memory-list',
+					);
+				}
+
+				if (subcommand === 'delete' || subcommand === 'rm') {
+					const id = args[1]?.trim();
+					if (!id) return errorMsg(USAGE, 'memory-error');
+
+					const deleted = await memoryManager.deleteMemory(id);
+					if (!deleted) {
+						return errorMsg(`Memory not found: ${id}`, 'memory-error');
+					}
+
+					return successMsg(`Deleted memory: ${id}`, 'memory-deleted');
+				}
+
+				if (subcommand === 'clear') {
+					await memoryManager.clearMemories();
+					return successMsg('Cleared project memories.', 'memory-cleared');
+				}
+
+				if (subcommand === 'propose') {
+					const proposals =
+						summarizerService.proposeMemoriesFromMessages(messages);
+					if (proposals.length === 0) {
+						return infoMsg(
+							'No durable memory proposals found.',
+							'memory-propose',
+						);
+					}
+
+					return infoMsg(
+						proposals
+							.map(proposal => `[${proposal.category}] ${proposal.content}`)
+							.join('\n'),
+						'memory-propose',
+					);
+				}
+
+				return errorMsg(USAGE, 'memory-error');
+			} catch (error) {
+				return errorMsg(
+					`Failed to manage memory: ${formatError(error)}`,
+					'memory-error',
+				);
+			}
+		},
+	};
+}
+
+export const memoryCommand: Command = createMemoryCommand();

--- a/source/hooks/chat-handler/useChatHandler.spec.tsx
+++ b/source/hooks/chat-handler/useChatHandler.spec.tsx
@@ -419,6 +419,7 @@ test('useChatHandler - drains queued message when setup fails before conversatio
 test('useChatHandler - injects project context from memory finder', async t => {
 	let hookResult: ChatHandlerReturn | null = null;
 	let sentMessages: Message[] = [];
+	const queuedComponents: React.ReactNode[] = [];
 	const client: LLMClient = {
 		...createMockClient(),
 		chat: async (messages, _tools, callbacks) => {
@@ -440,6 +441,9 @@ test('useChatHandler - injects project context from memory finder', async t => {
 	const props = createMockProps({
 		client,
 		toolManager: createMockToolManager(),
+		addToChatQueue: component => {
+			queuedComponents.push(component);
+		},
 		memoryFinder: {
 			findRelevantMemories: async (query, limit) => {
 				t.is(query, 'refactor auth');
@@ -472,6 +476,13 @@ test('useChatHandler - injects project context from memory finder', async t => {
 	t.true(
 		sentMessages[0].content.includes(
 			'- Auth uses Clerk and avoids middleware.',
+		),
+	);
+	t.true(
+		queuedComponents.some(
+			component =>
+				React.isValidElement(component) &&
+				component.props.message === 'Recalling 1 project memory...',
 		),
 	);
 	rendered.unmount();

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -4,7 +4,7 @@ import {ConversationStateManager} from '@/app/utils/conversation-state';
 import UserMessage from '@/components/user-message';
 import {getAppConfig} from '@/config/index';
 import {CommandIntegration} from '@/custom-commands/command-integration';
-import {appendRelevantProjectContext} from '@/memory/project-context';
+import {appendRelevantProjectContextWithCount} from '@/memory/project-context';
 import {SemanticMemoryManager} from '@/memory/semantic-memory-manager';
 import {generateKey} from '@/session/key-generator';
 import {getTuneToolMode} from '@/types/config';
@@ -367,13 +367,22 @@ export function useChatHandler({
 				);
 			}
 
-			systemPrompt = await appendRelevantProjectContext(
+			const projectContext = await appendRelevantProjectContextWithCount(
 				systemPrompt,
 				message,
 				projectMemoryFinder,
 				projectContextOptions,
 			);
+			systemPrompt = projectContext.systemPrompt;
 			setLastBuiltPrompt(systemPrompt);
+			if (projectContext.memoryCount > 0) {
+				addToChatQueue(
+					infoMsg(
+						`Recalling ${projectContext.memoryCount} project memor${projectContext.memoryCount === 1 ? 'y' : 'ies'}...`,
+						'memory-recall',
+					),
+				);
+			}
 
 			// Create stream request
 			const systemMessage: Message = {

--- a/source/memory/project-context.spec.ts
+++ b/source/memory/project-context.spec.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 import {
 	appendProjectContext,
 	appendRelevantProjectContext,
+	appendRelevantProjectContextWithCount,
 	formatProjectContext,
 } from './project-context.js';
 import type {SemanticMemory} from './semantic-memory-manager.js';
@@ -82,6 +83,22 @@ test('appendRelevantProjectContext appends relevant memories', async t => {
 	});
 
 	t.is(prompt, 'base prompt\n\n## Project Context\n\n- Auth uses Clerk.');
+});
+
+test('appendRelevantProjectContextWithCount reports injected memory count', async t => {
+	const result = await appendRelevantProjectContextWithCount(
+		'base prompt',
+		'auth',
+		{
+			findRelevantMemories: async () => [
+				memory('Auth uses Clerk.'),
+				memory('Use adapters.'),
+			],
+		},
+	);
+
+	t.is(result.memoryCount, 2);
+	t.true(result.systemPrompt.includes('## Project Context'));
 });
 
 test('appendRelevantProjectContext passes configured memory limit', async t => {

--- a/source/memory/project-context.ts
+++ b/source/memory/project-context.ts
@@ -8,6 +8,11 @@ export interface ProjectContextOptions {
 	tokenBudget?: number;
 }
 
+export interface ProjectContextResult {
+	systemPrompt: string;
+	memoryCount: number;
+}
+
 const DEFAULT_MEMORY_LIMIT = 8;
 const DEFAULT_TOKEN_BUDGET = 240;
 
@@ -19,7 +24,14 @@ export function formatProjectContext(
 	memories: SemanticMemory[],
 	options: ProjectContextOptions = {},
 ): string {
-	if (memories.length === 0) return '';
+	return formatProjectContextWithCount(memories, options).content;
+}
+
+function formatProjectContextWithCount(
+	memories: SemanticMemory[],
+	options: ProjectContextOptions = {},
+): {content: string; memoryCount: number} {
+	if (memories.length === 0) return {content: '', memoryCount: 0};
 
 	const tokenBudget = options.tokenBudget ?? DEFAULT_TOKEN_BUDGET;
 	const bullets: string[] = [];
@@ -34,9 +46,12 @@ export function formatProjectContext(
 		usedTokens += bulletTokens;
 	}
 
-	if (bullets.length === 0) return '';
+	if (bullets.length === 0) return {content: '', memoryCount: 0};
 
-	return `## Project Context\n\n${bullets.join('\n')}`;
+	return {
+		content: `## Project Context\n\n${bullets.join('\n')}`,
+		memoryCount: bullets.length,
+	};
 }
 
 export function appendProjectContext(
@@ -44,7 +59,10 @@ export function appendProjectContext(
 	memories: SemanticMemory[],
 	options?: ProjectContextOptions,
 ): string {
-	const projectContext = formatProjectContext(memories, options);
+	const projectContext = formatProjectContextWithCount(
+		memories,
+		options,
+	).content;
 	if (!projectContext) return systemPrompt;
 
 	return `${systemPrompt}\n\n${projectContext}`;
@@ -56,16 +74,38 @@ export async function appendRelevantProjectContext(
 	memoryFinder: MemoryFinder = new SemanticMemoryManager(),
 	options: ProjectContextOptions = {},
 ): Promise<string> {
-	try {
-		return appendProjectContext(
+	return (
+		await appendRelevantProjectContextWithCount(
 			systemPrompt,
+			query,
+			memoryFinder,
+			options,
+		)
+	).systemPrompt;
+}
+
+export async function appendRelevantProjectContextWithCount(
+	systemPrompt: string,
+	query: string,
+	memoryFinder: MemoryFinder = new SemanticMemoryManager(),
+	options: ProjectContextOptions = {},
+): Promise<ProjectContextResult> {
+	try {
+		const projectContext = formatProjectContextWithCount(
 			await memoryFinder.findRelevantMemories(
 				query,
 				options.memoryLimit ?? DEFAULT_MEMORY_LIMIT,
 			),
 			options,
 		);
+
+		if (!projectContext.content) return {systemPrompt, memoryCount: 0};
+
+		return {
+			systemPrompt: `${systemPrompt}\n\n${projectContext.content}`,
+			memoryCount: projectContext.memoryCount,
+		};
 	} catch {
-		return systemPrompt;
+		return {systemPrompt, memoryCount: 0};
 	}
 }

--- a/source/memory/summarizer-service.spec.ts
+++ b/source/memory/summarizer-service.spec.ts
@@ -5,6 +5,7 @@ import test from 'ava';
 import {SemanticMemoryManager} from './semantic-memory-manager.js';
 import {
 	inferMemoryCategory,
+	type MemoryProposal,
 	SummarizerService,
 	toCamelCaseCategory,
 } from './summarizer-service.js';
@@ -79,4 +80,87 @@ test('toCamelCaseCategory normalizes category names', t => {
 	t.is(toCamelCaseCategory('coding style'), 'codingStyle');
 	t.is(toCamelCaseCategory('BUG-FIX'), 'bugFix');
 	t.is(toCamelCaseCategory(''), 'project');
+});
+
+test('SummarizerService proposes durable memories from messages', t => {
+	const service = new SummarizerService();
+
+	t.deepEqual(
+		service.proposeMemoriesFromMessages([
+			{
+				role: 'system',
+				content: 'You are Nanocoder.',
+			},
+			{
+				role: 'user',
+				content: 'Use the existing provider abstraction for model changes.',
+			},
+			{
+				role: 'assistant',
+				content: 'Fixed the queued input regression by restoring drafts.',
+			},
+			{
+				role: 'tool',
+				content: 'command output',
+				tool_call_id: 'tool-1',
+				name: 'execute_bash',
+			},
+		]),
+		[
+			{
+				content: 'Use the existing provider abstraction for model changes.',
+				category: 'architecture',
+			},
+			{
+				content: 'Fixed the queued input regression by restoring drafts.',
+				category: 'bugFix',
+			},
+		] satisfies MemoryProposal[],
+	);
+});
+
+test('SummarizerService dedupes proposed memories', t => {
+	const service = new SummarizerService();
+
+	t.deepEqual(
+		service.proposeMemoriesFromMessages([
+			{
+				role: 'user',
+				content: 'Refactor the storage path later.',
+			},
+			{
+				role: 'assistant',
+				content: 'Refactor the storage path later.',
+			},
+		]),
+		[
+			{
+				content: 'Refactor the storage path later.',
+				category: 'refactor',
+			},
+		],
+	);
+});
+
+test('SummarizerService proposals do not save memories automatically', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+	const service = new SummarizerService(manager);
+
+	const proposals = service.proposeMemoriesFromMessages([
+		{
+			role: 'user',
+			content: 'TODO delete obsolete project memory later.',
+		},
+	]);
+
+	t.deepEqual(proposals, [
+		{
+			content: 'TODO delete obsolete project memory later.',
+			category: 'todo',
+		},
+	]);
+	t.deepEqual(await manager.listMemories(), []);
 });

--- a/source/memory/summarizer-service.ts
+++ b/source/memory/summarizer-service.ts
@@ -1,3 +1,4 @@
+import type {Message} from '@/types/core';
 import {
 	type SemanticMemory,
 	SemanticMemoryManager,
@@ -7,6 +8,11 @@ export interface RememberMemoryInput {
 	content: string;
 	category?: string;
 	sourceSessionId?: string;
+}
+
+export interface MemoryProposal {
+	content: string;
+	category: string;
 }
 
 const CATEGORY_RULES: Array<{category: string; pattern: RegExp}> = [
@@ -50,6 +56,26 @@ export class SummarizerService {
 			sourceSessionId: input.sourceSessionId,
 		});
 	}
+
+	proposeMemoriesFromMessages(messages: Message[]): MemoryProposal[] {
+		const proposals = new Map<string, MemoryProposal>();
+
+		for (const message of messages) {
+			if (message.role !== 'user' && message.role !== 'assistant') continue;
+
+			for (const candidate of splitMemoryCandidates(message.content)) {
+				const category = inferMemoryCategory(candidate);
+				if (category === 'project') continue;
+
+				const key = candidate.toLowerCase();
+				if (!proposals.has(key)) {
+					proposals.set(key, {content: candidate, category});
+				}
+			}
+		}
+
+		return [...proposals.values()];
+	}
 }
 
 export function inferMemoryCategory(content: string): string {
@@ -74,4 +100,11 @@ export function toCamelCaseCategory(value: string): string {
 			index === 0 ? part : `${part[0]?.toUpperCase() ?? ''}${part.slice(1)}`,
 		)
 		.join('');
+}
+
+function splitMemoryCandidates(content: string): string[] {
+	return content
+		.split(/\n+/u)
+		.map(part => part.trim())
+		.filter(part => part.length >= 12 && part.length <= 300);
 }


### PR DESCRIPTION
## Description

Adds Phase 4 semantic memory management for #619: `/memory list`, `/memory delete <id>`, `/memory clear`, plus recall feedback when project memories are injected into a prompt. Also adds a safe `/memory propose` path that suggests durable memory candidates without saving them automatically.

Closes #619 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))