### PR TITLE
feat: add session working directory shared by bash and file tools

### DIFF
--- a/.changeset/session-cwd.md
+++ b/.changeset/session-cwd.md
@@ -2,4 +2,4 @@
 "@nanocollective/nanocoder": minor
 ---
 
-File tools now resolve relative paths against the shell's current working directory, and `cd` in bash persists across commands — so relative reads and edits work after moving into a subdirectory or worktree.
+File tools now resolve relative paths against the shell's current working directory, and `cd` in bash persists across commands — so relative reads and edits work after moving into a subdirectory or worktree. File tools also accept absolute paths that point inside the project, and can still reach the project root or a sibling worktree after `cd`-ing into a subdirectory.

--- a/.changeset/session-cwd.md
+++ b/.changeset/session-cwd.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+File tools now resolve relative paths against the shell's current working directory, and `cd` in bash persists across commands — so relative reads and edits work after moving into a subdirectory or worktree.

--- a/source/services/bash-executor-cwd.spec.ts
+++ b/source/services/bash-executor-cwd.spec.ts
@@ -1,0 +1,49 @@
+import {mkdirSync, mkdtempSync, realpathSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {platform} from 'node:process';
+import test from 'ava';
+import {bashExecutor} from './bash-executor.js';
+import {getSessionCwd, resetSessionCwd, setSessionCwd} from './session-cwd.js';
+
+console.log('\nservices/bash-executor-cwd.spec.ts');
+
+const run = (cmd: string) => bashExecutor.execute(cmd).promise;
+
+test.serial('cd persists to the session cwd and the next command runs there', async t => {
+	if (platform === 'win32') {
+		t.pass('cd-persistence is unix-only for now');
+		return;
+	}
+	// realpath: `pwd -P` reports the symlink-resolved path (e.g. /private on macOS).
+	const base = realpathSync(mkdtempSync(join(tmpdir(), 'nc-bash-')));
+	const sub = join(base, 'nested');
+	mkdirSync(sub);
+	try {
+		setSessionCwd(base);
+		await run('cd nested');
+		t.is(getSessionCwd(), sub, 'cd updated the shared session cwd');
+		const r = await run('pwd');
+		t.is(r.fullOutput.trim(), sub, 'the following command spawned in the new dir');
+	} finally {
+		resetSessionCwd();
+		rmSync(base, {recursive: true, force: true});
+	}
+});
+
+test.serial('a failed cd leaves the session cwd untouched', async t => {
+	if (platform === 'win32') {
+		t.pass('cd-persistence is unix-only for now');
+		return;
+	}
+	const base = realpathSync(mkdtempSync(join(tmpdir(), 'nc-bash-')));
+	try {
+		setSessionCwd(base);
+		const r = await run('cd /definitely/not/a/real/dir');
+		t.not(r.exitCode, 0, 'the cd itself failed');
+		t.is(getSessionCwd(), base, 'a failed cd must not move the session cwd');
+	} finally {
+		resetSessionCwd();
+		rmSync(base, {recursive: true, force: true});
+	}
+});

--- a/source/services/bash-executor.ts
+++ b/source/services/bash-executor.ts
@@ -72,7 +72,9 @@ export class BashExecutor extends EventEmitter {
 		const spawnCommand =
 			cwdCaptureFile === undefined
 				? command
-				: `${command}\n__nc_ec=$?\ncommand pwd -P > '${cwdCaptureFile}' 2>/dev/null\nexit $__nc_ec`;
+				: // Blank line before the epilogue: a command ending in a trailing
+					// backslash would otherwise line-continue into `__nc_ec=$?`.
+					`${command}\n\n__nc_ec=$?\ncommand pwd -P > '${cwdCaptureFile}' 2>/dev/null\nexit $__nc_ec`;
 
 		const proc = isWindows
 			? spawn('cmd', ['/c', command], {cwd})
@@ -88,6 +90,8 @@ export class BashExecutor extends EventEmitter {
 			try {
 				if (existsSync(cwdCaptureFile)) {
 					const captured = readFileSync(cwdCaptureFile, 'utf8').trim();
+					// Concurrent bash runs race here; last close wins, which is fine
+					// since the session cwd is a single shared value either way.
 					if (captured) setSessionCwd(captured);
 				}
 			} catch {

--- a/source/services/bash-executor.ts
+++ b/source/services/bash-executor.ts
@@ -1,6 +1,9 @@
 import {type ChildProcess, spawn} from 'node:child_process';
 import {randomUUID} from 'node:crypto';
 import {EventEmitter} from 'node:events';
+import {existsSync, readFileSync, unlinkSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {platform} from 'node:process';
 
 import {
@@ -9,6 +12,7 @@ import {
 	INTERVAL_BASH_PROGRESS_MS,
 	TIMEOUT_BASH_DEFAULT_MS,
 } from '@/constants';
+import {getSafeSessionCwd, setSessionCwd} from './session-cwd.js';
 
 const isWindows = platform === 'win32';
 
@@ -31,6 +35,7 @@ interface ExecutionEntry {
 	timeoutId?: NodeJS.Timeout;
 	signal?: AbortSignal;
 	abortListener?: () => void;
+	cwdCaptureFile?: string;
 }
 
 export class BashExecutor extends EventEmitter {
@@ -56,13 +61,45 @@ export class BashExecutor extends EventEmitter {
 			error: null,
 		};
 
+		// Share the session cwd so bash and the file tools agree on relative paths.
+		const cwd = getSafeSessionCwd();
+
+		// Capture the shell's final dir to a temp file (not stdout, keeping output
+		// clean) so `cd` persists to later commands and the file tools. Unix only.
+		const cwdCaptureFile = isWindows
+			? undefined
+			: join(tmpdir(), `nanocoder-cwd-${executionId}`);
+		const spawnCommand =
+			cwdCaptureFile === undefined
+				? command
+				: `${command}\n__nc_ec=$?\ncommand pwd -P > '${cwdCaptureFile}' 2>/dev/null\nexit $__nc_ec`;
+
 		const proc = isWindows
-			? spawn('cmd', ['/c', command])
+			? spawn('cmd', ['/c', command], {cwd})
 			: // `detached` makes the child a process-group leader so cancel() can
 				// signal the whole tree (e.g. `pnpm test` -> node -> test runner),
 				// not just the `sh` wrapper. Without it a cancelled command's
 				// children keep running in the background.
-				spawn('sh', ['-c', command], {detached: true});
+				spawn('sh', ['-c', spawnCommand], {cwd, detached: true});
+
+		// Best-effort: a missed capture just leaves the cwd where it was.
+		const applyCapturedCwd = () => {
+			if (!cwdCaptureFile) return;
+			try {
+				if (existsSync(cwdCaptureFile)) {
+					const captured = readFileSync(cwdCaptureFile, 'utf8').trim();
+					if (captured) setSessionCwd(captured);
+				}
+			} catch {
+				// Non-fatal: leave the session cwd where it was.
+			} finally {
+				try {
+					if (existsSync(cwdCaptureFile)) unlinkSync(cwdCaptureFile);
+				} catch {
+					// best-effort cleanup
+				}
+			}
+		};
 
 		let outputBytes = 0;
 		let outputTruncated = false;
@@ -119,6 +156,7 @@ export class BashExecutor extends EventEmitter {
 				intervalId,
 				resolve,
 				signal: options?.signal,
+				cwdCaptureFile,
 			};
 
 			const ms = options?.timeoutMs ?? TIMEOUT_BASH_DEFAULT_MS;
@@ -153,6 +191,8 @@ export class BashExecutor extends EventEmitter {
 				// Only process if not already handled by cancel()
 				if (!this.executions.has(executionId)) return;
 
+				// Persist `cd` only on a real completion, not a cancel/timeout.
+				applyCapturedCwd();
 				clearInterval(intervalId);
 				state.isComplete = true;
 				state.exitCode = code;
@@ -170,6 +210,7 @@ export class BashExecutor extends EventEmitter {
 				// Only process if not already handled by cancel()
 				if (!this.executions.has(executionId)) return;
 
+				applyCapturedCwd();
 				clearInterval(intervalId);
 				state.isComplete = true;
 				state.error = error.message;
@@ -201,6 +242,16 @@ export class BashExecutor extends EventEmitter {
 		execution.process.stdin?.destroy();
 
 		this.killProcessTree(execution.process);
+		// Drop the cwd temp file; a killed command must not move the session cwd.
+		if (execution.cwdCaptureFile) {
+			try {
+				if (existsSync(execution.cwdCaptureFile)) {
+					unlinkSync(execution.cwdCaptureFile);
+				}
+			} catch {
+				// best-effort cleanup
+			}
+		}
 		execution.state.isComplete = true;
 		execution.state.error = reason;
 		this.emit('complete', {...execution.state});

--- a/source/services/session-cwd.spec.ts
+++ b/source/services/session-cwd.spec.ts
@@ -1,0 +1,40 @@
+import {mkdtempSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join, resolve} from 'node:path';
+import test from 'ava';
+import {
+	getSafeSessionCwd,
+	getSessionCwd,
+	resetSessionCwd,
+	setSessionCwd,
+} from './session-cwd.js';
+
+console.log('\nservices/session-cwd.spec.ts');
+
+test.serial('defaults to the process launch directory', t => {
+	resetSessionCwd();
+	t.is(getSessionCwd(), process.cwd());
+});
+
+test.serial('setSessionCwd stores an absolute path; blank input is ignored', t => {
+	resetSessionCwd();
+	const dir = mkdtempSync(join(tmpdir(), 'nc-cwd-'));
+	try {
+		setSessionCwd(dir);
+		t.is(getSessionCwd(), resolve(dir));
+		setSessionCwd('   ');
+		t.is(getSessionCwd(), resolve(dir), 'blank input must not clobber the cwd');
+	} finally {
+		resetSessionCwd();
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test.serial('getSafeSessionCwd recovers when the stored dir was removed', t => {
+	resetSessionCwd();
+	const dir = mkdtempSync(join(tmpdir(), 'nc-cwd-'));
+	setSessionCwd(dir);
+	rmSync(dir, {recursive: true, force: true}); // e.g. a torn-down worktree
+	t.is(getSafeSessionCwd(), process.cwd());
+	t.is(getSessionCwd(), process.cwd(), 'recovery also updates the stored value');
+});

--- a/source/services/session-cwd.spec.ts
+++ b/source/services/session-cwd.spec.ts
@@ -1,11 +1,13 @@
-import {mkdtempSync, rmSync} from 'node:fs';
+import {mkdirSync, mkdtempSync, rmSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join, resolve} from 'node:path';
 import test from 'ava';
 import {
+	getContainedSessionCwd,
 	getSafeSessionCwd,
 	getSessionCwd,
 	resetSessionCwd,
+	setProjectRoot,
 	setSessionCwd,
 } from './session-cwd.js';
 
@@ -29,6 +31,32 @@ test.serial('setSessionCwd stores an absolute path; blank input is ignored', t =
 		rmSync(dir, {recursive: true, force: true});
 	}
 });
+
+test.serial(
+	'getContainedSessionCwd clamps a session cwd outside the project to the root',
+	t => {
+		resetSessionCwd();
+		const root = mkdtempSync(join(tmpdir(), 'nc-root-'));
+		const inside = join(root, 'sub');
+		mkdirSync(inside);
+		const outside = mkdtempSync(join(tmpdir(), 'nc-out-'));
+		try {
+			setProjectRoot(root);
+			setSessionCwd(inside);
+			t.is(getContainedSessionCwd(), resolve(inside), 'a cwd inside is kept');
+			setSessionCwd(outside);
+			t.is(
+				getContainedSessionCwd(),
+				resolve(root),
+				'a cwd outside falls back to the project root',
+			);
+		} finally {
+			resetSessionCwd();
+			rmSync(root, {recursive: true, force: true});
+			rmSync(outside, {recursive: true, force: true});
+		}
+	},
+);
 
 test.serial('getSafeSessionCwd recovers when the stored dir was removed', t => {
 	resetSessionCwd();

--- a/source/services/session-cwd.ts
+++ b/source/services/session-cwd.ts
@@ -1,0 +1,41 @@
+import {existsSync, statSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+// Shared "where am I" for bash and every file tool. Without it, a `cd` in one
+// bash subshell never reaches the next command or the file tools — so a
+// relative read after `cd` into a worktree resolved against the launch dir.
+//
+// null means "not pinned yet": fall through to the live process.cwd() so tools
+// behave exactly as before until a bash `cd` actually moves the shell.
+let sessionCwd: string | null = null;
+
+export function getSessionCwd(): string {
+	return sessionCwd ?? process.cwd();
+}
+
+export function setSessionCwd(dir: string): void {
+	const trimmed = dir.trim();
+	if (!trimmed) return;
+	// Absolute so downstream `resolve(base, rel)` is stable.
+	sessionCwd = resolve(trimmed);
+}
+
+// Guards against a `cd`-ed-into dir being deleted mid-session (torn-down
+// worktree): unpin so bash/file tools fall back to the live process.cwd().
+export function getSafeSessionCwd(): string {
+	const current = sessionCwd ?? process.cwd();
+	try {
+		if (existsSync(current) && statSync(current).isDirectory()) {
+			return current;
+		}
+	} catch {
+		// fall through to unpin
+	}
+	sessionCwd = null;
+	return process.cwd();
+}
+
+// Test helper.
+export function resetSessionCwd(): void {
+	sessionCwd = null;
+}

--- a/source/services/session-cwd.ts
+++ b/source/services/session-cwd.ts
@@ -13,6 +13,25 @@ export function getSessionCwd(): string {
 	return sessionCwd ?? process.cwd();
 }
 
+// The containment boundary for the file tools: the project root (launch dir).
+// The session cwd moves DEEPER as `cd` descends; the boundary must NOT shrink
+// with it, or a tool can no longer reach the project root (or a sibling
+// worktree) once the shell is inside a subdir — the failure that rejected a
+// `list_directory` of the workspace root after a `cd` into a worktree. Nothing
+// process.chdir()s during a session (the daemon sets it once at entry), so the
+// live process.cwd() is the launch dir; `projectRoot` lets tests (or an explicit
+// startup call) pin it when the session cwd is not under the launch dir.
+let projectRoot: string | null = null;
+
+export function getProjectRoot(): string {
+	return projectRoot ?? resolve(process.cwd());
+}
+
+export function setProjectRoot(dir: string): void {
+	const trimmed = dir.trim();
+	if (trimmed) projectRoot = resolve(trimmed);
+}
+
 export function setSessionCwd(dir: string): void {
 	const trimmed = dir.trim();
 	if (!trimmed) return;
@@ -38,4 +57,5 @@ export function getSafeSessionCwd(): string {
 // Test helper.
 export function resetSessionCwd(): void {
 	sessionCwd = null;
+	projectRoot = null;
 }

--- a/source/services/session-cwd.ts
+++ b/source/services/session-cwd.ts
@@ -1,5 +1,5 @@
 import {existsSync, statSync} from 'node:fs';
-import {resolve} from 'node:path';
+import {resolve, sep} from 'node:path';
 
 // Shared "where am I" for bash and every file tool. Without it, a `cd` in one
 // bash subshell never reaches the next command or the file tools — so a
@@ -37,6 +37,16 @@ export function setSessionCwd(dir: string): void {
 	if (!trimmed) return;
 	// Absolute so downstream `resolve(base, rel)` is stable.
 	sessionCwd = resolve(trimmed);
+}
+
+// The session cwd clamped to the project root. A bash `cd /etc` moves the
+// session cwd outside the project; the pathless search tools use this as their
+// default root so they never glob/grep outside the project. Relative paths still
+// resolve against the true session cwd — only the default search root is clamped.
+export function getContainedSessionCwd(): string {
+	const cwd = getSafeSessionCwd();
+	const root = getProjectRoot();
+	return cwd === root || cwd.startsWith(root + sep) ? cwd : root;
 }
 
 // Guards against a `cd`-ed-into dir being deleted mid-session (torn-down

--- a/source/tools/file-ops/diff-edit.tsx
+++ b/source/tools/file-ops/diff-edit.tsx
@@ -5,7 +5,7 @@ import {Box, Text} from 'ink';
 import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {ThemeContext} from '@/hooks/useTheme';
-import {getSessionCwd} from '@/services/session-cwd';
+import {getSafeSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -170,7 +170,7 @@ function formatUpdatedFileContext(content: string): string {
 
 const executeDiffEdit = async (args: DiffEditArgs): Promise<string> => {
 	const {path, diff} = args;
-	const absPath = resolve(getSessionCwd(), path);
+	const absPath = resolve(getSafeSessionCwd(), path);
 	const blocks = parseDiffEditBlocks(diff);
 	const cached = await getCachedFileContent(absPath);
 	const fileContent = cached.content;
@@ -267,7 +267,7 @@ const diffEditFormatter = async (
 	args: DiffEditArgs,
 	result?: string,
 ): Promise<React.ReactElement> => {
-	const absPath = resolve(getSessionCwd(), args.path);
+	const absPath = resolve(getSafeSessionCwd(), args.path);
 
 	if (result === undefined && isVSCodeConnected()) {
 		try {
@@ -318,7 +318,7 @@ const diffEditValidator = async (
 		return {valid: false, error: formatError(error)};
 	}
 
-	const absPath = resolve(getSessionCwd(), args.path);
+	const absPath = resolve(getSafeSessionCwd(), args.path);
 	try {
 		await access(absPath, constants.F_OK);
 	} catch (error) {

--- a/source/tools/file-ops/diff-edit.tsx
+++ b/source/tools/file-ops/diff-edit.tsx
@@ -5,6 +5,7 @@ import {Box, Text} from 'ink';
 import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {ThemeContext} from '@/hooks/useTheme';
+import {getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -169,7 +170,7 @@ function formatUpdatedFileContext(content: string): string {
 
 const executeDiffEdit = async (args: DiffEditArgs): Promise<string> => {
 	const {path, diff} = args;
-	const absPath = resolve(path);
+	const absPath = resolve(getSessionCwd(), path);
 	const blocks = parseDiffEditBlocks(diff);
 	const cached = await getCachedFileContent(absPath);
 	const fileContent = cached.content;
@@ -266,7 +267,7 @@ const diffEditFormatter = async (
 	args: DiffEditArgs,
 	result?: string,
 ): Promise<React.ReactElement> => {
-	const absPath = resolve(args.path);
+	const absPath = resolve(getSessionCwd(), args.path);
 
 	if (result === undefined && isVSCodeConnected()) {
 		try {
@@ -317,7 +318,7 @@ const diffEditValidator = async (
 		return {valid: false, error: formatError(error)};
 	}
 
-	const absPath = resolve(args.path);
+	const absPath = resolve(getSessionCwd(), args.path);
 	try {
 		await access(absPath, constants.F_OK);
 	} catch (error) {

--- a/source/tools/file-ops/file-op.tsx
+++ b/source/tools/file-ops/file-op.tsx
@@ -2,6 +2,7 @@ import {constants, existsSync} from 'node:fs';
 import {access, copyFile, mkdir, rename, rm, stat} from 'node:fs/promises';
 import {dirname, resolve} from 'node:path';
 import {makeSimpleToolFormatter} from '@/components/simple-tool-formatter';
+import {getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {invalidateCache} from '@/utils/file-cache';
@@ -22,7 +23,7 @@ const executeFileOp = async (args: FileOpArgs): Promise<string> => {
 	const {operation} = args;
 
 	if (operation === 'mkdir') {
-		const absPath = resolve(args.path as string);
+		const absPath = resolve(getSessionCwd(), args.path as string);
 		const alreadyExists = existsSync(absPath);
 		await mkdir(absPath, {recursive: true});
 		return alreadyExists
@@ -31,7 +32,7 @@ const executeFileOp = async (args: FileOpArgs): Promise<string> => {
 	}
 
 	if (operation === 'delete') {
-		const absPath = resolve(args.path as string);
+		const absPath = resolve(getSessionCwd(), args.path as string);
 		const fileStat = await stat(absPath);
 		if (fileStat.isDirectory()) {
 			return `Error: "${args.path}" is a directory. Use execute_bash with rm -r for directory removal.`;
@@ -42,8 +43,8 @@ const executeFileOp = async (args: FileOpArgs): Promise<string> => {
 	}
 
 	// move | copy
-	const srcAbsPath = resolve(args.path as string);
-	const destAbsPath = resolve(args.destination as string);
+	const srcAbsPath = resolve(getSessionCwd(), args.path as string);
+	const destAbsPath = resolve(getSessionCwd(), args.destination as string);
 
 	if (operation === 'move') {
 		await rename(srcAbsPath, destAbsPath);
@@ -126,7 +127,7 @@ const fileOpValidator = async (
 		const pathResult = validatePath(args.path);
 		if (!pathResult.valid) return pathResult;
 
-		const absPath = resolve(args.path);
+		const absPath = resolve(getSessionCwd(), args.path);
 		try {
 			await access(absPath, constants.F_OK);
 		} catch {
@@ -147,7 +148,7 @@ const fileOpValidator = async (
 	const pairResult = validatePathPair(args.path, args.destination);
 	if (!pairResult.valid) return pairResult;
 
-	const srcAbsPath = resolve(args.path);
+	const srcAbsPath = resolve(getSessionCwd(), args.path);
 	try {
 		await access(srcAbsPath, constants.F_OK);
 	} catch {
@@ -165,7 +166,7 @@ const fileOpValidator = async (
 		};
 	}
 
-	const parentDir = dirname(resolve(args.destination));
+	const parentDir = dirname(resolve(getSessionCwd(), args.destination));
 	try {
 		await access(parentDir, constants.F_OK);
 	} catch {

--- a/source/tools/file-ops/file-op.tsx
+++ b/source/tools/file-ops/file-op.tsx
@@ -2,7 +2,7 @@ import {constants, existsSync} from 'node:fs';
 import {access, copyFile, mkdir, rename, rm, stat} from 'node:fs/promises';
 import {dirname, resolve} from 'node:path';
 import {makeSimpleToolFormatter} from '@/components/simple-tool-formatter';
-import {getSessionCwd} from '@/services/session-cwd';
+import {getSafeSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {invalidateCache} from '@/utils/file-cache';
@@ -23,7 +23,7 @@ const executeFileOp = async (args: FileOpArgs): Promise<string> => {
 	const {operation} = args;
 
 	if (operation === 'mkdir') {
-		const absPath = resolve(getSessionCwd(), args.path as string);
+		const absPath = resolve(getSafeSessionCwd(), args.path as string);
 		const alreadyExists = existsSync(absPath);
 		await mkdir(absPath, {recursive: true});
 		return alreadyExists
@@ -32,7 +32,7 @@ const executeFileOp = async (args: FileOpArgs): Promise<string> => {
 	}
 
 	if (operation === 'delete') {
-		const absPath = resolve(getSessionCwd(), args.path as string);
+		const absPath = resolve(getSafeSessionCwd(), args.path as string);
 		const fileStat = await stat(absPath);
 		if (fileStat.isDirectory()) {
 			return `Error: "${args.path}" is a directory. Use execute_bash with rm -r for directory removal.`;
@@ -43,8 +43,8 @@ const executeFileOp = async (args: FileOpArgs): Promise<string> => {
 	}
 
 	// move | copy
-	const srcAbsPath = resolve(getSessionCwd(), args.path as string);
-	const destAbsPath = resolve(getSessionCwd(), args.destination as string);
+	const srcAbsPath = resolve(getSafeSessionCwd(), args.path as string);
+	const destAbsPath = resolve(getSafeSessionCwd(), args.destination as string);
 
 	if (operation === 'move') {
 		await rename(srcAbsPath, destAbsPath);
@@ -127,7 +127,7 @@ const fileOpValidator = async (
 		const pathResult = validatePath(args.path);
 		if (!pathResult.valid) return pathResult;
 
-		const absPath = resolve(getSessionCwd(), args.path);
+		const absPath = resolve(getSafeSessionCwd(), args.path);
 		try {
 			await access(absPath, constants.F_OK);
 		} catch {
@@ -148,7 +148,7 @@ const fileOpValidator = async (
 	const pairResult = validatePathPair(args.path, args.destination);
 	if (!pairResult.valid) return pairResult;
 
-	const srcAbsPath = resolve(getSessionCwd(), args.path);
+	const srcAbsPath = resolve(getSafeSessionCwd(), args.path);
 	try {
 		await access(srcAbsPath, constants.F_OK);
 	} catch {
@@ -166,7 +166,7 @@ const fileOpValidator = async (
 		};
 	}
 
-	const parentDir = dirname(resolve(getSessionCwd(), args.destination));
+	const parentDir = dirname(resolve(getSafeSessionCwd(), args.destination));
 	try {
 		await access(parentDir, constants.F_OK);
 	} catch {

--- a/source/tools/file-ops/string-replace.tsx
+++ b/source/tools/file-ops/string-replace.tsx
@@ -3,7 +3,7 @@ import {access, writeFile} from 'node:fs/promises';
 import {resolve} from 'node:path';
 import React from 'react';
 import {getColors} from '@/config/index';
-import {getSessionCwd} from '@/services/session-cwd';
+import {getSafeSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -36,7 +36,7 @@ const executeStringReplace = async (
 		);
 	}
 
-	const absPath = resolve(getSessionCwd(), path);
+	const absPath = resolve(getSafeSessionCwd(), path);
 	const cached = await getCachedFileContent(absPath);
 	const fileContent = cached.content;
 
@@ -137,7 +137,7 @@ const stringReplaceFormatter = async (
 ): Promise<React.ReactElement> => {
 	const colors = getColors();
 	const {path, old_str, new_str} = args;
-	const absPath = resolve(getSessionCwd(), path);
+	const absPath = resolve(getSafeSessionCwd(), path);
 
 	if (result === undefined && isVSCodeConnected()) {
 		try {
@@ -181,7 +181,7 @@ const stringReplaceValidator = async (
 	const pathResult = validatePath(path);
 	if (!pathResult.valid) return pathResult;
 
-	const absPath = resolve(getSessionCwd(), path);
+	const absPath = resolve(getSafeSessionCwd(), path);
 	try {
 		await access(absPath, constants.F_OK);
 	} catch (error) {

--- a/source/tools/file-ops/string-replace.tsx
+++ b/source/tools/file-ops/string-replace.tsx
@@ -3,6 +3,7 @@ import {access, writeFile} from 'node:fs/promises';
 import {resolve} from 'node:path';
 import React from 'react';
 import {getColors} from '@/config/index';
+import {getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -35,7 +36,7 @@ const executeStringReplace = async (
 		);
 	}
 
-	const absPath = resolve(path);
+	const absPath = resolve(getSessionCwd(), path);
 	const cached = await getCachedFileContent(absPath);
 	const fileContent = cached.content;
 
@@ -136,7 +137,7 @@ const stringReplaceFormatter = async (
 ): Promise<React.ReactElement> => {
 	const colors = getColors();
 	const {path, old_str, new_str} = args;
-	const absPath = resolve(path);
+	const absPath = resolve(getSessionCwd(), path);
 
 	if (result === undefined && isVSCodeConnected()) {
 		try {
@@ -180,7 +181,7 @@ const stringReplaceValidator = async (
 	const pathResult = validatePath(path);
 	if (!pathResult.valid) return pathResult;
 
-	const absPath = resolve(path);
+	const absPath = resolve(getSessionCwd(), path);
 	try {
 		await access(absPath, constants.F_OK);
 	} catch (error) {

--- a/source/tools/file-ops/write-file.tsx
+++ b/source/tools/file-ops/write-file.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {DEFAULT_TERMINAL_COLUMNS} from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
-import {getSessionCwd} from '@/services/session-cwd';
+import {getSafeSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {truncateAnsi} from '@/utils/ansi-truncate';
@@ -30,7 +30,7 @@ const executeWriteFile = async (args: {
 	path: string;
 	content: unknown; // Note: change type to unknown to accept non-string
 }): Promise<string> => {
-	const absPath = resolve(getSessionCwd(), args.path);
+	const absPath = resolve(getSafeSessionCwd(), args.path);
 	const fileExists = existsSync(absPath);
 
 	// Type guard: ensure content is string for write operation
@@ -184,7 +184,7 @@ const writeFileFormatter = async (
 	result?: string,
 ): Promise<React.ReactElement> => {
 	const path = args.path || args.file_path || '';
-	const absPath = resolve(getSessionCwd(), path);
+	const absPath = resolve(getSafeSessionCwd(), path);
 
 	// Send diff to VS Code during preview phase (before execution)
 	if (result === undefined && isVSCodeConnected()) {
@@ -233,7 +233,7 @@ const writeFileValidator = async (args: {
 	const pathResult = validatePath(args.path);
 	if (!pathResult.valid) return pathResult;
 
-	const absPath = resolve(getSessionCwd(), args.path);
+	const absPath = resolve(getSafeSessionCwd(), args.path);
 
 	// Check if parent directory exists
 	const parentDir = dirname(absPath);

--- a/source/tools/file-ops/write-file.tsx
+++ b/source/tools/file-ops/write-file.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {DEFAULT_TERMINAL_COLUMNS} from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
+import {getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {truncateAnsi} from '@/utils/ansi-truncate';
@@ -29,7 +30,7 @@ const executeWriteFile = async (args: {
 	path: string;
 	content: unknown; // Note: change type to unknown to accept non-string
 }): Promise<string> => {
-	const absPath = resolve(args.path);
+	const absPath = resolve(getSessionCwd(), args.path);
 	const fileExists = existsSync(absPath);
 
 	// Type guard: ensure content is string for write operation
@@ -183,7 +184,7 @@ const writeFileFormatter = async (
 	result?: string,
 ): Promise<React.ReactElement> => {
 	const path = args.path || args.file_path || '';
-	const absPath = resolve(path);
+	const absPath = resolve(getSessionCwd(), path);
 
 	// Send diff to VS Code during preview phase (before execution)
 	if (result === undefined && isVSCodeConnected()) {
@@ -232,7 +233,7 @@ const writeFileValidator = async (args: {
 	const pathResult = validatePath(args.path);
 	if (!pathResult.valid) return pathResult;
 
-	const absPath = resolve(args.path);
+	const absPath = resolve(getSessionCwd(), args.path);
 
 	// Check if parent directory exists
 	const parentDir = dirname(absPath);

--- a/source/tools/find-files.spec.tsx
+++ b/source/tools/find-files.spec.tsx
@@ -1,10 +1,16 @@
-import {mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
 import {render} from 'ink-testing-library';
 import React from 'react';
 import {themes} from '../config/themes';
 import {ThemeContext} from '../hooks/useTheme';
+import {
+	resetSessionCwd,
+	setProjectRoot,
+	setSessionCwd,
+} from '../services/session-cwd';
 import {findFilesTool} from './find-files';
 
 // ============================================================================
@@ -527,6 +533,33 @@ test('find_files tool does not require confirmation', t => {
 	t.true(findFilesTool.readOnly);
 	t.is(findFilesTool.approval, undefined);
 });
+
+test.serial(
+	'find_files clamps to the project root when the session cwd escaped it',
+	async t => {
+		const root = mkdtempSync(join(tmpdir(), 'nc-proj-'));
+		const outside = mkdtempSync(join(tmpdir(), 'nc-outside-'));
+		try {
+			writeFileSync(join(root, 'inproject.marker'), '');
+			writeFileSync(join(outside, 'secret.marker'), '');
+			setProjectRoot(root);
+			setSessionCwd(outside); // like a bash `cd /etc`
+			const result = await findFilesTool.tool.execute!(
+				{pattern: '*.marker', maxResults: 50},
+				{toolCallId: 'test', messages: []},
+			);
+			t.true(result.includes('inproject.marker'), 'searches the project root');
+			t.false(
+				result.includes('secret.marker'),
+				'does not escape to the session cwd',
+			);
+		} finally {
+			resetSessionCwd();
+			rmSync(root, {recursive: true, force: true});
+			rmSync(outside, {recursive: true, force: true});
+		}
+	},
+);
 
 test('find_files tool has handler function', t => {
 	t.is(typeof findFilesTool.tool.execute, 'function');

--- a/source/tools/find-files.tsx
+++ b/source/tools/find-files.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {DEFAULT_FIND_FILES_RESULTS, MAX_FIND_FILES_RESULTS} from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
-import {getSessionCwd} from '@/services/session-cwd';
+import {getContainedSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -27,7 +27,9 @@ interface FindFilesArgs {
 }
 
 const executeFindFiles = async (args: FindFilesArgs): Promise<string> => {
-	const cwd = getSessionCwd();
+	// Clamp to the project root: a bash `cd` outside the project must not turn a
+	// pathless find into a glob over the whole filesystem.
+	const cwd = getContainedSessionCwd();
 	const maxResults = Math.min(
 		args.maxResults || DEFAULT_FIND_FILES_RESULTS,
 		MAX_FIND_FILES_RESULTS,

--- a/source/tools/find-files.tsx
+++ b/source/tools/find-files.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {DEFAULT_FIND_FILES_RESULTS, MAX_FIND_FILES_RESULTS} from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
+import {getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -26,7 +27,7 @@ interface FindFilesArgs {
 }
 
 const executeFindFiles = async (args: FindFilesArgs): Promise<string> => {
-	const cwd = process.cwd();
+	const cwd = getSessionCwd();
 	const maxResults = Math.min(
 		args.maxResults || DEFAULT_FIND_FILES_RESULTS,
 		MAX_FIND_FILES_RESULTS,

--- a/source/tools/list-directory.spec.tsx
+++ b/source/tools/list-directory.spec.tsx
@@ -1,10 +1,16 @@
-import {mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
 import {render} from 'ink-testing-library';
 import React from 'react';
 import {themes} from '../config/themes';
 import {ThemeContext} from '../hooks/useTheme';
+import {
+	resetSessionCwd,
+	setProjectRoot,
+	setSessionCwd,
+} from '../services/session-cwd';
 import {listDirectoryTool} from './list-directory';
 
 // ============================================================================
@@ -601,6 +607,30 @@ test('list_directory tool does not require confirmation', t => {
 	t.true(listDirectoryTool.readOnly);
 	t.is(listDirectoryTool.approval, undefined);
 });
+
+test.serial(
+	'list_directory applies the project-root .gitignore after a cd into a subdir',
+	async t => {
+		const root = mkdtempSync(join(tmpdir(), 'nc-lsroot-'));
+		try {
+			writeFileSync(join(root, '.gitignore'), '*.log\n');
+			writeFileSync(join(root, 'keep.txt'), '');
+			writeFileSync(join(root, 'skip.log'), '');
+			mkdirSync(join(root, 'sub'));
+			setProjectRoot(root);
+			setSessionCwd(join(root, 'sub')); // shell has cd-ed into a subdir
+			const result = await listDirectoryTool.tool.execute!(
+				{path: root},
+				{toolCallId: 'test', messages: []},
+			);
+			t.true(result.includes('keep.txt'), 'lists non-ignored files');
+			t.false(result.includes('skip.log'), 'root .gitignore still applies');
+		} finally {
+			resetSessionCwd();
+			rmSync(root, {recursive: true, force: true});
+		}
+	},
+);
 
 test('list_directory tool has handler function', t => {
 	t.is(typeof listDirectoryTool.tool.execute, 'function');

--- a/source/tools/list-directory.tsx
+++ b/source/tools/list-directory.tsx
@@ -1,10 +1,10 @@
 import {lstat, readdir} from 'node:fs/promises';
-import {join} from 'node:path';
+import {join, relative} from 'node:path';
 import {Box, Text} from 'ink';
 import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {ThemeContext} from '@/hooks/useTheme';
-import {getProjectRoot, getSessionCwd} from '@/services/session-cwd';
+import {getProjectRoot, getSafeSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -37,7 +37,7 @@ const executeListDirectory = async (
 	const showHiddenFiles = args.showHiddenFiles ?? false;
 
 	// Validate path
-	const cwd = getSessionCwd();
+	const cwd = getSafeSessionCwd();
 	const root = getProjectRoot();
 	if (!isValidFilePath(dirPath, root)) {
 		throw new Error(
@@ -46,7 +46,9 @@ const executeListDirectory = async (
 	}
 
 	const resolvedPath = resolveFilePath(dirPath, cwd, root);
-	const ig = loadGitignore(cwd);
+	// Load from the project root so root-level rules still apply after a `cd`
+	// into a subdir; entries are matched root-relative below.
+	const ig = loadGitignore(root);
 
 	try {
 		const entries: DirectoryEntry[] = [];
@@ -71,9 +73,11 @@ const executeListDirectory = async (
 						continue;
 					}
 
-					// Check if this item should be ignored using gitignore patterns
-					const itemPath = relativeTo ? join(relativeTo, item.name) : item.name;
-					if (ig.ignores(itemPath)) {
+					const fullPath = join(currentPath, item.name);
+
+					// Check if this item should be ignored using gitignore patterns.
+					// Match root-relative so the project-root .gitignore applies.
+					if (ig.ignores(relative(root, fullPath))) {
 						continue;
 					}
 
@@ -84,7 +88,6 @@ const executeListDirectory = async (
 						type = 'directory';
 					}
 
-					const fullPath = join(currentPath, item.name);
 					const relativePath = join(relativeTo, item.name);
 
 					// Only get stats for files (to get size)

--- a/source/tools/list-directory.tsx
+++ b/source/tools/list-directory.tsx
@@ -4,7 +4,7 @@ import {Box, Text} from 'ink';
 import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {ThemeContext} from '@/hooks/useTheme';
-import {getSessionCwd} from '@/services/session-cwd';
+import {getProjectRoot, getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -37,14 +37,15 @@ const executeListDirectory = async (
 	const showHiddenFiles = args.showHiddenFiles ?? false;
 
 	// Validate path
-	if (!isValidFilePath(dirPath)) {
+	const cwd = getSessionCwd();
+	const root = getProjectRoot();
+	if (!isValidFilePath(dirPath, root)) {
 		throw new Error(
-			`⚒ Invalid path. Path must be relative and within the project directory.`,
+			`⚒ Invalid path. Path must be within the project directory.`,
 		);
 	}
 
-	const cwd = getSessionCwd();
-	const resolvedPath = resolveFilePath(dirPath, cwd);
+	const resolvedPath = resolveFilePath(dirPath, cwd, root);
 	const ig = loadGitignore(cwd);
 
 	try {

--- a/source/tools/list-directory.tsx
+++ b/source/tools/list-directory.tsx
@@ -4,6 +4,7 @@ import {Box, Text} from 'ink';
 import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {ThemeContext} from '@/hooks/useTheme';
+import {getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -42,7 +43,7 @@ const executeListDirectory = async (
 		);
 	}
 
-	const cwd = process.cwd();
+	const cwd = getSessionCwd();
 	const resolvedPath = resolveFilePath(dirPath, cwd);
 	const ig = loadGitignore(cwd);
 

--- a/source/tools/read-file.tsx
+++ b/source/tools/read-file.tsx
@@ -12,6 +12,7 @@ import {
 	MAX_LINE_LENGTH_CHARS,
 } from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
+import {getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -27,7 +28,7 @@ const executeReadFile = async (args: {
 	end_line?: number;
 	metadata_only?: boolean;
 }): Promise<string> => {
-	const absPath = resolve(args.path);
+	const absPath = resolve(getSessionCwd(), args.path);
 
 	try {
 		// Handle explicit metadata_only request
@@ -340,7 +341,7 @@ const readFileFormatter = async (
 	try {
 		const path = args.path || args.file_path;
 		if (path && typeof path === 'string') {
-			const absPath = resolve(path);
+			const absPath = resolve(getSessionCwd(), path);
 			const cached = await getCachedFileContent(absPath);
 			const content = cached.content;
 			const lines = cached.lines;
@@ -400,7 +401,7 @@ const readFileValidator = async (args: {
 
 	// Verify the resolved path stays within project boundaries
 	try {
-		const cwd = process.cwd();
+		const cwd = getSessionCwd();
 		resolveFilePath(args.path, cwd);
 	} catch (error) {
 		const errorMessage = formatError(error);
@@ -410,7 +411,7 @@ const readFileValidator = async (args: {
 		};
 	}
 
-	const absPath = resolve(args.path);
+	const absPath = resolve(getSessionCwd(), args.path);
 
 	try {
 		await access(absPath, constants.F_OK);

--- a/source/tools/read-file.tsx
+++ b/source/tools/read-file.tsx
@@ -12,7 +12,7 @@ import {
 	MAX_LINE_LENGTH_CHARS,
 } from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
-import {getSessionCwd} from '@/services/session-cwd';
+import {getProjectRoot, getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -392,17 +392,18 @@ const readFileValidator = async (args: {
 	metadata_only?: boolean;
 }): Promise<{valid: true} | {valid: false; error: string}> => {
 	// Validate path boundary first to prevent directory traversal
-	if (!isValidFilePath(args.path)) {
+	const cwd = getSessionCwd();
+	const root = getProjectRoot();
+	if (!isValidFilePath(args.path, root)) {
 		return {
 			valid: false,
-			error: `Invalid file path: "${args.path}". Path must be relative and within the project directory.`,
+			error: `Invalid file path: "${args.path}". Path must be within the project directory.`,
 		};
 	}
 
 	// Verify the resolved path stays within project boundaries
 	try {
-		const cwd = getSessionCwd();
-		resolveFilePath(args.path, cwd);
+		resolveFilePath(args.path, cwd, root);
 	} catch (error) {
 		const errorMessage = formatError(error);
 		return {

--- a/source/tools/read-file.tsx
+++ b/source/tools/read-file.tsx
@@ -12,7 +12,7 @@ import {
 	MAX_LINE_LENGTH_CHARS,
 } from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
-import {getProjectRoot, getSessionCwd} from '@/services/session-cwd';
+import {getProjectRoot, getSafeSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -28,7 +28,7 @@ const executeReadFile = async (args: {
 	end_line?: number;
 	metadata_only?: boolean;
 }): Promise<string> => {
-	const absPath = resolve(getSessionCwd(), args.path);
+	const absPath = resolve(getSafeSessionCwd(), args.path);
 
 	try {
 		// Handle explicit metadata_only request
@@ -341,7 +341,7 @@ const readFileFormatter = async (
 	try {
 		const path = args.path || args.file_path;
 		if (path && typeof path === 'string') {
-			const absPath = resolve(getSessionCwd(), path);
+			const absPath = resolve(getSafeSessionCwd(), path);
 			const cached = await getCachedFileContent(absPath);
 			const content = cached.content;
 			const lines = cached.lines;
@@ -392,7 +392,7 @@ const readFileValidator = async (args: {
 	metadata_only?: boolean;
 }): Promise<{valid: true} | {valid: false; error: string}> => {
 	// Validate path boundary first to prevent directory traversal
-	const cwd = getSessionCwd();
+	const cwd = getSafeSessionCwd();
 	const root = getProjectRoot();
 	if (!isValidFilePath(args.path, root)) {
 		return {
@@ -412,7 +412,7 @@ const readFileValidator = async (args: {
 		};
 	}
 
-	const absPath = resolve(getSessionCwd(), args.path);
+	const absPath = resolve(getSafeSessionCwd(), args.path);
 
 	try {
 		await access(absPath, constants.F_OK);

--- a/source/tools/search-file-contents.spec.tsx
+++ b/source/tools/search-file-contents.spec.tsx
@@ -1,10 +1,16 @@
-import {mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
 import {render} from 'ink-testing-library';
 import React from 'react';
 import {themes} from '../config/themes';
 import {ThemeContext} from '../hooks/useTheme';
+import {
+	resetSessionCwd,
+	setProjectRoot,
+	setSessionCwd,
+} from '../services/session-cwd';
 import {searchFileContentsTool} from './search-file-contents';
 
 // ============================================================================
@@ -1834,6 +1840,33 @@ test.serial(
 // ============================================================================
 // Tests for Formatter with New Parameters
 // ============================================================================
+
+test.serial(
+	'search_file_contents clamps to the project root when the session cwd escaped it',
+	async t => {
+		const root = mkdtempSync(join(tmpdir(), 'nc-proj-'));
+		const outside = mkdtempSync(join(tmpdir(), 'nc-outside-'));
+		try {
+			writeFileSync(join(root, 'inproject.txt'), 'needle_marker here');
+			writeFileSync(join(outside, 'secret.txt'), 'needle_marker here');
+			setProjectRoot(root);
+			setSessionCwd(outside); // like a bash `cd /etc`
+			const result = await searchFileContentsTool.tool.execute!(
+				{query: 'needle_marker', maxResults: 30},
+				{toolCallId: 'test', messages: []},
+			);
+			t.true(result.includes('inproject.txt'), 'searches the project root');
+			t.false(
+				result.includes('secret.txt'),
+				'does not escape to the session cwd',
+			);
+		} finally {
+			resetSessionCwd();
+			rmSync(root, {recursive: true, force: true});
+			rmSync(outside, {recursive: true, force: true});
+		}
+	},
+);
 
 test('SearchFileContentsFormatter shows wholeWord indicator', t => {
 	const formatter = searchFileContentsTool.formatter;

--- a/source/tools/search-file-contents.tsx
+++ b/source/tools/search-file-contents.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {DEFAULT_SEARCH_RESULTS, MAX_SEARCH_RESULTS} from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
+import {getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -31,7 +32,7 @@ const executeSearchFileContents = async (
 		return 'Error: Search query cannot be empty';
 	}
 
-	const cwd = process.cwd();
+	const cwd = getSessionCwd();
 	const maxResults = Math.min(
 		args.maxResults || DEFAULT_SEARCH_RESULTS,
 		MAX_SEARCH_RESULTS,

--- a/source/tools/search-file-contents.tsx
+++ b/source/tools/search-file-contents.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {DEFAULT_SEARCH_RESULTS, MAX_SEARCH_RESULTS} from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
-import {getSessionCwd} from '@/services/session-cwd';
+import {getProjectRoot, getSessionCwd} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -39,14 +39,18 @@ const executeSearchFileContents = async (
 	);
 	const caseSensitive = args.caseSensitive || false;
 
-	// Validate and resolve search path if provided
+	// Validate and resolve search path if provided. Resolve relative to the
+	// session cwd, but bound containment to the project root so an absolute
+	// in-project path (e.g. the workspace root) is not rejected once the shell
+	// has `cd`-ed into a subdir.
+	const root = getProjectRoot();
 	let searchPath: string | undefined;
 	if (args.path) {
-		if (!isValidFilePath(args.path)) {
+		if (!isValidFilePath(args.path, root)) {
 			return `Error: Invalid path "${args.path}"`;
 		}
 		searchPath = path.resolve(cwd, args.path);
-		if (!searchPath.startsWith(path.resolve(cwd))) {
+		if (searchPath !== root && !searchPath.startsWith(root + path.sep)) {
 			return `Error: Path escapes project directory: ${args.path}`;
 		}
 	}

--- a/source/tools/search-file-contents.tsx
+++ b/source/tools/search-file-contents.tsx
@@ -4,7 +4,11 @@ import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {DEFAULT_SEARCH_RESULTS, MAX_SEARCH_RESULTS} from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
-import {getProjectRoot, getSessionCwd} from '@/services/session-cwd';
+import {
+	getContainedSessionCwd,
+	getProjectRoot,
+	getSessionCwd,
+} from '@/services/session-cwd';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -55,10 +59,14 @@ const executeSearchFileContents = async (
 		}
 	}
 
+	// Default search root when no path is given: clamp to the project so a `cd`
+	// outside it (e.g. `cd /etc`) can't grep the whole filesystem.
+	const searchRoot = getContainedSessionCwd();
+
 	try {
 		const {matches, truncated} = await searchProjectContents(
 			args.query,
-			cwd,
+			searchRoot,
 			maxResults,
 			caseSensitive,
 			args.include,

--- a/source/tools/session-cwd-resolution.spec.tsx
+++ b/source/tools/session-cwd-resolution.spec.tsx
@@ -1,0 +1,41 @@
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import {resetSessionCwd, setSessionCwd} from '@/services/session-cwd';
+import {readFileTool} from './read-file';
+
+console.log('\ntools/session-cwd-resolution.spec.tsx');
+
+// Regression: before the session-cwd fix, file tools resolved relative paths
+// against process.cwd() (the launch dir), so after `cd` into a worktree a
+// relative read_file looked in the wrong place and failed.
+
+test.serial('read_file resolves a relative path against the session cwd', async t => {
+	const dir = mkdtempSync(join(tmpdir(), 'nc-read-'));
+	try {
+		writeFileSync(join(dir, 'note.txt'), 'hello from the worktree\n');
+		setSessionCwd(dir);
+		const result = await readFileTool.tool.execute!(
+			{path: 'note.txt'},
+			{toolCallId: 't', messages: []},
+		);
+		t.regex(result, /hello from the worktree/);
+	} finally {
+		resetSessionCwd();
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test.serial('read_file validator accepts a relative path under the session cwd', async t => {
+	const dir = mkdtempSync(join(tmpdir(), 'nc-read-'));
+	try {
+		writeFileSync(join(dir, 'note.txt'), 'x');
+		setSessionCwd(dir);
+		const res = await readFileTool.validator!({path: 'note.txt'});
+		t.true(res.valid);
+	} finally {
+		resetSessionCwd();
+		rmSync(dir, {recursive: true, force: true});
+	}
+});

--- a/source/tools/session-cwd-resolution.spec.tsx
+++ b/source/tools/session-cwd-resolution.spec.tsx
@@ -3,6 +3,7 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
 import {resetSessionCwd, setSessionCwd} from '@/services/session-cwd';
+import {findFilesTool} from './find-files';
 import {readFileTool} from './read-file';
 
 console.log('\ntools/session-cwd-resolution.spec.tsx');
@@ -34,6 +35,22 @@ test.serial('read_file validator accepts a relative path under the session cwd',
 		setSessionCwd(dir);
 		const res = await readFileTool.validator!({path: 'note.txt'});
 		t.true(res.valid);
+	} finally {
+		resetSessionCwd();
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test.serial('find_files resolves the glob search root against the session cwd', async t => {
+	const dir = mkdtempSync(join(tmpdir(), 'nc-find-'));
+	try {
+		writeFileSync(join(dir, 'widget.ts'), 'export const x = 1;\n');
+		setSessionCwd(dir);
+		const result = await findFilesTool.tool.execute!(
+			{pattern: '*.ts'},
+			{toolCallId: 't', messages: []},
+		);
+		t.regex(result, /widget\.ts/);
 	} finally {
 		resetSessionCwd();
 		rmSync(dir, {recursive: true, force: true});

--- a/source/tools/session-cwd-resolution.spec.tsx
+++ b/source/tools/session-cwd-resolution.spec.tsx
@@ -2,7 +2,11 @@ import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
-import {resetSessionCwd, setSessionCwd} from '@/services/session-cwd';
+import {
+	resetSessionCwd,
+	setProjectRoot,
+	setSessionCwd,
+} from '@/services/session-cwd';
 import {findFilesTool} from './find-files';
 import {readFileTool} from './read-file';
 
@@ -17,6 +21,7 @@ test.serial('read_file resolves a relative path against the session cwd', async 
 	try {
 		writeFileSync(join(dir, 'note.txt'), 'hello from the worktree\n');
 		setSessionCwd(dir);
+		setProjectRoot(dir);
 		const result = await readFileTool.tool.execute!(
 			{path: 'note.txt'},
 			{toolCallId: 't', messages: []},
@@ -33,6 +38,7 @@ test.serial('read_file validator accepts a relative path under the session cwd',
 	try {
 		writeFileSync(join(dir, 'note.txt'), 'x');
 		setSessionCwd(dir);
+		setProjectRoot(dir);
 		const res = await readFileTool.validator!({path: 'note.txt'});
 		t.true(res.valid);
 	} finally {
@@ -46,6 +52,7 @@ test.serial('find_files resolves the glob search root against the session cwd', 
 	try {
 		writeFileSync(join(dir, 'widget.ts'), 'export const x = 1;\n');
 		setSessionCwd(dir);
+		setProjectRoot(dir);
 		const result = await findFilesTool.tool.execute!(
 			{pattern: '*.ts'},
 			{toolCallId: 't', messages: []},

--- a/source/utils/path-validation.spec.ts
+++ b/source/utils/path-validation.spec.ts
@@ -268,3 +268,29 @@ test.serial('resolveFilePath: resolves real files within a real project root', t
 		rmSync(base, {recursive: true, force: true});
 	}
 });
+
+test.serial('resolveFilePath: containmentRoot lets a deep session cwd still reach the project root (sim regression)', t => {
+	const root = mkdtempSync(join(tmpdir(), 'pathval-root-'));
+	try {
+		// Model cd-ed deep into a worktree subdir; the session cwd is now here.
+		const deepCwd = join(root, '.claude', 'worktrees', 'wt', 'kserp');
+		mkdirSync(deepCwd, {recursive: true});
+		writeFileSync(join(root, 'README.md'), '');
+
+		// Before the fix, containment used the (deep) session cwd, so listing the
+		// project root — an ANCESTOR — threw "escapes project directory". With the
+		// project root as containmentRoot it resolves fine.
+		t.is(resolveFilePath(root, deepCwd, root), root);
+		t.is(
+			resolveFilePath('README.md', root, root),
+			join(root, 'README.md'),
+			'a relative path against the root resolves under it',
+		);
+
+		// Containment is still enforced against the root: a true escape throws.
+		t.throws(() => resolveFilePath('/etc/passwd', deepCwd, root));
+		t.throws(() => resolveFilePath('../outside', root, root));
+	} finally {
+		rmSync(root, {recursive: true, force: true});
+	}
+});

--- a/source/utils/path-validation.ts
+++ b/source/utils/path-validation.ts
@@ -67,10 +67,18 @@ export function isValidFilePath(
 		return false;
 	}
 
-	// Absolute paths (Unix or Windows-drive) are accepted only when a containment
-	// root is known and they resolve inside it — weak models routinely pass
-	// absolute paths. resolveFilePath still runs the authoritative symlink check.
-	if (path.isAbsolute(filePath) || /^[A-Za-z]:[/\\]/.test(filePath)) {
+	// Windows-drive paths (`C:\`, `D:\`) are absolute only on Windows. On POSIX
+	// `path.resolve` would fold them into the cwd and they'd masquerade as an
+	// in-project relative path — reject them unless this platform actually treats
+	// them as absolute (Windows, where the containment check below still applies).
+	if (/^[A-Za-z]:[/\\]/.test(filePath) && !path.isAbsolute(filePath)) {
+		return false;
+	}
+
+	// Absolute paths are accepted only when a containment root is known and they
+	// resolve inside it — weak models routinely pass absolute paths.
+	// resolveFilePath still runs the authoritative symlink check.
+	if (path.isAbsolute(filePath)) {
 		if (!containmentRoot) {
 			return false;
 		}

--- a/source/utils/path-validation.ts
+++ b/source/utils/path-validation.ts
@@ -41,7 +41,10 @@ import path from 'node:path';
  * isValidFilePath('file\0.txt')         // false - null byte injection
  * ```
  */
-export function isValidFilePath(filePath: string): boolean {
+export function isValidFilePath(
+	filePath: string,
+	containmentRoot?: string,
+): boolean {
 	// Reject empty paths
 	if (!filePath || filePath.trim().length === 0) {
 		return false;
@@ -51,16 +54,6 @@ export function isValidFilePath(filePath: string): boolean {
 	// Check for '..' as a path segment, not substring (e.g. [[...slug]] is valid)
 	const segments = filePath.split(/[/\\]/);
 	if (segments.some(seg => seg === '..')) {
-		return false;
-	}
-
-	// Reject absolute paths (outside project)
-	if (path.isAbsolute(filePath)) {
-		return false;
-	}
-
-	// Reject Windows absolute paths (C:\, D:\, etc.) even on Unix systems
-	if (/^[A-Za-z]:[/\\]/.test(filePath)) {
 		return false;
 	}
 
@@ -74,7 +67,19 @@ export function isValidFilePath(filePath: string): boolean {
 		return false;
 	}
 
-	// Reject paths that start with special characters that could be problematic
+	// Absolute paths (Unix or Windows-drive) are accepted only when a containment
+	// root is known and they resolve inside it — weak models routinely pass
+	// absolute paths. resolveFilePath still runs the authoritative symlink check.
+	if (path.isAbsolute(filePath) || /^[A-Za-z]:[/\\]/.test(filePath)) {
+		if (!containmentRoot) {
+			return false;
+		}
+		const root = path.resolve(containmentRoot);
+		const abs = path.resolve(filePath);
+		return abs === root || abs.startsWith(root + path.sep);
+	}
+
+	// A relative path must not start with a separator
 	if (filePath.startsWith('/') || filePath.startsWith('\\')) {
 		return false;
 	}
@@ -112,20 +117,28 @@ export function isValidFilePath(filePath: string): boolean {
  * // Throws: File path escapes project directory via symlink
  * ```
  */
-export function resolveFilePath(filePath: string, cwd: string): string {
-	// Validate first
-	if (!isValidFilePath(filePath)) {
+export function resolveFilePath(
+	filePath: string,
+	cwd: string,
+	containmentRoot: string = cwd,
+): string {
+	// Relative paths resolve against `cwd` (the session cwd, which follows `cd`);
+	// containment is checked against `containmentRoot` (the project root, which
+	// does NOT shrink as `cd` descends). Defaulting the root to `cwd` keeps the
+	// single-arg contract for callers that don't separate the two.
+	if (!isValidFilePath(filePath, containmentRoot)) {
 		throw new Error(`Invalid file path: ${filePath}`);
 	}
 
 	const normalizedCwd = path.resolve(cwd);
+	const normalizedRoot = path.resolve(containmentRoot);
 	const absolutePath = path.resolve(normalizedCwd, filePath);
 
 	// Lexical containment. The trailing separator stops a sibling directory
 	// with a shared prefix (e.g. `/proj-evil` for project `/proj`) from passing.
 	if (
-		absolutePath !== normalizedCwd &&
-		!absolutePath.startsWith(normalizedCwd + path.sep)
+		absolutePath !== normalizedRoot &&
+		!absolutePath.startsWith(normalizedRoot + path.sep)
 	) {
 		throw new Error(
 			`File path escapes project directory: ${filePath} -> ${absolutePath}`,
@@ -137,9 +150,9 @@ export function resolveFilePath(filePath: string, cwd: string): string {
 	// in-project symlink pointing elsewhere. Resolve real paths (both sides,
 	// since the project root itself may sit under a symlink such as
 	// /tmp -> /private/tmp on macOS) and re-check.
-	const realCwd = realResolvedPrefix(normalizedCwd);
+	const realRoot = realResolvedPrefix(normalizedRoot);
 	const realTarget = realResolvedPrefix(absolutePath);
-	if (realTarget !== realCwd && !realTarget.startsWith(realCwd + path.sep)) {
+	if (realTarget !== realRoot && !realTarget.startsWith(realRoot + path.sep)) {
 		throw new Error(
 			`File path escapes project directory via symlink: ${filePath} -> ${realTarget}`,
 		);

--- a/source/utils/path-validators.ts
+++ b/source/utils/path-validators.ts
@@ -1,4 +1,4 @@
-import {getSessionCwd} from '@/services/session-cwd';
+import {getProjectRoot, getSessionCwd} from '@/services/session-cwd';
 import {formatError} from '@/utils/error-formatter';
 import {isValidFilePath, resolveFilePath} from '@/utils/path-validation';
 
@@ -8,16 +8,17 @@ type ValidationResult = {valid: true} | {valid: false; error: string};
  * Validates a single file path: checks format and project boundary.
  */
 export function validatePath(path: string): ValidationResult {
-	if (!isValidFilePath(path)) {
+	const cwd = getSessionCwd();
+	const root = getProjectRoot();
+	if (!isValidFilePath(path, root)) {
 		return {
 			valid: false,
-			error: `⚒ Invalid file path. Path must be relative and within the project directory.`,
+			error: `⚒ Invalid file path. Path must be within the project directory.`,
 		};
 	}
 
 	try {
-		const cwd = getSessionCwd();
-		resolveFilePath(path, cwd);
+		resolveFilePath(path, cwd, root);
 	} catch (error) {
 		const errorMessage = formatError(error);
 		return {
@@ -36,24 +37,25 @@ export function validatePathPair(
 	source: string,
 	destination: string,
 ): ValidationResult {
-	if (!isValidFilePath(source)) {
+	const cwd = getSessionCwd();
+	const root = getProjectRoot();
+	if (!isValidFilePath(source, root)) {
 		return {
 			valid: false,
-			error: `⚒ Invalid source path. Path must be relative and within the project directory.`,
+			error: `⚒ Invalid source path. Path must be within the project directory.`,
 		};
 	}
 
-	if (!isValidFilePath(destination)) {
+	if (!isValidFilePath(destination, root)) {
 		return {
 			valid: false,
-			error: `⚒ Invalid destination path. Path must be relative and within the project directory.`,
+			error: `⚒ Invalid destination path. Path must be within the project directory.`,
 		};
 	}
 
 	try {
-		const cwd = getSessionCwd();
-		resolveFilePath(source, cwd);
-		resolveFilePath(destination, cwd);
+		resolveFilePath(source, cwd, root);
+		resolveFilePath(destination, cwd, root);
 	} catch (error) {
 		const errorMessage = formatError(error);
 		return {

--- a/source/utils/path-validators.ts
+++ b/source/utils/path-validators.ts
@@ -1,3 +1,4 @@
+import {getSessionCwd} from '@/services/session-cwd';
 import {formatError} from '@/utils/error-formatter';
 import {isValidFilePath, resolveFilePath} from '@/utils/path-validation';
 
@@ -15,7 +16,7 @@ export function validatePath(path: string): ValidationResult {
 	}
 
 	try {
-		const cwd = process.cwd();
+		const cwd = getSessionCwd();
 		resolveFilePath(path, cwd);
 	} catch (error) {
 		const errorMessage = formatError(error);
@@ -50,7 +51,7 @@ export function validatePathPair(
 	}
 
 	try {
-		const cwd = process.cwd();
+		const cwd = getSessionCwd();
 		resolveFilePath(source, cwd);
 		resolveFilePath(destination, cwd);
 	} catch (error) {


### PR DESCRIPTION
## Description

This branch started from a concrete symptom: the file tools kept failing. A `list_directory`, `read_file`, or `find_files` run inside a subdirectory or a git worktree would error or quietly operate on the wrong location — an `ls`-style listing or a read that should have worked simply didn't — and the model would give up on the tools and fall back to raw shell commands to get anything done.

Investigating those failures surfaced three related causes, all about *where* the tools thought they were:

- The file tools resolved and searched relative paths against the directory nanocoder was **launched** from — not the directory the shell had `cd`-ed into. After moving into a subdirectory or worktree, a relative find/list/read looked in the wrong place.
- A `cd` in one `execute_bash` command did **not** carry over to the next command, so the shell never stayed where the model moved it.
- Absolute paths were **rejected outright** by the file tools, so a model that reached for an absolute path (a common instinct) got an error instead of a result.

This adds a shared session working directory so bash and the file tools agree on "where am I":

- The file tools (`read_file`, `list_directory`, `find_files`, `write_file`, `string_replace`, `diff_edit`, `search_file_contents`) resolve, search, and validate relative paths against the session's current directory — so a relative find/list/read/edit works from wherever the shell currently is.
- `cd` in `execute_bash` updates that directory and persists across commands: after each command the shell's final directory is captured and remembered, so the next command (and the file tools) start there.
- The file tools also accept **absolute paths that point inside the project**. Previously every absolute path was rejected, so a model that reached for an absolute path had to fall back to shell commands; now those tools work directly. Paths outside the project are still refused.

Before any `cd`, behavior is unchanged: the working directory follows the process's launch directory until a `cd` actually moves it. The path sandbox still refuses `..` escapes and anything outside the project. Containment is checked against the **project root**, so a tool can still reach the project root or a sibling worktree after the shell has `cd`-ed into a subdirectory, while relative paths continue to resolve against the current directory. `cd` persistence is currently POSIX-only; Windows keeps the prior per-command behavior.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

New specs: `source/services/session-cwd.spec.ts`, `source/services/bash-executor-cwd.spec.ts`, `source/tools/session-cwd-resolution.spec.tsx`, plus added cases in `source/utils/path-validation.spec.ts` covering absolute in-project paths and reaching the project root from a deep session cwd (with escapes still rejected). The absolute-path handling keeps the existing `file-tools-path-validation` guards green — Unix paths outside the project and Windows-drive paths are still rejected. The resolution spec is regression-proven — it fails against the pre-change resolution and passes with the fix.

`tsc`, biome, and the path/session/tool suites pass. A full `pnpm test:all` run passes except for a single config-file-resolution test (`getClosestConfigFile prefers cwd config over home`) that is unrelated to this change — it imports none of the modules this PR touches and fails the same way without these changes.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Verified in the CLI: `cd` into a subdirectory, then a relative `read_file` reads the correct file and a following `pwd` reports the new directory.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
