### PR TITLE
feat: add semantic memory setting

### DIFF
--- a/.changeset/semantic-memory-setting.md
+++ b/.changeset/semantic-memory-setting.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added a dedicated Semantic Memory toggle to `/settings` under Advanced, backed by the `semanticMemoryEnabled` preference. The setting defaults on to preserve existing behavior, and can be turned off to keep agents from persisting reusable context across sessions.

--- a/docs/configuration/preferences.md
+++ b/docs/configuration/preferences.md
@@ -30,6 +30,7 @@ Preferences follow the same location hierarchy as configuration files:
 | `nanocoderShape` | The nanocoder ASCII art shape |
 | `trustedDirectories` | Directories you've approved through the first-run security disclaimer |
 | `lastUpdateCheck` | Timestamp of the last update check (used to avoid checking too frequently) |
+| `semanticMemoryEnabled` | Enables semantic memory across sessions. Set to `false` or use `/settings` → **Advanced** → **Semantic Memory** to keep agents stateless. |
 
 ### Paste Configuration
 

--- a/source/app/components/settings-selector.spec.tsx
+++ b/source/app/components/settings-selector.spec.tsx
@@ -49,3 +49,13 @@ test('SettingsSelector main menu shows Display Settings option', t => {
 	t.truthy(output!.includes('Tool Results and Thinking'));
 	unmount();
 });
+
+test('SettingsSelector main menu shows Advanced option', t => {
+	const {lastFrame, unmount} = renderWithTheme(
+		<SettingsSelector onCancel={() => {}} />,
+	);
+	const output = lastFrame();
+	t.truthy(output);
+	t.truthy(output!.includes('Advanced'));
+	unmount();
+});

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -13,6 +13,7 @@ import {
 	getPasteThreshold,
 	getPrivacyPreference,
 	getReasoningExpanded,
+	getSemanticMemoryEnabled,
 	updateCompactToolDisplay,
 	updateNanocoderShape,
 	updateNotificationsPreference,
@@ -20,6 +21,7 @@ import {
 	updatePrivacyPreference,
 	updateReasoningExpanded,
 	updateSelectedTheme,
+	updateSemanticMemoryEnabled,
 } from '@/config/preferences';
 import {getThemeColors, themes} from '@/config/themes';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
@@ -39,6 +41,7 @@ type SettingsStep =
 	| 'notifications'
 	| 'display-settings'
 	| 'privacy'
+	| 'advanced'
 	| 'done';
 
 interface SettingsSelectorProps {
@@ -97,6 +100,11 @@ function SettingsMainMenu({
 			label: 'Privacy',
 			value: 'privacy',
 			description: 'Manage prompt scrubbing and sensitive data',
+		},
+		{
+			label: 'Advanced',
+			value: 'advanced',
+			description: 'Memory and advanced behavior',
 		},
 		{
 			label: 'Done',
@@ -1027,7 +1035,89 @@ export function SettingsSelector({onCancel}: SettingsSelectorProps) {
 					onCancel={onCancel}
 				/>
 			);
+		case 'advanced':
+			return (
+				<SettingsAdvancedPanel
+					onBack={() => setStep('main')}
+					onCancel={onCancel}
+				/>
+			);
 	}
+}
+
+// Advanced settings panel
+function SettingsAdvancedPanel({
+	onBack,
+	onCancel,
+}: {
+	onBack: () => void;
+	onCancel: () => void;
+}) {
+	const {boxWidth, isNarrow} = useResponsiveTerminal();
+	const {colors} = useTheme();
+
+	const [semanticMemoryEnabled, setSemanticMemoryEnabled] = useState(
+		getSemanticMemoryEnabled(),
+	);
+
+	useInput((_, key) => {
+		if (key.escape) {
+			onCancel();
+		}
+		if (key.shift && key.tab) {
+			onBack();
+		}
+	});
+
+	const items = useMemo(() => {
+		return [
+			{
+				label: `Semantic Memory: ${semanticMemoryEnabled ? 'ON' : 'OFF'}`,
+				value: 'semantic-memory',
+			},
+		];
+	}, [semanticMemoryEnabled]);
+
+	const handleSelect = () => {
+		const next = !semanticMemoryEnabled;
+		setSemanticMemoryEnabled(next);
+		updateSemanticMemoryEnabled(next);
+	};
+
+	const title = isNarrow ? 'Advanced' : 'Advanced Settings';
+
+	return (
+		<TitledBoxWithPreferences
+			title={title}
+			width={isNarrow ? '100%' : boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			{!isNarrow && (
+				<Box marginBottom={1}>
+					<Text color={colors.secondary}>
+						Toggle settings with Enter. Shift+Tab to go back, Esc to exit
+					</Text>
+				</Box>
+			)}
+
+			<Box marginBottom={1}>
+				<Text color={colors.warning}>
+					Semantic Memory recalls saved project context and injects it into
+					future prompts. Turn it off for stateless agent behavior.
+				</Text>
+			</Box>
+
+			<StyledSelectInput items={items} onSelect={handleSelect} />
+
+			<Box marginTop={1}>
+				<Text color={colors.secondary}>Enter/Esc</Text>
+			</Box>
+		</TitledBoxWithPreferences>
+	);
 }
 
 // Privacy settings panel

--- a/source/config/preferences.spec.ts
+++ b/source/config/preferences.spec.ts
@@ -9,6 +9,7 @@ import {
 	getNotificationsPreference,
 	getPasteThreshold,
 	getReasoningExpanded,
+	getSemanticMemoryEnabled,
 	loadPreferences,
 	resetPreferencesCache,
 	savePreferences,
@@ -18,6 +19,7 @@ import {
 	updateNotificationsPreference,
 	updatePasteThreshold,
 	updateReasoningExpanded,
+	updateSemanticMemoryEnabled,
 	getPrivacyPreference,
 	updatePrivacyPreference,
 } from './preferences';
@@ -1556,6 +1558,57 @@ test.serial('full workflow: update and retrieve privacy preference', t => {
 		updatePrivacyPreference(false);
 		const retrieved2 = getPrivacyPreference();
 		t.is(retrieved2, false);
+	} finally {
+		if (existsSync(preferencesPath)) {
+			rmSync(preferencesPath, {force: true});
+		}
+	}
+});
+
+test.serial('getSemanticMemoryEnabled returns true when not set', t => {
+	const preferencesPath = getTestPreferencesPath();
+	const preferences: UserPreferences = {};
+	writeFileSync(preferencesPath, JSON.stringify(preferences), 'utf-8');
+
+	try {
+		const result = getSemanticMemoryEnabled();
+		t.is(result, true);
+	} finally {
+		if (existsSync(preferencesPath)) {
+			rmSync(preferencesPath, {force: true});
+		}
+	}
+});
+
+test.serial('getSemanticMemoryEnabled returns false when disabled', t => {
+	const preferencesPath = getTestPreferencesPath();
+	const preferences: UserPreferences = {semanticMemoryEnabled: false};
+	writeFileSync(preferencesPath, JSON.stringify(preferences), 'utf-8');
+
+	try {
+		const result = getSemanticMemoryEnabled();
+		t.is(result, false);
+	} finally {
+		if (existsSync(preferencesPath)) {
+			rmSync(preferencesPath, {force: true});
+		}
+	}
+});
+
+test.serial('updateSemanticMemoryEnabled saves the preference correctly', t => {
+	const preferencesPath = getTestPreferencesPath();
+	if (existsSync(preferencesPath)) {
+		rmSync(preferencesPath, {force: true});
+	}
+
+	try {
+		updateSemanticMemoryEnabled(false);
+
+		t.true(existsSync(preferencesPath));
+		const content = readFileSync(preferencesPath, 'utf-8');
+		const parsed = JSON.parse(content) as UserPreferences;
+
+		t.is(parsed.semanticMemoryEnabled, false);
 	} finally {
 		if (existsSync(preferencesPath)) {
 			rmSync(preferencesPath, {force: true});

--- a/source/config/preferences.ts
+++ b/source/config/preferences.ts
@@ -192,3 +192,20 @@ export function updatePrivacyPreference(value: boolean): void {
 	preferences.enablePromptScrubbing = value;
 	savePreferences(preferences);
 }
+
+/**
+ * Get the semantic memory preference from preferences
+ */
+export function getSemanticMemoryEnabled(): boolean {
+	const preferences = loadPreferences();
+	return preferences.semanticMemoryEnabled ?? true;
+}
+
+/**
+ * Save the semantic memory preference
+ */
+export function updateSemanticMemoryEnabled(value: boolean): void {
+	const preferences = loadPreferences();
+	preferences.semanticMemoryEnabled = value;
+	savePreferences(preferences);
+}

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -3,6 +3,7 @@ import {appendToolDefinitionsToPrompt} from '@/ai-sdk-client/tools/system-prompt
 import {ConversationStateManager} from '@/app/utils/conversation-state';
 import UserMessage from '@/components/user-message';
 import {getAppConfig} from '@/config/index';
+import {getSemanticMemoryEnabled} from '@/config/preferences';
 import {CommandIntegration} from '@/custom-commands/command-integration';
 import {appendRelevantProjectContextWithCount} from '@/memory/project-context';
 import {SemanticMemoryManager} from '@/memory/semantic-memory-manager';
@@ -371,7 +372,10 @@ export function useChatHandler({
 				systemPrompt,
 				message,
 				projectMemoryFinder,
-				projectContextOptions,
+				{
+					...projectContextOptions,
+					semanticMemoryEnabled: getSemanticMemoryEnabled(),
+				},
 			);
 			systemPrompt = projectContext.systemPrompt;
 			setLastBuiltPrompt(systemPrompt);

--- a/source/memory/project-context.spec.ts
+++ b/source/memory/project-context.spec.ts
@@ -101,6 +101,22 @@ test('appendRelevantProjectContextWithCount reports injected memory count', asyn
 	t.true(result.systemPrompt.includes('## Project Context'));
 });
 
+test('appendRelevantProjectContextWithCount skips memory lookup when disabled', async t => {
+	const result = await appendRelevantProjectContextWithCount(
+		'base prompt',
+		'auth',
+		{
+			findRelevantMemories: async () => {
+				throw new Error('should not look up memories when disabled');
+			},
+		},
+		{semanticMemoryEnabled: false},
+	);
+
+	t.is(result.memoryCount, 0);
+	t.is(result.systemPrompt, 'base prompt');
+});
+
 test('appendRelevantProjectContext passes configured memory limit', async t => {
 	const prompt = await appendRelevantProjectContext(
 		'base prompt',

--- a/source/memory/project-context.ts
+++ b/source/memory/project-context.ts
@@ -6,6 +6,7 @@ export type MemoryFinder = Pick<SemanticMemoryManager, 'findRelevantMemories'>;
 export interface ProjectContextOptions {
 	memoryLimit?: number;
 	tokenBudget?: number;
+	semanticMemoryEnabled?: boolean;
 }
 
 export interface ProjectContextResult {
@@ -90,6 +91,10 @@ export async function appendRelevantProjectContextWithCount(
 	memoryFinder: MemoryFinder = new SemanticMemoryManager(),
 	options: ProjectContextOptions = {},
 ): Promise<ProjectContextResult> {
+	if (options.semanticMemoryEnabled === false) {
+		return {systemPrompt, memoryCount: 0};
+	}
+
 	try {
 		const projectContext = formatProjectContextWithCount(
 			await memoryFinder.findRelevantMemories(

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -407,4 +407,6 @@ export interface UserPreferences {
 	reasoningExpanded?: boolean;
 	compactToolDisplay?: boolean;
 	enablePromptScrubbing?: boolean;
+	/** Whether semantic memory is active. Default true to preserve existing behavior. */
+	semanticMemoryEnabled?: boolean;
 }


### PR DESCRIPTION
## Description

Adds a dedicated Semantic Memory toggle to `/settings` under Advanced so users can disable memory-backed behavior and keep agents stateless across sessions.

Motivation: semantic memory is useful for some workflows, but not every user wants an agent to carry reusable context forward. For users like me who find that behavior distracting or annoying, this makes stateless agent behavior available without editing preferences by hand.

The setting is persisted as `semanticMemoryEnabled` in `nanocoder-preferences.json`. It defaults to enabled to preserve existing behavior for existing users. When disabled, the chat handler passes that preference into project-context recall so semantic memory lookup is skipped and no saved project context is injected into the prompt.

<img width="787" height="560" alt="settings-option-demo" src="https://github.com/user-attachments/assets/a97a9ee1-d116-45de-815f-6f7200aafa82" />


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Verified:

- `node_modules/.bin/biome check source/app/components/settings-selector.tsx source/app/components/settings-selector.spec.tsx source/config/preferences.ts source/config/preferences.spec.ts source/hooks/chat-handler/useChatHandler.tsx source/memory/project-context.ts source/memory/project-context.spec.ts source/types/config.ts docs/configuration/preferences.md .changeset/semantic-memory-setting.md`
- `node_modules/.bin/tsc --noEmit`
- `NANOCODER_CONFIG_DIR=$(mktemp -d) node_modules/.bin/ava source/config/preferences.spec.ts source/memory/project-context.spec.ts source/app/components/settings-selector.spec.tsx source/hooks/chat-handler/useChatHandler.spec.tsx` (`110 tests passed`)
- `node_modules/.bin/tsc && node_modules/.bin/tsc-alias && cp source/commands/contributors.json dist/commands/contributors.json && chmod +x dist/cli.js`
- `pnpm run build` in the main checkout before manual testing

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Manual `/settings` verification completed: opened Settings, navigated to Advanced, searched with a partial `mem` query, and toggled the dedicated Semantic Memory row off.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

No logging was added because this is a persisted preference/UI toggle and does not introduce a new runtime operation.
