### PR TITLE
Voice mode scaffolding: settings, /voice command, and status UI (PR1 of 6)

### DIFF
--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -6,11 +6,14 @@ import {ModalSelectors} from '@/app/components/modal-selectors';
 import {FileExplorer} from '@/components/file-explorer';
 import {IdeSelector} from '@/components/ide-selector';
 import PlanReviewPrompt from '@/components/plan-review-prompt';
+import {VoiceStatusBar} from '@/components/voice-status-bar';
+import {getVoicePreference} from '@/config/preferences';
 import type {useChatHandler} from '@/hooks/chat-handler';
 import type {AppHandlers} from '@/hooks/useAppHandlers';
 import type {useAppState} from '@/hooks/useAppState';
 import type {useModeHandlers} from '@/hooks/useModeHandlers';
 import {useTerminalRows} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
 import {UIStateProvider} from '@/hooks/useUIState';
 import type {useUserMessageQueue} from '@/hooks/useUserMessageQueue';
 import type {useVSCodeServer} from '@/hooks/useVSCodeServer';
@@ -247,12 +250,41 @@ export function InteractiveApp({
 		{isActive: cancellable},
 	);
 
+	const isVoiceInputAppropriate =
+		!appState.activeMode &&
+		!appState.isToolConfirmationMode &&
+		!appState.isQuestionMode &&
+		pendingSubagentApproval === null &&
+		pendingToolConfirmation === null;
+
+	// Push-to-talk keybinding stub (Ctrl+T)
+	// This PR (PR1) only scaffolds the handler. Audio capture is not yet wired.
+	useInput(
+		(input, key) => {
+			if (key.ctrl && input === 't') {
+				// Stub: Log or no-op until audio pipeline is wired in later PRs
+				// console.debug('Push-to-talk triggered');
+			}
+		},
+		{isActive: isVoiceInputAppropriate},
+	);
+
 	// Fullscreen layout if and only if cli.tsx put us on the alternate
 	// screen. Inline mode (--no-alt-screen / alternateScreen:false pref),
 	// test renderers, and piped stdout all use the classic flow layout
 	// with Static + native scrollback.
 	const fullscreen = altScreenActive;
 	const terminalRows = useTerminalRows();
+	const {currentTheme} = useTheme();
+
+	// Load voice preferences once on mount and when messages change (e.g. after /voice command)
+	const [voicePref, setVoicePref] = React.useState(() => getVoicePreference());
+
+	// TEMPORARY: proxy-triggers voice pref re-read via chatComponents length. Will be replaced by real event-driven state updates once PR4 (hands-free VAD) introduces actual audio state events. Do not build further on this mechanism.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: Trigger preference re-read when commands execute
+	React.useEffect(() => {
+		setVoicePref(getVoicePreference());
+	}, [appState.chatComponents.length]);
 
 	return (
 		// Fullscreen layout on the alternate screen buffer: the root Box is
@@ -386,6 +418,14 @@ export function InteractiveApp({
 								fullscreen={fullscreen}
 							/>
 						</UIStateProvider>
+					)}
+
+				{appState.startChat &&
+					appState.activeMode === null &&
+					!appState.isSettingsMode &&
+					!appState.planReviewState?.show &&
+					voicePref.enabled && (
+						<VoiceStatusBar state="idle" theme={currentTheme} />
 					)}
 			</Box>
 		</Box>

--- a/source/commands/lazy-registry.ts
+++ b/source/commands/lazy-registry.ts
@@ -228,4 +228,9 @@ export const lazyCommands: LazyCommand[] = [
 			'Inspect what the prompt scrubber will remove from your prompts',
 		load: () => import('@/commands/privacy').then(m => m.privacyCommand),
 	},
+	{
+		name: 'voice',
+		description: 'Toggle realtime voice mode (scaffolding only)',
+		load: () => import('@/commands/voice').then(m => m.voiceCommand),
+	},
 ];

--- a/source/commands/voice.spec.tsx
+++ b/source/commands/voice.spec.tsx
@@ -1,0 +1,52 @@
+import test from 'ava';
+import {render} from 'ink-testing-library';
+import React from 'react';
+import {themes} from '../config/themes';
+import {ThemeContext} from '../hooks/useTheme';
+import {TitleShapeContext} from '../hooks/useTitleShape';
+import {voiceCommand} from './voice';
+
+const MockProviders = ({children}: {children: React.ReactNode}) => {
+	const mockTheme = {
+		currentTheme: 'tokyo-night' as const,
+		colors: themes['tokyo-night'].colors,
+		setCurrentTheme: () => {},
+	};
+
+	const mockTitleShape = {
+		currentTitleShape: 'pill' as const,
+		setCurrentTitleShape: () => {},
+	};
+
+	return (
+		<ThemeContext.Provider value={mockTheme}>
+			<TitleShapeContext.Provider value={mockTitleShape}>
+				{children}
+			</TitleShapeContext.Provider>
+		</ThemeContext.Provider>
+	);
+};
+
+test('voice command has correct name and description', t => {
+	t.is(voiceCommand.name, 'voice');
+	t.truthy(voiceCommand.description);
+});
+
+test('voice command has a handler function', t => {
+	t.is(typeof voiceCommand.handler, 'function');
+});
+
+test('voice command toggles state and renders InfoMessage', async t => {
+	const result = await voiceCommand.handler([], [], {} as any);
+	if (!React.isValidElement(result)) {
+		t.fail('Expected React element');
+		return;
+	}
+
+	const {lastFrame} = render(<MockProviders>{result}</MockProviders>);
+	const output = lastFrame();
+	
+	t.truthy(output);
+	t.regex(output!, /Voice mode (enabled|disabled)/);
+	t.regex(output!, /audio not yet wired — scaffolding only/);
+});

--- a/source/commands/voice.tsx
+++ b/source/commands/voice.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {InfoMessage} from '@/components/message-box';
+import {getVoicePreference, updateVoicePreference} from '@/config/preferences';
+import {generateKey} from '@/session/key-generator';
+import type {Command} from '@/types/index';
+
+export const voiceCommand: Command = {
+	name: 'voice',
+	description: 'Toggle realtime voice mode (scaffolding only)',
+	handler: async () => {
+		const currentConfig = getVoicePreference();
+		const newState = !currentConfig.enabled;
+
+		updateVoicePreference({
+			...currentConfig,
+			enabled: newState,
+		});
+
+		return React.createElement(InfoMessage, {
+			key: generateKey('voice-toggle'),
+			message: `Voice mode ${
+				newState ? 'enabled' : 'disabled'
+			} (audio not yet wired — scaffolding only).`,
+		});
+	},
+};

--- a/source/components/voice-status-bar.spec.tsx
+++ b/source/components/voice-status-bar.spec.tsx
@@ -1,0 +1,59 @@
+import test from 'ava';
+import React from 'react';
+import {renderWithTheme} from '../test-utils/render-with-theme';
+import {VoiceStatusBar} from './voice-status-bar';
+
+const defaultProps = {
+	theme: 'tokyo-night' as const,
+};
+
+test('VoiceStatusBar renders idle state correctly', t => {
+	const {lastFrame} = renderWithTheme(
+		<VoiceStatusBar {...defaultProps} state="idle" />
+	);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Idle/);
+});
+
+test('VoiceStatusBar renders listening state correctly', t => {
+	const {lastFrame} = renderWithTheme(
+		<VoiceStatusBar {...defaultProps} state="listening" />
+	);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Listening/);
+});
+
+test('VoiceStatusBar renders processing state correctly', t => {
+	const {lastFrame} = renderWithTheme(
+		<VoiceStatusBar {...defaultProps} state="processing" />
+	);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Processing/);
+});
+
+test('VoiceStatusBar renders speaking state correctly', t => {
+	const {lastFrame} = renderWithTheme(
+		<VoiceStatusBar {...defaultProps} state="speaking" />
+	);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Speaking/);
+});
+
+test('VoiceStatusBar works in narrow terminal', t => {
+	const originalColumns = process.stdout.columns;
+	process.stdout.columns = 50;
+
+	const {lastFrame} = renderWithTheme(
+		<VoiceStatusBar {...defaultProps} state="idle" />
+	);
+	
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Voice:/);
+
+	process.stdout.columns = originalColumns;
+});

--- a/source/components/voice-status-bar.tsx
+++ b/source/components/voice-status-bar.tsx
@@ -1,0 +1,85 @@
+import {Box, Text} from 'ink';
+import {memo} from 'react';
+
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {getThemeColors} from '@/config/themes';
+import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import type {ThemePreset} from '@/types/ui';
+
+export type VoiceState = 'idle' | 'listening' | 'processing' | 'speaking';
+
+export const VoiceStatusBar = memo(function VoiceStatusBar({
+	state,
+	theme,
+}: {
+	state: VoiceState;
+	theme: ThemePreset;
+}) {
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+	const colors = getThemeColors(theme);
+
+	const getStateColor = () => {
+		switch (state) {
+			case 'listening':
+				return colors.info; // Info for listening
+			case 'processing':
+				return colors.warning; // Yellow for thinking
+			case 'speaking':
+				return colors.success; // Green for speaking
+			case 'idle':
+			default:
+				return colors.secondary; // Dimmed for idle
+		}
+	};
+
+	const getStateLabel = () => {
+		switch (state) {
+			case 'listening':
+				return '● Listening...';
+			case 'processing':
+				return '○ Processing...';
+			case 'speaking':
+				return '♪ Speaking...';
+			case 'idle':
+			default:
+				return '○ Idle (Hold Ctrl+T to talk)';
+		}
+	};
+
+	const color = getStateColor();
+
+	return (
+		<>
+			{isNarrow ? (
+				<Box
+					flexDirection="column"
+					marginBottom={1}
+					borderStyle="round"
+					borderColor={color}
+					paddingY={1}
+					paddingX={2}
+				>
+					<Text color={color}>
+						<Text bold={true}>Voice: </Text>
+						{getStateLabel()}
+					</Text>
+				</Box>
+			) : (
+				<TitledBoxWithPreferences
+					title="Voice Status"
+					width={boxWidth}
+					borderColor={color}
+					paddingX={2}
+					paddingY={1}
+					flexDirection="column"
+					marginBottom={1}
+				>
+					<Text color={color}>
+						<Text bold={true}>State: </Text>
+						{getStateLabel()}
+					</Text>
+				</TitledBoxWithPreferences>
+			)}
+		</>
+	);
+});

--- a/source/config/preferences.ts
+++ b/source/config/preferences.ts
@@ -210,3 +210,29 @@ export function updateAlternateScreen(value: boolean): void {
 	preferences.alternateScreen = value;
 	savePreferences(preferences);
 }
+
+/**
+ * Get the voice configuration from preferences
+ */
+export function getVoicePreference(): import('@/types/config').VoiceConfig {
+	const preferences = loadPreferences();
+	return (
+		preferences.voice ?? {
+			enabled: false,
+			activationMode: 'push-to-talk',
+			sttBackend: 'local',
+			ttsBackend: 'local',
+		}
+	);
+}
+
+/**
+ * Save the voice configuration to preferences
+ */
+export function updateVoicePreference(
+	config: import('@/types/config').VoiceConfig,
+): void {
+	const preferences = loadPreferences();
+	preferences.voice = config;
+	savePreferences(preferences);
+}

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -401,6 +401,14 @@ export const TUNE_DEFAULTS: TuneConfig = {
 	aggressiveCompact: false,
 };
 
+export interface VoiceConfig {
+	enabled: boolean;
+	activationMode: 'push-to-talk' | 'hands-free';
+	voiceName?: string;
+	sttBackend: 'local' | 'cloud';
+	ttsBackend: 'local' | 'cloud';
+}
+
 export interface UserPreferences {
 	lastProvider?: string;
 	lastModel?: string;
@@ -427,4 +435,5 @@ export interface UserPreferences {
 	 * content. Also switchable per-run with the --no-alt-screen flag.
 	 */
 	alternateScreen?: boolean;
+	voice?: VoiceConfig;
 }


### PR DESCRIPTION
## Description

Brief description of what this PR does

**This is the first out of the 6 plan PRs. (see #622 for the 
full plan). This PR only adds the basic scaffolding - settings, a slash command, 
and a status indicator. There is no actual audio yet. Nothing in here touches the 
core chat/request pipeline.**

## Type of Change

- [x] New feature

## Changeset

- Added a `voice` section to user settings (off by default, defaults to local 
  speech-to-text and text-to-speech rather than a cloud provider - this matches 
  Nanocoder's "bring your own model" philosophy).
- Added a `/voice` command that turns voice mode on/off and saves the preference. 
  Right now it only flips the setting and shows a message - no audio yet.
- Added a small status bar component (`VoiceStatusBar`) that shows up when voice 
  mode is enabled, only during the actual chat session (not during provider setup 
  or other modal screens). It currently just displays "Idle."
- Added a stubbed `Ctrl+T` keybinding for push-to-talk. Right now it does nothing 
  when pressed - the actual microphone/audio work comes in a later PR.
- Added tests for all of the above.

## What this does NOT do

- No microphone or speaker support yet (that's PR2).
- No speech-to-text or text-to-speech yet (PR2/PR3).
- No hands-free / voice-activity-detection mode yet (PR4).
- No interruption handling yet (PR5).
- Nothing here changes how the assistant processes or responds to messages - this 
  PR is purely additive settings and UI.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
