### PR TITLE
feat: add interactive subagent session attachment for real-time monitoring and debugging

### DIFF
--- a/.changeset/interactive-subagent-inspection.md
+++ b/.changeset/interactive-subagent-inspection.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added the ability to attach to a running subagent session from the terminal UI for interactive debugging. This feature allows users to inspect exactly what a subagent is doing in real-time, including streaming text and reasoning. You can press `Ctrl+S` while a subagent is running to attach to it, cycle between multiple running subagents, and press `Esc` to detach.

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -136,13 +136,29 @@ export default function App({
 		if (key.ctrl && input === 'c') {
 			handleExit();
 		}
-		if (key.ctrl && input === 's' && !appState.attachedAgentId) {
+		if (key.ctrl && input === 's') {
 			const progresses = Array.from(getAllSubagentProgress().entries());
-			const running = progresses.find(
-				([_, p]) => p.status !== 'complete' && p.status !== 'error',
-			);
-			if (running) {
-				appState.setAttachedAgentId(running[0]);
+			const runningAgents = progresses
+				.filter(([_, p]) => p.status !== 'complete' && p.status !== 'error')
+				.map(([id]) => id);
+
+			if (runningAgents.length === 0) {
+				if (appState.attachedAgentId) {
+					appState.setAttachedAgentId(null);
+				}
+			} else {
+				if (!appState.attachedAgentId) {
+					appState.setAttachedAgentId(runningAgents[0]);
+				} else {
+					const currentIndex = runningAgents.indexOf(appState.attachedAgentId);
+					if (currentIndex !== -1 && runningAgents.length > 1) {
+						appState.setAttachedAgentId(
+							runningAgents[(currentIndex + 1) % runningAgents.length],
+						);
+					} else if (currentIndex === -1) {
+						appState.setAttachedAgentId(runningAgents[0]);
+					}
+				}
 			}
 		}
 	});

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -16,6 +16,7 @@ import {SuccessMessage} from '@/components/message-box';
 import SecurityDisclaimer from '@/components/security-disclaimer';
 import StreamingMessage from '@/components/streaming-message';
 import StreamingReasoning from '@/components/streaming-reasoning';
+import {SubagentView} from '@/components/subagent-view';
 import type {TitleShape} from '@/components/ui/styled-title';
 import {
 	shouldPromptExtensionInstall,
@@ -41,6 +42,7 @@ import {TitleShapeContext, updateTitleShape} from '@/hooks/useTitleShape';
 import {UIStateProvider} from '@/hooks/useUIState';
 import {useUserMessageQueue} from '@/hooks/useUserMessageQueue';
 import {useVSCodeServer} from '@/hooks/useVSCodeServer';
+import {getAllSubagentProgress} from '@/services/subagent-events';
 import {generateKey} from '@/session/key-generator';
 import type {ImageAttachment} from '@/types/core';
 import type {ThemePreset} from '@/types/ui';
@@ -133,6 +135,15 @@ export default function App({
 	useInput((input, key) => {
 		if (key.ctrl && input === 'c') {
 			handleExit();
+		}
+		if (key.ctrl && input === 's' && !appState.attachedAgentId) {
+			const progresses = Array.from(getAllSubagentProgress().entries());
+			const running = progresses.find(
+				([_, p]) => p.status !== 'complete' && p.status !== 'error',
+			);
+			if (running) {
+				appState.setAttachedAgentId(running[0]);
+			}
 		}
 	});
 
@@ -712,25 +723,34 @@ export default function App({
 						privacySessionMapRef: appState.privacySessionMapRef,
 					}}
 				>
-					<InteractiveApp
-						altScreenActive={altScreenActive}
-						appState={appState}
-						chatHandler={chatHandler}
-						modeHandlers={modeHandlers}
-						appHandlers={appHandlers}
-						vscodeServer={vscodeServer}
-						staticComponents={staticComponents}
-						clearKey={conversationId}
-						liveComponent={liveComponent}
-						pendingSubagentApproval={pendingSubagentApproval}
-						handleSubagentToolApproval={handleSubagentToolApproval}
-						pendingToolConfirmation={pendingToolConfirmation}
-						handleToolConfirmation={handleToolConfirmation}
-						handleQuestionAnswer={handleQuestionAnswer}
-						handleUserSubmit={handleUserSubmit}
-						userMessageQueue={userMessageQueue}
-						handleIdeSelect={handleIdeSelect}
-					/>
+					{appState.attachedAgentId ? (
+						<SubagentView
+							agentId={appState.attachedAgentId}
+							onDetach={() => appState.setAttachedAgentId(null)}
+							reasoningExpanded={appState.reasoningExpanded}
+							altScreenActive={altScreenActive}
+						/>
+					) : (
+						<InteractiveApp
+							altScreenActive={altScreenActive}
+							appState={appState}
+							chatHandler={chatHandler}
+							modeHandlers={modeHandlers}
+							appHandlers={appHandlers}
+							vscodeServer={vscodeServer}
+							staticComponents={staticComponents}
+							clearKey={conversationId}
+							liveComponent={liveComponent}
+							pendingSubagentApproval={pendingSubagentApproval}
+							handleSubagentToolApproval={handleSubagentToolApproval}
+							pendingToolConfirmation={pendingToolConfirmation}
+							handleToolConfirmation={handleToolConfirmation}
+							handleQuestionAnswer={handleQuestionAnswer}
+							handleUserSubmit={handleUserSubmit}
+							userMessageQueue={userMessageQueue}
+							handleIdeSelect={handleIdeSelect}
+						/>
+					)}
 				</PrivacyContext.Provider>
 			</TitleShapeContext.Provider>
 		</ThemeContext.Provider>

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -142,24 +142,24 @@ export default function App({
 				.filter(([_, p]) => p.status !== 'complete' && p.status !== 'error')
 				.map(([id]) => id);
 
-			if (runningAgents.length === 0) {
-				if (appState.attachedAgentId) {
-					appState.setAttachedAgentId(null);
+			appState.setAttachedAgentId(currentAttachedAgentId => {
+				if (runningAgents.length === 0) {
+					return null;
 				}
-			} else {
-				if (!appState.attachedAgentId) {
-					appState.setAttachedAgentId(runningAgents[0]);
-				} else {
-					const currentIndex = runningAgents.indexOf(appState.attachedAgentId);
-					if (currentIndex !== -1 && runningAgents.length > 1) {
-						appState.setAttachedAgentId(
-							runningAgents[(currentIndex + 1) % runningAgents.length],
-						);
-					} else if (currentIndex === -1) {
-						appState.setAttachedAgentId(runningAgents[0]);
-					}
+
+				if (!currentAttachedAgentId) {
+					return runningAgents[0];
 				}
-			}
+
+				const currentIndex = runningAgents.indexOf(currentAttachedAgentId);
+				if (currentIndex !== -1 && runningAgents.length > 1) {
+					return runningAgents[(currentIndex + 1) % runningAgents.length];
+				} else if (currentIndex === -1) {
+					return runningAgents[0];
+				}
+
+				return currentAttachedAgentId;
+			});
 		}
 	});
 

--- a/source/components/agent-progress.tsx
+++ b/source/components/agent-progress.tsx
@@ -118,7 +118,7 @@ export default function AgentProgress({
 					{agentId && (
 						<Box>
 							<Text color={colors.secondary} italic>
-								Press Ctrl+S to attach to session
+								Press Ctrl+S to attach/cycle sessions
 							</Text>
 						</Box>
 					)}

--- a/source/components/agent-progress.tsx
+++ b/source/components/agent-progress.tsx
@@ -107,12 +107,21 @@ export default function AgentProgress({
 			</Box>
 
 			{!isComplete && (
-				<Box>
-					<Text color={colors.secondary}>
-						{toolCallCount > 0 ? `${toolCallCount} tool calls` : ''}
-						{toolCallCount > 0 && tokenCount > 0 ? ' · ' : ''}
-						{tokenCount > 0 ? `~${tokenCount.toLocaleString()} tokens` : ''}
-					</Text>
+				<Box flexDirection="column">
+					<Box>
+						<Text color={colors.secondary}>
+							{toolCallCount > 0 ? `${toolCallCount} tool calls` : ''}
+							{toolCallCount > 0 && tokenCount > 0 ? ' · ' : ''}
+							{tokenCount > 0 ? `~${tokenCount.toLocaleString()} tokens` : ''}
+						</Text>
+					</Box>
+					{agentId && (
+						<Box>
+							<Text color={colors.secondary} italic>
+								Press Ctrl+S to attach to session
+							</Text>
+						</Box>
+					)}
 				</Box>
 			)}
 

--- a/source/components/subagent-view.tsx
+++ b/source/components/subagent-view.tsx
@@ -1,0 +1,131 @@
+import {Box, Text, useInput} from 'ink';
+import React, {useEffect, useReducer} from 'react';
+import AssistantMessage from '@/components/assistant-message';
+import ChatQueue from '@/components/chat-queue';
+import StreamingMessage from '@/components/streaming-message';
+import StreamingReasoning from '@/components/streaming-reasoning';
+import ToolMessage from '@/components/tool-message';
+import UserMessage from '@/components/user-message';
+import {useTheme} from '@/hooks/useTheme';
+import {getSubagentSession} from '@/services/subagent-session-store';
+
+interface SubagentViewProps {
+	agentId: string;
+	onDetach: () => void;
+	reasoningExpanded: boolean;
+	altScreenActive?: boolean;
+}
+
+export function SubagentView({
+	agentId,
+	onDetach,
+	reasoningExpanded,
+	altScreenActive = false,
+}: SubagentViewProps) {
+	const {colors} = useTheme();
+	const [, forceRender] = useReducer((x: number) => x + 1, 0);
+
+	// Poll the mutable session store every 100ms for updates
+	useEffect(() => {
+		const interval = setInterval(() => forceRender(), 100);
+		return () => clearInterval(interval);
+	}, []);
+
+	useInput((_input, key) => {
+		if (key.escape) {
+			onDetach();
+		}
+	});
+
+	const session = getSubagentSession(agentId);
+
+	// Automatically detach if session cleans up or completes
+	// This happens when subagent finishes running and executor cleans it up.
+	useEffect(() => {
+		if (!session) {
+			onDetach();
+		}
+	}, [session, onDetach]);
+
+	if (!session) {
+		return null;
+	}
+
+	const chatComponents = session.messages
+		.map((msg, index) => {
+			if (msg.role === 'user') {
+				return <UserMessage key={`user-${index}`} message={msg.content} />;
+			}
+			if (msg.role === 'assistant' && msg.content) {
+				return (
+					<AssistantMessage
+						key={`assistant-${index}`}
+						message={msg.content}
+						model="subagent"
+					/>
+				);
+			}
+			if (msg.role === 'tool') {
+				return (
+					<ToolMessage
+						key={`tool-${index}`}
+						message={`⚒ ${msg.name}: ${msg.content.slice(0, 100)}...`}
+						hideBox={true}
+					/>
+				);
+			}
+			return null;
+		})
+		.filter(Boolean);
+
+	const liveComponent =
+		session.streamingText || session.streamingReasoning ? (
+			<React.Fragment>
+				{session.streamingReasoning && !session.streamingText && (
+					<StreamingReasoning
+						reasoning={session.streamingReasoning}
+						expand={reasoningExpanded}
+					/>
+				)}
+				{session.streamingReasoning && session.streamingText && (
+					<AssistantMessage
+						message={`[Reasoning complete]\n${session.streamingReasoning}`}
+						model="subagent"
+					/>
+				)}
+				{session.streamingText && (
+					<StreamingMessage message={session.streamingText} model="subagent" />
+				)}
+			</React.Fragment>
+		) : null;
+
+	return (
+		<Box flexDirection="column" flexGrow={1} height="100%">
+			<Box
+				paddingX={1}
+				borderBottomColor={colors.secondary}
+				borderStyle="single"
+				borderTop={false}
+				borderLeft={false}
+				borderRight={false}
+			>
+				<Text color={colors.secondary}>Main Session &gt; </Text>
+				<Text color={colors.primary} bold>
+					{session.subagentName}
+				</Text>
+				<Box flexGrow={1} />
+				<Text color={colors.secondary}>Press Esc to detach</Text>
+			</Box>
+
+			<Box flexGrow={1} flexDirection="column">
+				<ChatQueue
+					staticComponents={[]}
+					queuedComponents={chatComponents}
+					disableStatic={altScreenActive}
+					renderLastQueuedComponentLive={false}
+				/>
+				{liveComponent && <Box paddingX={1}>{liveComponent}</Box>}
+			</Box>
+		</Box>
+	);
+}

--- a/source/components/subagent-view.tsx
+++ b/source/components/subagent-view.tsx
@@ -124,7 +124,11 @@ export function SubagentView({
 					disableStatic={altScreenActive}
 					renderLastQueuedComponentLive={false}
 				/>
-				{liveComponent && <Box paddingX={1}>{liveComponent}</Box>}
+				{liveComponent && (
+					<Box paddingX={1} flexDirection="column">
+						{liveComponent}
+					</Box>
+				)}
 			</Box>
 		</Box>
 	);

--- a/source/hooks/useAppState.tsx
+++ b/source/hooks/useAppState.tsx
@@ -135,6 +135,9 @@ export function useAppState(
 	// can rebuild with the real agent list instead of "No subagents available."
 	const [subagentsReady, setSubagentsReady] = useState<boolean>(false);
 
+	// Track which subagent (if any) the user is currently attached to for interactive debugging
+	const [attachedAgentId, setAttachedAgentId] = useState<string | null>(null);
+
 	// Set to preference on launch, but can be toggled freely during runtime
 	const [reasoningExpanded, setReasoningExpanded] = useState<boolean>(
 		preferences.reasoningExpanded ?? false,
@@ -378,6 +381,7 @@ export function useAppState(
 		currentToolIndex,
 		chatComponents,
 		tokenizer,
+		attachedAgentId,
 
 		// Setters
 		setClient,
@@ -433,6 +437,7 @@ export function useAppState(
 		liveComponent,
 		setLiveComponent,
 		privacySessionMapRef,
+		setAttachedAgentId,
 
 		// Utilities
 		addToChatQueue,

--- a/source/services/subagent-session-store.ts
+++ b/source/services/subagent-session-store.ts
@@ -1,0 +1,58 @@
+import type {Message} from '@/types/core';
+
+export interface SubagentSession {
+	agentId: string;
+	subagentName: string;
+	messages: Message[];
+	streamingText: string;
+	streamingReasoning: string;
+}
+
+const sessionStore = new Map<string, SubagentSession>();
+
+export function getSubagentSession(
+	agentId: string,
+): SubagentSession | undefined {
+	return sessionStore.get(agentId);
+}
+
+export function initSubagentSession(
+	agentId: string,
+	subagentName: string,
+	initialMessages: Message[],
+): void {
+	sessionStore.set(agentId, {
+		agentId,
+		subagentName,
+		messages: [...initialMessages],
+		streamingText: '',
+		streamingReasoning: '',
+	});
+}
+
+export function updateSubagentSessionMessages(
+	agentId: string,
+	messages: Message[],
+): void {
+	const session = sessionStore.get(agentId);
+	if (session) {
+		// Create a shallow copy so React detects the update if needed
+		session.messages = [...messages];
+	}
+}
+
+export function updateSubagentSessionStreaming(
+	agentId: string,
+	streamingText: string,
+	streamingReasoning: string,
+): void {
+	const session = sessionStore.get(agentId);
+	if (session) {
+		session.streamingText = streamingText;
+		session.streamingReasoning = streamingReasoning;
+	}
+}
+
+export function cleanupSubagentSession(agentId: string): void {
+	sessionStore.delete(agentId);
+}

--- a/source/subagents/subagent-executor.ts
+++ b/source/subagents/subagent-executor.ts
@@ -14,6 +14,12 @@ import {
 	updateSubagentProgress,
 	updateSubagentProgressById,
 } from '@/services/subagent-events';
+import {
+	cleanupSubagentSession,
+	initSubagentSession,
+	updateSubagentSessionMessages,
+	updateSubagentSessionStreaming,
+} from '@/services/subagent-session-store';
 import {resolveToolApproval} from '@/tools/approval-policy';
 import type {ToolManager} from '@/tools/tool-manager';
 import type {
@@ -175,6 +181,9 @@ export class SubagentExecutor {
 					executionTimeMs: Date.now() - startTime,
 				};
 			} finally {
+				if (agentId) {
+					cleanupSubagentSession(agentId);
+				}
 				restoreParent();
 			}
 		} catch (error) {
@@ -374,6 +383,13 @@ export class SubagentExecutor {
 		let totalToolCalls = 0;
 		let totalTokens = 0;
 
+		let streamingText = '';
+		let streamingReasoning = '';
+
+		if (agentId) {
+			initSubagentSession(agentId, config.name, messages);
+		}
+
 		// Rough token estimate: ~4 chars per token
 		const estimateTokens = (text: string) => Math.ceil(text.length / 4);
 
@@ -420,10 +436,38 @@ export class SubagentExecutor {
 				messages,
 				tools,
 				{
-					onToken: () => {
+					onToken: token => {
 						totalTokens++;
+						if (agentId) {
+							streamingText += token;
+							updateSubagentSessionStreaming(
+								agentId,
+								streamingText,
+								streamingReasoning,
+							);
+						}
 						// Update the live token count directly on the mutable
 						// progress object so the UI polls the latest value.
+						if (agentId) {
+							const progress = progressRef;
+							if (progress) {
+								progress.tokenCount = totalTokens;
+							}
+						} else {
+							subagentProgress.tokenCount = totalTokens;
+						}
+					},
+					onReasoningToken: token => {
+						totalTokens++;
+						if (agentId) {
+							streamingReasoning += token;
+							updateSubagentSessionStreaming(
+								agentId,
+								streamingText,
+								streamingReasoning,
+							);
+						}
+						// Update the live token count directly on the mutable
 						if (agentId) {
 							const progress = progressRef;
 							if (progress) {
@@ -459,6 +503,16 @@ export class SubagentExecutor {
 				content: responseContent,
 				tool_calls: toolCalls,
 			});
+			if (agentId) {
+				streamingText = '';
+				streamingReasoning = '';
+				updateSubagentSessionStreaming(
+					agentId,
+					streamingText,
+					streamingReasoning,
+				);
+				updateSubagentSessionMessages(agentId, messages);
+			}
 
 			// Execute each tool call — yield between each so Ink can render
 			for (const toolCall of toolCalls) {
@@ -491,6 +545,9 @@ export class SubagentExecutor {
 					tool_call_id: toolCall.id,
 					name: toolName,
 				});
+				if (agentId) {
+					updateSubagentSessionMessages(agentId, messages);
+				}
 
 				emitProgress('running', toolName);
 				await new Promise(resolve => setTimeout(resolve, 50));


### PR DESCRIPTION
Closes #679

### Description
This PR adds the ability to attach to a running subagent session from the terminal UI for interactive debugging. This makes developing and debugging custom subagents significantly easier while preserving the existing orchestration workflow.

### What changed
- **Subagent Session Store:** Added a lightweight `SubagentSessionStore` to decouple raw LLM token/reasoning streaming from the parent orchestration state.
- **Executor Hooks:** Updated `SubagentExecutor` to pump tokens, chunks, and tool events straight into the new session store as they are generated, cleaning up when the subagent finishes.
- **Subagent View UI:** Added a conditional `SubagentView` component that renders the live subagent trajectory. It includes a breadcrumb header indicating the active subagent (`Main Session > Subagent Name`).
- **Interactive Toggles:** Added a UI hint to `agent-progress.tsx` indicating that `Ctrl+S` is available. Bound `Ctrl+S` to switch the UI context to the running subagent, and `Esc` to immediately detach and return to the parent.

### Testing
- Verified that attaching/detaching does not interfere with the parent agent's execution state or generation stream.
- The session safely cleans up when the subagent finishes, even if the user is currently attached (automatically detaching the user).
