### PR TITLE
docs: add brew trust step for Homebrew taps

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,6 +30,12 @@ First, tap the repository:
 brew tap nano-collective/nanocoder https://github.com/Nano-Collective/nanocoder
 ```
 
+For Homebrew 6.x+ (and other setups that require a trusted third-party tap), trust the tap before installing:
+
+```bash
+brew trust nano-collective/nanocoder
+```
+
 Then install:
 
 ```bash


### PR DESCRIPTION
## Summary
- document the required `brew trust` step for Homebrew 6.x+ when installing from a third-party tap
- keep the installation flow aligned with the observed Homebrew error and successful recovery path

## Changes
- updated the Homebrew installation instructions in [docs/getting-started/installation.md](docs/getting-started/installation.md) to include `brew trust nano-collective/nanocoder` before `brew install nanocoder`