### PR TITLE
fix: address final phase 5 review remarks (test config, cleanup, persistence)

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
 		"files": [
 			"source/**/*.spec.ts",
 			"source/**/*.spec.tsx",
-			"plugins/vscode/src/**/*.spec.ts",
 			"!source/**/*-helpers.ts",
 			"!source/**/test-helpers.ts"
 		],

--- a/plugins/vscode/src/acp-client.ts
+++ b/plugins/vscode/src/acp-client.ts
@@ -326,17 +326,4 @@ export class NanocoderAcpClient {
 		}
 	}
 
-	async proceedPlan(): Promise<void> {
-		this.outputChannel.appendLine('ACP: proceedPlan requested. (TODO: Forward plan approval to server)');
-		// TODO: Implement the correct ACP interaction for Proceed in Plan Mode.
-	}
-
-	async modifyPlan(): Promise<void> {
-		this.outputChannel.appendLine('ACP: modifyPlan requested. (TODO: Forward refinement to server)');
-	}
-
-	async cancelPlan(): Promise<void> {
-		this.outputChannel.appendLine('ACP: cancelPlan requested.');
-		this.cancel();
-	}
 }

--- a/plugins/vscode/src/acp-process-manager.spec.ts
+++ b/plugins/vscode/src/acp-process-manager.spec.ts
@@ -9,7 +9,6 @@ test('AcpProcessManager - restart logic and retry backoff', (t) => {
 	const stateManager = new AcpStateManager();
 	const acpClient = { 
 		connection: null,
-		rebindClient: () => {},
 		initializeHandshake: async () => true,
 		dispose: () => {}
 	} as any as NanocoderAcpClient;

--- a/plugins/vscode/src/chat-webview-provider.ts
+++ b/plugins/vscode/src/chat-webview-provider.ts
@@ -115,18 +115,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 						this._outputChannel.appendLine(`[Webview] User requested to see diff for: ${message.toolCallId}`);
 						this._diffManager.showDiff(message.toolCallId);
 						break;
-					case 'proceedPlan':
-						this._outputChannel.appendLine('[Webview] User clicked Proceed on plan.');
-						this._acpClient.proceedPlan();
-						break;
-					case 'modifyPlan':
-						this._outputChannel.appendLine('[Webview] User clicked Modify on plan.');
-						this._acpClient.modifyPlan();
-						break;
-					case 'cancelPlan':
-						this._outputChannel.appendLine('[Webview] User clicked Cancel on plan review.');
-						this._acpClient.cancelPlan();
-						break;
+
 					case 'setMode':
 						this._outputChannel.appendLine(`[Webview] User selected mode: ${message.mode}`);
 						this._acpClient.setSessionMode(message.mode);

--- a/plugins/vscode/src/webview-protocol.ts
+++ b/plugins/vscode/src/webview-protocol.ts
@@ -54,10 +54,7 @@ export interface ExtensionMessagePermissionRequested {
 	toolCall: any;
 }
 
-export interface ExtensionMessageShowPlanReview {
-	type: 'showPlanReview';
-	description?: string;
-}
+
 
 export interface ExtensionMessageSyncState {
 	type: 'syncState';
@@ -86,7 +83,6 @@ export type ExtensionToWebviewMessage =
 	| ExtensionMessageToolUpdated
 	| ExtensionMessageToolCompleted
 	| ExtensionMessagePermissionRequested
-	| ExtensionMessageShowPlanReview
 	| ExtensionMessageSyncState
 	| ExtensionMessageUpdateSessions;
 
@@ -123,18 +119,6 @@ export interface WebviewMessageShowDiff {
 	toolCallId: string;
 }
 
-export interface WebviewMessageProceedPlan {
-	type: 'proceedPlan';
-}
-
-export interface WebviewMessageModifyPlan {
-	type: 'modifyPlan';
-}
-
-export interface WebviewMessageCancelPlan {
-	type: 'cancelPlan';
-}
-
 
 
 export interface WebviewMessageSetMode {
@@ -168,9 +152,6 @@ export type WebviewToExtensionMessage =
 	| WebviewMessageApproveTool
 	| WebviewMessageDenyTool
 	| WebviewMessageShowDiff
-	| WebviewMessageProceedPlan
-	| WebviewMessageModifyPlan
-	| WebviewMessageCancelPlan
 	| WebviewMessageSetMode
 	| WebviewMessageSetModel
 	| WebviewMessageListSessions

--- a/source/acp/acp-agent.ts
+++ b/source/acp/acp-agent.ts
@@ -164,10 +164,7 @@ export class AcpAgent implements Agent {
 		// the model always knows what the user is looking at.
 		let contextualUserText = userText;
 		if (session.activeFile) {
-			const selectionPart = session.activeSelection
-				? `\n\nSelected text:\n\`\`\`\n${session.activeSelection}\n\`\`\``
-				: '';
-			contextualUserText = `[Active file: ${session.activeFile}${selectionPart}]\n\n${userText}`;
+			contextualUserText = `[Active file: ${session.activeFile}]\n\n${userText}`;
 		}
 
 		session.messages = [
@@ -492,12 +489,15 @@ export class AcpAgent implements Agent {
 			}
 
 			const timestamp = new Date().toISOString();
-			const config = getAppConfig();
 
 			// We only want user/assistant messages for the title generation/saving
 			const saveableMessages = session.messages.filter(
 				m => m.role === 'user' || m.role === 'assistant',
 			);
+
+			if (saveableMessages.length === 0) {
+				return;
+			}
 
 			// Simple title generation if it's new
 			let title = existingSession?.title;
@@ -516,10 +516,18 @@ export class AcpAgent implements Agent {
 				createdAt: existingSession?.createdAt || timestamp,
 				lastAccessedAt: timestamp,
 				messageCount: saveableMessages.length,
-				provider: config.providers?.[0]?.name || 'openai',
-				model: config.providers?.[0]?.models?.[0] || 'gpt-4o',
+				provider: this.initContext.client.getProviderConfig().name || 'openai',
+				model: this.initContext.client.getCurrentModel() || 'gpt-4o',
 				workingDirectory: session.cwd,
-				messages: session.messages, // We save the raw AcpSession messages
+				messages: session.messages.map(m => {
+					if (m.role === 'user' && typeof m.content === 'string') {
+						return {
+							...m,
+							content: m.content.replace(/^\[Active file: [^\]]+\]\n\n/, ''),
+						};
+					}
+					return m;
+				}), // We save the raw AcpSession messages with UI prefix stripped
 			});
 		} catch (error) {
 			logger.error(`Failed to save session to disk: ${error}`);

--- a/source/acp/acp-session.ts
+++ b/source/acp/acp-session.ts
@@ -18,8 +18,6 @@ export class AcpSession {
 	turnActive = false;
 	/** URI of the file currently focused in the editor client (e.g. VS Code). */
 	activeFile?: string;
-	/** Currently selected text in the editor client, if any. */
-	activeSelection?: string;
 
 	constructor(options: {
 		sessionId: string;


### PR DESCRIPTION
This commit addresses the final code review remarks for the VS Code GUI Extension (Phase 5). It focuses on hardening session persistence, removing remaining dead code paths, and fixing the CI test suite timeout/failure caused by the extension specs.

## 1. Test Suite & Linting Fixes
- **VS Code Specs Removed from Root:** Modified the root `package.json` to exclude `plugins/vscode/src/**/*.spec.ts` from the `ava.files` glob. The VS Code extension specs require the extension host environment and were crashing the global `pnpm run test:ava` command due to missing `vscode` module dependencies.
- **Process Manager Mock Fix:** Removed the nonexistent `rebindClient` method mock from `acp-process-manager.spec.ts`.
- **Lint Warnings Addressed:** Removed an unused `config` variable initialization in `acp-agent.ts` to satisfy Biome's strict linting requirements.

## 2. Dead Code Elimination
- **Plan Review UI:** Fully purged the remaining stubs for the disabled Plan Review feature. Removed `proceedPlan()`, `modifyPlan()`, and `cancelPlan()` from `acp-client.ts`, stripped their handler switch cases from `chat-webview-provider.ts`, and deleted the associated types from `webview-protocol.ts`.
- **Active Selection Context:** Removed the obsolete `activeSelection` string context from `AcpSession` (`acp-session.ts`). The related template string logic that injected `Selected text:` into user prompts was successfully removed from `acp-agent.ts`.

## 3. Session Persistence Hardening
- **Deferred Session Creation:** Refactored `saveAcpSessionToDisk` (`acp-agent.ts`) to immediately return if there are no saveable user or assistant messages. This prevents the extension from spamming empty "New Session" files to disk immediately upon boot.
- **Accurate Model Metadata:** `saveAcpSessionToDisk` now queries the actual active client (`this.initContext.client.getProviderConfig().name` and `this.initContext.client.getCurrentModel()`) to populate the JSON metadata, rather than guessing from the first item in the configuration array.
- **Clean History Prefixing:** Added logic to `saveAcpSessionToDisk` to strip the UI-injected `[Active file: ...]\n\n` prefix from user messages before persisting them to disk, ensuring the saved history remains clean for future rendering or replays.
