### PR TITLE
feat: consolidate remaining settings into /settings with an in-TUI config editor

### DIFF
--- a/.changeset/settings-consolidation.md
+++ b/.changeset/settings-consolidation.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Moved the rest of nanocoder's configuration into the `/settings` menu, so you can set things up without editing `.json` files by hand. Settings are grouped into Appearance, Input, Behavior, Providers, and Advanced tabs. New menu items let you set the default mode, auto-compact, sessions, reasoning traces, tool auto-approval, and a Web Search API key; view your configured providers and MCP servers before opening the setup wizards; open the Tune Model and Connect IDE wizards; and see the active `NANOCODER_*` environment variables. Advanced also includes an in-app JSON editor for `agents.config.json`: edit strings with the cursor inside the quotes, flip booleans with the arrow keys, and save atomically (a crash can't leave a half-written file).

--- a/source/app/components/modal-selectors.tsx
+++ b/source/app/components/modal-selectors.tsx
@@ -11,6 +11,8 @@ import {SettingsSelector} from './settings-tabs';
 import {TuneSelector} from './tune-selector';
 
 export interface ModalSelectorsProps {
+	onLaunchTune?: () => void;
+	onLaunchIde?: () => void;
 	activeMode: ActiveMode;
 	isSettingsMode: boolean;
 	showAllSessions: boolean;
@@ -78,6 +80,8 @@ export function ModalSelectors({
 	onSessionSelect,
 	onSessionCancel,
 	onSettingsCancel,
+	onLaunchTune,
+	onLaunchIde,
 	tuneConfig,
 	onTuneSelect,
 	onTuneCancel,
@@ -104,7 +108,13 @@ export function ModalSelectors({
 	}
 
 	if (isSettingsMode) {
-		return <SettingsSelector onCancel={onSettingsCancel} />;
+		return (
+			<SettingsSelector
+				onCancel={onSettingsCancel}
+				onLaunchTune={onLaunchTune}
+				onLaunchIde={onLaunchIde}
+			/>
+		);
 	}
 
 	if (activeMode === 'modelDatabase') {

--- a/source/app/components/modal-selectors.tsx
+++ b/source/app/components/modal-selectors.tsx
@@ -13,6 +13,7 @@ import {TuneSelector} from './tune-selector';
 export interface ModalSelectorsProps {
 	onLaunchTune?: () => void;
 	onLaunchIde?: () => void;
+	onMcpChanged?: () => void | Promise<void>;
 	activeMode: ActiveMode;
 	isSettingsMode: boolean;
 	showAllSessions: boolean;
@@ -82,6 +83,7 @@ export function ModalSelectors({
 	onSettingsCancel,
 	onLaunchTune,
 	onLaunchIde,
+	onMcpChanged,
 	tuneConfig,
 	onTuneSelect,
 	onTuneCancel,
@@ -113,6 +115,7 @@ export function ModalSelectors({
 				onCancel={onSettingsCancel}
 				onLaunchTune={onLaunchTune}
 				onLaunchIde={onLaunchIde}
+				onMcpChanged={onMcpChanged}
 			/>
 		);
 	}

--- a/source/app/components/settings-auto-compact.tsx
+++ b/source/app/components/settings-auto-compact.tsx
@@ -1,0 +1,153 @@
+import {Box, Text, useInput} from 'ink';
+import SelectInput from 'ink-select-input';
+import {useMemo, useState} from 'react';
+import TextInput from '@/components/text-input';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {updateConfigNestedValue} from '@/config/config-writer';
+import {getAppConfig} from '@/config/index';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+import type {AutoCompactConfig, CompressionMode} from '@/types/config';
+
+const MODE_OPTIONS: CompressionMode[] = [
+	'default',
+	'conservative',
+	'aggressive',
+];
+
+const DEFAULT_CONFIG: AutoCompactConfig = {
+	enabled: true,
+	threshold: 60,
+	mode: 'conservative',
+	strategy: 'mechanical',
+	notifyUser: true,
+};
+
+/**
+ * Auto-compact settings (agents.config.json nanocoder.autoCompact). Each change
+ * persists atomically and directly — no keep/discard prompt.
+ */
+export function SettingsAutoCompactPanel({
+	onBack,
+	onCancel,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+
+	const [config, setConfig] = useState<AutoCompactConfig>(
+		getAppConfig().autoCompact ?? DEFAULT_CONFIG,
+	);
+	const [editing, setEditing] = useState(false);
+	const [editValue, setEditValue] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	useInput((_, key) => {
+		if (key.escape) {
+			if (editing) {
+				setEditing(false);
+				setError(null);
+			} else {
+				onCancel();
+			}
+		}
+		if (key.shift && key.tab && !editing) onBack();
+	});
+
+	const items = useMemo(
+		() => [
+			{label: `Enabled: ${config.enabled ? 'ON' : 'OFF'}`, value: 'enabled'},
+			{label: `Threshold: ${config.threshold}%`, value: 'threshold'},
+			{label: `Mode: ${config.mode}`, value: 'mode'},
+			{
+				label: `Notify: ${config.notifyUser ? 'ON' : 'OFF'}`,
+				value: 'notifyUser',
+			},
+		],
+		[config],
+	);
+
+	const persist = <K extends keyof AutoCompactConfig>(
+		key: K,
+		value: AutoCompactConfig[K],
+	) => {
+		setConfig(prev => ({...prev, [key]: value}));
+		updateConfigNestedValue('autoCompact', key, value);
+	};
+
+	const handleSelect = (item: {value: string}) => {
+		setError(null);
+		if (item.value === 'threshold') {
+			setEditValue(String(config.threshold));
+			setEditing(true);
+		} else if (item.value === 'mode') {
+			const idx = MODE_OPTIONS.indexOf(config.mode);
+			persist('mode', MODE_OPTIONS[(idx + 1) % MODE_OPTIONS.length]);
+		} else if (item.value === 'enabled') {
+			persist('enabled', !config.enabled);
+		} else if (item.value === 'notifyUser') {
+			persist('notifyUser', !config.notifyUser);
+		}
+	};
+
+	const submitThreshold = (value: string) => {
+		const num = Number.parseInt(value.trim(), 10);
+		if (Number.isNaN(num)) return setError('Must be a number');
+		if (num < 50 || num > 95) return setError('Must be between 50 and 95');
+		persist('threshold', num);
+		setEditing(false);
+	};
+
+	return (
+		<TitledBoxWithPreferences
+			title="Settings · Auto-Compact"
+			width={isNarrow ? '100%' : boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			{editing ? (
+				<Box flexDirection="column">
+					<Text color={colors.secondary}>
+						Threshold % (50–95). Current: {config.threshold}%
+					</Text>
+					<Box marginY={1} borderStyle="round" borderColor={colors.secondary}>
+						<TextInput
+							value={editValue}
+							onChange={setEditValue}
+							onSubmit={submitThreshold}
+						/>
+					</Box>
+					{error && <Text color={colors.error}>⚠ {error}</Text>}
+					<Text color={colors.secondary}>Enter to save · Esc to cancel</Text>
+				</Box>
+			) : (
+				<Box flexDirection="column">
+					<Box marginBottom={1}>
+						<Text color={colors.secondary}>
+							Enter toggles/cycles a setting · Shift+Tab back · Esc exit
+						</Text>
+					</Box>
+					<SelectInput
+						items={items}
+						onSelect={handleSelect}
+						indicatorComponent={({isSelected}) => (
+							<Text color={isSelected ? colors.primary : colors.text}>
+								{isSelected ? '> ' : '  '}
+							</Text>
+						)}
+						itemComponent={({isSelected, label}) => (
+							<Text color={isSelected ? colors.primary : colors.text}>
+								{label}
+							</Text>
+						)}
+					/>
+				</Box>
+			)}
+		</TitledBoxWithPreferences>
+	);
+}

--- a/source/app/components/settings-auto-compact.tsx
+++ b/source/app/components/settings-auto-compact.tsx
@@ -19,7 +19,7 @@ const DEFAULT_CONFIG: AutoCompactConfig = {
 	enabled: true,
 	threshold: 60,
 	mode: 'conservative',
-	strategy: 'mechanical',
+	strategy: 'llm',
 	notifyUser: true,
 };
 
@@ -129,19 +129,24 @@ export function SettingsAutoCompactPanel({
 				<Box flexDirection="column">
 					<Box marginBottom={1}>
 						<Text color={colors.secondary}>
-							Enter toggles/cycles a setting · Shift+Tab back · Esc exit
+							Enter toggles/cycles a setting · Shift+Tab back · Esc back
 						</Text>
 					</Box>
 					<SelectInput
 						items={items}
 						onSelect={handleSelect}
 						indicatorComponent={({isSelected}) => (
-							<Text color={isSelected ? colors.primary : colors.text}>
-								{isSelected ? '> ' : '  '}
-							</Text>
+							<Box minWidth={2}>
+								<Text color={isSelected ? colors.primary : colors.text}>
+									{isSelected ? '>' : ' '}
+								</Text>
+							</Box>
 						)}
 						itemComponent={({isSelected, label}) => (
-							<Text color={isSelected ? colors.primary : colors.text}>
+							<Text
+								color={isSelected ? colors.primary : colors.text}
+								wrap="truncate-end"
+							>
 								{label}
 							</Text>
 						)}

--- a/source/app/components/settings-default-mode.tsx
+++ b/source/app/components/settings-default-mode.tsx
@@ -1,0 +1,95 @@
+import {Box, Text, useInput} from 'ink';
+import SelectInput from 'ink-select-input';
+import {useMemo, useState} from 'react';
+import {type CliMode, VALID_MODES} from '@/app/types';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {updateConfigValue} from '@/config/config-writer';
+import {loadDefaultMode} from '@/config/index';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+
+const MODE_DESCRIPTIONS: Record<string, string> = {
+	normal: 'Standard — all tool calls require approval',
+	'auto-accept': 'Semi-auto — read-only tools auto-run; writes prompt',
+	yolo: 'Fully automatic — no confirmations at all',
+	plan: 'Read-only exploration — only read/search/list tools',
+};
+
+/**
+ * Default development mode for new sessions. Persists atomically to
+ * nanocoder.defaultMode in agents.config.json.
+ */
+export function SettingsDefaultModePanel({
+	onBack,
+	onCancel,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+
+	const currentMode = loadDefaultMode();
+	const [selectedMode, setSelectedMode] = useState<CliMode | undefined>(
+		currentMode,
+	);
+
+	useInput((_, key) => {
+		if (key.escape) onCancel();
+		if (key.shift && key.tab) onBack();
+	});
+
+	const items = useMemo(
+		() =>
+			(VALID_MODES as readonly string[]).map(mode => ({
+				label: `${mode}${selectedMode === mode ? ' *' : ''} — ${
+					MODE_DESCRIPTIONS[mode] ?? ''
+				}`,
+				value: mode,
+			})),
+		[selectedMode],
+	);
+
+	const initialIndex = useMemo(() => {
+		const idx = selectedMode
+			? (VALID_MODES as readonly string[]).indexOf(selectedMode)
+			: 0;
+		return idx >= 0 ? idx : 0;
+	}, [selectedMode]);
+
+	const handleSelect = (item: {value: string}) => {
+		const mode = item.value as CliMode;
+		updateConfigValue('defaultMode', mode);
+		setSelectedMode(mode);
+		onBack();
+	};
+
+	return (
+		<TitledBoxWithPreferences
+			title="Settings · Default Mode"
+			width={isNarrow ? '100%' : boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			<Box marginBottom={1}>
+				<Text color={colors.secondary}>
+					Initial development mode for new sessions. Current:{' '}
+					{currentMode ?? '(not set — defaults to normal)'}
+				</Text>
+			</Box>
+			<SelectInput
+				items={items}
+				initialIndex={initialIndex}
+				onSelect={handleSelect}
+			/>
+			<Box marginTop={1}>
+				<Text color={colors.secondary}>
+					Enter to apply · Shift+Tab back · Esc exit
+				</Text>
+			</Box>
+		</TitledBoxWithPreferences>
+	);
+}

--- a/source/app/components/settings-default-mode.tsx
+++ b/source/app/components/settings-default-mode.tsx
@@ -10,7 +10,8 @@ import {useTheme} from '@/hooks/useTheme';
 
 const MODE_DESCRIPTIONS: Record<string, string> = {
 	normal: 'Standard — all tool calls require approval',
-	'auto-accept': 'Semi-auto — read-only tools auto-run; writes prompt',
+	'auto-accept':
+		'Semi-auto — most tools auto-run; bash and destructive git prompt',
 	yolo: 'Fully automatic — no confirmations at all',
 	plan: 'Read-only exploration — only read/search/list tools',
 };
@@ -42,9 +43,7 @@ export function SettingsDefaultModePanel({
 	const items = useMemo(
 		() =>
 			(VALID_MODES as readonly string[]).map(mode => ({
-				label: `${mode}${selectedMode === mode ? ' *' : ''} — ${
-					MODE_DESCRIPTIONS[mode] ?? ''
-				}`,
+				label: `${mode}${selectedMode === mode ? ' *' : ''}`,
 				value: mode,
 			})),
 		[selectedMode],
@@ -80,14 +79,39 @@ export function SettingsDefaultModePanel({
 					{currentMode ?? '(not set — defaults to normal)'}
 				</Text>
 			</Box>
+			{/* Label and description are separate rows: as one long string they
+			    wrapped with no hanging indent, so continuation lines ran flush
+			    left and the list read as a jumble on narrow terminals. */}
 			<SelectInput
 				items={items}
 				initialIndex={initialIndex}
 				onSelect={handleSelect}
+				itemComponent={({isSelected, label}) => {
+					const mode = label.replace(' *', '');
+					const description = MODE_DESCRIPTIONS[mode] ?? '';
+					const color = isSelected ? colors.primary : colors.text;
+					if (isNarrow) {
+						return (
+							<Box flexDirection="column">
+								<Text color={color}>{label}</Text>
+								<Text color={colors.secondary} wrap="truncate-end">
+									{'  '}
+									{description}
+								</Text>
+							</Box>
+						);
+					}
+					return (
+						<Text wrap="truncate-end">
+							<Text color={color}>{label}</Text>
+							<Text color={colors.secondary}> — {description}</Text>
+						</Text>
+					);
+				}}
 			/>
 			<Box marginTop={1}>
 				<Text color={colors.secondary}>
-					Enter to apply · Shift+Tab back · Esc exit
+					Enter to apply · Shift+Tab back · Esc back
 				</Text>
 			</Box>
 		</TitledBoxWithPreferences>

--- a/source/app/components/settings-environment.tsx
+++ b/source/app/components/settings-environment.tsx
@@ -1,0 +1,64 @@
+import {Box, Text, useInput} from 'ink';
+import {useMemo} from 'react';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+
+/**
+ * Read-only view of the active NANOCODER_* environment variables. These are set
+ * externally and override config; shown here so they're discoverable.
+ */
+export function SettingsEnvironmentPanel({
+	onBack,
+	onCancel,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+
+	useInput((_, key) => {
+		if (key.escape) onCancel();
+		if (key.shift && key.tab) onBack();
+	});
+
+	const vars = useMemo(
+		() =>
+			Object.entries(process.env)
+				.filter(([k]) => k.startsWith('NANOCODER_'))
+				.sort(([a], [b]) => a.localeCompare(b)),
+		[],
+	);
+
+	return (
+		<TitledBoxWithPreferences
+			title="Settings · Environment"
+			width={isNarrow ? '100%' : boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			<Box marginBottom={1}>
+				<Text color={colors.secondary}>
+					Active NANOCODER_* variables (read-only, set outside the app).
+				</Text>
+			</Box>
+			{vars.length === 0 ? (
+				<Text color={colors.text}>(none set)</Text>
+			) : (
+				vars.map(([k, v]) => (
+					<Text key={k} color={colors.text}>
+						<Text color={colors.primary}>{k}</Text>
+						<Text color={colors.secondary}>={v}</Text>
+					</Text>
+				))
+			)}
+			<Box marginTop={1}>
+				<Text color={colors.secondary}>Shift+Tab back · Esc exit</Text>
+			</Box>
+		</TitledBoxWithPreferences>
+	);
+}

--- a/source/app/components/settings-environment.tsx
+++ b/source/app/components/settings-environment.tsx
@@ -4,6 +4,15 @@ import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
 
+const SECRET_NAME = /(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH)/;
+
+/** Credentials are readable over a shoulder or a screen share — show only a stub. */
+function maskValue(name: string, value: string): string {
+	if (!SECRET_NAME.test(name)) return value;
+	if (value.length <= 4) return '*'.repeat(value.length);
+	return `${value.slice(0, 4)}${'*'.repeat(Math.min(12, value.length - 4))}`;
+}
+
 /**
  * Read-only view of the active NANOCODER_* environment variables. These are set
  * externally and override config; shown here so they're discoverable.
@@ -50,14 +59,14 @@ export function SettingsEnvironmentPanel({
 				<Text color={colors.text}>(none set)</Text>
 			) : (
 				vars.map(([k, v]) => (
-					<Text key={k} color={colors.text}>
+					<Text key={k} color={colors.text} wrap="truncate-end">
 						<Text color={colors.primary}>{k}</Text>
-						<Text color={colors.secondary}>={v}</Text>
+						<Text color={colors.secondary}>={maskValue(k, v ?? '')}</Text>
 					</Text>
 				))
 			)}
 			<Box marginTop={1}>
-				<Text color={colors.secondary}>Shift+Tab back · Esc exit</Text>
+				<Text color={colors.secondary}>Shift+Tab back · Esc back</Text>
 			</Box>
 		</TitledBoxWithPreferences>
 	);

--- a/source/app/components/settings-json-config.tsx
+++ b/source/app/components/settings-json-config.tsx
@@ -1,0 +1,25 @@
+import {useCallback} from 'react';
+import {JsonViewer} from '@/components/json-viewer';
+import {getAppConfig} from '@/config/index';
+
+/**
+ * Read-only tree view of the effective agents.config.json. First slice of the
+ * in-TUI JSON editor; write-back (atomic) lands in a follow-up.
+ */
+export function SettingsJsonConfigPanel({
+	onBack,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const config = getAppConfig();
+	const handleCancel = useCallback(() => onBack(), [onBack]);
+	return (
+		<JsonViewer
+			data={config}
+			title="agents.config.json (effective)"
+			readOnly
+			onCancel={handleCancel}
+		/>
+	);
+}

--- a/source/app/components/settings-json-config.tsx
+++ b/source/app/components/settings-json-config.tsx
@@ -1,10 +1,14 @@
-import {useCallback} from 'react';
+import {readFileSync} from 'node:fs';
+import {useCallback, useState} from 'react';
+import {writeConfigFileAtomic} from '@/config/config-writer';
+import {getClosestConfigFile} from '@/config/index';
 import {JsonViewer} from '@/components/json-viewer';
-import {getAppConfig} from '@/config/index';
 
 /**
- * Read-only tree view of the effective agents.config.json. First slice of the
- * in-TUI JSON editor; write-back (atomic) lands in a follow-up.
+ * In-TUI editor for agents.config.json. The tree editor can only produce valid
+ * JSON, and `w` writes it back atomically. Unsaved edits live only in the
+ * viewer's state, so exiting without saving leaves the file untouched (real
+ * rollback — no keep/discard prompt).
  */
 export function SettingsJsonConfigPanel({
 	onBack,
@@ -12,13 +16,27 @@ export function SettingsJsonConfigPanel({
 	onBack: () => void;
 	onCancel: () => void;
 }) {
-	const config = getAppConfig();
+	const [filePath] = useState(() => getClosestConfigFile('agents.config.json'));
+	const [data] = useState<unknown>(() => {
+		try {
+			return JSON.parse(readFileSync(filePath, 'utf-8'));
+		} catch {
+			return {};
+		}
+	});
+
+	const handleSave = useCallback(
+		(next: unknown) => writeConfigFileAtomic(filePath, next),
+		[filePath],
+	);
 	const handleCancel = useCallback(() => onBack(), [onBack]);
+
 	return (
 		<JsonViewer
-			data={config}
-			title="agents.config.json (effective)"
-			readOnly
+			data={data}
+			title="agents.config.json"
+			filePath={filePath}
+			onSave={handleSave}
 			onCancel={handleCancel}
 		/>
 	);

--- a/source/app/components/settings-json-config.tsx
+++ b/source/app/components/settings-json-config.tsx
@@ -1,27 +1,34 @@
 import {readFileSync} from 'node:fs';
 import {useCallback, useState} from 'react';
+import {JsonViewer} from '@/components/json-viewer';
 import {writeConfigFileAtomic} from '@/config/config-writer';
 import {getClosestConfigFile} from '@/config/index';
-import {JsonViewer} from '@/components/json-viewer';
 
 /**
- * In-TUI editor for agents.config.json. The tree editor can only produce valid
- * JSON, and `w` writes it back atomically. Unsaved edits live only in the
- * viewer's state, so exiting without saving leaves the file untouched (real
- * rollback — no keep/discard prompt).
+ * In-TUI editor for a JSON config file (agents.config.json, .mcp.json, …). The
+ * tree editor can only produce valid JSON, and `w` writes it back atomically.
+ * Unsaved edits live only in the viewer's state, so exiting without saving
+ * leaves the file untouched (real rollback — no keep/discard prompt).
  */
 export function SettingsJsonConfigPanel({
+	configFileName = 'agents.config.json',
+	title,
+	initialPath,
 	onBack,
 }: {
+	configFileName?: string;
+	title?: string;
+	initialPath?: string[];
 	onBack: () => void;
 	onCancel: () => void;
 }) {
-	const [filePath] = useState(() => getClosestConfigFile('agents.config.json'));
+	const [filePath] = useState(() => getClosestConfigFile(configFileName));
 	const [data] = useState<unknown>(() => {
 		try {
 			return JSON.parse(readFileSync(filePath, 'utf-8'));
 		} catch {
-			return {};
+			// Missing/empty file: seed the expected shape so the editor is usable.
+			return configFileName.includes('mcp') ? {mcpServers: {}} : {};
 		}
 	});
 
@@ -34,8 +41,9 @@ export function SettingsJsonConfigPanel({
 	return (
 		<JsonViewer
 			data={data}
-			title="agents.config.json"
+			title={title ?? configFileName}
 			filePath={filePath}
+			initialPath={initialPath}
 			onSave={handleSave}
 			onCancel={handleCancel}
 		/>

--- a/source/app/components/settings-mcp-list.tsx
+++ b/source/app/components/settings-mcp-list.tsx
@@ -1,0 +1,86 @@
+import {Box, Text, useInput} from 'ink';
+import SelectInput from 'ink-select-input';
+import {useState} from 'react';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {getAppConfig} from '@/config/index';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+import {McpWizard} from '@/wizards/mcp-wizard';
+
+/**
+ * Lists the configured MCP servers first, then opens the existing MCP wizard to
+ * add/edit rather than jumping straight into it.
+ */
+export function SettingsMcpListPanel({
+	onBack,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+	const [editing, setEditing] = useState(false);
+
+	const servers = getAppConfig().mcpServers ?? [];
+
+	useInput((_, key) => {
+		if (editing) return;
+		if (key.escape) onBack();
+		if (key.shift && key.tab) onBack();
+	});
+
+	if (editing) {
+		return (
+			<McpWizard
+				projectDir={process.cwd()}
+				onComplete={onBack}
+				onCancel={() => setEditing(false)}
+			/>
+		);
+	}
+
+	const items = [
+		...servers.map((s, i) => {
+			const detail = s.command ? s.command : s.url ? s.url : '(no endpoint)';
+			return {
+				label: `${s.name}  ·  ${s.transport}  ·  ${detail}`,
+				value: String(i),
+			};
+		}),
+		{label: '＋ Add or edit MCP servers…', value: 'edit'},
+	];
+
+	return (
+		<TitledBoxWithPreferences
+			title="Settings · MCP Servers"
+			width={isNarrow ? '100%' : boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			<Box marginBottom={1}>
+				<Text color={colors.secondary}>
+					{servers.length} server{servers.length === 1 ? '' : 's'} configured.
+					Enter opens the wizard to add or edit.
+				</Text>
+			</Box>
+			<SelectInput
+				items={items}
+				onSelect={() => setEditing(true)}
+				indicatorComponent={({isSelected}) => (
+					<Text color={isSelected ? colors.primary : colors.text}>
+						{isSelected ? '> ' : '  '}
+					</Text>
+				)}
+				itemComponent={({isSelected, label}) => (
+					<Text color={isSelected ? colors.primary : colors.text}>{label}</Text>
+				)}
+			/>
+			<Box marginTop={1}>
+				<Text color={colors.secondary}>Shift+Tab back · Esc exit</Text>
+			</Box>
+		</TitledBoxWithPreferences>
+	);
+}

--- a/source/app/components/settings-mcp-list.tsx
+++ b/source/app/components/settings-mcp-list.tsx
@@ -13,9 +13,11 @@ import {McpWizard} from '@/wizards/mcp-wizard';
  */
 export function SettingsMcpListPanel({
 	onBack,
+	onMcpChanged,
 }: {
 	onBack: () => void;
 	onCancel: () => void;
+	onMcpChanged?: () => void | Promise<void>;
 }) {
 	const {colors} = useTheme();
 	const {boxWidth, isNarrow} = useResponsiveTerminal();
@@ -33,7 +35,12 @@ export function SettingsMcpListPanel({
 		return (
 			<McpWizard
 				projectDir={process.cwd()}
-				onComplete={onBack}
+				onComplete={() => {
+					// Rebuild the running session's MCP connections; otherwise a server
+					// added here stays inert until the next launch.
+					void onMcpChanged?.();
+					onBack();
+				}}
 				onCancel={() => setEditing(false)}
 			/>
 		);
@@ -47,7 +54,7 @@ export function SettingsMcpListPanel({
 				value: String(i),
 			};
 		}),
-		{label: '＋ Add or edit MCP servers…', value: 'edit'},
+		{label: '+ Add or edit MCP servers…', value: 'edit'},
 	];
 
 	return (
@@ -70,16 +77,23 @@ export function SettingsMcpListPanel({
 				items={items}
 				onSelect={() => setEditing(true)}
 				indicatorComponent={({isSelected}) => (
-					<Text color={isSelected ? colors.primary : colors.text}>
-						{isSelected ? '> ' : '  '}
-					</Text>
+					<Box minWidth={2}>
+						<Text color={isSelected ? colors.primary : colors.text}>
+							{isSelected ? '>' : ' '}
+						</Text>
+					</Box>
 				)}
 				itemComponent={({isSelected, label}) => (
-					<Text color={isSelected ? colors.primary : colors.text}>{label}</Text>
+					<Text
+						color={isSelected ? colors.primary : colors.text}
+						wrap="truncate-end"
+					>
+						{label}
+					</Text>
 				)}
 			/>
 			<Box marginTop={1}>
-				<Text color={colors.secondary}>Shift+Tab back · Esc exit</Text>
+				<Text color={colors.secondary}>Shift+Tab back · Esc back</Text>
 			</Box>
 		</TitledBoxWithPreferences>
 	);

--- a/source/app/components/settings-providers-list.tsx
+++ b/source/app/components/settings-providers-list.tsx
@@ -1,0 +1,87 @@
+import {Box, Text, useInput} from 'ink';
+import SelectInput from 'ink-select-input';
+import {useState} from 'react';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {getAppConfig} from '@/config/index';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+import {ProviderWizard} from '@/wizards/provider-wizard';
+
+/**
+ * Lists the configured AI providers first (inspired by openclaude's
+ * ProviderManager and codex/opencode provider pickers), then opens the existing
+ * provider wizard to add/edit rather than jumping straight into it.
+ */
+export function SettingsProvidersListPanel({
+	onBack,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+	const [editing, setEditing] = useState(false);
+
+	const providers = getAppConfig().providers ?? [];
+
+	useInput((_, key) => {
+		if (editing) return;
+		if (key.escape) onBack();
+		if (key.shift && key.tab) onBack();
+	});
+
+	if (editing) {
+		return (
+			<ProviderWizard
+				projectDir={process.cwd()}
+				onComplete={onBack}
+				onCancel={() => setEditing(false)}
+			/>
+		);
+	}
+
+	const items = [
+		...providers.map((p, i) => {
+			const where = p.baseUrl ? p.baseUrl : 'default endpoint';
+			const models = p.models?.length
+				? `${p.models[0]}${p.models.length > 1 ? ` +${p.models.length - 1}` : ''}`
+				: 'no models';
+			return {label: `${p.name}  ·  ${where}  ·  ${models}`, value: String(i)};
+		}),
+		{label: '＋ Add or edit providers…', value: 'edit'},
+	];
+
+	return (
+		<TitledBoxWithPreferences
+			title="Settings · Providers"
+			width={isNarrow ? '100%' : boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			<Box marginBottom={1}>
+				<Text color={colors.secondary}>
+					{providers.length} provider{providers.length === 1 ? '' : 's'}{' '}
+					configured. Enter opens the wizard to add or edit.
+				</Text>
+			</Box>
+			<SelectInput
+				items={items}
+				onSelect={() => setEditing(true)}
+				indicatorComponent={({isSelected}) => (
+					<Text color={isSelected ? colors.primary : colors.text}>
+						{isSelected ? '> ' : '  '}
+					</Text>
+				)}
+				itemComponent={({isSelected, label}) => (
+					<Text color={isSelected ? colors.primary : colors.text}>{label}</Text>
+				)}
+			/>
+			<Box marginTop={1}>
+				<Text color={colors.secondary}>Shift+Tab back · Esc exit</Text>
+			</Box>
+		</TitledBoxWithPreferences>
+	);
+}

--- a/source/app/components/settings-providers-list.tsx
+++ b/source/app/components/settings-providers-list.tsx
@@ -48,7 +48,7 @@ export function SettingsProvidersListPanel({
 				: 'no models';
 			return {label: `${p.name}  ·  ${where}  ·  ${models}`, value: String(i)};
 		}),
-		{label: '＋ Add or edit providers…', value: 'edit'},
+		{label: '+ Add or edit providers…', value: 'edit'},
 	];
 
 	return (
@@ -71,16 +71,23 @@ export function SettingsProvidersListPanel({
 				items={items}
 				onSelect={() => setEditing(true)}
 				indicatorComponent={({isSelected}) => (
-					<Text color={isSelected ? colors.primary : colors.text}>
-						{isSelected ? '> ' : '  '}
-					</Text>
+					<Box minWidth={2}>
+						<Text color={isSelected ? colors.primary : colors.text}>
+							{isSelected ? '>' : ' '}
+						</Text>
+					</Box>
 				)}
 				itemComponent={({isSelected, label}) => (
-					<Text color={isSelected ? colors.primary : colors.text}>{label}</Text>
+					<Text
+						color={isSelected ? colors.primary : colors.text}
+						wrap="truncate-end"
+					>
+						{label}
+					</Text>
 				)}
 			/>
 			<Box marginTop={1}>
-				<Text color={colors.secondary}>Shift+Tab back · Esc exit</Text>
+				<Text color={colors.secondary}>Shift+Tab back · Esc back</Text>
 			</Box>
 		</TitledBoxWithPreferences>
 	);

--- a/source/app/components/settings-reasoning-traces.tsx
+++ b/source/app/components/settings-reasoning-traces.tsx
@@ -1,0 +1,81 @@
+import {Box, Text, useInput} from 'ink';
+import SelectInput from 'ink-select-input';
+import {useMemo, useState} from 'react';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {
+	getReasoningExpanded,
+	updateReasoningExpanded,
+} from '@/config/preferences';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+
+/**
+ * Toggle whether reasoning traces are expanded by default. Persists to
+ * nanocoder-preferences.json (reasoningExpanded).
+ */
+export function SettingsReasoningTracesPanel({
+	onBack,
+	onCancel,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+
+	const [enabled, setEnabled] = useState(getReasoningExpanded() ?? false);
+
+	useInput((_, key) => {
+		if (key.escape) onCancel();
+		if (key.shift && key.tab) onBack();
+	});
+
+	const items = useMemo(
+		() => [
+			{
+				label: `Reasoning Traces: ${enabled ? 'Expanded' : 'Collapsed'}`,
+				value: 'toggle',
+				description: enabled
+					? 'Full reasoning traces are displayed by default'
+					: 'Reasoning traces are collapsed by default (Ctrl+R to toggle)',
+			},
+		],
+		[enabled],
+	);
+
+	const handleSelect = () => {
+		const next = !enabled;
+		updateReasoningExpanded(next);
+		setEnabled(next);
+	};
+
+	return (
+		<TitledBoxWithPreferences
+			title="Settings · Reasoning Traces"
+			width={isNarrow ? '100%' : boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			<Box marginBottom={1}>
+				<Text color={colors.secondary}>
+					Press Enter to toggle · Shift+Tab back · Esc exit
+				</Text>
+			</Box>
+			<SelectInput
+				items={items}
+				onSelect={handleSelect}
+				indicatorComponent={({isSelected}) => (
+					<Text color={isSelected ? colors.primary : colors.text}>
+						{isSelected ? '> ' : '  '}
+					</Text>
+				)}
+				itemComponent={({isSelected, label}) => (
+					<Text color={isSelected ? colors.primary : colors.text}>{label}</Text>
+				)}
+			/>
+		</TitledBoxWithPreferences>
+	);
+}

--- a/source/app/components/settings-reasoning-traces.tsx
+++ b/source/app/components/settings-reasoning-traces.tsx
@@ -61,19 +61,26 @@ export function SettingsReasoningTracesPanel({
 		>
 			<Box marginBottom={1}>
 				<Text color={colors.secondary}>
-					Press Enter to toggle · Shift+Tab back · Esc exit
+					Press Enter to toggle · Shift+Tab back · Esc back
 				</Text>
 			</Box>
 			<SelectInput
 				items={items}
 				onSelect={handleSelect}
 				indicatorComponent={({isSelected}) => (
-					<Text color={isSelected ? colors.primary : colors.text}>
-						{isSelected ? '> ' : '  '}
-					</Text>
+					<Box minWidth={2}>
+						<Text color={isSelected ? colors.primary : colors.text}>
+							{isSelected ? '>' : ' '}
+						</Text>
+					</Box>
 				)}
 				itemComponent={({isSelected, label}) => (
-					<Text color={isSelected ? colors.primary : colors.text}>{label}</Text>
+					<Text
+						color={isSelected ? colors.primary : colors.text}
+						wrap="truncate-end"
+					>
+						{label}
+					</Text>
 				)}
 			/>
 		</TitledBoxWithPreferences>

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -49,7 +49,10 @@ export type ManagedSettingsPanel =
 	| 'providers-config'
 	| 'mcp-config'
 	| 'default-mode'
-	| 'reasoning-traces';
+	| 'reasoning-traces'
+	| 'auto-compact'
+	| 'sessions'
+	| 'tool-approval';
 
 export interface SettingsSelectorProps {
 	onCancel: () => void;

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -45,7 +45,9 @@ export type ManagedSettingsPanel =
 	| 'display-settings'
 	| 'privacy'
 	| 'json-config'
-	| 'web-search';
+	| 'web-search'
+	| 'providers-config'
+	| 'mcp-config';
 
 export interface SettingsSelectorProps {
 	onCancel: () => void;

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -47,7 +47,9 @@ export type ManagedSettingsPanel =
 	| 'json-config'
 	| 'web-search'
 	| 'providers-config'
-	| 'mcp-config';
+	| 'mcp-config'
+	| 'default-mode'
+	| 'reasoning-traces';
 
 export interface SettingsSelectorProps {
 	onCancel: () => void;

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -43,7 +43,8 @@ export type ManagedSettingsPanel =
 	| 'paste-threshold'
 	| 'notifications'
 	| 'display-settings'
-	| 'privacy';
+	| 'privacy'
+	| 'json-config';
 
 export interface SettingsSelectorProps {
 	onCancel: () => void;

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -52,7 +52,8 @@ export type ManagedSettingsPanel =
 	| 'reasoning-traces'
 	| 'auto-compact'
 	| 'sessions'
-	| 'tool-approval';
+	| 'tool-approval'
+	| 'environment';
 
 export interface SettingsSelectorProps {
 	onCancel: () => void;

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -57,6 +57,10 @@ export type ManagedSettingsPanel =
 
 export interface SettingsSelectorProps {
 	onCancel: () => void;
+	/** Close settings and launch the tune wizard (app-level mode switch). */
+	onLaunchTune?: () => void;
+	/** Close settings and launch the IDE-connection wizard. */
+	onLaunchIde?: () => void;
 }
 
 function ThemePreviewMessage({

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -44,7 +44,8 @@ export type ManagedSettingsPanel =
 	| 'notifications'
 	| 'display-settings'
 	| 'privacy'
-	| 'json-config';
+	| 'json-config'
+	| 'web-search';
 
 export interface SettingsSelectorProps {
 	onCancel: () => void;

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -61,6 +61,11 @@ export interface SettingsSelectorProps {
 	onLaunchTune?: () => void;
 	/** Close settings and launch the IDE-connection wizard. */
 	onLaunchIde?: () => void;
+	/**
+	 * Rebuild the live MCP connections after the MCP panel edits config. Without
+	 * this, servers added here only take effect on the next launch.
+	 */
+	onMcpChanged?: () => void | Promise<void>;
 }
 
 function ThemePreviewMessage({
@@ -242,7 +247,7 @@ export function SettingsThemePanel({
 				<ThemeMiniPreview colors={previewColors} compact />
 				<Box marginBottom={1}></Box>
 				<Text color={previewColors.secondary}>
-					↑↓ navigate · Enter select · Esc exit
+					↑↓ navigate · Enter select · Esc back
 				</Text>
 			</TitledBoxWithPreferences>
 		);
@@ -264,7 +269,7 @@ export function SettingsThemePanel({
 			</Text>
 			<Box marginBottom={1}>
 				<Text color={previewColors.secondary}>
-					↑↓ navigate · Enter apply · Shift+Tab back · Esc exit
+					↑↓ navigate · Enter apply · Shift+Tab back · Esc back
 				</Text>
 			</Box>
 
@@ -431,7 +436,7 @@ export function SettingsTitleShapePanel({
 		>
 			<Box marginBottom={1}>
 				<Text color={colors.secondary}>
-					Enter to apply, Shift+Tab to go back, Esc to exit
+					Enter to apply, Shift+Tab to go back, Esc to go back
 				</Text>
 			</Box>
 
@@ -555,7 +560,7 @@ export function SettingsNanocoderShapePanel({
 			>
 				<Box marginBottom={1}>
 					<Text color={colors.secondary}>
-						Enter to apply, Shift+Tab to go back, Esc to exit
+						Enter to apply, Shift+Tab to go back, Esc to go back
 					</Text>
 				</Box>
 
@@ -661,7 +666,7 @@ export function SettingsPasteThresholdPanel({
 				<Text color={colors.secondary}>
 					{isNarrow
 						? 'Enter/Shift+Tab/Esc'
-						: 'Enter to apply, Shift+Tab to go back, Esc to exit'}
+						: 'Enter to apply, Shift+Tab to go back, Esc to go back'}
 				</Text>
 			</Box>
 		</TitledBoxWithPreferences>
@@ -763,7 +768,7 @@ export function SettingsNotificationsPanel({
 			{!isNarrow && (
 				<Box marginBottom={1}>
 					<Text color={colors.secondary}>
-						Toggle settings with Enter. Shift+Tab to go back, Esc to exit
+						Toggle settings with Enter. Shift+Tab to go back, Esc to go back
 					</Text>
 				</Box>
 			)}
@@ -842,7 +847,7 @@ export function SettingsDisplayPanel({
 			{!isNarrow && (
 				<Box marginBottom={1}>
 					<Text color={colors.secondary}>
-						Toggle settings with Enter. Shift+Tab to go back, Esc to exit
+						Toggle settings with Enter. Shift+Tab to go back, Esc to go back
 					</Text>
 				</Box>
 			)}
@@ -908,7 +913,7 @@ export function SettingsPrivacyPanel({
 			{!isNarrow && (
 				<Box marginBottom={1}>
 					<Text color={colors.secondary}>
-						Toggle settings with Enter. Shift+Tab to go back, Esc to exit
+						Toggle settings with Enter. Shift+Tab to go back, Esc to go back
 					</Text>
 				</Box>
 			)}

--- a/source/app/components/settings-sessions.tsx
+++ b/source/app/components/settings-sessions.tsx
@@ -1,0 +1,165 @@
+import {Box, Text, useInput} from 'ink';
+import SelectInput from 'ink-select-input';
+import {useMemo, useState} from 'react';
+import TextInput from '@/components/text-input';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {updateConfigNestedValue} from '@/config/config-writer';
+import {getAppConfig} from '@/config/index';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+import type {AppConfig} from '@/types/config';
+
+type Sessions = NonNullable<AppConfig['sessions']>;
+
+const DEFAULTS: Sessions = {
+	autoSave: true,
+	saveInterval: 30000,
+	maxSessions: 50,
+	maxMessages: 1000,
+	retentionDays: 30,
+	directory: '',
+};
+
+// Numeric fields with their minimum accepted value.
+const NUM_MIN: Record<string, number> = {
+	saveInterval: 1000,
+	maxSessions: 1,
+	maxMessages: 1,
+	retentionDays: 1,
+};
+
+/**
+ * Session save/retention settings (agents.config.json nanocoder.sessions).
+ * Each change persists atomically and directly — no keep/discard prompt.
+ */
+export function SettingsSessionsPanel({
+	onBack,
+	onCancel,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+
+	const [config, setConfig] = useState<Sessions>(
+		getAppConfig().sessions ?? DEFAULTS,
+	);
+	const [editField, setEditField] = useState<string | null>(null);
+	const [editValue, setEditValue] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	useInput((_, key) => {
+		if (key.escape) {
+			if (editField) {
+				setEditField(null);
+				setError(null);
+			} else {
+				onCancel();
+			}
+		}
+		if (key.shift && key.tab && !editField) onBack();
+	});
+
+	const items = useMemo(
+		() => [
+			{
+				label: `Auto-Save: ${config.autoSave ? 'ON' : 'OFF'}`,
+				value: 'autoSave',
+			},
+			{label: `Save Interval: ${config.saveInterval}ms`, value: 'saveInterval'},
+			{label: `Max Sessions: ${config.maxSessions}`, value: 'maxSessions'},
+			{label: `Max Messages: ${config.maxMessages}`, value: 'maxMessages'},
+			{
+				label: `Retention Days: ${config.retentionDays}`,
+				value: 'retentionDays',
+			},
+			{
+				label: `Directory: ${config.directory || '(default)'}`,
+				value: 'directory',
+			},
+		],
+		[config],
+	);
+
+	const persist = <K extends keyof Sessions>(key: K, value: Sessions[K]) => {
+		setConfig(prev => ({...prev, [key]: value}));
+		updateConfigNestedValue('sessions', key, value);
+	};
+
+	const handleSelect = (item: {value: string}) => {
+		setError(null);
+		if (item.value === 'autoSave') {
+			persist('autoSave', !config.autoSave);
+			return;
+		}
+		const key = item.value as keyof Sessions;
+		setEditValue(String(config[key] ?? ''));
+		setEditField(item.value);
+	};
+
+	const submit = (value: string) => {
+		if (!editField) return;
+		const trimmed = value.trim();
+		if (editField === 'directory') {
+			persist('directory', trimmed);
+			setEditField(null);
+			return;
+		}
+		const num = Number.parseInt(trimmed, 10);
+		if (Number.isNaN(num)) return setError('Must be a number');
+		const min = NUM_MIN[editField] ?? 1;
+		if (num < min) return setError(`Must be at least ${min}`);
+		persist(editField as keyof Sessions, num as never);
+		setEditField(null);
+	};
+
+	return (
+		<TitledBoxWithPreferences
+			title="Settings · Sessions"
+			width={isNarrow ? '100%' : boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			{editField ? (
+				<Box flexDirection="column">
+					<Text color={colors.secondary}>Edit {editField}:</Text>
+					<Box marginY={1} borderStyle="round" borderColor={colors.secondary}>
+						<TextInput
+							value={editValue}
+							onChange={setEditValue}
+							onSubmit={submit}
+						/>
+					</Box>
+					{error && <Text color={colors.error}>⚠ {error}</Text>}
+					<Text color={colors.secondary}>Enter to save · Esc to cancel</Text>
+				</Box>
+			) : (
+				<Box flexDirection="column">
+					<Box marginBottom={1}>
+						<Text color={colors.secondary}>
+							Enter edits/toggles a field · Shift+Tab back · Esc exit
+						</Text>
+					</Box>
+					<SelectInput
+						items={items}
+						onSelect={handleSelect}
+						indicatorComponent={({isSelected}) => (
+							<Text color={isSelected ? colors.primary : colors.text}>
+								{isSelected ? '> ' : '  '}
+							</Text>
+						)}
+						itemComponent={({isSelected, label}) => (
+							<Text color={isSelected ? colors.primary : colors.text}>
+								{label}
+							</Text>
+						)}
+					/>
+				</Box>
+			)}
+		</TitledBoxWithPreferences>
+	);
+}

--- a/source/app/components/settings-sessions.tsx
+++ b/source/app/components/settings-sessions.tsx
@@ -141,19 +141,24 @@ export function SettingsSessionsPanel({
 				<Box flexDirection="column">
 					<Box marginBottom={1}>
 						<Text color={colors.secondary}>
-							Enter edits/toggles a field · Shift+Tab back · Esc exit
+							Enter edits/toggles a field · Shift+Tab back · Esc back
 						</Text>
 					</Box>
 					<SelectInput
 						items={items}
 						onSelect={handleSelect}
 						indicatorComponent={({isSelected}) => (
-							<Text color={isSelected ? colors.primary : colors.text}>
-								{isSelected ? '> ' : '  '}
-							</Text>
+							<Box minWidth={2}>
+								<Text color={isSelected ? colors.primary : colors.text}>
+									{isSelected ? '>' : ' '}
+								</Text>
+							</Box>
 						)}
 						itemComponent={({isSelected, label}) => (
-							<Text color={isSelected ? colors.primary : colors.text}>
+							<Text
+								color={isSelected ? colors.primary : colors.text}
+								wrap="truncate-end"
+							>
 								{label}
 							</Text>
 						)}

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -22,6 +22,7 @@ import {McpWizard} from '@/wizards/mcp-wizard';
 import {ProviderWizard} from '@/wizards/provider-wizard';
 import {SettingsAutoCompactPanel} from './settings-auto-compact';
 import {SettingsDefaultModePanel} from './settings-default-mode';
+import {SettingsEnvironmentPanel} from './settings-environment';
 import {SettingsJsonConfigPanel} from './settings-json-config';
 import {SettingsReasoningTracesPanel} from './settings-reasoning-traces';
 import type {
@@ -203,6 +204,13 @@ function buildRowsForTab(
 				},
 				{
 					kind: 'managed',
+					id: 'environment',
+					label: 'Environment',
+					value: 'view',
+					panel: 'environment',
+				},
+				{
+					kind: 'managed',
 					id: 'web-search',
 					label: 'Web Search',
 					value: getAppConfig().nanocoderTools?.webSearch?.apiKey
@@ -343,6 +351,8 @@ function renderManagedPanel(
 			return <SettingsSessionsPanel onBack={onBack} onCancel={onBack} />;
 		case 'tool-approval':
 			return <SettingsToolApprovalPanel onBack={onBack} onCancel={onBack} />;
+		case 'environment':
+			return <SettingsEnvironmentPanel onBack={onBack} onCancel={onBack} />;
 		case 'providers-config':
 			return (
 				<ProviderWizard

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -17,6 +17,8 @@ import {useTheme} from '@/hooks/useTheme';
 import {useTitleShape} from '@/hooks/useTitleShape';
 import {fuzzyScore} from '@/utils/fuzzy-matching';
 import {DEFAULT_SINGLE_LINE_PASTE_THRESHOLD} from '@/utils/paste-utils';
+import {McpWizard} from '@/wizards/mcp-wizard';
+import {ProviderWizard} from '@/wizards/provider-wizard';
 import {SettingsJsonConfigPanel} from './settings-json-config';
 import type {
 	ManagedSettingsPanel,
@@ -169,22 +171,22 @@ function buildRowsForTab(
 				{
 					kind: 'managed',
 					id: 'providers-config',
-					label: 'Providers',
-					value: `${getAppConfig().providers?.length ?? 0}`,
+					label: 'Configure Providers',
+					value: `${getAppConfig().providers?.length ?? 0} configured`,
 					panel: 'providers-config',
 				},
 				{
 					kind: 'managed',
 					id: 'mcp-config',
-					label: 'MCP Servers',
-					value: `${getAppConfig().mcpServers?.length ?? 0}`,
+					label: 'Configure MCP Servers',
+					value: `${getAppConfig().mcpServers?.length ?? 0} configured`,
 					panel: 'mcp-config',
 				},
 				{
 					kind: 'managed',
 					id: 'json-config',
-					label: 'Config (JSON)',
-					value: 'edit',
+					label: 'Edit Config Files',
+					value: 'agents.config.json',
 					panel: 'json-config',
 				},
 			];
@@ -291,19 +293,17 @@ function renderManagedPanel(
 			return <SettingsWebSearchPanel onBack={onBack} onCancel={onBack} />;
 		case 'providers-config':
 			return (
-				<SettingsJsonConfigPanel
-					title="Providers (agents.config.json)"
-					initialPath={['nanocoder', 'providers']}
-					onBack={onBack}
+				<ProviderWizard
+					projectDir={process.cwd()}
+					onComplete={onBack}
 					onCancel={onBack}
 				/>
 			);
 		case 'mcp-config':
 			return (
-				<SettingsJsonConfigPanel
-					configFileName=".mcp.json"
-					title="MCP Servers (.mcp.json)"
-					onBack={onBack}
+				<McpWizard
+					projectDir={process.cwd()}
+					onComplete={onBack}
 					onCancel={onBack}
 				/>
 			);

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -168,6 +168,20 @@ function buildRowsForTab(
 				},
 				{
 					kind: 'managed',
+					id: 'providers-config',
+					label: 'Providers',
+					value: `${getAppConfig().providers?.length ?? 0}`,
+					panel: 'providers-config',
+				},
+				{
+					kind: 'managed',
+					id: 'mcp-config',
+					label: 'MCP Servers',
+					value: `${getAppConfig().mcpServers?.length ?? 0}`,
+					panel: 'mcp-config',
+				},
+				{
+					kind: 'managed',
 					id: 'json-config',
 					label: 'Config (JSON)',
 					value: 'edit',
@@ -275,6 +289,24 @@ function renderManagedPanel(
 			return <SettingsJsonConfigPanel onBack={onBack} onCancel={onBack} />;
 		case 'web-search':
 			return <SettingsWebSearchPanel onBack={onBack} onCancel={onBack} />;
+		case 'providers-config':
+			return (
+				<SettingsJsonConfigPanel
+					title="Providers (agents.config.json)"
+					initialPath={['nanocoder', 'providers']}
+					onBack={onBack}
+					onCancel={onBack}
+				/>
+			);
+		case 'mcp-config':
+			return (
+				<SettingsJsonConfigPanel
+					configFileName=".mcp.json"
+					title="MCP Servers (.mcp.json)"
+					onBack={onBack}
+					onCancel={onBack}
+				/>
+			);
 	}
 }
 

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -48,7 +48,12 @@ import {SettingsWebSearchPanel} from './settings-web-search';
  * Every existing preference must be reachable from exactly one of these
  * four tabs.
  */
-export type SettingsTabId = 'appearance' | 'input' | 'display' | 'advanced';
+export type SettingsTabId =
+	| 'appearance'
+	| 'input'
+	| 'behavior'
+	| 'providers'
+	| 'advanced';
 
 interface TabDefinition {
 	id: SettingsTabId;
@@ -58,7 +63,8 @@ interface TabDefinition {
 const TABS: TabDefinition[] = [
 	{id: 'appearance', label: 'Appearance'},
 	{id: 'input', label: 'Input'},
-	{id: 'display', label: 'Display'},
+	{id: 'behavior', label: 'Behavior'},
+	{id: 'providers', label: 'Providers'},
 	{id: 'advanced', label: 'Advanced'},
 ];
 
@@ -147,7 +153,7 @@ function buildRowsForTab(
 				},
 			];
 		}
-		case 'display':
+		case 'behavior':
 			return [
 				{
 					kind: 'managed',
@@ -162,16 +168,6 @@ function buildRowsForTab(
 					label: 'Reasoning Traces',
 					value: getReasoningExpanded() ? 'expanded' : 'collapsed',
 					panel: 'reasoning-traces',
-				},
-			];
-		case 'advanced':
-			return [
-				{
-					kind: 'managed',
-					id: 'privacy',
-					label: 'Privacy',
-					value: getPrivacyPreference() ? 'on' : 'off',
-					panel: 'privacy',
 				},
 				{
 					kind: 'managed',
@@ -195,29 +191,9 @@ function buildRowsForTab(
 						getAppConfig().sessions?.autoSave === false ? 'manual' : 'auto',
 					panel: 'sessions',
 				},
-				{
-					kind: 'managed',
-					id: 'tool-approval',
-					label: 'Tool Auto-Approval',
-					value: `${getAppConfig().alwaysAllow?.length ?? 0} tools`,
-					panel: 'tool-approval',
-				},
-				{
-					kind: 'managed',
-					id: 'environment',
-					label: 'Environment',
-					value: 'view',
-					panel: 'environment',
-				},
-				{
-					kind: 'managed',
-					id: 'web-search',
-					label: 'Web Search',
-					value: getAppConfig().nanocoderTools?.webSearch?.apiKey
-						? 'configured'
-						: 'not set',
-					panel: 'web-search',
-				},
+			];
+		case 'providers':
+			return [
 				{
 					kind: 'managed',
 					id: 'providers-config',
@@ -234,10 +210,43 @@ function buildRowsForTab(
 				},
 				{
 					kind: 'managed',
+					id: 'web-search',
+					label: 'Web Search',
+					value: getAppConfig().nanocoderTools?.webSearch?.apiKey
+						? 'configured'
+						: 'not set',
+					panel: 'web-search',
+				},
+				{
+					kind: 'managed',
+					id: 'tool-approval',
+					label: 'Tool Auto-Approval',
+					value: `${getAppConfig().alwaysAllow?.length ?? 0} tools`,
+					panel: 'tool-approval',
+				},
+			];
+		case 'advanced':
+			return [
+				{
+					kind: 'managed',
+					id: 'privacy',
+					label: 'Privacy',
+					value: getPrivacyPreference() ? 'on' : 'off',
+					panel: 'privacy',
+				},
+				{
+					kind: 'managed',
 					id: 'json-config',
 					label: 'Edit Config Files',
 					value: 'agents.config.json',
 					panel: 'json-config',
+				},
+				{
+					kind: 'managed',
+					id: 'environment',
+					label: 'Environment',
+					value: 'view',
+					panel: 'environment',
 				},
 			];
 	}

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -18,12 +18,12 @@ import {useTheme} from '@/hooks/useTheme';
 import {useTitleShape} from '@/hooks/useTitleShape';
 import {fuzzyScore} from '@/utils/fuzzy-matching';
 import {DEFAULT_SINGLE_LINE_PASTE_THRESHOLD} from '@/utils/paste-utils';
-import {McpWizard} from '@/wizards/mcp-wizard';
-import {ProviderWizard} from '@/wizards/provider-wizard';
 import {SettingsAutoCompactPanel} from './settings-auto-compact';
 import {SettingsDefaultModePanel} from './settings-default-mode';
 import {SettingsEnvironmentPanel} from './settings-environment';
 import {SettingsJsonConfigPanel} from './settings-json-config';
+import {SettingsMcpListPanel} from './settings-mcp-list';
+import {SettingsProvidersListPanel} from './settings-providers-list';
 import {SettingsReasoningTracesPanel} from './settings-reasoning-traces';
 import type {
 	ManagedSettingsPanel,
@@ -408,21 +408,9 @@ function renderManagedPanel(
 		case 'environment':
 			return <SettingsEnvironmentPanel onBack={onBack} onCancel={onBack} />;
 		case 'providers-config':
-			return (
-				<ProviderWizard
-					projectDir={process.cwd()}
-					onComplete={onBack}
-					onCancel={onBack}
-				/>
-			);
+			return <SettingsProvidersListPanel onBack={onBack} onCancel={onBack} />;
 		case 'mcp-config':
-			return (
-				<McpWizard
-					projectDir={process.cwd()}
-					onComplete={onBack}
-					onCancel={onBack}
-				/>
-			);
+			return <SettingsMcpListPanel onBack={onBack} onCancel={onBack} />;
 	}
 }
 

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -3,6 +3,7 @@ import {Box, Text, useInput} from 'ink';
 import type {ReactElement} from 'react';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {StyledTitle} from '@/components/ui/styled-title';
+import {getAppConfig} from '@/config/index';
 import {
 	getAlternateScreen,
 	getNanocoderShape,
@@ -16,6 +17,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {useTitleShape} from '@/hooks/useTitleShape';
 import {fuzzyScore} from '@/utils/fuzzy-matching';
 import {DEFAULT_SINGLE_LINE_PASTE_THRESHOLD} from '@/utils/paste-utils';
+import {SettingsJsonConfigPanel} from './settings-json-config';
 import type {
 	ManagedSettingsPanel,
 	SettingsSelectorProps,
@@ -29,7 +31,7 @@ import {
 	SettingsThemePanel,
 	SettingsTitleShapePanel,
 } from './settings-selector';
-import {SettingsJsonConfigPanel} from './settings-json-config';
+import {SettingsWebSearchPanel} from './settings-web-search';
 
 /**
  * Tab categories are our own settings, grouped for browsability — not the
@@ -157,6 +159,15 @@ function buildRowsForTab(
 				},
 				{
 					kind: 'managed',
+					id: 'web-search',
+					label: 'Web Search',
+					value: getAppConfig().nanocoderTools?.webSearch?.apiKey
+						? 'configured'
+						: 'not set',
+					panel: 'web-search',
+				},
+				{
+					kind: 'managed',
 					id: 'json-config',
 					label: 'Config (JSON)',
 					value: 'edit',
@@ -262,6 +273,8 @@ function renderManagedPanel(
 			return <SettingsPrivacyPanel onBack={onBack} onCancel={onBack} />;
 		case 'json-config':
 			return <SettingsJsonConfigPanel onBack={onBack} onCancel={onBack} />;
+		case 'web-search':
+			return <SettingsWebSearchPanel onBack={onBack} onCancel={onBack} />;
 	}
 }
 

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -29,6 +29,7 @@ import {
 	SettingsThemePanel,
 	SettingsTitleShapePanel,
 } from './settings-selector';
+import {SettingsJsonConfigPanel} from './settings-json-config';
 
 /**
  * Tab categories are our own settings, grouped for browsability — not the
@@ -154,6 +155,13 @@ function buildRowsForTab(
 					value: getPrivacyPreference() ? 'on' : 'off',
 					panel: 'privacy',
 				},
+				{
+					kind: 'managed',
+					id: 'json-config',
+					label: 'Config (JSON)',
+					value: 'view',
+					panel: 'json-config',
+				},
 			];
 	}
 }
@@ -252,6 +260,8 @@ function renderManagedPanel(
 			return <SettingsDisplayPanel onBack={onBack} onCancel={onBack} />;
 		case 'privacy':
 			return <SettingsPrivacyPanel onBack={onBack} onCancel={onBack} />;
+		case 'json-config':
+			return <SettingsJsonConfigPanel onBack={onBack} onCancel={onBack} />;
 	}
 }
 

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -89,15 +89,30 @@ type SettingRow =
 			label: string;
 			value: string;
 			panel: ManagedSettingsPanel;
+	  }
+	| {
+			// Launches an app-level flow (e.g. the tune / IDE wizards) rather than
+			// opening an in-settings panel.
+			kind: 'action';
+			id: string;
+			label: string;
+			value: string;
+			onAction: () => void;
 	  };
 
 const MAX_VISIBLE_ROWS = 4;
 const SEARCH_PLACEHOLDER = 'Search settings…';
 
+interface RowActions {
+	onLaunchTune?: () => void;
+	onLaunchIde?: () => void;
+}
+
 function buildRowsForTab(
 	tabId: SettingsTabId,
 	currentTheme: string,
 	currentTitleShape: string,
+	actions: RowActions = {},
 ): SettingRow[] {
 	switch (tabId) {
 		case 'appearance': {
@@ -225,8 +240,8 @@ function buildRowsForTab(
 					panel: 'tool-approval',
 				},
 			];
-		case 'advanced':
-			return [
+		case 'advanced': {
+			const rows: SettingRow[] = [
 				{
 					kind: 'managed',
 					id: 'privacy',
@@ -249,6 +264,26 @@ function buildRowsForTab(
 					panel: 'environment',
 				},
 			];
+			if (actions.onLaunchTune) {
+				rows.push({
+					kind: 'action',
+					id: 'tune',
+					label: 'Tune Model',
+					value: 'model params',
+					onAction: actions.onLaunchTune,
+				});
+			}
+			if (actions.onLaunchIde) {
+				rows.push({
+					kind: 'action',
+					id: 'connect-ide',
+					label: 'Connect IDE',
+					value: 'wizard',
+					onAction: actions.onLaunchIde,
+				});
+			}
+			return rows;
+		}
 	}
 }
 
@@ -285,13 +320,23 @@ function filterRows(rows: SettingRow[], query: string): SettingRow[] {
  * hook can't otherwise observe (a managed sub-panel writes preferences.json
  * directly, outside this component's React state).
  */
-function useTabRows(tabId: SettingsTabId, version: number): SettingRow[] {
+function useTabRows(
+	tabId: SettingsTabId,
+	version: number,
+	actions: RowActions,
+): SettingRow[] {
 	const {currentTheme} = useTheme();
 	const {currentTitleShape} = useTitleShape();
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: version deliberately drives a full recompute — see doc comment above.
 	return useMemo(
-		() => buildRowsForTab(tabId, currentTheme, currentTitleShape ?? 'pill'),
+		() =>
+			buildRowsForTab(
+				tabId,
+				currentTheme,
+				currentTitleShape ?? 'pill',
+				actions,
+			),
 		[version, tabId, currentTheme, currentTitleShape],
 	);
 }
@@ -434,7 +479,11 @@ function TabBar({
 	);
 }
 
-export function SettingsSelector({onCancel}: SettingsSelectorProps) {
+export function SettingsSelector({
+	onCancel,
+	onLaunchTune,
+	onLaunchIde,
+}: SettingsSelectorProps) {
 	const {colors} = useTheme();
 	const {boxWidth, isNarrow} = useResponsiveTerminal();
 
@@ -494,7 +543,7 @@ export function SettingsSelector({onCancel}: SettingsSelectorProps) {
 		updateFocus('header');
 	}, [activeTab]);
 
-	const allRows = useTabRows(activeTab, version);
+	const allRows = useTabRows(activeTab, version, {onLaunchTune, onLaunchIde});
 	const filteredRows = useMemo(
 		() => filterRows(allRows, query),
 		[allRows, query],
@@ -531,6 +580,10 @@ export function SettingsSelector({onCancel}: SettingsSelectorProps) {
 		if (row.kind === 'boolean') {
 			row.onToggle();
 			setVersion(v => v + 1);
+			return;
+		}
+		if (row.kind === 'action') {
+			row.onAction();
 			return;
 		}
 		setOpenPanel(row.panel);

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -20,6 +20,7 @@ import {fuzzyScore} from '@/utils/fuzzy-matching';
 import {DEFAULT_SINGLE_LINE_PASTE_THRESHOLD} from '@/utils/paste-utils';
 import {McpWizard} from '@/wizards/mcp-wizard';
 import {ProviderWizard} from '@/wizards/provider-wizard';
+import {SettingsAutoCompactPanel} from './settings-auto-compact';
 import {SettingsDefaultModePanel} from './settings-default-mode';
 import {SettingsJsonConfigPanel} from './settings-json-config';
 import {SettingsReasoningTracesPanel} from './settings-reasoning-traces';
@@ -36,6 +37,8 @@ import {
 	SettingsThemePanel,
 	SettingsTitleShapePanel,
 } from './settings-selector';
+import {SettingsSessionsPanel} from './settings-sessions';
+import {SettingsToolApprovalPanel} from './settings-tool-approval';
 import {SettingsWebSearchPanel} from './settings-web-search';
 
 /**
@@ -178,6 +181,28 @@ function buildRowsForTab(
 				},
 				{
 					kind: 'managed',
+					id: 'auto-compact',
+					label: 'Auto-Compact',
+					value: getAppConfig().autoCompact?.enabled === false ? 'off' : 'on',
+					panel: 'auto-compact',
+				},
+				{
+					kind: 'managed',
+					id: 'sessions',
+					label: 'Sessions',
+					value:
+						getAppConfig().sessions?.autoSave === false ? 'manual' : 'auto',
+					panel: 'sessions',
+				},
+				{
+					kind: 'managed',
+					id: 'tool-approval',
+					label: 'Tool Auto-Approval',
+					value: `${getAppConfig().alwaysAllow?.length ?? 0} tools`,
+					panel: 'tool-approval',
+				},
+				{
+					kind: 'managed',
 					id: 'web-search',
 					label: 'Web Search',
 					value: getAppConfig().nanocoderTools?.webSearch?.apiKey
@@ -312,6 +337,12 @@ function renderManagedPanel(
 			return <SettingsDefaultModePanel onBack={onBack} onCancel={onBack} />;
 		case 'reasoning-traces':
 			return <SettingsReasoningTracesPanel onBack={onBack} onCancel={onBack} />;
+		case 'auto-compact':
+			return <SettingsAutoCompactPanel onBack={onBack} onCancel={onBack} />;
+		case 'sessions':
+			return <SettingsSessionsPanel onBack={onBack} onCancel={onBack} />;
+		case 'tool-approval':
+			return <SettingsToolApprovalPanel onBack={onBack} onCancel={onBack} />;
 		case 'providers-config':
 			return (
 				<ProviderWizard

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -3,13 +3,14 @@ import {Box, Text, useInput} from 'ink';
 import type {ReactElement} from 'react';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {StyledTitle} from '@/components/ui/styled-title';
-import {getAppConfig} from '@/config/index';
+import {getAppConfig, loadDefaultMode} from '@/config/index';
 import {
 	getAlternateScreen,
 	getNanocoderShape,
 	getNotificationsPreference,
 	getPasteThreshold,
 	getPrivacyPreference,
+	getReasoningExpanded,
 	updateAlternateScreen,
 } from '@/config/preferences';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
@@ -19,7 +20,9 @@ import {fuzzyScore} from '@/utils/fuzzy-matching';
 import {DEFAULT_SINGLE_LINE_PASTE_THRESHOLD} from '@/utils/paste-utils';
 import {McpWizard} from '@/wizards/mcp-wizard';
 import {ProviderWizard} from '@/wizards/provider-wizard';
+import {SettingsDefaultModePanel} from './settings-default-mode';
 import {SettingsJsonConfigPanel} from './settings-json-config';
+import {SettingsReasoningTracesPanel} from './settings-reasoning-traces';
 import type {
 	ManagedSettingsPanel,
 	SettingsSelectorProps,
@@ -149,6 +152,13 @@ function buildRowsForTab(
 					value: 'configure',
 					panel: 'display-settings',
 				},
+				{
+					kind: 'managed',
+					id: 'reasoning-traces',
+					label: 'Reasoning Traces',
+					value: getReasoningExpanded() ? 'expanded' : 'collapsed',
+					panel: 'reasoning-traces',
+				},
 			];
 		case 'advanced':
 			return [
@@ -158,6 +168,13 @@ function buildRowsForTab(
 					label: 'Privacy',
 					value: getPrivacyPreference() ? 'on' : 'off',
 					panel: 'privacy',
+				},
+				{
+					kind: 'managed',
+					id: 'default-mode',
+					label: 'Default Mode',
+					value: loadDefaultMode() ?? 'normal',
+					panel: 'default-mode',
 				},
 				{
 					kind: 'managed',
@@ -291,6 +308,10 @@ function renderManagedPanel(
 			return <SettingsJsonConfigPanel onBack={onBack} onCancel={onBack} />;
 		case 'web-search':
 			return <SettingsWebSearchPanel onBack={onBack} onCancel={onBack} />;
+		case 'default-mode':
+			return <SettingsDefaultModePanel onBack={onBack} onCancel={onBack} />;
+		case 'reasoning-traces':
+			return <SettingsReasoningTracesPanel onBack={onBack} onCancel={onBack} />;
 		case 'providers-config':
 			return (
 				<ProviderWizard

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -159,7 +159,7 @@ function buildRowsForTab(
 					kind: 'managed',
 					id: 'json-config',
 					label: 'Config (JSON)',
-					value: 'view',
+					value: 'edit',
 					panel: 'json-config',
 				},
 			];

--- a/source/app/components/settings-tabs.tsx
+++ b/source/app/components/settings-tabs.tsx
@@ -3,7 +3,7 @@ import {Box, Text, useInput} from 'ink';
 import type {ReactElement} from 'react';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {StyledTitle} from '@/components/ui/styled-title';
-import {getAppConfig, loadDefaultMode} from '@/config/index';
+import {getAppConfig, loadDefaultMode, reloadAppConfig} from '@/config/index';
 import {
 	getAlternateScreen,
 	getNanocoderShape,
@@ -46,7 +46,7 @@ import {SettingsWebSearchPanel} from './settings-web-search';
  * Tab categories are our own settings, grouped for browsability — not the
  * Status/Config/Usage read-only surfaces (those live at /status and /usage).
  * Every existing preference must be reachable from exactly one of these
- * four tabs.
+ * its tabs.
  */
 export type SettingsTabId =
 	| 'appearance'
@@ -375,6 +375,7 @@ function SettingRowLine({
 function renderManagedPanel(
 	panel: ManagedSettingsPanel,
 	onBack: () => void,
+	onMcpChanged?: () => void | Promise<void>,
 ): ReactElement {
 	switch (panel) {
 		case 'theme':
@@ -410,7 +411,13 @@ function renderManagedPanel(
 		case 'providers-config':
 			return <SettingsProvidersListPanel onBack={onBack} onCancel={onBack} />;
 		case 'mcp-config':
-			return <SettingsMcpListPanel onBack={onBack} onCancel={onBack} />;
+			return (
+				<SettingsMcpListPanel
+					onBack={onBack}
+					onCancel={onBack}
+					onMcpChanged={onMcpChanged}
+				/>
+			);
 	}
 }
 
@@ -436,18 +443,25 @@ function TabBar({
 }) {
 	const {colors} = useTheme();
 	const {currentTitleShape} = useTitleShape();
+	const {isNarrow} = useResponsiveTerminal();
 	const shape = currentTitleShape ?? 'pill';
 
 	return (
+		// wrap: the strip overflowed the panel border on narrow terminals, spilling
+		// the active pill's cap glyph outside the frame. The "Settings" prefix is
+		// redundant with the panel title, so it's the first thing to go.
 		<Box
 			key={`${activeTab}-${headerFocused}`}
 			flexDirection="row"
+			flexWrap="wrap"
 			gap={1}
 			marginBottom={1}
 		>
-			<Text bold color={colors.primary}>
-				Settings
-			</Text>
+			{!isNarrow && (
+				<Text bold color={colors.primary}>
+					Settings
+				</Text>
+			)}
 			{TABS.map(tab => {
 				const isActive = tab.id === activeTab;
 				if (isActive) {
@@ -471,6 +485,7 @@ export function SettingsSelector({
 	onCancel,
 	onLaunchTune,
 	onLaunchIde,
+	onMcpChanged,
 }: SettingsSelectorProps) {
 	const {colors} = useTheme();
 	const {boxWidth, isNarrow} = useResponsiveTerminal();
@@ -709,10 +724,14 @@ export function SettingsSelector({
 
 	if (openPanel) {
 		const onBack = () => {
+			// getAppConfig() is module-cached, so a panel (or a wizard it launched)
+			// that wrote to disk leaves the cache stale and the row values below
+			// would recompute from pre-edit data.
+			reloadAppConfig();
 			setVersion(v => v + 1);
 			setOpenPanel(null);
 		};
-		return renderManagedPanel(openPanel, onBack);
+		return renderManagedPanel(openPanel, onBack, onMcpChanged);
 	}
 
 	const width = isNarrow ? '100%' : boxWidth;

--- a/source/app/components/settings-tool-approval.tsx
+++ b/source/app/components/settings-tool-approval.tsx
@@ -1,0 +1,75 @@
+import {Box, Text, useInput} from 'ink';
+import SelectInput from 'ink-select-input';
+import {useMemo} from 'react';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {getAppConfig} from '@/config/index';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+
+/**
+ * Read-only view of the tools that run without confirmation (agents.config.json
+ * alwaysAllow + nanocoderTools.alwaysAllow). Editing is done in the config file.
+ */
+export function SettingsToolApprovalPanel({
+	onBack,
+	onCancel,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+
+	const tools = getAppConfig().alwaysAllow ?? [];
+
+	useInput((_, key) => {
+		if (key.escape) onCancel();
+		if (key.shift && key.tab) onBack();
+	});
+
+	const items = useMemo(() => {
+		const rows = [
+			{label: `Auto-approved tools (${tools.length})`, value: 'info'},
+		];
+		if (tools.length === 0) {
+			rows.push({label: '  (none configured)', value: 'empty'});
+		} else {
+			for (const tool of tools) rows.push({label: `  ${tool}`, value: tool});
+		}
+		return rows;
+	}, [tools]);
+
+	return (
+		<TitledBoxWithPreferences
+			title="Settings · Tool Auto-Approval"
+			width={isNarrow ? '100%' : boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			<Box marginBottom={1}>
+				<Text color={colors.secondary}>
+					These tools run without confirmation. Edit agents.config.json to
+					change.
+				</Text>
+			</Box>
+			<SelectInput
+				items={items}
+				onSelect={() => {}}
+				indicatorComponent={({isSelected}) => (
+					<Text color={isSelected ? colors.primary : colors.text}>
+						{isSelected ? '> ' : '  '}
+					</Text>
+				)}
+				itemComponent={({isSelected, label}) => (
+					<Text color={isSelected ? colors.primary : colors.text}>{label}</Text>
+				)}
+			/>
+			<Box marginTop={1}>
+				<Text color={colors.secondary}>Shift+Tab back · Esc exit</Text>
+			</Box>
+		</TitledBoxWithPreferences>
+	);
+}

--- a/source/app/components/settings-tool-approval.tsx
+++ b/source/app/components/settings-tool-approval.tsx
@@ -7,8 +7,8 @@ import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
 
 /**
- * Read-only view of the tools that run without confirmation (agents.config.json
- * alwaysAllow + nanocoderTools.alwaysAllow). Editing is done in the config file.
+ * Read-only view of the tools that run without confirmation (the top-level
+ * agents.config.json alwaysAllow). Editing is done in the config file.
  */
 export function SettingsToolApprovalPanel({
 	onBack,
@@ -59,16 +59,23 @@ export function SettingsToolApprovalPanel({
 				items={items}
 				onSelect={() => {}}
 				indicatorComponent={({isSelected}) => (
-					<Text color={isSelected ? colors.primary : colors.text}>
-						{isSelected ? '> ' : '  '}
-					</Text>
+					<Box minWidth={2}>
+						<Text color={isSelected ? colors.primary : colors.text}>
+							{isSelected ? '>' : ' '}
+						</Text>
+					</Box>
 				)}
 				itemComponent={({isSelected, label}) => (
-					<Text color={isSelected ? colors.primary : colors.text}>{label}</Text>
+					<Text
+						color={isSelected ? colors.primary : colors.text}
+						wrap="truncate-end"
+					>
+						{label}
+					</Text>
 				)}
 			/>
 			<Box marginTop={1}>
-				<Text color={colors.secondary}>Shift+Tab back · Esc exit</Text>
+				<Text color={colors.secondary}>Shift+Tab back · Esc back</Text>
 			</Box>
 		</TitledBoxWithPreferences>
 	);

--- a/source/app/components/settings-web-search.tsx
+++ b/source/app/components/settings-web-search.tsx
@@ -1,0 +1,119 @@
+import {Box, Text, useInput} from 'ink';
+import {useState} from 'react';
+import TextInput from '@/components/text-input';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {updateConfigNestedValue} from '@/config/config-writer';
+import {getAppConfig} from '@/config/index';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+
+/**
+ * Web Search settings: set/replace the Brave Search API key that web_search
+ * reads from nanocoder.nanocoderTools.webSearch.apiKey. Saves persist directly
+ * and atomically (no keep/discard prompt).
+ */
+export function SettingsWebSearchPanel({
+	onBack,
+	onCancel,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+
+	const [hasApiKey, setHasApiKey] = useState(() =>
+		Boolean(getAppConfig().nanocoderTools?.webSearch?.apiKey),
+	);
+	const [editMode, setEditMode] = useState(false);
+	const [inputValue, setInputValue] = useState('');
+	const [saved, setSaved] = useState(false);
+
+	useInput((_, key) => {
+		if (key.escape) {
+			if (editMode) {
+				setEditMode(false);
+				setInputValue('');
+			} else {
+				onCancel();
+			}
+			return;
+		}
+		if (key.shift && key.tab && !editMode) {
+			onBack();
+			return;
+		}
+		if (key.return && !editMode && !saved) {
+			setEditMode(true);
+		}
+	});
+
+	const handleSave = (value: string) => {
+		const trimmed = value.trim();
+		if (trimmed) {
+			// Preserve any other webSearch fields; only replace the key.
+			updateConfigNestedValue('nanocoderTools', 'webSearch', {
+				...getAppConfig().nanocoderTools?.webSearch,
+				apiKey: trimmed,
+			});
+			setHasApiKey(true);
+			setSaved(true);
+		} else {
+			setEditMode(false);
+			setInputValue('');
+		}
+	};
+
+	const width = isNarrow ? '100%' : boxWidth;
+	const title = isNarrow ? 'Web Search' : 'Settings · Web Search';
+
+	return (
+		<TitledBoxWithPreferences
+			title={title}
+			width={width}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			{saved ? (
+				<Text color={colors.success}>✓ API key saved. Esc to exit.</Text>
+			) : editMode ? (
+				<Box flexDirection="column">
+					<Text color={colors.secondary}>
+						Enter your Brave Search API key. Leave empty to cancel.
+					</Text>
+					<Box marginY={1} borderStyle="round" borderColor={colors.secondary}>
+						<TextInput
+							value={inputValue}
+							onChange={setInputValue}
+							onSubmit={handleSave}
+							mask="*"
+						/>
+					</Box>
+					<Text color={colors.secondary}>Enter to save · Esc to cancel</Text>
+				</Box>
+			) : (
+				<Box flexDirection="column">
+					<Text color={colors.secondary}>
+						Web search uses the Brave Search API.
+					</Text>
+					<Box marginTop={1}>
+						<Text color={hasApiKey ? colors.success : colors.text}>
+							{hasApiKey
+								? '✓ API key is configured'
+								: 'No API key configured — web search is unavailable'}
+						</Text>
+					</Box>
+					<Box marginTop={1}>
+						<Text color={colors.secondary}>
+							Enter to {hasApiKey ? 'change' : 'add'} · Shift+Tab back · Esc
+							exit
+						</Text>
+					</Box>
+				</Box>
+			)}
+		</TitledBoxWithPreferences>
+	);
+}

--- a/source/app/components/settings-web-search.tsx
+++ b/source/app/components/settings-web-search.tsx
@@ -27,7 +27,7 @@ export function SettingsWebSearchPanel({
 	);
 	const [editMode, setEditMode] = useState(false);
 	const [inputValue, setInputValue] = useState('');
-	const [saved, setSaved] = useState(false);
+	const [justSaved, setJustSaved] = useState(false);
 
 	useInput((_, key) => {
 		if (key.escape) {
@@ -43,7 +43,8 @@ export function SettingsWebSearchPanel({
 			onBack();
 			return;
 		}
-		if (key.return && !editMode && !saved) {
+		if (key.return && !editMode) {
+			setJustSaved(false);
 			setEditMode(true);
 		}
 	});
@@ -57,11 +58,12 @@ export function SettingsWebSearchPanel({
 				apiKey: trimmed,
 			});
 			setHasApiKey(true);
-			setSaved(true);
-		} else {
-			setEditMode(false);
-			setInputValue('');
+			setJustSaved(true);
 		}
+		// Either way, drop back to the summary — staying in a terminal "saved"
+		// state made the key unchangeable without leaving and re-entering.
+		setEditMode(false);
+		setInputValue('');
 	};
 
 	const width = isNarrow ? '100%' : boxWidth;
@@ -77,9 +79,7 @@ export function SettingsWebSearchPanel({
 			flexDirection="column"
 			marginBottom={1}
 		>
-			{saved ? (
-				<Text color={colors.success}>✓ API key saved. Esc to exit.</Text>
-			) : editMode ? (
+			{editMode ? (
 				<Box flexDirection="column">
 					<Text color={colors.secondary}>
 						Enter your Brave Search API key. Leave empty to cancel.
@@ -101,15 +101,17 @@ export function SettingsWebSearchPanel({
 					</Text>
 					<Box marginTop={1}>
 						<Text color={hasApiKey ? colors.success : colors.text}>
-							{hasApiKey
-								? '✓ API key is configured'
-								: 'No API key configured — web search is unavailable'}
+							{justSaved
+								? '✓ API key saved'
+								: hasApiKey
+									? '✓ API key is configured'
+									: 'No API key configured — web search is unavailable'}
 						</Text>
 					</Box>
 					<Box marginTop={1}>
 						<Text color={colors.secondary}>
 							Enter to {hasApiKey ? 'change' : 'add'} · Shift+Tab back · Esc
-							exit
+							back
 						</Text>
 					</Box>
 				</Box>

--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -328,6 +328,14 @@ export function InteractiveApp({
 							onMcpWizardComplete={modeHandlers.handleMcpWizardComplete}
 							onMcpWizardCancel={modeHandlers.handleMcpWizardCancel}
 							onSettingsCancel={modeHandlers.handleSettingsCancel}
+							onLaunchTune={() => {
+								modeHandlers.handleSettingsCancel();
+								modeHandlers.enterTune();
+							}}
+							onLaunchIde={() => {
+								modeHandlers.handleSettingsCancel();
+								modeHandlers.enterIdeSelectionMode();
+							}}
 							tuneConfig={appState.tune}
 							onTuneSelect={modeHandlers.handleTuneSelect}
 							onTuneCancel={modeHandlers.handleTuneCancel}

--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -75,6 +75,19 @@ export function InteractiveApp({
 	altScreenActive = false,
 }: InteractiveAppProps): React.ReactElement {
 	const nextRestoredDraftIdRef = React.useRef(1);
+	// Tune / IDE are launched by closing settings first, so their exit has no way
+	// to know it should land back in settings rather than in chat.
+	const launchedFromSettingsRef = React.useRef(false);
+	const returnFromLaunchedWizard = React.useCallback(
+		(exit: () => void) => () => {
+			exit();
+			if (launchedFromSettingsRef.current) {
+				launchedFromSettingsRef.current = false;
+				modeHandlers.enterSettingsMode();
+			}
+		},
+		[modeHandlers],
+	);
 	const [submittedDraft, setSubmittedDraft] =
 		React.useState<SubmittedInputDraft | null>(null);
 	const [restoredDraft, setRestoredDraft] =
@@ -305,8 +318,14 @@ export function InteractiveApp({
 				{appState.isIdeSelectionMode && (
 					<Box marginLeft={-1} flexDirection="column">
 						<IdeSelector
-							onSelect={handleIdeSelect}
-							onCancel={modeHandlers.handleIdeSelectionCancel}
+							onSelect={ide => {
+								// Completing lands in chat so the result is visible.
+								launchedFromSettingsRef.current = false;
+								handleIdeSelect(ide);
+							}}
+							onCancel={returnFromLaunchedWizard(
+								modeHandlers.handleIdeSelectionCancel,
+							)}
 						/>
 					</Box>
 				)}
@@ -328,17 +347,27 @@ export function InteractiveApp({
 							onMcpWizardComplete={modeHandlers.handleMcpWizardComplete}
 							onMcpWizardCancel={modeHandlers.handleMcpWizardCancel}
 							onSettingsCancel={modeHandlers.handleSettingsCancel}
+							onMcpChanged={modeHandlers.reloadMcpServers}
 							onLaunchTune={() => {
+								launchedFromSettingsRef.current = true;
 								modeHandlers.handleSettingsCancel();
 								modeHandlers.enterTune();
 							}}
 							onLaunchIde={() => {
+								launchedFromSettingsRef.current = true;
 								modeHandlers.handleSettingsCancel();
 								modeHandlers.enterIdeSelectionMode();
 							}}
 							tuneConfig={appState.tune}
-							onTuneSelect={modeHandlers.handleTuneSelect}
-							onTuneCancel={modeHandlers.handleTuneCancel}
+							onTuneSelect={config => {
+								// Tune clears the conversation and prints a summary — land in
+								// chat so that output isn't hidden behind the settings panel.
+								launchedFromSettingsRef.current = false;
+								return modeHandlers.handleTuneSelect(config);
+							}}
+							onTuneCancel={returnFromLaunchedWizard(
+								modeHandlers.handleTuneCancel,
+							)}
 							onCheckpointSelect={appHandlers.handleCheckpointSelect}
 							onCheckpointCancel={appHandlers.handleCheckpointCancel}
 							onSessionSelect={sessionId =>

--- a/source/components/json-viewer/index.ts
+++ b/source/components/json-viewer/index.ts
@@ -1,16 +1,3 @@
 export type {JsonFlatRow, JsonKind, JsonNode} from './json-tree';
-export {
-	addSibling,
-	collapseBeyondDepth,
-	deleteAtPath,
-	extractTreeValue,
-	findNodeByPath,
-	flattenTree,
-	getValueAtPath,
-	parseJsonToTree,
-	parseKeyValueInput,
-	setValueAtPath,
-	toggleCollapse,
-} from './json-tree';
 export type {JsonViewerProps} from './json-viewer';
 export {JsonViewer} from './json-viewer';

--- a/source/components/json-viewer/index.ts
+++ b/source/components/json-viewer/index.ts
@@ -1,0 +1,16 @@
+export type {JsonFlatRow, JsonKind, JsonNode} from './json-tree';
+export {
+	addSibling,
+	collapseBeyondDepth,
+	deleteAtPath,
+	extractTreeValue,
+	findNodeByPath,
+	flattenTree,
+	getValueAtPath,
+	parseJsonToTree,
+	parseKeyValueInput,
+	setValueAtPath,
+	toggleCollapse,
+} from './json-tree';
+export type {JsonViewerProps} from './json-viewer';
+export {JsonViewer} from './json-viewer';

--- a/source/components/json-viewer/json-tree.spec.ts
+++ b/source/components/json-viewer/json-tree.spec.ts
@@ -85,6 +85,19 @@ test('flattenTree: simple object', t => {
 	t.is(rows[3].value, '}');
 });
 
+test('flattenTree: sibling comma sits on the close bracket, not the open', t => {
+	const tree = parseJsonToTree({a: {x: 1}, b: 2});
+	const rows = flattenTree(tree);
+	const openOfA = rows.find(r => r.key === 'a' && r.value === '{');
+	t.truthy(openOfA);
+	t.is(openOfA?.trailing, '', 'open bracket must not carry a trailing comma');
+	const closeOfA = rows.find(
+		(r, i) => r.value === '}' && rows[i + 1]?.key === 'b',
+	);
+	t.truthy(closeOfA);
+	t.is(closeOfA?.trailing, ',', 'close bracket carries the sibling comma');
+});
+
 test('flattenTree: collapsed object shows summary', t => {
 	const tree = parseJsonToTree({a: {b: 1, c: 2}});
 	tree.children[0].collapsed = true;

--- a/source/components/json-viewer/json-tree.spec.ts
+++ b/source/components/json-viewer/json-tree.spec.ts
@@ -1,0 +1,376 @@
+import anyTest, {type ExecutionContext} from 'ava';
+import {
+	collapseBeyondDepth,
+	deleteAtPath,
+	extractTreeValue,
+	findNodeByPath,
+	flattenTree,
+	parseJsonToTree,
+	parseKeyValueInput,
+	setValueAtPath,
+	toggleCollapse,
+	addSibling,
+	getValueAtPath,
+} from './json-tree';
+
+const test = anyTest as any;
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
+
+test('parseJsonToTree: primitive values', t => {
+	t.is(parseJsonToTree(null).kind, 'null');
+	t.is(parseJsonToTree(null).value, null);
+
+	t.is(parseJsonToTree(true).kind, 'boolean');
+	t.is(parseJsonToTree(true).value, true);
+
+	t.is(parseJsonToTree(42).kind, 'number');
+	t.is(parseJsonToTree(42).value, 42);
+
+	t.is(parseJsonToTree('hello').kind, 'string');
+	t.is(parseJsonToTree('hello').value, 'hello');
+});
+
+test('parseJsonToTree: object', t => {
+	const tree = parseJsonToTree({name: 'test', count: 3});
+	t.is(tree.kind, 'object');
+	t.is(tree.size, 2);
+	t.is(tree.children[0].key, 'name');
+	t.is(tree.children[0].value, 'test');
+	t.is(tree.children[1].key, 'count');
+	t.is(tree.children[1].value, 3);
+});
+
+test('parseJsonToTree: array', t => {
+	const tree = parseJsonToTree([1, 'two', true]);
+	t.is(tree.kind, 'array');
+	t.is(tree.size, 3);
+	t.is(tree.children[0].value, 1);
+	t.is(tree.children[1].value, 'two');
+	t.is(tree.children[2].value, true);
+});
+
+test('parseJsonToTree: nested structure', t => {
+	const tree = parseJsonToTree({a: {b: [1, 2]}});
+	t.is(tree.kind, 'object');
+	t.is(tree.children[0].key, 'a');
+	t.is(tree.children[0].children[0].key, 'b');
+	t.is(tree.children[0].children[0].children[0].value, 1);
+	t.is(tree.children[0].children[0].children[1].value, 2);
+});
+
+test('parseJsonToTree: depth tracking', t => {
+	const tree = parseJsonToTree({a: {b: {c: 'deep'}}});
+	t.is(tree.depth, 0);
+	t.is(tree.children[0].depth, 1);
+	t.is(tree.children[0].children[0].depth, 2);
+	t.is(tree.children[0].children[0].children[0].depth, 3);
+});
+
+// ─── Flattening ──────────────────────────────────────────────────────────────
+
+test('flattenTree: simple object', t => {
+	const tree = parseJsonToTree({a: 1, b: 'two'});
+	const rows = flattenTree(tree);
+
+	t.is(rows.length, 4); // { , a:1, b:"two", }
+	t.is(rows[0].value, '{');
+	t.is(rows[0].hasChildren, true);
+	t.is(rows[1].key, 'a');
+	t.is(rows[1].value, '1');
+	t.is(rows[1].trailing, ',');
+	t.is(rows[2].key, 'b');
+	t.is(rows[2].value, '"two"');
+	t.is(rows[2].trailing, '');
+	t.is(rows[3].value, '}');
+});
+
+test('flattenTree: collapsed object shows summary', t => {
+	const tree = parseJsonToTree({a: {b: 1, c: 2}});
+	tree.children[0].collapsed = true;
+	const rows = flattenTree(tree);
+
+	t.is(rows.length, 3); // { , a: { ... }, }
+	t.is(rows[1].value, '{ ... }');
+	t.is(rows[1].isCollapsed, true);
+	t.is(rows[1].hiddenCount, 2);
+});
+
+test('flattenTree: array', t => {
+	const tree = parseJsonToTree([1, 2, 3]);
+	const rows = flattenTree(tree);
+
+	t.is(rows.length, 5); // [ , 1, 2, 3, ]
+	t.is(rows[0].value, '[');
+	t.is(rows[1].value, '1');
+	t.is(rows[1].trailing, ',');
+	t.is(rows[3].value, '3');
+	t.is(rows[3].trailing, '');
+	t.is(rows[4].value, ']');
+});
+
+test('flattenTree: path segments', t => {
+	const tree = parseJsonToTree({providers: {ollama: {url: 'http://localhost'}}});
+	const rows = flattenTree(tree);
+
+	// Find the url row
+	const urlRow = rows.find(r => r.key === 'url');
+	t.truthy(urlRow);
+	t.true(urlRow!.pathSegments.includes('providers'));
+	t.true(urlRow!.pathSegments.includes('ollama'));
+	t.true(urlRow!.pathSegments.includes('url'));
+});
+
+test('flattenTree: array index in path', t => {
+	const tree = parseJsonToTree({items: [{name: 'first'}]});
+	const rows = flattenTree(tree);
+
+	const nameRow = rows.find(r => r.key === 'name');
+	t.truthy(nameRow);
+	t.true(nameRow!.pathSegments.includes('[0]'));
+});
+
+test('flattenTree: line numbers are sequential', t => {
+	const tree = parseJsonToTree({a: 1, b: 2, c: 3});
+	const rows = flattenTree(tree);
+
+	for (let i = 0; i < rows.length; i++) {
+		t.is(rows[i].lineNumber, i + 1);
+	}
+});
+
+// ─── Path Utilities ──────────────────────────────────────────────────────────
+
+test('findNodeByPath: object path', t => {
+	const tree = parseJsonToTree({a: {b: {c: 'found'}}});
+	const node = findNodeByPath(tree, ['a', 'b', 'c']);
+	t.truthy(node);
+	t.is(node!.value, 'found');
+});
+
+test('findNodeByPath: array path', t => {
+	const tree = parseJsonToTree({items: [{name: 'first'}, {name: 'second'}]});
+	const node = findNodeByPath(tree, ['items', '[1]', 'name']);
+	t.truthy(node);
+	t.is(node!.value, 'second');
+});
+
+test('findNodeByPath: nonexistent path returns null', t => {
+	const tree = parseJsonToTree({a: 1});
+	t.is(findNodeByPath(tree, ['a', 'b']), null);
+	t.is(findNodeByPath(tree, ['z']), null);
+});
+
+test('getValueAtPath: nested value', t => {
+	const data = {a: {b: {c: 'deep'}}};
+	t.is(getValueAtPath(data, ['a', 'b', 'c']), 'deep');
+	t.deepEqual(getValueAtPath(data, ['a', 'b']), {c: 'deep'});
+});
+
+// ─── Mutations ───────────────────────────────────────────────────────────────
+
+test('toggleCollapse: toggles collapsed state', t => {
+	const tree = parseJsonToTree({a: {b: 1}});
+	t.is(tree.children[0].collapsed, false);
+
+	const updated = toggleCollapse(tree, ['a']);
+	t.is(updated.children[0].collapsed, true);
+
+	const updated2 = toggleCollapse(updated, ['a']);
+	t.is(updated2.children[0].collapsed, false);
+});
+
+test('toggleCollapse: original tree unchanged', t => {
+	const tree = parseJsonToTree({a: {b: 1}});
+	toggleCollapse(tree, ['a']);
+	t.is(tree.children[0].collapsed, false);
+});
+
+test('collapseBeyondDepth: collapses nodes beyond maxDepth', t => {
+	const tree = parseJsonToTree({a: {b: {c: {d: 'deep'}}}});
+	const collapsed = collapseBeyondDepth(tree, 1);
+
+	t.is(collapsed.collapsed, false);
+	t.is(collapsed.children[0].collapsed, true); // depth 1 >= maxDepth 1
+});
+
+test('setValueAtPath: changes primitive value', t => {
+	const tree = parseJsonToTree({name: 'old', count: 5});
+	const updated = setValueAtPath(tree, ['name'], 'new');
+
+	t.is(updated.children[0].value, 'new');
+	t.is(updated.children[1].value, 5);
+});
+
+test('setValueAtPath: nested value', t => {
+	const tree = parseJsonToTree({a: {b: {c: 1}}});
+	const updated = setValueAtPath(tree, ['a', 'b', 'c'], 99);
+
+	const node = findNodeByPath(updated, ['a', 'b', 'c']);
+	t.is(node!.value, 99);
+});
+
+test('setValueAtPath: original tree unchanged', t => {
+	const tree = parseJsonToTree({name: 'old'});
+	setValueAtPath(tree, ['name'], 'new');
+	t.is(tree.children[0].value, 'old');
+});
+
+test('deleteAtPath: removes object property', t => {
+	const tree = parseJsonToTree({a: 1, b: 2, c: 3});
+	const updated = deleteAtPath(tree, ['b']);
+
+	t.is(updated.size, 2);
+	t.is(updated.children[0].key, 'a');
+	t.is(updated.children[1].key, 'c');
+});
+
+test('deleteAtPath: removes array element', t => {
+	const tree = parseJsonToTree([1, 2, 3]);
+	const updated = deleteAtPath(tree, ['[1]']);
+
+	t.is(updated.size, 2);
+	t.is(updated.children[0].value, 1);
+	t.is(updated.children[1].value, 3);
+	t.is(updated.children[1].index, 1); // re-indexed
+});
+
+test('addSibling: adds to object', t => {
+	const tree = parseJsonToTree({a: 1});
+	const updated = addSibling(tree, ['a'], {key: 'b', value: null});
+
+	t.is(updated.size, 2);
+	t.is(updated.children[1].key, 'b');
+	t.is(updated.children[1].value, null);
+});
+
+test('addSibling: adds to array', t => {
+	const tree = parseJsonToTree([1, 2]);
+	const updated = addSibling(tree, ['[0]'], {key: '', value: null});
+
+	t.is(updated.size, 3);
+	t.is(updated.children[0].value, 1);
+	t.is(updated.children[1].value, null);
+	t.is(updated.children[2].value, 2);
+});
+
+// ─── Extract ─────────────────────────────────────────────────────────────────
+
+test('extractTreeValue: round-trips data', t => {
+	const original = {name: 'test', items: [1, {nested: true}], count: null};
+	const tree = parseJsonToTree(original);
+	const extracted = extractTreeValue(tree);
+
+	t.deepEqual(extracted, original);
+});
+
+test('extractTreeValue: after mutation round-trips', t => {
+	const original = {a: {b: 1}};
+	const tree = parseJsonToTree(original);
+	const updated = setValueAtPath(tree, ['a', 'b'], 99);
+	const extracted = extractTreeValue(updated);
+
+	t.deepEqual(extracted, {a: {b: 99}});
+});
+
+test('extractTreeValue: after delete round-trips', t => {
+	const original = {a: 1, b: 2, c: 3};
+	const tree = parseJsonToTree(original);
+	const updated = deleteAtPath(tree, ['b']);
+	const extracted = extractTreeValue(updated);
+
+	t.deepEqual(extracted, {a: 1, c: 3});
+});
+
+// ─── parseKeyValueInput ────────────────────────────────────────────────────
+
+test('parseKeyValueInput: key only', t => {
+	const {key, value} = parseKeyValueInput('myKey');
+	t.is(key, 'myKey');
+	t.is(value, null);
+});
+
+test('parseKeyValueInput: key with null value', t => {
+	const {key, value} = parseKeyValueInput('myKey:');
+	t.is(key, 'myKey');
+	t.is(value, null);
+});
+
+test('parseKeyValueInput: key with string value', t => {
+	const {key, value} = parseKeyValueInput('myKey: hello');
+	t.is(key, 'myKey');
+	t.is(value, 'hello');
+});
+
+test('parseKeyValueInput: key with quoted string value', t => {
+	const {key, value} = parseKeyValueInput('myKey: "hello world"');
+	t.is(key, 'myKey');
+	t.is(value, 'hello world');
+});
+
+test('parseKeyValueInput: key with number value', t => {
+	const {key, value} = parseKeyValueInput('myKey: 42');
+	t.is(key, 'myKey');
+	t.is(value, 42);
+});
+
+test('parseKeyValueInput: key with boolean value', t => {
+	t.is(parseKeyValueInput('myKey: true').value, true);
+	t.is(parseKeyValueInput('myKey: false').value, false);
+});
+
+test('parseKeyValueInput: key with null literal', t => {
+	t.is(parseKeyValueInput('myKey: null').value, null);
+});
+
+test('parseKeyValueInput: key with empty object', t => {
+	const {key, value} = parseKeyValueInput('myKey: {}');
+	t.is(key, 'myKey');
+	t.deepEqual(value, {});
+});
+
+test('parseKeyValueInput: key with empty array', t => {
+	const {key, value} = parseKeyValueInput('myKey: []');
+	t.is(key, 'myKey');
+	t.deepEqual(value, []);
+});
+
+test('parseKeyValueInput: key with valid JSON object', t => {
+	const {key, value} = parseKeyValueInput('myKey: {"a": 1, "b": 2}');
+	t.is(key, 'myKey');
+	t.deepEqual(value, {a: 1, b: 2});
+});
+
+test('parseKeyValueInput: key with lenient object (unquoted keys)', t => {
+	const {key, value} = parseKeyValueInput('myKey: {a: 1, b: hello}');
+	t.is(key, 'myKey');
+	t.deepEqual(value, {a: 1, b: 'hello'});
+});
+
+test('parseKeyValueInput: key with nested lenient object', t => {
+	const {key, value} = parseKeyValueInput('myKey: {sub: {deep: val}}');
+	t.is(key, 'myKey');
+	t.deepEqual(value, {sub: {deep: 'val'}});
+});
+
+test('parseKeyValueInput: key with array value', t => {
+	const {key, value} = parseKeyValueInput('myKey: [1, 2, 3]');
+	t.is(key, 'myKey');
+	t.deepEqual(value, [1, 2, 3]);
+});
+
+test('parseKeyValueInput: empty input defaults', t => {
+	const {key, value} = parseKeyValueInput('');
+	t.is(key, 'newKey');
+	t.is(value, null);
+});
+
+test('parseKeyValueInput: integrates with addSibling', t => {
+	const tree = parseJsonToTree({existing: 1});
+	const parsed = parseKeyValueInput('newKey: {a: 1, b: 2}');
+	const updated = addSibling(tree, ['existing'], parsed);
+
+	t.is(updated.size, 2);
+	const extracted = extractTreeValue(updated);
+	t.deepEqual(extracted, {existing: 1, newKey: {a: 1, b: 2}});
+});

--- a/source/components/json-viewer/json-tree.spec.ts
+++ b/source/components/json-viewer/json-tree.spec.ts
@@ -1,4 +1,4 @@
-import anyTest, {type ExecutionContext} from 'ava';
+import anyTest, {type TestFn} from 'ava';
 import {
 	collapseBeyondDepth,
 	deleteAtPath,
@@ -13,7 +13,7 @@ import {
 	getValueAtPath,
 } from './json-tree';
 
-const test = anyTest as any;
+const test = anyTest as TestFn;
 
 // ─── Parsing ─────────────────────────────────────────────────────────────────
 
@@ -83,6 +83,27 @@ test('flattenTree: simple object', t => {
 	t.is(rows[2].value, '"two"');
 	t.is(rows[2].trailing, '');
 	t.is(rows[3].value, '}');
+});
+
+test('flattenTree: row paths are dot-separated, with array indices attached', t => {
+	const rows = flattenTree(
+		parseJsonToTree({providers: [{baseUrl: 'http://x'}]}),
+	);
+	const paths = rows.map(r => r.path);
+
+	// These used to join with '', rendering "providersollamaurl" in the status bar.
+	t.true(paths.includes('providers'));
+	t.true(paths.includes('providers[0]'));
+	t.true(paths.includes('providers[0].baseUrl'));
+});
+
+test('flattenTree: distinct segment splits do not collide into one path', t => {
+	const a = flattenTree(parseJsonToTree({a: {bc: 1}})).map(r => r.path);
+	const b = flattenTree(parseJsonToTree({ab: {c: 1}})).map(r => r.path);
+
+	t.true(a.includes('a.bc'));
+	t.true(b.includes('ab.c'));
+	t.false(a.includes('ab.c'));
 });
 
 test('flattenTree: sibling comma sits on the close bracket, not the open', t => {

--- a/source/components/json-viewer/json-tree.ts
+++ b/source/components/json-viewer/json-tree.ts
@@ -203,7 +203,8 @@ function flattenNode(
 				trailing,
 			});
 		} else {
-			// Open bracket row
+			// Open bracket row. No trailing comma here — the sibling comma belongs
+			// on the CLOSE bracket row below, not after an opening `{`/`[`.
 			rows.push({
 				path,
 				pathSegments: [...pathSegments],
@@ -215,7 +216,7 @@ function flattenNode(
 				isCollapsed: false,
 				hiddenCount: 0,
 				lineNumber: nextLine(),
-				trailing,
+				trailing: '',
 			});
 
 			// Children

--- a/source/components/json-viewer/json-tree.ts
+++ b/source/components/json-viewer/json-tree.ts
@@ -1,0 +1,930 @@
+/**
+ * Pure-TypeScript JSON tree data structures and mutation utilities.
+ * No React dependencies — importable from components, config layers, or tests.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type JsonKind =
+	| 'null'
+	| 'boolean'
+	| 'number'
+	| 'string'
+	| 'object'
+	| 'array';
+
+export interface JsonNode {
+	kind: JsonKind;
+	/** Key name for object properties; undefined for array elements and root */
+	key: string | undefined;
+	/** Raw value for primitives */
+	value: unknown;
+	/** Child nodes for objects and arrays */
+	children: JsonNode[];
+	/** Depth from root (root = 0) */
+	depth: number;
+	/** Whether children are collapsed in the viewer */
+	collapsed: boolean;
+	/** Number of children (for objects/arrays) */
+	size: number;
+	/** 0-based index among siblings */
+	index: number;
+}
+
+/** A single flattened row ready for rendering */
+export interface JsonFlatRow {
+	/** Dot-separated JSONPath (e.g. "nanocoder.tune.toolProfile") */
+	path: string;
+	/** Array of path segments */
+	pathSegments: string[];
+	/** Visual indentation level */
+	indent: number;
+	/** Display key (undefined for array elements) */
+	key: string | undefined;
+	/** Display value string */
+	value: string;
+	/** JSON kind for color-coding */
+	kind: JsonKind;
+	/** Whether this row can be expanded/collapsed */
+	hasChildren: boolean;
+	/** Whether children are currently collapsed */
+	isCollapsed: boolean;
+	/** Number of hidden children when collapsed */
+	hiddenCount: number;
+	/** 1-based line number in the flattened view */
+	lineNumber: number;
+	/** Trailing punctuation (",", "}", "]") */
+	trailing: string;
+}
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
+
+/**
+ * Convert any JSON-serializable value into a JsonNode tree.
+ */
+export function parseJsonToTree(
+	data: unknown,
+	_key: string | undefined = undefined,
+	_depth: number = 0,
+	_index: number = 0,
+): JsonNode {
+	if (data === null) {
+		return {
+			kind: 'null',
+			key: _key,
+			value: null,
+			children: [],
+			depth: _depth,
+			collapsed: false,
+			size: 0,
+			index: _index,
+		};
+	}
+	if (typeof data === 'boolean') {
+		return {
+			kind: 'boolean',
+			key: _key,
+			value: data,
+			children: [],
+			depth: _depth,
+			collapsed: false,
+			size: 0,
+			index: _index,
+		};
+	}
+	if (typeof data === 'number') {
+		return {
+			kind: 'number',
+			key: _key,
+			value: data,
+			children: [],
+			depth: _depth,
+			collapsed: false,
+			size: 0,
+			index: _index,
+		};
+	}
+	if (typeof data === 'string') {
+		return {
+			kind: 'string',
+			key: _key,
+			value: data,
+			children: [],
+			depth: _depth,
+			collapsed: false,
+			size: 0,
+			index: _index,
+		};
+	}
+	if (Array.isArray(data)) {
+		const children = data.map((item, i) =>
+			parseJsonToTree(item, undefined, _depth + 1, i),
+		);
+		return {
+			kind: 'array',
+			key: _key,
+			value: data,
+			children,
+			depth: _depth,
+			collapsed: false,
+			size: children.length,
+			index: _index,
+		};
+	}
+	if (typeof data === 'object') {
+		const entries = Object.entries(data as Record<string, unknown>);
+		const children = entries.map(([k, v], i) =>
+			parseJsonToTree(v, k, _depth + 1, i),
+		);
+		return {
+			kind: 'object',
+			key: _key,
+			value: data,
+			children,
+			depth: _depth,
+			collapsed: false,
+			size: children.length,
+			index: _index,
+		};
+	}
+	// Fallback for undefined or other edge cases
+	return {
+		kind: 'null',
+		key: _key,
+		value: data,
+		children: [],
+		depth: _depth,
+		collapsed: false,
+		size: 0,
+		index: _index,
+	};
+}
+
+// ─── Flattening ──────────────────────────────────────────────────────────────
+
+/**
+ * Flatten a JsonNode tree into an array of renderable rows.
+ * Respects collapsed state — collapsed nodes show a single summary row.
+ */
+export function flattenTree(root: JsonNode): JsonFlatRow[] {
+	const rows: JsonFlatRow[] = [];
+	let lineNumber = 0;
+	flattenNode(root, [], rows, () => ++lineNumber, false);
+	return rows;
+}
+
+function flattenNode(
+	node: JsonNode,
+	pathSegments: string[],
+	rows: JsonFlatRow[],
+	nextLine: () => number,
+	isLast: boolean,
+): void {
+	const path = buildPath(pathSegments);
+	const trailing = isLast ? '' : ',';
+
+	if (node.kind === 'object' || node.kind === 'array') {
+		const openBracket = node.kind === 'object' ? '{' : '[';
+		const closeBracket = node.kind === 'object' ? '}' : ']';
+
+		if (node.collapsed) {
+			// Single collapsed row: { ... } or [ ... ]
+			rows.push({
+				path,
+				pathSegments: [...pathSegments],
+				indent: node.depth,
+				key: node.key,
+				value: `${openBracket} ... ${closeBracket}`,
+				kind: node.kind,
+				hasChildren: true,
+				isCollapsed: true,
+				hiddenCount: node.size,
+				lineNumber: nextLine(),
+				trailing,
+			});
+		} else {
+			// Open bracket row
+			rows.push({
+				path,
+				pathSegments: [...pathSegments],
+				indent: node.depth,
+				key: node.key,
+				value: openBracket,
+				kind: node.kind,
+				hasChildren: true,
+				isCollapsed: false,
+				hiddenCount: 0,
+				lineNumber: nextLine(),
+				trailing,
+			});
+
+			// Children
+			node.children.forEach((child, i) => {
+				const childPath =
+					node.kind === 'array'
+						? [...pathSegments, `[${i}]`]
+						: [...pathSegments, child.key ?? ''];
+				const childIsLast = i === node.children.length - 1;
+				flattenNode(child, childPath, rows, nextLine, childIsLast);
+			});
+
+			// Close bracket row
+			rows.push({
+				path,
+				pathSegments: [...pathSegments],
+				indent: node.depth,
+				key: undefined,
+				value: closeBracket,
+				kind: node.kind,
+				hasChildren: false,
+				isCollapsed: false,
+				hiddenCount: 0,
+				lineNumber: nextLine(),
+				trailing,
+			});
+		}
+	} else {
+		// Primitive row
+		rows.push({
+			path,
+			pathSegments: [...pathSegments],
+			indent: node.depth,
+			key: node.key,
+			value: formatValue(node.value, node.kind),
+			kind: node.kind,
+			hasChildren: false,
+			isCollapsed: false,
+			hiddenCount: 0,
+			lineNumber: nextLine(),
+			trailing,
+		});
+	}
+}
+
+function buildPath(segments: string[]): string {
+	if (segments.length === 0) return '$';
+	return segments
+		.map(seg => {
+			// Array indices: $.items[0]
+			if (/^\[\d+\]$/.test(seg)) {
+				return seg;
+			}
+			// Object keys with dots: $.key.name
+			return seg;
+		})
+		.join('');
+}
+
+function formatValue(value: unknown, kind: JsonKind): string {
+	if (kind === 'null') return 'null';
+	if (kind === 'boolean') return String(value);
+	if (kind === 'number') return String(value);
+	if (kind === 'string') return `"${value}"`;
+	return String(value);
+}
+
+// ─── Path Utilities ──────────────────────────────────────────────────────────
+
+/**
+ * Find a node by its path segments in the tree.
+ */
+export function findNodeByPath(
+	root: JsonNode,
+	segments: string[],
+): JsonNode | null {
+	if (segments.length === 0) return root;
+
+	const [first, ...rest] = segments;
+
+	if (root.kind === 'array') {
+		const match = first.match(/^\[(\d+)\]$/);
+		if (!match) return null;
+		const idx = parseInt(match[1], 10);
+		const child = root.children[idx];
+		if (!child) return null;
+		return rest.length === 0 ? child : findNodeByPath(child, rest);
+	}
+
+	if (root.kind === 'object') {
+		const child = root.children.find(c => c.key === first);
+		if (!child) return null;
+		return rest.length === 0 ? child : findNodeByPath(child, rest);
+	}
+
+	return null;
+}
+
+/**
+ * Get the raw value at a path in the original data.
+ */
+export function getValueAtPath(data: unknown, segments: string[]): unknown {
+	if (segments.length === 0) return data;
+	const [first, ...rest] = segments;
+
+	if (Array.isArray(data)) {
+		const match = first.match(/^\[(\d+)\]$/);
+		if (!match) return undefined;
+		const idx = parseInt(match[1], 10);
+		return getValueAtPath(data[idx], rest);
+	}
+
+	if (data && typeof data === 'object') {
+		return getValueAtPath((data as Record<string, unknown>)[first], rest);
+	}
+
+	return undefined;
+}
+
+/**
+ * Parse a `key: value` input string from the add-sibling flow.
+ * Returns `{ key, value }` where `value` is the parsed JSON value.
+ *
+ * Supports:
+ *   - `myKey`            → { key: 'myKey', value: null }
+ *   - `myKey: hello`     → { key: 'myKey', value: 'hello' }
+ *   - `myKey: 42`        → { key: 'myKey', value: 42 }
+ *   - `myKey: {}`        → { key: 'myKey', value: {} }
+ *   - `myKey: {a: 1}`    → { key: 'myKey', value: { a: 1 } }  (lenient)
+ *   - `myKey: [1,2,3]`   → { key: 'myKey', value: [1, 2, 3] }
+ */
+export function parseKeyValueInput(input: string): {
+	key: string;
+	value: unknown;
+} {
+	const trimmed = input.trim();
+	if (trimmed.length === 0) {
+		return {key: 'newKey', value: null};
+	}
+
+	// Split on the first colon to separate key from value
+	const colonIndex = trimmed.indexOf(':');
+	if (colonIndex === -1) {
+		// No colon — treat entire input as the key with null value
+		return {key: trimmed.trim(), value: null};
+	}
+
+	const key = trimmed.slice(0, colonIndex).trim();
+	const rawValue = trimmed.slice(colonIndex + 1).trim();
+
+	// No value after colon
+	if (rawValue.length === 0) {
+		return {key: key || 'newKey', value: null};
+	}
+
+	// Try strict JSON.parse first
+	try {
+		return {key: key || 'newKey', value: JSON.parse(rawValue)};
+	} catch {}
+
+	// Lenient parsing for bare {key: value} or [value] patterns
+	const lenient = tryLenientParse(rawValue);
+	if (lenient !== null) {
+		return {key: key || 'newKey', value: lenient};
+	}
+
+	// Fallback: treat as a plain string
+	return {key: key || 'newKey', value: rawValue};
+}
+
+/**
+ * Attempt to parse a value that looks like JSON but may have unquoted keys
+ * or unquoted string values, e.g. `{a: 1, b: hello}` or `[one, two]`.
+ * Returns null if the input doesn't look like a structured value.
+ */
+function tryLenientParse(input: string): unknown {
+	const trimmed = input.trim();
+
+	// Only attempt lenient parsing for object/array literals
+	if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) {
+		return null;
+	}
+
+	// Transform: quote unquoted keys and unquoted string values
+	// Strategy: wrap bare identifiers in quotes
+	let transformed = lenifyJson(trimmed);
+
+	try {
+		return JSON.parse(transformed);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Transform lenient JSON-like input into valid JSON by quoting
+ * unquoted keys and string values.
+ */
+function lenifyJson(input: string): string {
+	const result: string[] = [];
+	let i = 0;
+	let inString = false;
+	let expectColon = false;
+	let afterColon = true;
+	let _depth = 0;
+
+	while (i < input.length) {
+		const ch = input[i];
+
+		if (inString) {
+			result.push(ch);
+			if (ch === '\\' && i + 1 < input.length) {
+				i++;
+				result.push(input[i]);
+			} else if (ch === '"') {
+				inString = false;
+			}
+			i++;
+			continue;
+		}
+
+		// Outside a string
+		if (ch === '"') {
+			inString = true;
+			result.push(ch);
+			i++;
+			continue;
+		}
+
+		if (ch === '{' || ch === '[') {
+			_depth++;
+			result.push(ch);
+			expectColon = false;
+			afterColon = false;
+			i++;
+			continue;
+		}
+
+		if (ch === '}' || ch === ']') {
+			_depth--;
+			result.push(ch);
+			i++;
+			continue;
+		}
+
+		if (ch === ':') {
+			expectColon = true;
+			afterColon = true;
+			result.push(ch);
+			i++;
+			continue;
+		}
+
+		if (ch === ',') {
+			result.push(ch);
+			expectColon = false;
+			afterColon = false;
+			i++;
+			continue;
+		}
+
+		// Skip whitespace
+		if (/\s/.test(ch)) {
+			result.push(ch);
+			i++;
+			continue;
+		}
+
+		// Read a bare token (unquoted identifier or literal)
+		const tokenStart = i;
+		while (
+			i < input.length &&
+			!'{}[]:,"'.includes(input[i]) &&
+			!/\s/.test(input[i])
+		) {
+			i++;
+		}
+		const token = input.slice(tokenStart, i);
+
+		if (token.length === 0) {
+			i++;
+			continue;
+		}
+
+		// Determine if this token needs quoting
+		if (expectColon || afterColon) {
+			// This is a value position
+			const parsed = tryParseLiteral(token);
+			if (parsed !== null) {
+				// It's a known literal (true, false, null, number)
+				result.push(token);
+			} else {
+				// It's an unquoted string value
+				result.push(`"${escapeJsonString(token)}"`);
+			}
+			expectColon = false;
+			afterColon = false;
+		} else {
+			// This is a key position (inside an object)
+			const parsed = tryParseLiteral(token);
+			if (parsed !== null) {
+				// It's a literal used as a key — quote it
+				result.push(`"${escapeJsonString(token)}"`);
+			} else {
+				// Bare identifier key
+				result.push(`"${escapeJsonString(token)}"`);
+			}
+		}
+	}
+
+	return result.join('');
+}
+
+/**
+ * Try to parse a token as a JSON literal (number, boolean, null).
+ * Returns the parsed value or null if it's not a known literal.
+ */
+function tryParseLiteral(token: string): unknown {
+	if (token === 'true') return true;
+	if (token === 'false') return false;
+	if (token === 'null') return null;
+	if (/^-?\d+\.?\d*$/.test(token)) return Number(token);
+	return null;
+}
+
+/** Escape a string for JSON embedding */
+function escapeJsonString(s: string): string {
+	return s
+		.replace(/\\/g, '\\\\')
+		.replace(/"/g, '\\"')
+		.replace(/\n/g, '\\n')
+		.replace(/\r/g, '\\r')
+		.replace(/\t/g, '\\t');
+}
+
+// ─── Mutations ───────────────────────────────────────────────────────────────
+
+/**
+ * Toggle collapsed state of a node at the given path.
+ */
+export function toggleCollapse(root: JsonNode, segments: string[]): JsonNode {
+	if (segments.length === 0) {
+		return cloneNode({...root, collapsed: !root.collapsed});
+	}
+
+	const [first, ...rest] = segments;
+
+	if (root.kind === 'array') {
+		const match = first.match(/^\[(\d+)\]$/);
+		if (!match) return root;
+		const idx = parseInt(match[1], 10);
+		const newChildren = [...root.children];
+		newChildren[idx] = toggleCollapse(newChildren[idx], rest);
+		return cloneNode({...root, children: newChildren});
+	}
+
+	if (root.kind === 'object') {
+		const newChildren = root.children.map(child => {
+			if (child.key === first) {
+				return toggleCollapse(child, rest);
+			}
+			return child;
+		});
+		return cloneNode({...root, children: newChildren});
+	}
+
+	return root;
+}
+
+/**
+ * Collapse all nodes beyond the given depth.
+ */
+export function collapseBeyondDepth(
+	root: JsonNode,
+	maxDepth: number,
+): JsonNode {
+	return cloneNode(collapseNodeAtDepth(root, 0, maxDepth));
+}
+
+function collapseNodeAtDepth(
+	node: JsonNode,
+	currentDepth: number,
+	maxDepth: number,
+): JsonNode {
+	if (node.kind !== 'object' && node.kind !== 'array') {
+		return node;
+	}
+
+	const shouldCollapse = currentDepth >= maxDepth;
+
+	const newChildren = node.children.map(child =>
+		collapseNodeAtDepth(child, currentDepth + 1, maxDepth),
+	);
+
+	return cloneNode({
+		...node,
+		collapsed: shouldCollapse || node.collapsed,
+		children: newChildren,
+	});
+}
+
+/**
+ * Set a primitive value at the given path.
+ * Returns a new tree with the updated value.
+ */
+export function setValueAtPath(
+	root: JsonNode,
+	segments: string[],
+	newValue: unknown,
+): JsonNode {
+	if (segments.length === 0) {
+		// Replace entire root
+		return parseJsonToTree(newValue);
+	}
+
+	const [first, ...rest] = segments;
+
+	if (root.kind === 'array') {
+		const match = first.match(/^\[(\d+)\]$/);
+		if (!match) return root;
+		const idx = parseInt(match[1], 10);
+		const newChildren = [...root.children];
+		if (rest.length === 0) {
+			newChildren[idx] = parseJsonToTree(
+				newValue,
+				undefined,
+				root.depth + 1,
+				idx,
+			);
+		} else {
+			newChildren[idx] = setValueAtPath(newChildren[idx], rest, newValue);
+		}
+		return cloneNode({
+			...root,
+			children: newChildren,
+			value: newChildren,
+			size: newChildren.length,
+		});
+	}
+
+	if (root.kind === 'object') {
+		const newChildren = root.children.map(child => {
+			if (child.key === first) {
+				if (rest.length === 0) {
+					return parseJsonToTree(newValue, first, root.depth + 1, child.index);
+				}
+				return setValueAtPath(child, rest, newValue);
+			}
+			return child;
+		});
+		const newValueObj = objectFromChildren(newChildren);
+		return cloneNode({
+			...root,
+			children: newChildren,
+			value: newValueObj,
+			size: newChildren.length,
+		});
+	}
+
+	return root;
+}
+
+/**
+ * Add a new sibling after the node at the given path.
+ * `parsedEntry` contains the key and (optionally) value to insert.
+ * For arrays: `key` is ignored and `value` is used.
+ */
+export function addSibling(
+	root: JsonNode,
+	segments: string[],
+	parsedEntry: {key: string; value: unknown},
+): JsonNode {
+	if (root.kind !== 'object' && root.kind !== 'array') {
+		return root;
+	}
+
+	// If segments is empty, add to root
+	if (segments.length === 0) {
+		return addToRoot(root, parsedEntry);
+	}
+
+	const [first, ...rest] = segments;
+
+	if (root.kind === 'array') {
+		const match = first.match(/^\[(\d+)\]$/);
+		if (!match) return root;
+		const idx = parseInt(match[1], 10);
+		const newChildren = [...root.children];
+
+		if (rest.length === 0) {
+			// Add after the matched index
+			const newNode = parseJsonToTree(
+				parsedEntry.value,
+				undefined,
+				root.depth + 1,
+				idx + 1,
+			);
+			newChildren.splice(idx + 1, 0, newNode);
+			// Re-index
+			const reindexed = newChildren.map((c, i) => cloneNode({...c, index: i}));
+			return cloneNode({
+				...root,
+				children: reindexed,
+				value: reindexed,
+				size: reindexed.length,
+			});
+		}
+
+		newChildren[idx] = addSibling(newChildren[idx], rest, parsedEntry);
+		const newValueArr = arrayFromChildren(newChildren);
+		return cloneNode({
+			...root,
+			children: newChildren,
+			value: newValueArr,
+			size: newChildren.length,
+		});
+	}
+
+	if (root.kind === 'object') {
+		// First, check if we're adding at this level (rest.length === 0)
+		if (rest.length === 0) {
+			const newChildren: JsonNode[] = [];
+			for (const child of root.children) {
+				newChildren.push(child);
+				if (child.key === first) {
+					const newNode = parseJsonToTree(
+						parsedEntry.value,
+						parsedEntry.key,
+						root.depth + 1,
+						newChildren.length,
+					);
+					newChildren.push(newNode);
+				}
+			}
+			const newValueObj = objectFromChildren(newChildren);
+			return cloneNode({
+				...root,
+				children: newChildren,
+				value: newValueObj,
+				size: newChildren.length,
+			});
+		}
+
+		// Descend into the matched child
+		const newChildren = root.children.map(child => {
+			if (child.key === first) {
+				return addSibling(child, rest, parsedEntry);
+			}
+			return child;
+		});
+		const newValueObj = objectFromChildren(newChildren);
+		return cloneNode({
+			...root,
+			children: newChildren,
+			value: newValueObj,
+			size: newChildren.length,
+		});
+	}
+
+	return root;
+}
+
+/**
+ * Delete the node at the given path.
+ */
+export function deleteAtPath(root: JsonNode, segments: string[]): JsonNode {
+	if (segments.length === 0) {
+		return parseJsonToTree(null);
+	}
+
+	const [first, ...rest] = segments;
+
+	if (root.kind === 'array') {
+		const match = first.match(/^\[(\d+)\]$/);
+		if (!match) return root;
+		const idx = parseInt(match[1], 10);
+
+		if (rest.length === 0) {
+			const newChildren = root.children.filter((_, i) => i !== idx);
+			const reindexed = newChildren.map((c, i) => cloneNode({...c, index: i}));
+			return cloneNode({
+				...root,
+				children: reindexed,
+				value: reindexed,
+				size: reindexed.length,
+			});
+		}
+
+		const newChildren = [...root.children];
+		newChildren[idx] = deleteAtPath(newChildren[idx], rest);
+		const newValueArr = arrayFromChildren(newChildren);
+		return cloneNode({
+			...root,
+			children: newChildren,
+			value: newValueArr,
+			size: newChildren.length,
+		});
+	}
+
+	if (root.kind === 'object') {
+		if (rest.length === 0) {
+			const newChildren = root.children.filter(c => c.key !== first);
+			const newValueObj = objectFromChildren(newChildren);
+			return cloneNode({
+				...root,
+				children: newChildren,
+				value: newValueObj,
+				size: newChildren.length,
+			});
+		}
+
+		const newChildren = root.children.map(child => {
+			if (child.key === first) {
+				return deleteAtPath(child, rest);
+			}
+			return child;
+		});
+		const newValueObj = objectFromChildren(newChildren);
+		return cloneNode({
+			...root,
+			children: newChildren,
+			value: newValueObj,
+			size: newChildren.length,
+		});
+	}
+
+	return root;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function addToRoot(
+	root: JsonNode,
+	parsedEntry: {key: string; value: unknown},
+): JsonNode {
+	if (root.kind === 'object') {
+		const newNode = parseJsonToTree(
+			parsedEntry.value,
+			parsedEntry.key,
+			root.depth + 1,
+			root.children.length,
+		);
+		const newChildren = [...root.children, newNode];
+		const newValueObj = objectFromChildren(newChildren);
+		return cloneNode({
+			...root,
+			children: newChildren,
+			value: newValueObj,
+			size: newChildren.length,
+		});
+	}
+	if (root.kind === 'array') {
+		const newNode = parseJsonToTree(
+			parsedEntry.value,
+			undefined,
+			root.depth + 1,
+			root.children.length,
+		);
+		const newChildren = [...root.children, newNode];
+		return cloneNode({
+			...root,
+			children: newChildren,
+			value: newChildren,
+			size: newChildren.length,
+		});
+	}
+	return root;
+}
+
+function cloneNode(node: JsonNode): JsonNode {
+	return {
+		kind: node.kind,
+		key: node.key,
+		value: node.value,
+		children: node.children,
+		depth: node.depth,
+		collapsed: node.collapsed,
+		size: node.size,
+		index: node.index,
+	};
+}
+
+function objectFromChildren(children: JsonNode[]): Record<string, unknown> {
+	const obj: Record<string, unknown> = {};
+	for (const child of children) {
+		if (child.key !== undefined) {
+			obj[child.key] = extractRawValue(child);
+		}
+	}
+	return obj;
+}
+
+function arrayFromChildren(children: JsonNode[]): unknown[] {
+	return children.map(child => extractRawValue(child));
+}
+
+function extractRawValue(node: JsonNode): unknown {
+	if (node.kind === 'object') {
+		return objectFromChildren(node.children);
+	}
+	if (node.kind === 'array') {
+		return arrayFromChildren(node.children);
+	}
+	return node.value;
+}
+
+/**
+ * Extract the raw JSON-serializable value from a JsonNode tree.
+ */
+export function extractTreeValue(root: JsonNode): unknown {
+	return extractRawValue(root);
+}

--- a/source/components/json-viewer/json-tree.ts
+++ b/source/components/json-viewer/json-tree.ts
@@ -262,18 +262,18 @@ function flattenNode(
 	}
 }
 
-function buildPath(segments: string[]): string {
+/**
+ * Dot-separated JSONPath: ["providers","[1]","baseUrl"] → "providers[1].baseUrl".
+ * Array indices attach to the preceding segment without a dot. Exported so the
+ * viewer's initialPath lookup uses the SAME encoding — a separator-less join
+ * made ["a","bc"] and ["ab","c"] collide.
+ */
+export function buildPath(segments: string[]): string {
 	if (segments.length === 0) return '$';
-	return segments
-		.map(seg => {
-			// Array indices: $.items[0]
-			if (/^\[\d+\]$/.test(seg)) {
-				return seg;
-			}
-			// Object keys with dots: $.key.name
-			return seg;
-		})
-		.join('');
+	return segments.reduce((acc, seg) => {
+		if (/^\[\d+\]$/.test(seg)) return acc + seg;
+		return acc === '' ? seg : `${acc}.${seg}`;
+	}, '');
 }
 
 function formatValue(value: unknown, kind: JsonKind): string {
@@ -419,9 +419,8 @@ function lenifyJson(input: string): string {
 	const result: string[] = [];
 	let i = 0;
 	let inString = false;
-	let expectColon = false;
-	let afterColon = true;
-	let _depth = 0;
+	// One flag: ':' opens a value position, '{'/'['/',' returns to a key position.
+	let inValuePosition = true;
 
 	while (i < input.length) {
 		const ch = input[i];
@@ -447,24 +446,20 @@ function lenifyJson(input: string): string {
 		}
 
 		if (ch === '{' || ch === '[') {
-			_depth++;
 			result.push(ch);
-			expectColon = false;
-			afterColon = false;
+			inValuePosition = false;
 			i++;
 			continue;
 		}
 
 		if (ch === '}' || ch === ']') {
-			_depth--;
 			result.push(ch);
 			i++;
 			continue;
 		}
 
 		if (ch === ':') {
-			expectColon = true;
-			afterColon = true;
+			inValuePosition = true;
 			result.push(ch);
 			i++;
 			continue;
@@ -472,8 +467,7 @@ function lenifyJson(input: string): string {
 
 		if (ch === ',') {
 			result.push(ch);
-			expectColon = false;
-			afterColon = false;
+			inValuePosition = false;
 			i++;
 			continue;
 		}
@@ -502,7 +496,7 @@ function lenifyJson(input: string): string {
 		}
 
 		// Determine if this token needs quoting
-		if (expectColon || afterColon) {
+		if (inValuePosition) {
 			// This is a value position
 			const parsed = tryParseLiteral(token);
 			if (parsed !== null) {
@@ -512,18 +506,10 @@ function lenifyJson(input: string): string {
 				// It's an unquoted string value
 				result.push(`"${escapeJsonString(token)}"`);
 			}
-			expectColon = false;
-			afterColon = false;
+			inValuePosition = false;
 		} else {
-			// This is a key position (inside an object)
-			const parsed = tryParseLiteral(token);
-			if (parsed !== null) {
-				// It's a literal used as a key — quote it
-				result.push(`"${escapeJsonString(token)}"`);
-			} else {
-				// Bare identifier key
-				result.push(`"${escapeJsonString(token)}"`);
-			}
+			// Key position: bare or literal-looking, it always ends up quoted.
+			result.push(`"${escapeJsonString(token)}"`);
 		}
 	}
 
@@ -559,7 +545,7 @@ function escapeJsonString(s: string): string {
  */
 export function toggleCollapse(root: JsonNode, segments: string[]): JsonNode {
 	if (segments.length === 0) {
-		return cloneNode({...root, collapsed: !root.collapsed});
+		return {...root, collapsed: !root.collapsed};
 	}
 
 	const [first, ...rest] = segments;
@@ -570,7 +556,7 @@ export function toggleCollapse(root: JsonNode, segments: string[]): JsonNode {
 		const idx = parseInt(match[1], 10);
 		const newChildren = [...root.children];
 		newChildren[idx] = toggleCollapse(newChildren[idx], rest);
-		return cloneNode({...root, children: newChildren});
+		return {...root, children: newChildren};
 	}
 
 	if (root.kind === 'object') {
@@ -580,7 +566,7 @@ export function toggleCollapse(root: JsonNode, segments: string[]): JsonNode {
 			}
 			return child;
 		});
-		return cloneNode({...root, children: newChildren});
+		return {...root, children: newChildren};
 	}
 
 	return root;
@@ -593,7 +579,7 @@ export function collapseBeyondDepth(
 	root: JsonNode,
 	maxDepth: number,
 ): JsonNode {
-	return cloneNode(collapseNodeAtDepth(root, 0, maxDepth));
+	return collapseNodeAtDepth(root, 0, maxDepth);
 }
 
 function collapseNodeAtDepth(
@@ -611,11 +597,11 @@ function collapseNodeAtDepth(
 		collapseNodeAtDepth(child, currentDepth + 1, maxDepth),
 	);
 
-	return cloneNode({
+	return {
 		...node,
 		collapsed: shouldCollapse || node.collapsed,
 		children: newChildren,
-	});
+	};
 }
 
 /**
@@ -649,12 +635,12 @@ export function setValueAtPath(
 		} else {
 			newChildren[idx] = setValueAtPath(newChildren[idx], rest, newValue);
 		}
-		return cloneNode({
+		return {
 			...root,
 			children: newChildren,
 			value: newChildren,
 			size: newChildren.length,
-		});
+		};
 	}
 
 	if (root.kind === 'object') {
@@ -668,12 +654,12 @@ export function setValueAtPath(
 			return child;
 		});
 		const newValueObj = objectFromChildren(newChildren);
-		return cloneNode({
+		return {
 			...root,
 			children: newChildren,
 			value: newValueObj,
 			size: newChildren.length,
-		});
+		};
 	}
 
 	return root;
@@ -716,23 +702,23 @@ export function addSibling(
 			);
 			newChildren.splice(idx + 1, 0, newNode);
 			// Re-index
-			const reindexed = newChildren.map((c, i) => cloneNode({...c, index: i}));
-			return cloneNode({
+			const reindexed = newChildren.map((c, i) => ({...c, index: i}));
+			return {
 				...root,
 				children: reindexed,
 				value: reindexed,
 				size: reindexed.length,
-			});
+			};
 		}
 
 		newChildren[idx] = addSibling(newChildren[idx], rest, parsedEntry);
 		const newValueArr = arrayFromChildren(newChildren);
-		return cloneNode({
+		return {
 			...root,
 			children: newChildren,
 			value: newValueArr,
 			size: newChildren.length,
-		});
+		};
 	}
 
 	if (root.kind === 'object') {
@@ -752,12 +738,12 @@ export function addSibling(
 				}
 			}
 			const newValueObj = objectFromChildren(newChildren);
-			return cloneNode({
+			return {
 				...root,
 				children: newChildren,
 				value: newValueObj,
 				size: newChildren.length,
-			});
+			};
 		}
 
 		// Descend into the matched child
@@ -768,12 +754,12 @@ export function addSibling(
 			return child;
 		});
 		const newValueObj = objectFromChildren(newChildren);
-		return cloneNode({
+		return {
 			...root,
 			children: newChildren,
 			value: newValueObj,
 			size: newChildren.length,
-		});
+		};
 	}
 
 	return root;
@@ -796,36 +782,36 @@ export function deleteAtPath(root: JsonNode, segments: string[]): JsonNode {
 
 		if (rest.length === 0) {
 			const newChildren = root.children.filter((_, i) => i !== idx);
-			const reindexed = newChildren.map((c, i) => cloneNode({...c, index: i}));
-			return cloneNode({
+			const reindexed = newChildren.map((c, i) => ({...c, index: i}));
+			return {
 				...root,
 				children: reindexed,
 				value: reindexed,
 				size: reindexed.length,
-			});
+			};
 		}
 
 		const newChildren = [...root.children];
 		newChildren[idx] = deleteAtPath(newChildren[idx], rest);
 		const newValueArr = arrayFromChildren(newChildren);
-		return cloneNode({
+		return {
 			...root,
 			children: newChildren,
 			value: newValueArr,
 			size: newChildren.length,
-		});
+		};
 	}
 
 	if (root.kind === 'object') {
 		if (rest.length === 0) {
 			const newChildren = root.children.filter(c => c.key !== first);
 			const newValueObj = objectFromChildren(newChildren);
-			return cloneNode({
+			return {
 				...root,
 				children: newChildren,
 				value: newValueObj,
 				size: newChildren.length,
-			});
+			};
 		}
 
 		const newChildren = root.children.map(child => {
@@ -835,12 +821,12 @@ export function deleteAtPath(root: JsonNode, segments: string[]): JsonNode {
 			return child;
 		});
 		const newValueObj = objectFromChildren(newChildren);
-		return cloneNode({
+		return {
 			...root,
 			children: newChildren,
 			value: newValueObj,
 			size: newChildren.length,
-		});
+		};
 	}
 
 	return root;
@@ -861,12 +847,12 @@ function addToRoot(
 		);
 		const newChildren = [...root.children, newNode];
 		const newValueObj = objectFromChildren(newChildren);
-		return cloneNode({
+		return {
 			...root,
 			children: newChildren,
 			value: newValueObj,
 			size: newChildren.length,
-		});
+		};
 	}
 	if (root.kind === 'array') {
 		const newNode = parseJsonToTree(
@@ -876,27 +862,14 @@ function addToRoot(
 			root.children.length,
 		);
 		const newChildren = [...root.children, newNode];
-		return cloneNode({
+		return {
 			...root,
 			children: newChildren,
 			value: newChildren,
 			size: newChildren.length,
-		});
+		};
 	}
 	return root;
-}
-
-function cloneNode(node: JsonNode): JsonNode {
-	return {
-		kind: node.kind,
-		key: node.key,
-		value: node.value,
-		children: node.children,
-		depth: node.depth,
-		collapsed: node.collapsed,
-		size: node.size,
-		index: node.index,
-	};
 }
 
 function objectFromChildren(children: JsonNode[]): Record<string, unknown> {

--- a/source/components/json-viewer/json-viewer.spec.tsx
+++ b/source/components/json-viewer/json-viewer.spec.tsx
@@ -1,0 +1,154 @@
+import {mkdtempSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import React from 'react';
+
+// CRITICAL: redirect config reads to a temp dir BEFORE the component (and its
+// @/config chain) loads, so the machine's real preferences can't leak in.
+process.env.NANOCODER_CONFIG_DIR = mkdtempSync(
+	join(tmpdir(), 'nanocoder-jsonviewer-'),
+);
+
+const {renderWithTheme} = await import('../../test-utils/render-with-theme');
+const {JsonViewer} = await import('./json-viewer');
+
+const DOWN = '[B';
+
+function tick(ms = 60): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Every assertion here is a regression guard for a way the editor silently
+ * corrupted the config file it was editing.
+ */
+
+test('typing a value containing w/q/? does not save, exit or open help', async t => {
+	let saved: unknown;
+	let cancelled = false;
+	const {stdin, unmount} = renderWithTheme(
+			<JsonViewer
+				data={{model: 'x'}}
+				onSave={value => {
+					saved = value;
+				}}
+				onCancel={() => {
+					cancelled = true;
+				}}
+		/>,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('e');
+	await tick();
+
+	// One character per chunk — that is how a real terminal delivers typing, and
+	// it is the only way `input === 'w'` can match. These used to run as bare
+	// shortcuts because the checks sat above the edit-mode guard.
+	for (const char of 'qw?') {
+		stdin.write(char);
+		await tick();
+	}
+
+	t.is(saved, undefined, 'w must not write to disk mid-edit');
+	t.false(cancelled, 'q must not exit the editor mid-edit');
+	unmount();
+});
+
+test('a string edit commits the typed value intact', async t => {
+	let latest: unknown;
+	const {stdin, unmount} = renderWithTheme(
+			<JsonViewer
+				data={{model: 'x'}}
+				onChange={value => {
+					latest = value;
+				}}
+		/>,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('e');
+	await tick();
+	// One char per chunk, as a real terminal sends typing.
+	for (const char of 'qwen3') {
+		stdin.write(char);
+		await tick();
+	}
+	stdin.write('\r');
+	await tick();
+
+	// The editor seeds the input with the current value, so typing appends to it.
+	t.deepEqual(latest, {model: 'xqwen3'}, 'q and w must reach the text input');
+	unmount();
+});
+
+test('a non-numeric number edit is rejected instead of retyping the value', async t => {
+	let latest: unknown;
+	const {stdin, lastFrame, unmount} = renderWithTheme(
+			<JsonViewer
+				data={{threshold: 42}}
+				onChange={value => {
+					latest = value;
+				}}
+		/>,
+	);
+	await tick();
+
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('e');
+	await tick();
+	stdin.write('abc');
+	await tick();
+	stdin.write('\r');
+	await tick();
+
+	// The old fallback wrote currentRow.value — the FORMATTED string — turning the
+	// number 42 into the string "42".
+	t.deepEqual(latest, {threshold: 42}, 'the number must survive a failed edit');
+	t.regex(lastFrame() ?? '', /not a number/, 'the editor reports the error');
+	unmount();
+});
+
+test('a collapsed container cannot be edited into a string', async t => {
+	let latest: unknown;
+	const data = {providers: {ollama: {url: 'http://localhost'}}};
+	const {stdin, unmount} = renderWithTheme(
+			<JsonViewer
+				data={data}
+				initialCollapsedDepth={1}
+				onChange={value => {
+					latest = value;
+				}}
+		/>,
+	);
+	await tick();
+
+	// Cursor onto the collapsed "providers" row, then e + Enter — this used to
+	// replace the whole subtree with the literal string "{ ... }".
+	stdin.write(DOWN);
+	await tick();
+	stdin.write('e');
+	await tick();
+	stdin.write('\r');
+	await tick();
+
+	t.deepEqual(latest, data, 'the subtree must be untouched');
+	unmount();
+});
+
+test('the status bar renders the shortcut hints without stray quotes', async t => {
+	const {lastFrame, unmount} = renderWithTheme(<JsonViewer data={{a: 1}} />);
+	await tick();
+
+	const frame = lastFrame() ?? '';
+	t.regex(frame, /\?:help/);
+	t.regex(frame, /q:exit/);
+	t.notRegex(frame, /' '/, 'raw JSX text leaked literal quotes into the bar');
+	unmount();
+});

--- a/source/components/json-viewer/json-viewer.tsx
+++ b/source/components/json-viewer/json-viewer.tsx
@@ -1,0 +1,521 @@
+import {Box, Text, useInput} from 'ink';
+import TextInput from 'ink-text-input';
+import {type ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+import type {Colors} from '@/types/ui';
+import {
+	addSibling,
+	collapseBeyondDepth,
+	deleteAtPath,
+	extractTreeValue,
+	flattenTree,
+	type JsonFlatRow,
+	type JsonNode,
+	parseJsonToTree,
+	parseKeyValueInput,
+	setValueAtPath,
+	toggleCollapse,
+} from './json-tree';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface JsonViewerProps {
+	/** JSON data to display and edit */
+	data: unknown;
+	/** Display title (e.g. filename) */
+	title?: string;
+	/** Path to the config file (shown in status bar) */
+	filePath?: string;
+	/** Callback when changes are saved to disk */
+	onSave?: (data: unknown) => void;
+	/** Callback fired whenever the tree changes — carries current data */
+	onChange?: (data: unknown) => void;
+	/** Callback to exit the viewer — carries current data for dirty check */
+	onCancel?: (currentData: unknown) => void;
+	/** Auto-collapse nodes beyond this depth (default: 4) */
+	initialCollapsedDepth?: number;
+	/** Pre-navigate cursor to this JSONPath segments array */
+	initialPath?: string[];
+	/** Read-only mode — disables edit/add/delete */
+	readOnly?: boolean;
+}
+
+type EditMode = 'browse' | 'edit' | 'add-key' | 'add-value';
+
+// ─── Color Helpers ───────────────────────────────────────────────────────────
+
+function getValueColor(kind: string, colors: Colors): string {
+	switch (kind) {
+		case 'string':
+			return colors.success;
+		case 'number':
+			return colors.info;
+		case 'boolean':
+			return colors.warning;
+		case 'null':
+			return colors.secondary;
+		default:
+			return colors.text;
+	}
+}
+
+function getBracketColor(kind: string, colors: Colors): string {
+	return kind === 'object' ? colors.primary : colors.tool;
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export function JsonViewer({
+	data,
+	title,
+	filePath,
+	onSave,
+	onChange,
+	onCancel,
+	initialCollapsedDepth = 4,
+	initialPath,
+	readOnly = false,
+}: JsonViewerProps) {
+	const {colors} = useTheme();
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+
+	// Tree state
+	const [tree, setTree] = useState<JsonNode>(() => {
+		let t = parseJsonToTree(data);
+		if (initialCollapsedDepth > 0) {
+			t = collapseBeyondDepth(t, initialCollapsedDepth);
+		}
+		return t;
+	});
+
+	// Cursor position (index into flattened rows)
+	const [cursorIndex, setCursorIndex] = useState(0);
+
+	// Edit mode
+	const [editMode, setEditMode] = useState<EditMode>('browse');
+	const [editValue, setEditValue] = useState('');
+
+	// Help modal
+	const [showHelp, setShowHelp] = useState(false);
+
+	// Dirty tracking
+	const originalData = JSON.stringify(data);
+	const isDirty = JSON.stringify(extractTreeValue(tree)) !== originalData;
+
+	// Flatten tree for rendering
+	const rows = useMemo(() => flattenTree(tree), [tree]);
+
+	// Notify parent whenever the tree changes
+	useEffect(() => {
+		onChange?.(extractTreeValue(tree));
+	}, [tree, onChange]);
+
+	// Visible rows (viewport)
+	const viewportHeight = isNarrow ? 15 : 20;
+	const [scrollOffset, setScrollOffset] = useState(0);
+
+	// Ensure cursor stays in bounds
+	useEffect(() => {
+		if (cursorIndex >= rows.length) {
+			setCursorIndex(Math.max(0, rows.length - 1));
+		}
+	}, [rows.length, cursorIndex]);
+
+	// Scroll to keep cursor visible
+	useEffect(() => {
+		if (cursorIndex < scrollOffset) {
+			setScrollOffset(cursorIndex);
+		} else if (cursorIndex >= scrollOffset + viewportHeight) {
+			setScrollOffset(cursorIndex - viewportHeight + 1);
+		}
+	}, [cursorIndex, viewportHeight, scrollOffset]);
+
+	// Navigate to initial path
+	useEffect(() => {
+		if (!initialPath || initialPath.length === 0 || rows.length === 0) return;
+		const targetPath = initialPath.join('');
+		const foundIdx = rows.findIndex(
+			r =>
+				r.pathSegments.join('') === targetPath || r.path.endsWith(targetPath),
+		);
+		if (foundIdx >= 0) {
+			setCursorIndex(foundIdx);
+			setScrollOffset(Math.max(0, foundIdx - Math.floor(viewportHeight / 2)));
+		}
+	}, [viewportHeight, rows, initialPath]);
+
+	// Current row
+	const currentRow = rows[cursorIndex];
+
+	// ─── Actions ───────────────────────────────────────────────────────────
+
+	const moveCursor = useCallback(
+		(delta: number) => {
+			setCursorIndex(prev =>
+				Math.max(0, Math.min(rows.length - 1, prev + delta)),
+			);
+		},
+		[rows.length],
+	);
+
+	const expandNode = useCallback(() => {
+		if (!currentRow?.hasChildren) return;
+		setTree(prev => toggleCollapse(prev, currentRow.pathSegments));
+		// After expanding, cursor will shift — handled by useEffect
+	}, [currentRow]);
+
+	const collapseNode = useCallback(() => {
+		if (!currentRow?.hasChildren || currentRow.isCollapsed) return;
+		setTree(prev => toggleCollapse(prev, currentRow.pathSegments));
+	}, [currentRow]);
+
+	const startEdit = useCallback(() => {
+		if (readOnly || !currentRow) return;
+		// Can edit primitives or collapsed nodes (expand first)
+		if (currentRow.hasChildren && !currentRow.isCollapsed) return;
+		if (
+			currentRow.value === '{' ||
+			currentRow.value === '}' ||
+			currentRow.value === '[' ||
+			currentRow.value === ']'
+		)
+			return;
+
+		setEditMode('edit');
+		setEditValue(currentRow.value.replace(/^"|"$/g, ''));
+	}, [readOnly, currentRow]);
+
+	const commitEdit = useCallback(() => {
+		if (!currentRow) return;
+		const segments = currentRow.pathSegments;
+		let newValue: unknown = editValue;
+
+		// Type coercion
+		if (currentRow.kind === 'number') {
+			const num = Number(editValue);
+			newValue = Number.isNaN(num) ? currentRow.value : num;
+		} else if (currentRow.kind === 'boolean') {
+			newValue = editValue.toLowerCase() === 'true';
+		} else if (currentRow.kind === 'null') {
+			newValue = editValue.toLowerCase() === 'null' ? null : editValue;
+		}
+
+		setTree(prev => setValueAtPath(prev, segments, newValue));
+		setEditMode('browse');
+		setEditValue('');
+	}, [currentRow, editValue]);
+
+	const cancelEdit = useCallback(() => {
+		setEditMode('browse');
+		setEditValue('');
+	}, []);
+
+	const startAdd = useCallback(() => {
+		if (readOnly || !currentRow) return;
+		setEditMode('add-key');
+		setEditValue('');
+	}, [readOnly, currentRow]);
+
+	const commitAdd = useCallback(() => {
+		if (!currentRow) return;
+		const segments = currentRow.pathSegments;
+		const parsed = parseKeyValueInput(editValue);
+		setTree(prev => addSibling(prev, segments, parsed));
+		setEditMode('browse');
+		setEditValue('');
+	}, [currentRow, editValue]);
+
+	const deleteItem = useCallback(() => {
+		if (readOnly || !currentRow) return;
+		// Can't delete root
+		if (currentRow.pathSegments.length === 0) return;
+		// Can't delete closing brackets
+		if (currentRow.value === '}' || currentRow.value === ']') return;
+		// Can't delete opening brackets — delete the whole node
+		const segments =
+			currentRow.hasChildren && !currentRow.isCollapsed
+				? currentRow.pathSegments
+				: currentRow.pathSegments;
+		setTree(prev => deleteAtPath(prev, segments));
+	}, [readOnly, currentRow]);
+
+	const saveChanges = useCallback(() => {
+		const value = extractTreeValue(tree);
+		onSave?.(value);
+	}, [tree, onSave]);
+
+	const handleExit = useCallback(() => {
+		onCancel?.(extractTreeValue(tree));
+	}, [tree, onCancel]);
+
+	// ─── Key Handling ──────────────────────────────────────────────────────
+
+	useInput((input, key) => {
+		// Help toggle (always available)
+		if (input === '?' && !key.ctrl && !key.shift) {
+			setShowHelp(prev => !prev);
+			return;
+		}
+
+		// Escape handling
+		if (key.escape) {
+			if (showHelp) {
+				setShowHelp(false);
+				return;
+			}
+			if (editMode !== 'browse') {
+				cancelEdit();
+				return;
+			}
+			handleExit();
+			return;
+		}
+
+		// Shift+Tab = exit
+		if (key.shift && key.tab) {
+			if (editMode !== 'browse') {
+				cancelEdit();
+				return;
+			}
+			handleExit();
+			return;
+		}
+
+		// Save/exit shortcuts (always available, like ?)
+		if (input === 'w' && !key.ctrl && !key.shift) {
+			saveChanges();
+			return;
+		}
+		if (input === 'q' && !key.ctrl && !key.shift) {
+			if (editMode !== 'browse') {
+				cancelEdit();
+				return;
+			}
+			handleExit();
+			return;
+		}
+
+		// If in edit mode, let TextInput handle input
+		if (editMode !== 'browse') return;
+
+		// If help is showing, only allow escape and ?
+		if (showHelp) return;
+
+		// Navigation
+		if (input === 'k' || key.upArrow) {
+			moveCursor(-1);
+		} else if (input === 'j' || key.downArrow) {
+			moveCursor(1);
+		} else if (input === 'l' || key.rightArrow) {
+			expandNode();
+		} else if (input === 'h' || key.leftArrow || key.backspace) {
+			collapseNode();
+		} else if (key.return || input === 'e') {
+			startEdit();
+		} else if (input === 'a') {
+			startAdd();
+		} else if (input === 'd') {
+			deleteItem();
+		}
+	});
+
+	// ─── Render ────────────────────────────────────────────────────────────
+
+	const indentStr = '  ';
+
+	if (showHelp) {
+		return (
+			<TitledBoxWithPreferences
+				title="Keybindings"
+				width={boxWidth}
+				borderColor={colors.primary}
+				paddingX={2}
+				paddingY={1}
+				flexDirection="column"
+				marginBottom={1}
+			>
+				<Text color={colors.secondary} bold>
+					Navigation
+				</Text>
+				<HelpRow label="Move up" keybind="k / ↑" colors={colors} />
+				<HelpRow label="Move down" keybind="j / ↓" colors={colors} />
+				<HelpRow label="Expand" keybind="l / →" colors={colors} />
+				<HelpRow label="Collapse" keybind="h / ← / Backspace" colors={colors} />
+				<Box marginTop={1} />
+				<Text color={colors.secondary} bold>
+					Editing
+				</Text>
+				<HelpRow label="Edit value" keybind="e / Enter" colors={colors} />
+				<HelpRow label="Add sibling" keybind="a" colors={colors} />
+				<HelpRow label="Delete" keybind="d" colors={colors} />
+				<HelpRow label="Save to disk" keybind="w" colors={colors} />
+				<Box marginTop={1} />
+				<Text color={colors.secondary} bold>
+					General
+				</Text>
+				<HelpRow label="Toggle help" keybind="?" colors={colors} />
+				<HelpRow
+					label="Exit (with dirty check)"
+					keybind="q / Esc / Shift+Tab"
+					colors={colors}
+				/>
+				<Box marginTop={1} />
+				<Text color={colors.secondary}>Press ? or Esc to close</Text>
+			</TitledBoxWithPreferences>
+		);
+	}
+
+	return (
+		<TitledBoxWithPreferences
+			title={title || 'JSON Viewer'}
+			width={boxWidth}
+			borderColor={colors.primary}
+			paddingX={isNarrow ? 1 : 2}
+			paddingY={0}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			{/* Header */}
+			<Box marginBottom={1}>
+				<Text color={colors.secondary}>
+					{filePath ? `${filePath}  ` : ''}
+					{rows.length} line{rows.length !== 1 ? 's' : ''}
+					{isDirty ? '  ● modified' : ''}
+					{readOnly ? '  (read-only)' : ''}
+				</Text>
+			</Box>
+
+			{/* JSON Content */}
+			<Box
+				borderStyle="round"
+				borderColor={isDirty ? colors.warning : colors.secondary}
+				paddingX={1}
+				flexDirection="column"
+			>
+				{rows
+					.slice(scrollOffset, scrollOffset + viewportHeight)
+					.map((row, i) => {
+						const globalIndex = scrollOffset + i;
+						const isHighlighted =
+							globalIndex === cursorIndex && editMode === 'browse';
+
+						return (
+							<Box key={globalIndex}>
+								{/* Line number */}
+								<Text color={colors.secondary}>
+									{String(row.lineNumber).padStart(3, ' ')}
+								</Text>
+								<Text color={isHighlighted ? colors.primary : colors.text}>
+									{' '}
+								</Text>
+
+								{/* Highlighted row gets inverse */}
+								{isHighlighted ? (
+									<Text
+										color={colors.base}
+										backgroundColor={colors.primary}
+										bold
+									>
+										{renderRowContent(row, indentStr, colors, true)}
+									</Text>
+								) : (
+									<Text>{renderRowContent(row, indentStr, colors, false)}</Text>
+								)}
+
+								{/* Edit input overlay */}
+								{globalIndex === cursorIndex && editMode !== 'browse' && (
+									<Box>
+										<Text color={colors.warning}>
+											{' '}
+											<TextInput
+												value={editValue}
+												onChange={setEditValue}
+												onSubmit={
+													editMode === 'add-key' ? commitAdd : commitEdit
+												}
+												focus
+											/>
+										</Text>
+									</Box>
+								)}
+							</Box>
+						);
+					})}
+			</Box>
+
+			{/* Status Bar */}
+			<Box marginTop={1} flexDirection="row">
+				<Box>
+					<Text color={colors.secondary}>
+						{currentRow ? `${currentRow.path}  ` : ''}
+						Line {currentRow?.lineNumber ?? 0}/{rows.length}
+					</Text>
+				</Box>
+				<Box
+					width={isNarrow ? undefined : '50%'}
+					flexDirection="row"
+					justifyContent="flex-end"
+				>
+					<Text color={colors.secondary}>
+						{!readOnly && 'e:edit  a:add  d:del  w:write  '}' '?:help ' 'q:exit'
+					</Text>
+				</Box>
+			</Box>
+		</TitledBoxWithPreferences>
+	);
+}
+
+// ─── Render Helpers ──────────────────────────────────────────────────────────
+
+function renderRowContent(
+	row: JsonFlatRow,
+	indentStr: string,
+	colors: Colors,
+	_isHighlighted: boolean,
+): ReactNode {
+	const indent = indentStr.repeat(row.indent);
+
+	return (
+		<>
+			<Text color={colors.text}>{indent}</Text>
+			{row.key !== undefined && (
+				<>
+					<Text color={colors.primary} bold>
+						"{row.key}"
+					</Text>
+					<Text color={colors.secondary}>: </Text>
+				</>
+			)}
+			{row.kind === 'object' || row.kind === 'array' ? (
+				<Text color={getBracketColor(row.kind, colors)} bold>
+					{row.value}
+				</Text>
+			) : (
+				<Text color={getValueColor(row.kind, colors)}>{row.value}</Text>
+			)}
+			<Text color={colors.secondary}>{row.trailing}</Text>
+			{row.isCollapsed && row.hiddenCount > 0 && (
+				<Text color={colors.secondary}> ({row.hiddenCount} hidden)</Text>
+			)}
+		</>
+	);
+}
+
+function HelpRow({
+	label,
+	keybind,
+	colors,
+}: {
+	label: string;
+	keybind: string;
+	colors: Colors;
+}) {
+	return (
+		<Box>
+			<Text color={colors.primary} bold>{`${keybind}`}</Text>
+			<Text color={colors.text}> — {label}</Text>
+		</Box>
+	);
+}

--- a/source/components/json-viewer/json-viewer.tsx
+++ b/source/components/json-viewer/json-viewer.tsx
@@ -1,6 +1,6 @@
 import {Box, Text, useInput} from 'ink';
-import TextInput from '@/components/text-input';
 import {type ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
+import TextInput from '@/components/text-input';
 import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
@@ -297,6 +297,25 @@ export function JsonViewer({
 			return;
 		}
 
+		// Boolean editing: pick the value with arrow keys / space instead of typing.
+		if (editMode === 'edit' && currentRow?.kind === 'boolean') {
+			if (
+				key.leftArrow ||
+				key.rightArrow ||
+				key.upArrow ||
+				key.downArrow ||
+				input === ' '
+			) {
+				setEditValue(v => (v === 'true' ? 'false' : 'true'));
+				return;
+			}
+			if (key.return) {
+				commitEdit();
+				return;
+			}
+			return;
+		}
+
 		// If in edit mode, let TextInput handle input
 		if (editMode !== 'browse') return;
 
@@ -412,7 +431,16 @@ export function JsonViewer({
 								</Text>
 
 								{/* Highlighted row gets inverse */}
-								{isHighlighted ? (
+								{globalIndex === cursorIndex && editMode === 'edit' ? (
+									<EditRow
+										row={row}
+										indent={indentStr.repeat(row.indent)}
+										colors={colors}
+										editValue={editValue}
+										setEditValue={setEditValue}
+										onSubmit={commitEdit}
+									/>
+								) : isHighlighted ? (
 									<Text
 										color={colors.base}
 										backgroundColor={colors.primary}
@@ -424,17 +452,15 @@ export function JsonViewer({
 									<Text>{renderRowContent(row, indentStr, colors, false)}</Text>
 								)}
 
-								{/* Edit input overlay */}
-								{globalIndex === cursorIndex && editMode !== 'browse' && (
+								{/* Add-key overlay: entering a new "key": value pair. */}
+								{globalIndex === cursorIndex && editMode === 'add-key' && (
 									<Box>
 										<Text color={colors.warning}>
 											{' '}
 											<TextInput
 												value={editValue}
 												onChange={setEditValue}
-												onSubmit={
-													editMode === 'add-key' ? commitAdd : commitEdit
-												}
+												onSubmit={commitAdd}
 												focus
 											/>
 										</Text>
@@ -468,6 +494,77 @@ export function JsonViewer({
 }
 
 // ─── Render Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * In-place editor for the row under the cursor: the input sits where the value
+ * was (inside the quotes for strings, so the cursor lands on the text), and
+ * booleans are picked with the arrow keys instead of typed.
+ */
+function EditRow({
+	row,
+	indent,
+	colors,
+	editValue,
+	setEditValue,
+	onSubmit,
+}: {
+	row: JsonFlatRow;
+	indent: string;
+	colors: Colors;
+	editValue: string;
+	setEditValue: (value: string) => void;
+	onSubmit: () => void;
+}): ReactNode {
+	const input = (
+		<TextInput
+			value={editValue}
+			onChange={setEditValue}
+			onSubmit={onSubmit}
+			focus
+		/>
+	);
+
+	let editor: ReactNode;
+	if (row.kind === 'boolean') {
+		editor = (
+			<Text>
+				<Text
+					color={editValue === 'true' ? colors.primary : colors.secondary}
+					bold={editValue === 'true'}
+				>
+					true
+				</Text>
+				<Text color={colors.secondary}> </Text>
+				<Text
+					color={editValue === 'false' ? colors.primary : colors.secondary}
+					bold={editValue === 'false'}
+				>
+					false
+				</Text>
+				<Text color={colors.secondary}> ←/→ to change</Text>
+			</Text>
+		);
+	} else if (row.kind === 'string') {
+		editor = <Text color={colors.warning}>"{input}"</Text>;
+	} else {
+		editor = <Text color={colors.warning}>{input}</Text>;
+	}
+
+	return (
+		<Box>
+			<Text color={colors.text}>{indent}</Text>
+			{row.key !== undefined && (
+				<Text>
+					<Text color={colors.primary} bold>
+						"{row.key}"
+					</Text>
+					<Text color={colors.secondary}>: </Text>
+				</Text>
+			)}
+			{editor}
+		</Box>
+	);
+}
 
 function renderRowContent(
 	row: JsonFlatRow,

--- a/source/components/json-viewer/json-viewer.tsx
+++ b/source/components/json-viewer/json-viewer.tsx
@@ -1,5 +1,5 @@
 import {Box, Text, useInput} from 'ink';
-import TextInput from 'ink-text-input';
+import TextInput from '@/components/text-input';
 import {type ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
 import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';

--- a/source/components/json-viewer/json-viewer.tsx
+++ b/source/components/json-viewer/json-viewer.tsx
@@ -1,5 +1,12 @@
 import {Box, Text, useInput} from 'ink';
-import {type ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import TextInput from '@/components/text-input';
 import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
@@ -7,6 +14,7 @@ import {useTheme} from '@/hooks/useTheme';
 import type {Colors} from '@/types/ui';
 import {
 	addSibling,
+	buildPath,
 	collapseBeyondDepth,
 	deleteAtPath,
 	extractTreeValue,
@@ -42,7 +50,7 @@ export interface JsonViewerProps {
 	readOnly?: boolean;
 }
 
-type EditMode = 'browse' | 'edit' | 'add-key' | 'add-value';
+type EditMode = 'browse' | 'edit' | 'add-key';
 
 // ─── Color Helpers ───────────────────────────────────────────────────────────
 
@@ -93,12 +101,26 @@ export function JsonViewer({
 	// Cursor position (index into flattened rows)
 	const [cursorIndex, setCursorIndex] = useState(0);
 
-	// Edit mode
-	const [editMode, setEditMode] = useState<EditMode>('browse');
+	// Edit mode. Ink dispatches every keypress parsed from one stdin chunk in the
+	// same call stack with no re-render between, so the key handler must branch on
+	// a ref — reading the state would still say 'browse' for the rest of a pasted
+	// "e"+value burst and let those characters run as bare shortcuts.
+	const [editMode, setEditModeState] = useState<EditMode>('browse');
+	const editModeRef = useRef<EditMode>('browse');
+	const setEditMode = useCallback((next: EditMode) => {
+		editModeRef.current = next;
+		setEditModeState(next);
+	}, []);
 	const [editValue, setEditValue] = useState('');
+	const [editError, setEditError] = useState<string | null>(null);
 
-	// Help modal
-	const [showHelp, setShowHelp] = useState(false);
+	// Help modal (same stale-within-a-chunk caveat as editMode above)
+	const [showHelp, setShowHelpState] = useState(false);
+	const showHelpRef = useRef(false);
+	const setShowHelp = useCallback((next: boolean) => {
+		showHelpRef.current = next;
+		setShowHelpState(next);
+	}, []);
 
 	// Dirty tracking
 	const originalData = JSON.stringify(data);
@@ -135,10 +157,9 @@ export function JsonViewer({
 	// Navigate to initial path
 	useEffect(() => {
 		if (!initialPath || initialPath.length === 0 || rows.length === 0) return;
-		const targetPath = initialPath.join('');
+		const targetPath = buildPath(initialPath);
 		const foundIdx = rows.findIndex(
-			r =>
-				r.pathSegments.join('') === targetPath || r.path.endsWith(targetPath),
+			r => r.path === targetPath || r.path.endsWith(`.${targetPath}`),
 		);
 		if (foundIdx >= 0) {
 			setCursorIndex(foundIdx);
@@ -173,29 +194,30 @@ export function JsonViewer({
 
 	const startEdit = useCallback(() => {
 		if (readOnly || !currentRow) return;
-		// Can edit primitives or collapsed nodes (expand first)
-		if (currentRow.hasChildren && !currentRow.isCollapsed) return;
-		if (
-			currentRow.value === '{' ||
-			currentRow.value === '}' ||
-			currentRow.value === '[' ||
-			currentRow.value === ']'
-		)
-			return;
+		// Containers hold no scalar to edit — l/→ expands them instead. Editing a
+		// collapsed one used to replace the whole subtree with the string "{ ... }".
+		if (currentRow.kind === 'object' || currentRow.kind === 'array') return;
 
 		setEditMode('edit');
 		setEditValue(currentRow.value.replace(/^"|"$/g, ''));
-	}, [readOnly, currentRow]);
+		setEditError(null);
+	}, [readOnly, currentRow, setEditMode]);
 
 	const commitEdit = useCallback(() => {
 		if (!currentRow) return;
 		const segments = currentRow.pathSegments;
 		let newValue: unknown = editValue;
 
-		// Type coercion
+		// Type coercion. A bad number keeps the editor open — the old fallback wrote
+		// currentRow.value, the FORMATTED display string, silently retyping 42 as "42".
 		if (currentRow.kind === 'number') {
-			const num = Number(editValue);
-			newValue = Number.isNaN(num) ? currentRow.value : num;
+			const trimmed = editValue.trim();
+			const num = Number(trimmed);
+			if (trimmed === '' || Number.isNaN(num)) {
+				setEditError('not a number');
+				return;
+			}
+			newValue = num;
 		} else if (currentRow.kind === 'boolean') {
 			newValue = editValue.toLowerCase() === 'true';
 		} else if (currentRow.kind === 'null') {
@@ -205,18 +227,20 @@ export function JsonViewer({
 		setTree(prev => setValueAtPath(prev, segments, newValue));
 		setEditMode('browse');
 		setEditValue('');
-	}, [currentRow, editValue]);
+		setEditError(null);
+	}, [currentRow, editValue, setEditMode]);
 
 	const cancelEdit = useCallback(() => {
 		setEditMode('browse');
 		setEditValue('');
-	}, []);
+		setEditError(null);
+	}, [setEditMode]);
 
 	const startAdd = useCallback(() => {
 		if (readOnly || !currentRow) return;
 		setEditMode('add-key');
 		setEditValue('');
-	}, [readOnly, currentRow]);
+	}, [readOnly, currentRow, setEditMode]);
 
 	const commitAdd = useCallback(() => {
 		if (!currentRow) return;
@@ -225,7 +249,7 @@ export function JsonViewer({
 		setTree(prev => addSibling(prev, segments, parsed));
 		setEditMode('browse');
 		setEditValue('');
-	}, [currentRow, editValue]);
+	}, [currentRow, editValue, setEditMode]);
 
 	const deleteItem = useCallback(() => {
 		if (readOnly || !currentRow) return;
@@ -233,12 +257,9 @@ export function JsonViewer({
 		if (currentRow.pathSegments.length === 0) return;
 		// Can't delete closing brackets
 		if (currentRow.value === '}' || currentRow.value === ']') return;
-		// Can't delete opening brackets — delete the whole node
-		const segments =
-			currentRow.hasChildren && !currentRow.isCollapsed
-				? currentRow.pathSegments
-				: currentRow.pathSegments;
-		setTree(prev => deleteAtPath(prev, segments));
+		// An opening bracket row shares the container's path, so this removes the
+		// whole node rather than just the bracket line.
+		setTree(prev => deleteAtPath(prev, currentRow.pathSegments));
 	}, [readOnly, currentRow]);
 
 	const saveChanges = useCallback(() => {
@@ -253,19 +274,13 @@ export function JsonViewer({
 	// ─── Key Handling ──────────────────────────────────────────────────────
 
 	useInput((input, key) => {
-		// Help toggle (always available)
-		if (input === '?' && !key.ctrl && !key.shift) {
-			setShowHelp(prev => !prev);
-			return;
-		}
-
 		// Escape handling
 		if (key.escape) {
-			if (showHelp) {
+			if (showHelpRef.current) {
 				setShowHelp(false);
 				return;
 			}
-			if (editMode !== 'browse') {
+			if (editModeRef.current !== 'browse') {
 				cancelEdit();
 				return;
 			}
@@ -275,21 +290,7 @@ export function JsonViewer({
 
 		// Shift+Tab = exit
 		if (key.shift && key.tab) {
-			if (editMode !== 'browse') {
-				cancelEdit();
-				return;
-			}
-			handleExit();
-			return;
-		}
-
-		// Save/exit shortcuts (always available, like ?)
-		if (input === 'w' && !key.ctrl && !key.shift) {
-			saveChanges();
-			return;
-		}
-		if (input === 'q' && !key.ctrl && !key.shift) {
-			if (editMode !== 'browse') {
+			if (editModeRef.current !== 'browse') {
 				cancelEdit();
 				return;
 			}
@@ -298,7 +299,7 @@ export function JsonViewer({
 		}
 
 		// Boolean editing: pick the value with arrow keys / space instead of typing.
-		if (editMode === 'edit' && currentRow?.kind === 'boolean') {
+		if (editModeRef.current === 'edit' && currentRow?.kind === 'boolean') {
 			if (
 				key.leftArrow ||
 				key.rightArrow ||
@@ -316,11 +317,29 @@ export function JsonViewer({
 			return;
 		}
 
-		// If in edit mode, let TextInput handle input
-		if (editMode !== 'browse') return;
+		// If in edit mode, let TextInput handle input. Everything below this line is
+		// a bare-letter shortcut, so it MUST stay here: TextInput runs its own
+		// useInput and both hooks see every keystroke, so typing a value containing
+		// w/q/? used to save, cancel or pop the help overlay mid-edit.
+		if (editModeRef.current !== 'browse') return;
+
+		// Help toggle
+		if (input === '?' && !key.ctrl && !key.shift) {
+			setShowHelp(!showHelpRef.current);
+			return;
+		}
 
 		// If help is showing, only allow escape and ?
-		if (showHelp) return;
+		if (showHelpRef.current) return;
+
+		if (input === 'w' && !key.ctrl && !key.shift) {
+			saveChanges();
+			return;
+		}
+		if (input === 'q' && !key.ctrl && !key.shift) {
+			handleExit();
+			return;
+		}
 
 		// Navigation
 		if (input === 'k' || key.upArrow) {
@@ -348,7 +367,7 @@ export function JsonViewer({
 		return (
 			<TitledBoxWithPreferences
 				title="Keybindings"
-				width={boxWidth}
+				width={isNarrow ? '100%' : boxWidth}
 				borderColor={colors.primary}
 				paddingX={2}
 				paddingY={1}
@@ -389,7 +408,7 @@ export function JsonViewer({
 	return (
 		<TitledBoxWithPreferences
 			title={title || 'JSON Viewer'}
-			width={boxWidth}
+			width={isNarrow ? '100%' : boxWidth}
 			borderColor={colors.primary}
 			paddingX={isNarrow ? 1 : 2}
 			paddingY={0}
@@ -445,11 +464,16 @@ export function JsonViewer({
 										color={colors.base}
 										backgroundColor={colors.primary}
 										bold
+										wrap="truncate-end"
 									>
 										{renderRowContent(row, indentStr, colors, true)}
 									</Text>
 								) : (
-									<Text>{renderRowContent(row, indentStr, colors, false)}</Text>
+									/* truncate, don't wrap: a long value (an API key) used to
+									   reflow onto the next line and swallow its gutter number */
+									<Text wrap="truncate-end">
+										{renderRowContent(row, indentStr, colors, false)}
+									</Text>
 								)}
 
 								{/* Add-key overlay: entering a new "key": value pair. */}
@@ -472,20 +496,22 @@ export function JsonViewer({
 			</Box>
 
 			{/* Status Bar */}
-			<Box marginTop={1} flexDirection="row">
-				<Box>
-					<Text color={colors.secondary}>
-						{currentRow ? `${currentRow.path}  ` : ''}
-						Line {currentRow?.lineNumber ?? 0}/{rows.length}
-					</Text>
+			<Box marginTop={1} flexDirection={isNarrow ? 'column' : 'row'}>
+				<Box flexGrow={1}>
+					{editError ? (
+						<Text color={colors.error}>
+							{editError} — Esc to cancel, or fix the value
+						</Text>
+					) : (
+						<Text color={colors.secondary}>
+							{currentRow ? `${currentRow.path}  ` : ''}
+							Line {currentRow?.lineNumber ?? 0}/{rows.length}
+						</Text>
+					)}
 				</Box>
-				<Box
-					width={isNarrow ? undefined : '50%'}
-					flexDirection="row"
-					justifyContent="flex-end"
-				>
+				<Box flexDirection="row" justifyContent="flex-end">
 					<Text color={colors.secondary}>
-						{!readOnly && 'e:edit  a:add  d:del  w:write  '}' '?:help ' 'q:exit'
+						{`${readOnly ? '' : 'e:edit  a:add  d:del  w:write  '}?:help  q:exit`}
 					</Text>
 				</Box>
 			</Box>
@@ -570,31 +596,35 @@ function renderRowContent(
 	row: JsonFlatRow,
 	indentStr: string,
 	colors: Colors,
-	_isHighlighted: boolean,
+	isHighlighted: boolean,
 ): ReactNode {
 	const indent = indentStr.repeat(row.indent);
+	// The cursor row is drawn on a colors.primary background. Syntax colors are
+	// picked for the normal background, and the key's own colors.primary rendered
+	// it invisible against it, so let the row inherit the inverse pair instead.
+	const tint = (color: string) => (isHighlighted ? undefined : color);
 
 	return (
 		<>
-			<Text color={colors.text}>{indent}</Text>
+			<Text color={tint(colors.text)}>{indent}</Text>
 			{row.key !== undefined && (
 				<>
-					<Text color={colors.primary} bold>
+					<Text color={tint(colors.primary)} bold>
 						"{row.key}"
 					</Text>
-					<Text color={colors.secondary}>: </Text>
+					<Text color={tint(colors.secondary)}>: </Text>
 				</>
 			)}
 			{row.kind === 'object' || row.kind === 'array' ? (
-				<Text color={getBracketColor(row.kind, colors)} bold>
+				<Text color={tint(getBracketColor(row.kind, colors))} bold>
 					{row.value}
 				</Text>
 			) : (
-				<Text color={getValueColor(row.kind, colors)}>{row.value}</Text>
+				<Text color={tint(getValueColor(row.kind, colors))}>{row.value}</Text>
 			)}
-			<Text color={colors.secondary}>{row.trailing}</Text>
+			<Text color={tint(colors.secondary)}>{row.trailing}</Text>
 			{row.isCollapsed && row.hiddenCount > 0 && (
-				<Text color={colors.secondary}> ({row.hiddenCount} hidden)</Text>
+				<Text color={tint(colors.secondary)}> ({row.hiddenCount} hidden)</Text>
 			)}
 		</>
 	);

--- a/source/components/ui/styled-select-input.tsx
+++ b/source/components/ui/styled-select-input.tsx
@@ -1,4 +1,4 @@
-import {Text} from 'ink';
+import {Box, Text} from 'ink';
 import SelectInput from 'ink-select-input';
 
 import {useTheme} from '@/hooks/useTheme';
@@ -34,13 +34,24 @@ export function StyledSelectInput<V>(props: StyledSelectInputProps<V>) {
 	return (
 		<SelectInput
 			{...props}
+			// Fixed-width indicator: Ink trims a trailing space only on rows that
+			// overflow, which left truncated rows a column left of short ones.
 			indicatorComponent={({isSelected}) => (
-				<Text color={isSelected ? colors.primary : colors.text}>
-					{isSelected ? '> ' : '  '}
-				</Text>
+				<Box minWidth={2}>
+					<Text color={isSelected ? colors.primary : colors.text}>
+						{isSelected ? '>' : ' '}
+					</Text>
+				</Box>
 			)}
+			// Truncate rather than wrap: a long label (a path, a URL) reflowed with
+			// no hanging indent and the list read as a jumble on narrow terminals.
 			itemComponent={({isSelected, label}) => (
-				<Text color={isSelected ? colors.primary : colors.text}>{label}</Text>
+				<Text
+					color={isSelected ? colors.primary : colors.text}
+					wrap="truncate-end"
+				>
+					{label}
+				</Text>
 			)}
 		/>
 	);

--- a/source/config/config-writer.ts
+++ b/source/config/config-writer.ts
@@ -32,36 +32,6 @@ export function updateConfigValue<K extends string, V>(
 }
 
 /**
- * Reads a specific value from the global agents.config.json under `nanocoder`.
- */
-export function getConfigValue<T = unknown>(
-	nanocoderKey: string,
-): T | undefined {
-	const config = readConfigObject(getGlobalConfigPath());
-	if (!config) return undefined;
-	return (config.nanocoder as Record<string, unknown>)?.[nanocoderKey] as
-		| T
-		| undefined;
-}
-
-/**
- * Reads a nested value: getConfigNestedValue('autoCompact', 'threshold') reads
- * nanocoder.autoCompact.threshold.
- */
-export function getConfigNestedValue<T = unknown>(
-	parentKey: string,
-	childKey: string,
-): T | undefined {
-	const config = readConfigObject(getGlobalConfigPath());
-	if (!config) return undefined;
-	const parent = (config.nanocoder as Record<string, unknown>)?.[parentKey];
-	if (parent && typeof parent === 'object') {
-		return (parent as Record<string, unknown>)?.[childKey] as T | undefined;
-	}
-	return undefined;
-}
-
-/**
  * Updates a nested value: updateConfigNestedValue('autoCompact', 'threshold', 75).
  */
 export function updateConfigNestedValue<K extends string, V>(
@@ -82,24 +52,6 @@ export function updateConfigNestedValue<K extends string, V>(
 	}
 	(nanocoder[parentKey] as Record<string, unknown>)[childKey] = value;
 	writeConfigObject(configPath, config, 'nested update');
-}
-
-/**
- * Replaces an entire nested object: updateConfigObject('autoCompact', {...}).
- */
-export function updateConfigObject<
-	K extends string,
-	V extends Record<string, unknown>,
->(parentKey: K, value: V): void {
-	const configPath = getGlobalConfigPath();
-	const config = readConfigObject(configPath);
-	if (!config) return;
-
-	if (!config.nanocoder || typeof config.nanocoder !== 'object') {
-		config.nanocoder = {};
-	}
-	(config.nanocoder as Record<string, unknown>)[parentKey] = value;
-	writeConfigObject(configPath, config, 'object update');
 }
 
 /**

--- a/source/config/config-writer.ts
+++ b/source/config/config-writer.ts
@@ -1,0 +1,158 @@
+import {randomUUID} from 'node:crypto';
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {getConfigPath} from '@/config/paths';
+import {logError} from '@/utils/message-queue';
+
+/**
+ * Reads the global agents.config.json, merges the given partial update into the
+ * `nanocoder` key, and writes it back atomically. Creates the file if missing.
+ * The write counterpart to the various `load*` functions in config/index.ts.
+ */
+export function updateConfigValue<K extends string, V>(
+	nanocoderKey: K,
+	value: V,
+): void {
+	const configPath = getGlobalConfigPath();
+	const config = readConfigObject(configPath);
+	if (!config) return;
+
+	if (!config.nanocoder || typeof config.nanocoder !== 'object') {
+		config.nanocoder = {};
+	}
+	(config.nanocoder as Record<string, unknown>)[nanocoderKey] = value;
+	writeConfigObject(configPath, config, 'update');
+}
+
+/**
+ * Reads a specific value from the global agents.config.json under `nanocoder`.
+ */
+export function getConfigValue<T = unknown>(
+	nanocoderKey: string,
+): T | undefined {
+	const config = readConfigObject(getGlobalConfigPath());
+	if (!config) return undefined;
+	return (config.nanocoder as Record<string, unknown>)?.[nanocoderKey] as
+		| T
+		| undefined;
+}
+
+/**
+ * Reads a nested value: getConfigNestedValue('autoCompact', 'threshold') reads
+ * nanocoder.autoCompact.threshold.
+ */
+export function getConfigNestedValue<T = unknown>(
+	parentKey: string,
+	childKey: string,
+): T | undefined {
+	const config = readConfigObject(getGlobalConfigPath());
+	if (!config) return undefined;
+	const parent = (config.nanocoder as Record<string, unknown>)?.[parentKey];
+	if (parent && typeof parent === 'object') {
+		return (parent as Record<string, unknown>)?.[childKey] as T | undefined;
+	}
+	return undefined;
+}
+
+/**
+ * Updates a nested value: updateConfigNestedValue('autoCompact', 'threshold', 75).
+ */
+export function updateConfigNestedValue<K extends string, V>(
+	parentKey: K,
+	childKey: string,
+	value: V,
+): void {
+	const configPath = getGlobalConfigPath();
+	const config = readConfigObject(configPath);
+	if (!config) return;
+
+	if (!config.nanocoder || typeof config.nanocoder !== 'object') {
+		config.nanocoder = {};
+	}
+	const nanocoder = config.nanocoder as Record<string, unknown>;
+	if (!nanocoder[parentKey] || typeof nanocoder[parentKey] !== 'object') {
+		nanocoder[parentKey] = {};
+	}
+	(nanocoder[parentKey] as Record<string, unknown>)[childKey] = value;
+	writeConfigObject(configPath, config, 'nested update');
+}
+
+/**
+ * Replaces an entire nested object: updateConfigObject('autoCompact', {...}).
+ */
+export function updateConfigObject<
+	K extends string,
+	V extends Record<string, unknown>,
+>(parentKey: K, value: V): void {
+	const configPath = getGlobalConfigPath();
+	const config = readConfigObject(configPath);
+	if (!config) return;
+
+	if (!config.nanocoder || typeof config.nanocoder !== 'object') {
+		config.nanocoder = {};
+	}
+	(config.nanocoder as Record<string, unknown>)[parentKey] = value;
+	writeConfigObject(configPath, config, 'object update');
+}
+
+/**
+ * Atomically write an arbitrary config file with pretty-printed JSON. Used by the
+ * in-TUI JSON editor so a crash mid-write can never leave a truncated config.
+ */
+export function writeConfigFileAtomic(filePath: string, data: unknown): void {
+	const dir = dirname(filePath);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, {recursive: true});
+	}
+	atomicWriteFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function readConfigObject(
+	configPath: string,
+): Record<string, unknown> | undefined {
+	try {
+		if (existsSync(configPath)) {
+			return JSON.parse(readFileSync(configPath, 'utf-8'));
+		}
+		return {};
+	} catch (error) {
+		logError(`Failed to read config for update: ${String(error)}`);
+		return undefined;
+	}
+}
+
+function writeConfigObject(
+	configPath: string,
+	config: Record<string, unknown>,
+	label: string,
+): void {
+	try {
+		writeConfigFileAtomic(configPath, config);
+	} catch (error) {
+		logError(`Failed to write config ${label}: ${String(error)}`);
+	}
+}
+
+function atomicWriteFileSync(filePath: string, data: string): void {
+	const tmpPath = `${filePath}.${randomUUID()}.tmp`;
+	try {
+		writeFileSync(tmpPath, data, 'utf-8');
+		renameSync(tmpPath, filePath);
+	} catch (error) {
+		try {
+			unlinkSync(tmpPath);
+		} catch {}
+		throw error;
+	}
+}
+
+function getGlobalConfigPath(): string {
+	return join(getConfigPath(), 'agents.config.json');
+}

--- a/source/config/config-writer.ts
+++ b/source/config/config-writer.ts
@@ -7,12 +7,12 @@ import {
 	unlinkSync,
 	writeFileSync,
 } from 'node:fs';
-import {dirname, join} from 'node:path';
-import {getConfigPath} from '@/config/paths';
+import {dirname} from 'node:path';
+import {getClosestConfigFile} from '@/config/index';
 import {logError} from '@/utils/message-queue';
 
 /**
- * Reads the global agents.config.json, merges the given partial update into the
+ * Reads the active agents.config.json, merges the given partial update into the
  * `nanocoder` key, and writes it back atomically. Creates the file if missing.
  * The write counterpart to the various `load*` functions in config/index.ts.
  */
@@ -20,7 +20,7 @@ export function updateConfigValue<K extends string, V>(
 	nanocoderKey: K,
 	value: V,
 ): void {
-	const configPath = getGlobalConfigPath();
+	const configPath = getActiveConfigPath();
 	const config = readConfigObject(configPath);
 	if (!config) return;
 
@@ -39,7 +39,7 @@ export function updateConfigNestedValue<K extends string, V>(
 	childKey: string,
 	value: V,
 ): void {
-	const configPath = getGlobalConfigPath();
+	const configPath = getActiveConfigPath();
 	const config = readConfigObject(configPath);
 	if (!config) return;
 
@@ -105,6 +105,11 @@ function atomicWriteFileSync(filePath: string, data: string): void {
 	}
 }
 
-function getGlobalConfigPath(): string {
-	return join(getConfigPath(), 'agents.config.json');
+/**
+ * Same resolution the loaders use (project agents.config.json shadows the user
+ * one). Writing to the global file unconditionally meant a project config
+ * silently shadowed every settings change on the next launch.
+ */
+function getActiveConfigPath(): string {
+	return getClosestConfigFile('agents.config.json');
 }

--- a/source/hooks/useModeHandlers.tsx
+++ b/source/hooks/useModeHandlers.tsx
@@ -277,6 +277,36 @@ export function useModeHandlers({
 		}
 	};
 
+	/**
+	 * Pick up MCP config written to disk: drop the module-level config cache and
+	 * rebuild the live server connections. Split out of the wizard handler so the
+	 * settings panel can reuse it without also exiting the current mode.
+	 */
+	const reloadMcpServers = async () => {
+		reloadAppConfig();
+
+		const toolManager = getToolManager();
+		if (!toolManager) return;
+		try {
+			await reinitializeMCPServers(toolManager);
+			addToChatQueue(
+				<SuccessMessage
+					key={generateKey('mcp-reinit')}
+					message="MCP servers reinitialized with new configuration."
+					hideBox={true}
+				/>,
+			);
+		} catch (mcpError) {
+			addToChatQueue(
+				<ErrorMessage
+					key={generateKey('mcp-reinit-error')}
+					message={`Failed to reinitialize MCP servers: ${String(mcpError)}`}
+					hideBox={true}
+				/>,
+			);
+		}
+	};
+
 	// Handle MCP wizard complete - reinitializes MCP servers
 	const handleMcpWizardComplete = async (configPath?: string) => {
 		exitMode();
@@ -289,29 +319,7 @@ export function useModeHandlers({
 				/>,
 			);
 
-			reloadAppConfig();
-
-			const toolManager = getToolManager();
-			if (toolManager) {
-				try {
-					await reinitializeMCPServers(toolManager);
-					addToChatQueue(
-						<SuccessMessage
-							key={generateKey('mcp-reinit')}
-							message="MCP servers reinitialized with new configuration."
-							hideBox={true}
-						/>,
-					);
-				} catch (mcpError) {
-					addToChatQueue(
-						<ErrorMessage
-							key={generateKey('mcp-reinit-error')}
-							message={`Failed to reinitialize MCP servers: ${String(mcpError)}`}
-							hideBox={true}
-						/>,
-					);
-				}
-			}
+			await reloadMcpServers();
 		}
 	};
 
@@ -378,6 +386,7 @@ export function useModeHandlers({
 		handleConfigWizardCancel: exitMode,
 		handleMcpWizardComplete,
 		handleMcpWizardCancel: exitMode,
+		reloadMcpServers,
 		handleSettingsCancel: () => setIsSettingsMode(false),
 		handleExplorerCancel: exitMode,
 		handleIdeSelectionCancel: exitMode,


### PR DESCRIPTION
## Description

Resolves #697.

This adds the rest of nanocoder's settings to the `/settings` menu, so you can set things up without opening `.json` files and editing them by hand. It builds on the tabbed settings menu from #687.

### What's new
<img width="936" height="637" alt="settings-consolidation-demo" src="https://github.com/user-attachments/assets/a71ae6e7-acc3-4a87-8011-7fc032a4cf59" />

The menu now has five tabs: Appearance, Input, Behavior, Providers, and Advanced.

You can now change these from the menu:

- **Behavior:** default mode, auto-compact, sessions, and reasoning traces.
- **Providers:** your Web Search API key, and a read-only list of tools allowed to run without asking.
- **Advanced:** an in-app JSON editor, a read-only list of your active `NANOCODER_*` environment variables, and shortcuts that open the existing Tune Model and Connect IDE wizards.

For Providers and MCP servers, the menu first shows a list of what you already have (name, address, and models), then opens the setup wizard to add or change things.

### The JSON editor

"Edit Config Files" opens `agents.config.json` as a tree you can move through and edit right there. We worked to make it feel interactive:

- When you edit text, the cursor goes **inside the quotes**, so it feels like you are really typing in the value.
- For true/false values, you flip them with the **arrow keys** instead of typing the words.
- Press `w` to save. Saves are safe: the file is written to a temporary file and then swapped in, so a crash cannot leave a broken config. If you leave without saving, nothing changes.

A short recording of the whole menu and the editor is attached below.

### How this is different from the earlier draft (#563)

This ports @grenkoca's earlier draft (#563), rebuilt to fit the newer tab menu:

- The draft used its own menu layout. Everything here lives in the tabs from #687 instead.
- The draft had a "keep or discard" popup whose "discard" did not actually undo changes. We removed it. Changes save right away, and unsaved edits are simply dropped, so there is nothing to undo.
- Providers and MCP servers now open the existing wizards, which read your real config (it can be spread across several files). The draft opened a raw JSON view that only saw part of it.
- The code that writes the config file now saves safely (atomically). The draft's version was flagged for not doing this.

The ported commits credit @grenkoca with `Co-authored-by:`.

We left out one thing on purpose: GitHub Copilot and Codex login, which fit better in the provider-switching flow than in the settings menu.

## Type of Change

- [x] New feature

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files (the JSON tree's data structures and mutations are covered in `json-tree.spec.ts`)
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

Verified in a live session (see the attached recording): every tab and panel, the provider and MCP lists, the wizards launching and returning, and the JSON editor's in-place string edit, boolean arrow-select, and atomic save. These are configuration and input-layer changes, so behavior is provider-agnostic.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes
