### PR TITLE
Add web runtime bridge for browser chat(Phase 4)

### DIFF
--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -62,6 +62,7 @@ export default function App({
 	altScreenActive = false,
 	initialSession,
 	openSessionSelectorOnStart = false,
+	webRuntimeBridge,
 }: AppProps) {
 	// Resolve the initial development mode with this precedence:
 	// 1. --mode CLI flag (highest priority)
@@ -255,7 +256,11 @@ export default function App({
 			appState.setCompactToolCounts(null);
 			appState.compactToolCountsRef.current = {};
 			appState.setLiveTaskList(null);
+			webRuntimeBridge?.completeTurn();
 			drainQueuedUserMessage();
+		},
+		onError: error => {
+			webRuntimeBridge?.failTurn(error);
 		},
 		// A turn that started in plan mode finished uninterrupted — a plan was
 		// produced. Flag it so the interactive UI can show the plan review bar.
@@ -489,6 +494,47 @@ export default function App({
 		handleChatMessage: chatHandler.handleChatMessage,
 		dismissActiveEditor: vscodeServer.dismissActiveEditor,
 	});
+	const webRuntimeStateRef = React.useRef({
+		isGenerating: chatHandler.isGenerating,
+		submitMessage: appHandlers.handleMessageSubmit,
+		cancel: appHandlers.handleCancel,
+	});
+	webRuntimeStateRef.current = {
+		isGenerating: chatHandler.isGenerating,
+		submitMessage: appHandlers.handleMessageSubmit,
+		cancel: appHandlers.handleCancel,
+	};
+
+	React.useEffect(() => {
+		if (
+			!webRuntimeBridge ||
+			!isEffectivelyTrusted ||
+			!appState.client ||
+			!appState.toolManager
+		) {
+			return;
+		}
+
+		return webRuntimeBridge.bindRuntimeHandlers({
+			submitMessage: message => {
+				if (webRuntimeStateRef.current.isGenerating) {
+					throw new Error('Nanocoder is already processing a turn.');
+				}
+
+				return webRuntimeStateRef.current.submitMessage(message);
+			},
+			cancel: () => webRuntimeStateRef.current.cancel(),
+		});
+	}, [
+		webRuntimeBridge,
+		isEffectivelyTrusted,
+		appState.client,
+		appState.toolManager,
+	]);
+
+	React.useEffect(() => {
+		webRuntimeBridge?.publishAssistantContent(chatHandler.streamingContent);
+	}, [webRuntimeBridge, chatHandler.streamingContent]);
 
 	// Apply a session resolved by cli.tsx from --continue/--resume <id> (or open
 	// the picker for a bare --resume), once on mount. Reuses the exact same

--- a/source/app/types.ts
+++ b/source/app/types.ts
@@ -1,5 +1,6 @@
 import type {Session} from '@/session/session-manager';
 import type {DevelopmentMode} from '@/types/core';
+import type {WebRuntimeBridge} from '@/web/runtime-bridge';
 
 /**
  * Valid user-selectable boot modes. Single source of truth — used by the
@@ -54,6 +55,11 @@ export interface AppProps {
 	 * (activeMode `'sessionSelector'`) as soon as the app mounts.
 	 */
 	openSessionSelectorOnStart?: boolean;
+	/**
+	 * Optional bridge for the localhost browser surface. The normal terminal
+	 * runtime remains the owner of providers, tools, and conversation state.
+	 */
+	webRuntimeBridge?: WebRuntimeBridge;
 }
 
 /**

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -11,6 +11,7 @@
 // defeating the purpose. Heavy imports live inside `main()` below and are
 // pulled in via dynamic `await import()` only when the app actually boots.
 import nodeModule from 'node:module';
+import type {WebRuntimeBridge} from '@/web/runtime-bridge';
 
 // Enable V8 compile cache (Node 22.8+). After the first run, Node caches
 // bytecode for every module on disk so subsequent launches skip parsing
@@ -24,6 +25,7 @@ const {version} = require('../package.json');
 
 // Parse CLI arguments
 const args = process.argv.slice(2);
+const webMode = args.includes('--web') || args.includes('--gui');
 
 // Handle --version/-v flag — fast path, no heavy imports
 if (args.includes('--version') || args.includes('-v')) {
@@ -116,28 +118,6 @@ Examples:
   nanocoder --resume
   `);
 	process.exit(0);
-}
-
-if (args.includes('--web') || args.includes('--gui')) {
-	const {startLocalWebServer} = await import('@/web/server');
-	const webServer = await startLocalWebServer();
-
-	console.log('Nanocoder web mode started.');
-	console.log(`Local URL: ${webServer.url}`);
-	console.log('Press Ctrl+C to stop.');
-
-	const shutdown = async () => {
-		await webServer.close();
-		process.exit(0);
-	};
-	process.once('SIGINT', () => {
-		void shutdown();
-	});
-	process.once('SIGTERM', () => {
-		void shutdown();
-	});
-
-	await new Promise<void>(() => {});
 }
 
 // Validate output format value to prevent injection
@@ -605,6 +585,38 @@ async function main(): Promise<void> {
 			}) as unknown as NodeJS.ReadStream;
 		}
 
+		let webRuntimeBridge: WebRuntimeBridge | undefined;
+		if (webMode) {
+			const [
+				{createWebRuntimeBridge},
+				{startLocalWebServer},
+				{getShutdownManager},
+			] = await Promise.all([
+				import('@/web/runtime-bridge'),
+				import('@/web/server'),
+				import('@/utils/shutdown'),
+			]);
+			let broadcastEvent: Parameters<typeof createWebRuntimeBridge>[0] =
+				() => {};
+			webRuntimeBridge = createWebRuntimeBridge(event => {
+				broadcastEvent(event);
+			});
+			const webServer = await startLocalWebServer({
+				onClientEvent: webRuntimeBridge.handleClientEvent,
+			});
+			broadcastEvent = webServer.broadcastEvent;
+
+			getShutdownManager().register({
+				name: 'web-server',
+				priority: 10,
+				handler: webServer.close,
+			});
+
+			console.log('Nanocoder web mode started.');
+			console.log(`Local URL: ${webServer.url}`);
+			console.log('Press Ctrl+C to stop.');
+		}
+
 		const result = render(
 			<App
 				vscodeMode={vscodeMode}
@@ -618,6 +630,7 @@ async function main(): Promise<void> {
 				altScreenActive={useAltScreen}
 				initialSession={initialSession}
 				openSessionSelectorOnStart={openSessionSelectorOnStart}
+				webRuntimeBridge={webRuntimeBridge}
 			/>,
 			{
 				// Ctrl+C is handled inside App (routed through the shutdown

--- a/source/hooks/chat-handler/types.ts
+++ b/source/hooks/chat-handler/types.ts
@@ -31,6 +31,7 @@ export interface UseChatHandlerProps {
 	>;
 	nonInteractiveMode?: boolean;
 	onConversationComplete?: () => void;
+	onError?: (error: unknown) => void;
 	// Fired when a turn that STARTED in plan mode runs to completion without
 	// being interrupted — i.e. a plan was actually produced. Decided here rather
 	// than inferred from ambient state (isConversationComplete + current mode),

--- a/source/hooks/chat-handler/useChatHandler.spec.tsx
+++ b/source/hooks/chat-handler/useChatHandler.spec.tsx
@@ -338,6 +338,43 @@ test('useChatHandler - callbacks are provided', t => {
 	t.is(typeof props.onConversationComplete, 'function');
 });
 
+test('useChatHandler - reports setup failures through the error observer', async t => {
+	let hookResult: ChatHandlerReturn | null = null;
+	const observedErrors: unknown[] = [];
+	const throwingToolManager = {
+		...createMockToolManager(),
+		getToolNames: () => {
+			throw new Error('command prompt failed');
+		},
+	} as NonNullable<UseChatHandlerProps['toolManager']>;
+	const customCommandLoader = {
+		findRelevantCommands: () => [],
+	} as unknown as NonNullable<UseChatHandlerProps['customCommandLoader']>;
+
+	const rendered = render(
+		<TestHookComponent
+			{...createMockProps({
+				client: createMockClient(),
+				toolManager: throwingToolManager,
+				customCommandLoader,
+				onError: error => {
+					observedErrors.push(error);
+				},
+			})}
+			onResult={result => {
+				hookResult = result;
+			}}
+		/>,
+	);
+
+	await waitForCondition(() => hookResult !== null);
+	await hookResult!.handleChatMessage('current turn');
+
+	t.is(observedErrors.length, 1);
+	t.is((observedErrors[0] as Error).message, 'command prompt failed');
+	rendered.unmount();
+});
+
 test('useChatHandler - drains queued message when setup fails before conversation loop', async t => {
 	type QueueDrainHarnessResult = {
 		chatHandler: ChatHandlerReturn;

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -78,6 +78,7 @@ export function useChatHandler({
 	developmentModeRef,
 	nonInteractiveMode = false,
 	onConversationComplete,
+	onError,
 	onPlanTurnComplete,
 	reasoningExpandedRef,
 	compactToolDisplayRef,
@@ -262,6 +263,7 @@ export function useChatHandler({
 					},
 				});
 			} catch (error) {
+				onError?.(error);
 				displayError(error, 'chat-error');
 				// Signal completion on error to avoid hanging in non-interactive mode
 				onConversationComplete?.();
@@ -282,6 +284,7 @@ export function useChatHandler({
 			developmentModeRef,
 			nonInteractiveMode,
 			onConversationComplete,
+			onError,
 			reasoningExpandedRef,
 			compactToolDisplayRef,
 			compactToolCountsRef,
@@ -381,6 +384,7 @@ export function useChatHandler({
 				onPlanTurnComplete?.();
 			}
 		} catch (error) {
+			onError?.(error);
 			displayError(error, 'chat-error');
 			onConversationComplete?.();
 		} finally {

--- a/source/web/page.spec.ts
+++ b/source/web/page.spec.ts
@@ -41,3 +41,24 @@ test('web mode messages layer does not block empty-state prompt clicks', t => {
 	t.true(page.includes('.empty-state {'));
 	t.true(page.includes('z-index: 2;'));
 });
+
+test('web mode composer sends cancellation for the active runtime turn', t => {
+	const page = renderWebModePage();
+
+	t.true(page.includes('let activeTurnId = null'));
+	t.true(page.includes("sendClientEvent({type: 'cancel', id: activeTurnId})"));
+	t.true(page.includes("sendButton.classList.toggle('is-cancel', isActive)"));
+	t.true(page.includes("isActive ? 'Cancel response' : 'Send message'"));
+	t.true(page.includes('Nanocoder is working. Use the stop button to cancel.'));
+	t.false(page.includes("appendMessage('system', 'Turn completed'"));
+});
+
+test('web mode renders streamed assistant output as safe markdown', t => {
+	const page = renderWebModePage();
+
+	t.true(page.includes('function renderAssistantText(element, text)'));
+	t.true(page.includes("document.createElement('pre')"));
+	t.true(page.includes("document.createElement('li')"));
+	t.true(page.includes('textElement.dataset.rawText = nextText'));
+	t.false(page.includes("appendMessage('assistant', '', 'Assistant output')"));
+});

--- a/source/web/page.ts
+++ b/source/web/page.ts
@@ -269,18 +269,80 @@ export function renderWebModePage(): string {
 			background: rgba(245, 242, 235, 0.055);
 			color: #f5f2eb;
 			line-height: 1.5;
-			white-space: pre-wrap;
 			overflow-wrap: anywhere;
 			box-shadow: 0 12px 40px rgba(0, 0, 0, 0.14);
 		}
+		.message:not(.assistant) .message-content {
+			white-space: pre-wrap;
+		}
 		.message.user {
 			align-self: flex-end;
+			width: auto;
+			max-width: min(680px, 85%);
+			border-radius: 16px 16px 4px 16px;
 			background: #f5f2eb;
 			color: #17151d;
 		}
 		.message.assistant {
 			align-self: flex-start;
-			background: rgba(245, 242, 235, 0.08);
+			width: min(820px, 100%);
+			padding: 4px 0 18px;
+			border: 0;
+			background: transparent;
+			box-shadow: none;
+		}
+		.markdown {
+			font-size: 15px;
+			line-height: 1.7;
+		}
+		.markdown > :first-child {
+			margin-top: 0;
+		}
+		.markdown > :last-child {
+			margin-bottom: 0;
+		}
+		.markdown h1,
+		.markdown h2,
+		.markdown h3 {
+			margin: 24px 0 10px;
+			color: var(--tn-text);
+			font-size: 18px;
+			line-height: 1.35;
+		}
+		.markdown p,
+		.markdown ul,
+		.markdown ol,
+		.markdown pre {
+			margin: 0 0 14px;
+		}
+		.markdown p,
+		.markdown li {
+			color: inherit;
+		}
+		.markdown ul,
+		.markdown ol {
+			padding-left: 24px;
+		}
+		.markdown li + li {
+			margin-top: 5px;
+		}
+		.markdown code {
+			border-radius: 4px;
+			background: rgba(125, 207, 255, 0.1);
+			padding: 2px 5px;
+			font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+			font-size: 0.9em;
+		}
+		.markdown pre {
+			overflow-x: auto;
+			border: 1px solid var(--tn-border);
+			border-radius: 8px;
+			background: #12131c;
+			padding: 14px 16px;
+		}
+		.markdown pre code {
+			background: transparent;
+			padding: 0;
 		}
 		.message.system {
 			align-self: center;
@@ -458,6 +520,13 @@ export function renderWebModePage(): string {
 		.send-button:not(:disabled):hover {
 			transform: translateY(-1px);
 			background: #6ee7a1;
+		}
+		.send-button.is-cancel {
+			background: #ff7675;
+			color: #08090b;
+		}
+		.send-button.is-cancel:not(:disabled):hover {
+			background: #ff9493;
 		}
 		.send-button:disabled,
 		textarea:disabled {
@@ -646,10 +715,12 @@ export function renderWebModePage(): string {
 			border-color: var(--tn-border);
 			background: rgba(36, 40, 59, 0.82);
 		}
-		.message.assistant,
 		.message.system,
 		.mode-pill {
 			background: rgba(36, 40, 59, 0.72);
+		}
+		.message.assistant {
+			background: transparent;
 		}
 		.message.system {
 			color: var(--tn-text);
@@ -735,7 +806,7 @@ export function renderWebModePage(): string {
 				</div>
 				<div class="composer-meta">
 					<div class="model-pill">Nanocoder local session</div>
-					<p class="note">Enter sends. Shift+Enter creates a new line.</p>
+					<p class="note" id="composerNote">Enter sends. Shift+Enter creates a new line.</p>
 				</div>
 			</form>
 		</main>
@@ -752,6 +823,7 @@ export function renderWebModePage(): string {
 			const sessionMenuButton = document.querySelector('#sessionMenuButton');
 			const historyButton = document.querySelector('#historyButton');
 			const settingsButton = document.querySelector('#settingsButton');
+			const composerNote = document.querySelector('#composerNote');
 			const threadSearchInput = document.querySelector('#threadSearchInput');
 			const threadButtons = Array.from(document.querySelectorAll('.thread-item'));
 			const token = new URLSearchParams(window.location.search).get('token');
@@ -775,6 +847,8 @@ export function renderWebModePage(): string {
 			];
 			let messageCounter = 0;
 			let storedMessages = [];
+			let activeTurnId = null;
+			let isConnected = false;
 
 		function setStatus(text, state) {
 			statusElement.textContent = text;
@@ -782,8 +856,26 @@ export function renderWebModePage(): string {
 		}
 
 			function setComposerEnabled(isEnabled) {
-				messageInput.disabled = !isEnabled;
+				isConnected = isEnabled;
+				messageInput.disabled = !isEnabled || activeTurnId !== null;
 				sendButton.disabled = !isEnabled;
+			}
+
+			function setActiveTurn(id) {
+				activeTurnId = id;
+				const isActive = id !== null;
+				messageInput.disabled = !isConnected || isActive;
+				sendButton.disabled = !isConnected;
+				sendButton.classList.toggle('is-cancel', isActive);
+				sendButton.textContent = isActive ? '■' : '↑';
+				sendButton.setAttribute(
+					'aria-label',
+					isActive ? 'Cancel response' : 'Send message',
+				);
+				composerNote.textContent = isActive
+					? 'Nanocoder is working. Use the stop button to cancel.'
+					: 'Enter sends. Shift+Enter creates a new line.';
+				newChatButton.disabled = isActive;
 			}
 
 			function readStoredMessages() {
@@ -859,13 +951,116 @@ export function renderWebModePage(): string {
 			emptyState.hidden = true;
 		}
 
+		function appendInlineMarkdown(element, text) {
+			const inlineCodeMarker = String.fromCharCode(96);
+			let remainingText = text;
+
+			while (remainingText) {
+				const strongIndex = remainingText.indexOf('**');
+				const codeIndex = remainingText.indexOf(inlineCodeMarker);
+				const markerIndexes = [strongIndex, codeIndex].filter(index => index >= 0);
+
+				if (markerIndexes.length === 0) {
+					element.append(document.createTextNode(remainingText));
+					return;
+				}
+
+				const markerIndex = Math.min(...markerIndexes);
+				if (markerIndex > 0) {
+					element.append(document.createTextNode(remainingText.slice(0, markerIndex)));
+					remainingText = remainingText.slice(markerIndex);
+				}
+
+				const marker = remainingText.startsWith('**') ? '**' : inlineCodeMarker;
+				const closingIndex = remainingText.indexOf(marker, marker.length);
+				if (closingIndex < 0) {
+					element.append(document.createTextNode(remainingText));
+					return;
+				}
+
+				const inlineElement = document.createElement(marker === '**' ? 'strong' : 'code');
+				inlineElement.textContent = remainingText.slice(marker.length, closingIndex);
+				element.append(inlineElement);
+				remainingText = remainingText.slice(closingIndex + marker.length);
+			}
+		}
+
+		function renderAssistantText(element, text) {
+			element.replaceChildren();
+			const codeFence = String.fromCharCode(96).repeat(3);
+			let codeElement = null;
+			let listElement = null;
+
+			for (const line of text.split('\\n')) {
+				if (line.trim().startsWith(codeFence)) {
+					if (codeElement) {
+						codeElement = null;
+					} else {
+						const preElement = document.createElement('pre');
+						codeElement = document.createElement('code');
+						preElement.append(codeElement);
+						element.append(preElement);
+					}
+					listElement = null;
+					continue;
+				}
+
+				if (codeElement) {
+					codeElement.textContent += (codeElement.textContent ? '\\n' : '') + line;
+					continue;
+				}
+
+				if (!line.trim()) {
+					listElement = null;
+					continue;
+				}
+
+				const headingMatch = /^(#{1,3})\\s+(.*)$/.exec(line);
+				const unorderedMatch = /^[-*]\\s+(.*)$/.exec(line);
+				const orderedMatch = /^\\d+\\.\\s+(.*)$/.exec(line);
+
+				if (headingMatch) {
+					const headingElement = document.createElement('h' + headingMatch[1].length);
+					appendInlineMarkdown(headingElement, headingMatch[2]);
+					element.append(headingElement);
+					listElement = null;
+					continue;
+				}
+
+				const listMatch = unorderedMatch ?? orderedMatch;
+				if (listMatch) {
+					const listTag = unorderedMatch ? 'UL' : 'OL';
+					if (!listElement || listElement.tagName !== listTag) {
+						listElement = document.createElement(listTag.toLowerCase());
+						element.append(listElement);
+					}
+					const itemElement = document.createElement('li');
+					appendInlineMarkdown(itemElement, listMatch[1]);
+					listElement.append(itemElement);
+					continue;
+				}
+
+				const paragraphElement = document.createElement('p');
+				appendInlineMarkdown(paragraphElement, line);
+				element.append(paragraphElement);
+				listElement = null;
+			}
+		}
+
 			function appendMessage(role, text, metaText, shouldStore = true) {
 				hideEmptyState();
 				const messageElement = document.createElement('div');
 				messageElement.className = 'message ' + role;
-			const textElement = document.createElement('div');
-			textElement.textContent = text;
-			messageElement.append(textElement);
+				const textElement = document.createElement('div');
+				textElement.className = 'message-content';
+				if (role === 'assistant') {
+					textElement.classList.add('markdown');
+					textElement.dataset.rawText = text;
+					renderAssistantText(textElement, text);
+				} else {
+					textElement.textContent = text;
+				}
+				messageElement.append(textElement);
 
 			if (metaText) {
 				const metaElement = document.createElement('div');
@@ -934,12 +1129,14 @@ export function renderWebModePage(): string {
 		function appendAssistantDelta(id, text) {
 			let messageElement = assistantMessages.get(id);
 			if (!messageElement) {
-				messageElement = appendMessage('assistant', '', 'Assistant output');
+				messageElement = appendMessage('assistant', '');
 				assistantMessages.set(id, messageElement);
 			}
 
 			const textElement = messageElement.firstElementChild;
-			textElement.textContent += text;
+			const nextText = (textElement.dataset.rawText ?? '') + text;
+			textElement.dataset.rawText = nextText;
+			renderAssistantText(textElement, nextText);
 			messageList.scrollTop = messageList.scrollHeight;
 		}
 
@@ -999,11 +1196,15 @@ export function renderWebModePage(): string {
 			}
 
 			if (message.type === 'turn_completed') {
-				appendMessage('system', 'Turn completed', message.id);
+				if (message.id === activeTurnId) {
+					setActiveTurn(null);
+					messageInput.focus();
+				}
 				return;
 			}
 
 			if (message.type === 'error') {
+				setActiveTurn(null);
 				appendMessage('system error', message.message);
 				return;
 			}
@@ -1012,6 +1213,10 @@ export function renderWebModePage(): string {
 			}
 
 			function submitUserMessage(text) {
+				if (activeTurnId) {
+					return;
+				}
+
 				const trimmedText = text.trim();
 				if (!trimmedText) {
 					return;
@@ -1021,10 +1226,12 @@ export function renderWebModePage(): string {
 				const messageElement = appendMessage('user', trimmedText, 'Sending...');
 				pendingMessages.set(id, messageElement);
 				messageInput.value = '';
+				setActiveTurn(id);
 
 				if (!sendClientEvent({type: 'user_message', id, text: trimmedText})) {
 					updateMessageMeta(messageElement, 'Not sent');
 					pendingMessages.delete(id);
+					setActiveTurn(null);
 				}
 			}
 
@@ -1059,11 +1266,13 @@ export function renderWebModePage(): string {
 			}
 		});
 		socket.addEventListener('close', () => {
+			setActiveTurn(null);
 			setStatus('Disconnected', 'disconnected');
 			setComposerEnabled(false);
 			setEmptyState('Disconnected', 'Restart nanocoder --web to open a fresh local session.');
 		});
 		socket.addEventListener('error', () => {
+			setActiveTurn(null);
 			setStatus('Connection failed', 'failed');
 			setComposerEnabled(false);
 			setEmptyState('Connection failed', 'The browser could not reach the local Nanocoder server.');
@@ -1071,6 +1280,13 @@ export function renderWebModePage(): string {
 
 			messageForm.addEventListener('submit', event => {
 				event.preventDefault();
+				if (activeTurnId) {
+					sendClientEvent({type: 'cancel', id: activeTurnId});
+					sendButton.disabled = true;
+					composerNote.textContent = 'Cancelling the active Nanocoder turn...';
+					return;
+				}
+
 				submitUserMessage(messageInput.value);
 			});
 

--- a/source/web/runtime-bridge.spec.ts
+++ b/source/web/runtime-bridge.spec.ts
@@ -1,0 +1,147 @@
+import test from 'ava';
+import type {WebServerEvent} from './protocol.js';
+import {createWebRuntimeBridge} from './runtime-bridge.js';
+
+const userMessage = (id: string, text = 'hello') => ({
+	type: 'user_message' as const,
+	id,
+	text,
+});
+
+test('web runtime bridge rejects messages until the runtime is ready', async t => {
+	const bridge = createWebRuntimeBridge(() => {});
+
+	await t.throwsAsync(bridge.handleClientEvent(userMessage('turn-1')), {
+		message: 'Nanocoder runtime is still starting.',
+	});
+});
+
+test('web runtime bridge accepts one browser turn without waiting for completion', async t => {
+	const submittedMessages: string[] = [];
+	let resolveSubmission: (() => void) | undefined;
+	const submission = new Promise<void>(resolve => {
+		resolveSubmission = resolve;
+	});
+	const bridge = createWebRuntimeBridge(() => {});
+	bridge.bindRuntimeHandlers({
+		submitMessage: text => {
+			submittedMessages.push(text);
+			return submission;
+		},
+		cancel: () => {},
+	});
+
+	await bridge.handleClientEvent(userMessage('turn-1', 'from browser'));
+
+	t.deepEqual(submittedMessages, ['from browser']);
+	await t.throwsAsync(bridge.handleClientEvent(userMessage('turn-2')), {
+		message: 'Nanocoder is already processing a browser turn.',
+	});
+
+	resolveSubmission?.();
+	await submission;
+});
+
+test('web runtime bridge publishes assistant deltas and completion for the active turn', async t => {
+	const events: WebServerEvent[] = [];
+	let resolveSubmission: (() => void) | undefined;
+	const submission = new Promise<void>(resolve => {
+		resolveSubmission = resolve;
+	});
+	const bridge = createWebRuntimeBridge(event => {
+		events.push(event);
+	});
+	bridge.bindRuntimeHandlers({
+		submitMessage: () => submission,
+		cancel: () => {},
+	});
+
+	await bridge.handleClientEvent(userMessage('turn-1'));
+	bridge.publishAssistantContent('Hel');
+	bridge.publishAssistantContent('Hello');
+	bridge.publishAssistantContent('');
+	bridge.publishAssistantContent('Again');
+	bridge.completeTurn();
+
+	t.deepEqual(events, [
+		{type: 'assistant_delta', id: 'turn-1', text: 'Hel'},
+		{type: 'assistant_delta', id: 'turn-1', text: 'lo'},
+		{type: 'assistant_delta', id: 'turn-1', text: 'Again'},
+		{type: 'turn_completed', id: 'turn-1'},
+	]);
+
+	resolveSubmission?.();
+	await submission;
+	t.is(events.length, 4);
+});
+
+test('web runtime bridge cancels only the matching active browser turn', async t => {
+	let cancelCount = 0;
+	const bridge = createWebRuntimeBridge(() => {});
+	bridge.bindRuntimeHandlers({
+		submitMessage: () => new Promise<void>(() => {}),
+		cancel: () => {
+			cancelCount++;
+		},
+	});
+
+	await bridge.handleClientEvent(userMessage('turn-1'));
+	await t.throwsAsync(
+		bridge.handleClientEvent({type: 'cancel', id: 'turn-2'}),
+		{message: 'This browser turn is no longer active.'},
+	);
+	await bridge.handleClientEvent({type: 'cancel', id: 'turn-1'});
+
+	t.is(cancelCount, 1);
+});
+
+test('web runtime bridge reports asynchronous submission failures and clears the turn', async t => {
+	const events: WebServerEvent[] = [];
+	const submittedMessages: string[] = [];
+	const bridge = createWebRuntimeBridge(event => {
+		events.push(event);
+	});
+	bridge.bindRuntimeHandlers({
+		submitMessage: async text => {
+			submittedMessages.push(text);
+			if (text === 'fail') {
+				throw new Error('Model request failed.');
+			}
+		},
+		cancel: () => {},
+	});
+
+	await bridge.handleClientEvent(userMessage('turn-1', 'fail'));
+	await new Promise(resolve => setTimeout(resolve, 0));
+	await bridge.handleClientEvent(userMessage('turn-2', 'retry'));
+	await new Promise(resolve => setTimeout(resolve, 0));
+
+	t.deepEqual(submittedMessages, ['fail', 'retry']);
+	t.deepEqual(events, [
+		{type: 'error', message: 'Model request failed.'},
+		{type: 'turn_completed', id: 'turn-2'},
+	]);
+});
+
+test('web runtime bridge cleanup does not remove a newer handler binding', async t => {
+	const submittedMessages: string[] = [];
+	const bridge = createWebRuntimeBridge(() => {});
+	const releaseFirstBinding = bridge.bindRuntimeHandlers({
+		submitMessage: text => {
+			submittedMessages.push(`first:${text}`);
+		},
+		cancel: () => {},
+	});
+	bridge.bindRuntimeHandlers({
+		submitMessage: text => {
+			submittedMessages.push(`second:${text}`);
+		},
+		cancel: () => {},
+	});
+
+	releaseFirstBinding();
+	await bridge.handleClientEvent(userMessage('turn-1', 'hello'));
+	await new Promise(resolve => setTimeout(resolve, 0));
+
+	t.deepEqual(submittedMessages, ['second:hello']);
+});

--- a/source/web/runtime-bridge.ts
+++ b/source/web/runtime-bridge.ts
@@ -1,0 +1,132 @@
+import type {WebClientEvent, WebServerEvent} from './protocol.js';
+
+export interface WebRuntimeHandlers {
+	submitMessage: (text: string) => void | Promise<void>;
+	cancel: () => void;
+}
+
+export interface WebRuntimeBridge {
+	handleClientEvent: (event: WebClientEvent) => Promise<void>;
+	bindRuntimeHandlers: (handlers: WebRuntimeHandlers) => () => void;
+	publishAssistantContent: (content: string) => void;
+	completeTurn: () => void;
+	failTurn: (error: unknown) => void;
+}
+
+export function createWebRuntimeBridge(
+	broadcastEvent: (event: WebServerEvent) => void,
+): WebRuntimeBridge {
+	let runtimeHandlers: WebRuntimeHandlers | null = null;
+	let activeTurnId: string | null = null;
+	let previousAssistantContent = '';
+
+	const clearActiveTurn = () => {
+		activeTurnId = null;
+		previousAssistantContent = '';
+	};
+
+	const completeActiveTurn = (expectedTurnId?: string) => {
+		if (!activeTurnId || (expectedTurnId && activeTurnId !== expectedTurnId)) {
+			return;
+		}
+
+		broadcastEvent({type: 'turn_completed', id: activeTurnId});
+		clearActiveTurn();
+	};
+
+	const failActiveTurn = (error: unknown, expectedTurnId?: string) => {
+		if (!activeTurnId || (expectedTurnId && activeTurnId !== expectedTurnId)) {
+			return;
+		}
+
+		broadcastEvent({
+			type: 'error',
+			message:
+				error instanceof Error
+					? error.message
+					: 'Nanocoder could not complete this turn.',
+		});
+		clearActiveTurn();
+	};
+
+	return {
+		async handleClientEvent(event) {
+			if (event.type === 'hello') {
+				return;
+			}
+
+			if (!runtimeHandlers) {
+				throw new Error('Nanocoder runtime is still starting.');
+			}
+
+			if (event.type === 'cancel') {
+				if (!activeTurnId || event.id !== activeTurnId) {
+					throw new Error('This browser turn is no longer active.');
+				}
+
+				runtimeHandlers.cancel();
+				return;
+			}
+
+			if (activeTurnId) {
+				throw new Error('Nanocoder is already processing a browser turn.');
+			}
+
+			activeTurnId = event.id;
+			previousAssistantContent = '';
+
+			try {
+				const submission = runtimeHandlers.submitMessage(event.text);
+				void Promise.resolve(submission).then(
+					() => completeActiveTurn(event.id),
+					error => failActiveTurn(error, event.id),
+				);
+			} catch (error) {
+				clearActiveTurn();
+				throw error;
+			}
+		},
+
+		bindRuntimeHandlers(handlers) {
+			runtimeHandlers = handlers;
+
+			return () => {
+				if (runtimeHandlers === handlers) {
+					runtimeHandlers = null;
+				}
+			};
+		},
+
+		publishAssistantContent(content) {
+			if (!activeTurnId) {
+				return;
+			}
+
+			if (content.length === 0) {
+				previousAssistantContent = '';
+				return;
+			}
+
+			const delta = content.startsWith(previousAssistantContent)
+				? content.slice(previousAssistantContent.length)
+				: content;
+			previousAssistantContent = content;
+
+			if (delta.length > 0) {
+				broadcastEvent({
+					type: 'assistant_delta',
+					id: activeTurnId,
+					text: delta,
+				});
+			}
+		},
+
+		completeTurn() {
+			completeActiveTurn();
+		},
+
+		failTurn(error) {
+			failActiveTurn(error);
+		},
+	};
+}


### PR DESCRIPTION

## Description

Connects Nanocoder’s local browser UI to the existing terminal runtime.

Browser messages are now forwarded to the real Nanocoder chat handler through the localhost WebSocket bridge. Assistant output is streamed back to the browser, and completion, cancellation, and error events are handled without duplicating provider, tool, or conversation state.

 PR targets `feat/web-mode` and builds on the earlier web-mode phases.
Phase 4 #628 
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Screenshot 
<img width="1692" height="662" alt="Screenshot 2026-07-21 at 11 47 44 AM" src="https://github.com/user-attachments/assets/2c05ed5d-3934-42b0-902c-3f57d075e46f" />
<img width="1672" height="865" alt="Screenshot 2026-07-21 at 11 48 00 AM" src="https://github.com/user-attachments/assets/e917a54f-b635-41e5-a97f-1fc55feeda90" />

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Result: `99 tests passed`

TypeScript and changed-file Biome checks also pass.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)
- [x] Verified browser messages and streamed assistant output locally

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

