### PR TITLE
feat: implement tab-based command completion triggering and improve completion state management

### DIFF
--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -759,6 +759,8 @@ test('arrow key navigation updates the selected completion', async t => {
 
 	stdin.write('/');
 	await wait();
+	stdin.write('\t');
+	await wait();
 
 	const beforeNav = lastFrame()!;
 	t.regex(beforeNav, /Available commands:/);
@@ -783,6 +785,8 @@ test('Enter selects the highlighted completion and populates the input', async t
 
 	stdin.write('/');
 	await wait();
+	stdin.write('\t');
+	await wait();
 
 	t.regex(lastFrame()!, /Available commands:/);
 
@@ -803,20 +807,22 @@ test('typing a space after a command hides completions so args submit', async t 
 		</TestWrapper>,
 	);
 
-	stdin.write('/test-help');
+	stdin.write('/test');
+	await wait();
+	stdin.write('\t');
 	await wait();
 
 	// While still typing the command name, completions are visible
 	t.regex(lastFrame()!, /Available commands:/);
 
 	// Once a space is typed, the user is entering arguments - completions hide
-	// so Enter submits the full `/test-help arg` instead of selecting `/test-help`
+	// so Enter submits the full `/test arg` instead of selecting `/test`
 	stdin.write(' arg');
 	await wait();
 
 	const afterArg = lastFrame()!;
 	t.notRegex(afterArg, /Available commands:/);
-	t.regex(afterArg, /\/test-help arg/);
+	t.regex(afterArg, /\/test arg/);
 
 	unmount();
 });
@@ -829,6 +835,8 @@ test('completion menu dismissal/reset after selection or escape', async t => {
 	);
 
 	stdin.write('/');
+	await wait();
+	stdin.write('\t');
 	await wait();
 
 	t.regex(lastFrame()!, /Available commands:/);
@@ -845,6 +853,8 @@ test('completion menu dismissal/reset after selection or escape', async t => {
 	await wait();
 
 	stdin.write('/');
+	await wait();
+	stdin.write('\t');
 	await wait();
 
 	t.regex(lastFrame()!, /Available commands:/);
@@ -870,6 +880,8 @@ test('UserInput renders completions text when typing /', async t => {
 	await new Promise(resolve => setTimeout(resolve, 50));
 	stdin.write('/');
 	await new Promise(resolve => setTimeout(resolve, 150));
+	stdin.write('\t');
+	await wait();
 
 	const output = lastFrame()!;
 	t.truthy(output);
@@ -889,6 +901,8 @@ test('UserInput windows long slash completion lists', async t => {
 	);
 
 	stdin.write('/zz');
+	await wait();
+	stdin.write('\t');
 	await wait();
 
 	const firstFrame = lastFrame()!;
@@ -925,6 +939,8 @@ test('UserInput renders completions BEFORE the mode indicator (inside the input 
 	await new Promise(resolve => setTimeout(resolve, 50));
 	stdin.write('/');
 	await new Promise(resolve => setTimeout(resolve, 150));
+	stdin.write('\t');
+	await wait();
 
 	const output = lastFrame()!;
 	t.truthy(output);
@@ -950,6 +966,8 @@ test('UserInput completions appear on a line above the mode indicator', async t 
 	await new Promise(resolve => setTimeout(resolve, 50));
 	stdin.write('/');
 	await new Promise(resolve => setTimeout(resolve, 150));
+	stdin.write('\t');
+	await wait();
 
 	const output = lastFrame()!;
 	const lines = output.split('\n');

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -311,8 +311,15 @@ export default function UserInput({
 		}
 		if (commandCompletions.length > 0) {
 			setCompletions(commandCompletions);
-			setShowCompletions(true);
-			setSelectedCompletionIndex(0);
+			if (showCompletions) {
+				setSelectedCompletionIndex(prev =>
+					prev >= commandCompletions.length
+						? commandCompletions.length - 1
+						: prev < 0
+							? 0
+							: prev,
+				);
+			}
 		} else if (showCompletions) {
 			setCompletions([]);
 			setShowCompletions(false);
@@ -456,6 +463,16 @@ export default function UserInput({
 
 	// Handle escape key logic
 	const handleEscape = useCallback(() => {
+		if (showCompletions) {
+			setShowCompletions(false);
+			setSelectedCompletionIndex(-1);
+			return;
+		}
+		if (isFileAutocompleteMode) {
+			setIsFileAutocompleteMode(false);
+			setFileCompletions([]);
+			return;
+		}
 		if (showClearMessage) {
 			resetInput();
 			resetUIState();
@@ -466,7 +483,11 @@ export default function UserInput({
 			setShowClearMessage(true);
 		}
 	}, [
+		showCompletions,
+		isFileAutocompleteMode,
 		showClearMessage,
+		setShowCompletions,
+		setSelectedCompletionIndex,
 		resetInput,
 		resetUIState,
 		onDismissActiveEditor,
@@ -715,6 +736,7 @@ export default function UserInput({
 					// Show completions when there are multiple matches
 					setCompletions(commandCompletions);
 					setShowCompletions(true);
+					setSelectedCompletionIndex(0);
 				}
 				return;
 			}


### PR DESCRIPTION
## Description

Closes #681

This PR resolves the issue where the slash-command completion UI was overly eager, which interfered with history navigation and required multiple keystrokes to submit valid commands.

Key changes:
1. **Manual Autocomplete Trigger (`TAB`)**: Slash command completions no longer trigger automatically when typing `/` or when navigating backward in history. They are now triggered manually by pressing the `TAB` key, allowing seamless `↑`/`↓` history navigation over old commands.
2. **Double `ENTER` Fix**: Because completions aren't eagerly displayed, users can now type a valid slash command and submit it with a single `ENTER` press.
3. **Improved `ESC` Behavior**: Pressing `ESC` while the completion menu is open now strictly closes the menu and preserves the current input text, rather than abruptly clearing the entire entry.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

*(Note: Run `pnpm changeset` locally before merging to document this for the changelog)*

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

*(Note: These changes are strictly localized to the UI/input behavior and do not affect provider/API functionality)*

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))