### PR TITLE
fix: show command suggestions on type and select the highlighted one with Tab

### DIFF
--- a/.changeset/command-completion.md
+++ b/.changeset/command-completion.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Command suggestions now appear as soon as you type `/`, and Tab selects the highlighted suggestion. Previously the menu was Tab-triggered and often failed to render, especially in alternate-screen mode.

--- a/.changeset/command-completion.md
+++ b/.changeset/command-completion.md
@@ -2,4 +2,4 @@
 "@nanocollective/nanocoder": patch
 ---
 
-Command suggestions now appear as soon as you type `/`, and Tab selects the highlighted suggestion. Previously the menu was Tab-triggered and often failed to render, especially in alternate-screen mode.
+Command suggestions now appear as soon as you type `/`, and Tab selects the highlighted suggestion. Previously the menu was Tab-triggered and often failed to render, especially in alternate-screen mode. Recalling a `/command` from history with the arrow keys no longer opens the menu, so ↑/↓ keep navigating history freely — the menu returns as soon as you type.

--- a/source/components/user-input-completion.spec.tsx
+++ b/source/components/user-input-completion.spec.tsx
@@ -5,6 +5,7 @@ import stripAnsi from 'strip-ansi';
 import {themes} from '../config/themes';
 import {ThemeContext} from '../hooks/useTheme';
 import {UIStateProvider} from '../hooks/useUIState';
+import {promptHistory} from '../prompt-history';
 import UserInput from './user-input';
 
 console.log('\nuser-input-completion.spec.tsx');
@@ -37,6 +38,7 @@ const waitForFrame = async (
 };
 
 const DOWN = '\u001B[B';
+const UP = '\u001B[A';
 const TAB = '\t';
 
 // Regression: upstream #696 made the command menu Tab-triggered, and it often
@@ -68,5 +70,41 @@ test('Tab selects the highlighted suggestion when the menu is open', async t => 
 	stdin.write(TAB); // select the highlighted one
 	await waitForFrame(lastFrame, /\/zzbeta/);
 	t.regex(stripAnsi(lastFrame() ?? ''), /\/zzbeta/);
+	unmount();
+});
+
+// Regression (reviewer feedback on #701): auto-showing the menu on `/` must NOT
+// fire when the input was RECALLED from history — otherwise the open menu
+// captures the arrow keys and blocks further history navigation. A recalled
+// `/command` stays quiet until the user types into it.
+test('a command recalled from history does not auto-open the menu until typed', async t => {
+	// Seed the most-recent history entry as a partial command that matches BOTH
+	// custom commands. If the menu opened, `zzbeta` (a menu-only string, never in
+	// the `/zz` input) would appear in the frame.
+	promptHistory.addPrompt('/zz');
+
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput forceFocus={true} customCommands={['zzalpha', 'zzbeta']} />
+		</TestWrapper>,
+	);
+
+	stdin.write(UP); // recall `/zz` from history
+	await waitForFrame(lastFrame, /\/zz/);
+	await wait(300); // give any (unwanted) auto-show time to render
+	t.notRegex(
+		stripAnsi(lastFrame() ?? ''),
+		/zzbeta/,
+		'menu stays closed for a history-recalled command',
+	);
+
+	stdin.write('a'); // typing re-enables the menu -> `/zza` matches zzalpha
+	await waitForFrame(lastFrame, /zzalpha/);
+	t.regex(
+		stripAnsi(lastFrame() ?? ''),
+		/zzalpha/,
+		'typing into the recalled command surfaces suggestions again',
+	);
+
 	unmount();
 });

--- a/source/components/user-input-completion.spec.tsx
+++ b/source/components/user-input-completion.spec.tsx
@@ -1,0 +1,72 @@
+import test from 'ava';
+import {render} from 'ink-testing-library';
+import React from 'react';
+import stripAnsi from 'strip-ansi';
+import {themes} from '../config/themes';
+import {ThemeContext} from '../hooks/useTheme';
+import {UIStateProvider} from '../hooks/useUIState';
+import UserInput from './user-input';
+
+console.log('\nuser-input-completion.spec.tsx');
+
+const TestWrapper = ({children}: {children: React.ReactNode}) => (
+	<ThemeContext.Provider
+		value={{
+			currentTheme: 'tokyo-night' as const,
+			colors: themes['tokyo-night'].colors,
+			setCurrentTheme: () => {},
+		}}
+	>
+		<UIStateProvider>{children}</UIStateProvider>
+	</ThemeContext.Provider>
+);
+
+const wait = (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));
+
+const waitForFrame = async (
+	lastFrame: () => string | undefined,
+	pattern: RegExp,
+	timeoutMs = 3000,
+) => {
+	const startedAt = Date.now();
+	while (Date.now() - startedAt < timeoutMs) {
+		if (pattern.test(lastFrame() ?? '')) return;
+		await wait(25);
+	}
+	throw new Error(`Timed out waiting for ${pattern}`);
+};
+
+const DOWN = '\u001B[B';
+const TAB = '\t';
+
+// Regression: upstream #696 made the command menu Tab-triggered, and it often
+// failed to render at all (esp. in alt-screen). These cover show-on-`/` and
+// Tab-to-select-the-highlighted.
+
+test('typing / auto-shows the command suggestion menu', async t => {
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput forceFocus={true} customCommands={['zzalpha', 'zzbeta']} />
+		</TestWrapper>,
+	);
+	stdin.write('/zz');
+	await waitForFrame(lastFrame, /zzalpha/);
+	t.regex(stripAnsi(lastFrame() ?? ''), /zzalpha/);
+	unmount();
+});
+
+test('Tab selects the highlighted suggestion when the menu is open', async t => {
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput forceFocus={true} customCommands={['zzalpha', 'zzbeta']} />
+		</TestWrapper>,
+	);
+	stdin.write('/zz');
+	await waitForFrame(lastFrame, /zzbeta/);
+	stdin.write(DOWN); // highlight the second suggestion (zzbeta)
+	await wait();
+	stdin.write(TAB); // select the highlighted one
+	await waitForFrame(lastFrame, /\/zzbeta/);
+	t.regex(stripAnsi(lastFrame() ?? ''), /\/zzbeta/);
+	unmount();
+});

--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -759,7 +759,6 @@ test('arrow key navigation updates the selected completion', async t => {
 
 	stdin.write('/');
 	await wait();
-	stdin.write('\t');
 	await wait();
 
 	const beforeNav = lastFrame()!;
@@ -785,7 +784,6 @@ test('Enter selects the highlighted completion and populates the input', async t
 
 	stdin.write('/');
 	await wait();
-	stdin.write('\t');
 	await wait();
 
 	t.regex(lastFrame()!, /Available commands:/);
@@ -809,7 +807,6 @@ test('typing a space after a command hides completions so args submit', async t 
 
 	stdin.write('/test');
 	await wait();
-	stdin.write('\t');
 	await wait();
 
 	// While still typing the command name, completions are visible
@@ -836,7 +833,6 @@ test('completion menu dismissal/reset after selection or escape', async t => {
 
 	stdin.write('/');
 	await wait();
-	stdin.write('\t');
 	await wait();
 
 	t.regex(lastFrame()!, /Available commands:/);
@@ -854,7 +850,6 @@ test('completion menu dismissal/reset after selection or escape', async t => {
 
 	stdin.write('/');
 	await wait();
-	stdin.write('\t');
 	await wait();
 
 	t.regex(lastFrame()!, /Available commands:/);
@@ -880,7 +875,6 @@ test('UserInput renders completions text when typing /', async t => {
 	await new Promise(resolve => setTimeout(resolve, 50));
 	stdin.write('/');
 	await new Promise(resolve => setTimeout(resolve, 150));
-	stdin.write('\t');
 	await wait();
 
 	const output = lastFrame()!;
@@ -902,7 +896,6 @@ test('UserInput windows long slash completion lists', async t => {
 
 	stdin.write('/zz');
 	await wait();
-	stdin.write('\t');
 	await wait();
 
 	const firstFrame = lastFrame()!;
@@ -939,7 +932,6 @@ test('UserInput renders completions BEFORE the mode indicator (inside the input 
 	await new Promise(resolve => setTimeout(resolve, 50));
 	stdin.write('/');
 	await new Promise(resolve => setTimeout(resolve, 150));
-	stdin.write('\t');
 	await wait();
 
 	const output = lastFrame()!;
@@ -966,7 +958,6 @@ test('UserInput completions appear on a line above the mode indicator', async t 
 	await new Promise(resolve => setTimeout(resolve, 50));
 	stdin.write('/');
 	await new Promise(resolve => setTimeout(resolve, 150));
-	stdin.write('\t');
 	await wait();
 
 	const output = lastFrame()!;

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -110,6 +110,11 @@ export default function UserInput({
 	// Input value for which the user dismissed the completion menu with Escape,
 	// so the auto-show effect doesn't immediately re-open it until they type more.
 	const dismissedForInputRef = useRef<string | null>(null);
+	// True while the current input came from history navigation (↑/↓), not typing.
+	// A recalled `/command` must NOT auto-open the suggestion menu — otherwise the
+	// menu captures ↑/↓ and history navigation is blocked. Cleared on any keystroke
+	// so editing the recalled command surfaces suggestions again.
+	const inputFromHistoryRef = useRef(false);
 	// Store the full InputState draft when starting history navigation, so it can be restored
 	const savedDraftRef = useRef<InputState>({
 		displayValue: '',
@@ -315,8 +320,12 @@ export default function UserInput({
 		if (commandCompletions.length > 0) {
 			setCompletions(commandCompletions);
 			// Show the menu as soon as completions exist (typing `/`), not only on
-			// Tab — unless the user dismissed it with Escape for this exact input.
-			if (dismissedForInputRef.current !== input) {
+			// Tab — unless the user dismissed it with Escape for this exact input,
+			// or the input was recalled from history (keep ↑/↓ free to navigate).
+			if (
+				!inputFromHistoryRef.current &&
+				dismissedForInputRef.current !== input
+			) {
 				setShowCompletions(true);
 			}
 			setSelectedCompletionIndex(prev =>
@@ -514,6 +523,10 @@ export default function UserInput({
 			const history = promptHistory.getHistory();
 			if (history.length === 0) return;
 
+			// This value is being recalled, not typed — suppress the auto-show so a
+			// recalled `/command` doesn't hijack ↑/↓ from further history navigation.
+			inputFromHistoryRef.current = true;
+
 			if (direction === 'up') {
 				if (historyIndex === -1) {
 					// Save the full current state before starting navigation
@@ -575,6 +588,16 @@ export default function UserInput({
 			setOriginalInput,
 			setInputState,
 		],
+	);
+
+	// Any keystroke means the user is composing, not navigating — re-enable the
+	// auto-show so editing a recalled command surfaces suggestions again.
+	const handleInputChange = useCallback(
+		(value: string) => {
+			inputFromHistoryRef.current = false;
+			updateInput(value);
+		},
+		[updateInput],
 	);
 
 	const handleQueueNavigation = useCallback(
@@ -973,7 +996,7 @@ export default function UserInput({
 					<TextInput
 						key={textInputKey}
 						value={input}
-						onChange={updateInput}
+						onChange={handleInputChange}
 						onEdgeArrow={handleHistoryNavigation}
 						onSubmit={handleSubmit}
 						onEnter={handleSubmit}

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -107,9 +107,9 @@ export default function UserInput({
 	const inputWrapWidth = boxWidth - 3;
 	const [textInputKey, setTextInputKey] = useState(0);
 	const completionJustSelectedRef = useRef(false);
-	// Escape-dismissed guard: re-armed on the next input change so the auto-show
-	// effect doesn't immediately re-open a menu the user just dismissed.
-	const completionsDismissedRef = useRef(false);
+	// Input value for which the user dismissed the completion menu with Escape,
+	// so the auto-show effect doesn't immediately re-open it until they type more.
+	const dismissedForInputRef = useRef<string | null>(null);
 	// Store the full InputState draft when starting history navigation, so it can be restored
 	const savedDraftRef = useRef<InputState>({
 		displayValue: '',
@@ -306,12 +306,6 @@ export default function UserInput({
 		] as Completion[];
 	}, [input, isCommandMode, isFileAutocompleteMode, customCommands]);
 
-	// Re-arm auto-show on every input change, so an Escape-dismiss lasts only
-	// until the next keystroke.
-	useEffect(() => {
-		completionsDismissedRef.current = false;
-	}, [input]);
-
 	// Update UI state for command completions
 	useEffect(() => {
 		if (completionJustSelectedRef.current) {
@@ -321,8 +315,8 @@ export default function UserInput({
 		if (commandCompletions.length > 0) {
 			setCompletions(commandCompletions);
 			// Show the menu as soon as completions exist (typing `/`), not only on
-			// Tab — unless the user just dismissed it with Escape for this input.
-			if (!completionsDismissedRef.current) {
+			// Tab — unless the user dismissed it with Escape for this exact input.
+			if (dismissedForInputRef.current !== input) {
 				setShowCompletions(true);
 			}
 			setSelectedCompletionIndex(prev =>
@@ -338,6 +332,7 @@ export default function UserInput({
 			setSelectedCompletionIndex(-1);
 		}
 	}, [
+		input,
 		commandCompletions,
 		showCompletions,
 		setCompletions,
@@ -482,7 +477,7 @@ export default function UserInput({
 		if (showCompletions) {
 			setShowCompletions(false);
 			setSelectedCompletionIndex(-1);
-			completionsDismissedRef.current = true;
+			dismissedForInputRef.current = input;
 			return;
 		}
 		if (isFileAutocompleteMode) {
@@ -500,6 +495,7 @@ export default function UserInput({
 			setShowClearMessage(true);
 		}
 	}, [
+		input,
 		showCompletions,
 		isFileAutocompleteMode,
 		showClearMessage,

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -107,6 +107,9 @@ export default function UserInput({
 	const inputWrapWidth = boxWidth - 3;
 	const [textInputKey, setTextInputKey] = useState(0);
 	const completionJustSelectedRef = useRef(false);
+	// Escape-dismissed guard: re-armed on the next input change so the auto-show
+	// effect doesn't immediately re-open a menu the user just dismissed.
+	const completionsDismissedRef = useRef(false);
 	// Store the full InputState draft when starting history navigation, so it can be restored
 	const savedDraftRef = useRef<InputState>({
 		displayValue: '',
@@ -303,6 +306,12 @@ export default function UserInput({
 		] as Completion[];
 	}, [input, isCommandMode, isFileAutocompleteMode, customCommands]);
 
+	// Re-arm auto-show on every input change, so an Escape-dismiss lasts only
+	// until the next keystroke.
+	useEffect(() => {
+		completionsDismissedRef.current = false;
+	}, [input]);
+
 	// Update UI state for command completions
 	useEffect(() => {
 		if (completionJustSelectedRef.current) {
@@ -311,8 +320,11 @@ export default function UserInput({
 		}
 		if (commandCompletions.length > 0) {
 			setCompletions(commandCompletions);
-			// Show the menu as soon as completions exist (typing `/`), not only on Tab.
-			setShowCompletions(true);
+			// Show the menu as soon as completions exist (typing `/`), not only on
+			// Tab — unless the user just dismissed it with Escape for this input.
+			if (!completionsDismissedRef.current) {
+				setShowCompletions(true);
+			}
 			setSelectedCompletionIndex(prev =>
 				prev >= commandCompletions.length
 					? commandCompletions.length - 1
@@ -470,6 +482,7 @@ export default function UserInput({
 		if (showCompletions) {
 			setShowCompletions(false);
 			setSelectedCompletionIndex(-1);
+			completionsDismissedRef.current = true;
 			return;
 		}
 		if (isFileAutocompleteMode) {

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -311,15 +311,15 @@ export default function UserInput({
 		}
 		if (commandCompletions.length > 0) {
 			setCompletions(commandCompletions);
-			if (showCompletions) {
-				setSelectedCompletionIndex(prev =>
-					prev >= commandCompletions.length
-						? commandCompletions.length - 1
-						: prev < 0
-							? 0
-							: prev,
-				);
-			}
+			// Show the menu as soon as completions exist (typing `/`), not only on Tab.
+			setShowCompletions(true);
+			setSelectedCompletionIndex(prev =>
+				prev >= commandCompletions.length
+					? commandCompletions.length - 1
+					: prev < 0
+						? 0
+						: prev,
+			);
 		} else if (showCompletions) {
 			setCompletions([]);
 			setShowCompletions(false);
@@ -722,8 +722,23 @@ export default function UserInput({
 
 			// Command completion - use pre-calculated commandCompletions
 			if (input.startsWith('/')) {
-				// Don't auto-complete on Tab when completions list is visible - use Enter to select
+				// Tab selects the highlighted suggestion when the menu is open. #696 made
+				// completion Tab-triggered, but that often failed to render the menu
+				// (especially in alt-screen); show-on-`/` + Tab-to-select is more reliable.
 				if (showCompletions && completions.length > 0) {
+					const selected =
+						completions[
+							selectedCompletionIndex >= 0 ? selectedCompletionIndex : 0
+						];
+					const completedText = `/${selected.name}`;
+					completionJustSelectedRef.current = true;
+					setInputState({
+						displayValue: completedText,
+						placeholderContent: {},
+					});
+					setShowCompletions(false);
+					setSelectedCompletionIndex(-1);
+					setTextInputKey(prev => prev + 1);
 					return;
 				}
 				if (commandCompletions.length === 1) {


### PR DESCRIPTION
## Description

The slash-command suggestion menu often didn't appear. After typing `/` you'd frequently see nothing, and in alternate-screen (fullscreen) mode the menu regularly failed to render at all — so there was no reliable way to discover or complete commands. The completion added in #696 is Tab-triggered, and in practice that path doesn't surface the menu dependably.

These changes will make command completion behave predictably:

- The suggestion menu appears **as soon as you type `/`** (and as you keep typing the command prefix), instead of only after pressing Tab.
- When the menu is open, **Tab selects the currently highlighted suggestion** (completing the input to that command and closing the menu). Arrow keys still move the highlight and Enter still selects, so all three work together.

This changes the interaction introduced in #696 — intentionally: showing on `/` plus Tab-to-select is more reliable than the Tab-to-open flow, which frequently left the menu unrendered (most visibly in alternate-screen mode).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

A spec covers "typing `/` shows suggestions" and "Tab selects the highlighted suggestion". A full `pnpm test:all` run is pending before merge.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Verified in a live session: typing `/` shows the menu with descriptions; ↑/↓ move the highlight; Tab completes to the highlighted command; Enter still selects. This is an input-layer change, so it is provider-agnostic.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
