### PR TITLE
fix semantic memory category

### DIFF
--- a/source/memory/summarizer-service.spec.ts
+++ b/source/memory/summarizer-service.spec.ts
@@ -70,6 +70,10 @@ test('inferMemoryCategory maps durable facts to stable categories', t => {
 		inferMemoryCategory('Use camel case for new command variables.'),
 		'codingStyle',
 	);
+	t.is(
+		inferMemoryCategory('Use camelCase for all variable names.'),
+		'codingStyle',
+	);
 	t.is(inferMemoryCategory('This fixes the queued input regression.'), 'bugFix');
 	t.is(inferMemoryCategory('Refactor the old storage path later.'), 'refactor');
 	t.is(inferMemoryCategory('TODO delete obsolete project memory.'), 'todo');

--- a/source/memory/summarizer-service.ts
+++ b/source/memory/summarizer-service.ts
@@ -35,7 +35,8 @@ const CATEGORY_RULES: Array<{category: string; pattern: RegExp}> = [
 	},
 	{
 		category: 'codingStyle',
-		pattern: /\b(style|convention|format|formatting|naming|camel case|lint)\b/i,
+		pattern:
+			/\b(style|convention|format|formatting|naming|camel ?case|lint)\b/i,
 	},
 ];
 


### PR DESCRIPTION
## Description

Fixes semantic memory category inference so `camelCase` (no space) is classified as `codingStyle`, not missed by the previous `camel case`-only rule.

Updates the `codingStyle` regex to `camel ?case` and adds a regression test for the camelCase form.

Closes #619 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))