### PR TITLE
feat: add browser approvals, questions, and tool status for web mode (Phase 5)

### DIFF
--- a/.changeset/calm-web-world.md
+++ b/.changeset/calm-web-world.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Add browser approvals, questions, and live tool status to local web mode so coding-agent turns can finish safely in the browser UI.

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -49,6 +49,7 @@ import {setGlobalMessageQueue} from '@/utils/message-queue';
 import {setNotificationsConfig} from '@/utils/notifications';
 import {getShutdownManager} from '@/utils/shutdown';
 import {isExtensionInstalled} from '@/vscode/extension-installer';
+import {setWebToolLifecyclePublisher} from '@/web/tool-lifecycle';
 
 export default function App({
 	vscodeMode = false,
@@ -196,6 +197,7 @@ export default function App({
 	} = useGlobalHandlerQueues({
 		setPendingQuestion: appState.setPendingQuestion,
 		setIsQuestionMode: appState.setIsQuestionMode,
+		webRuntimeBridge,
 	});
 
 	// Initialize notifications config from app config (once)
@@ -535,6 +537,22 @@ export default function App({
 	React.useEffect(() => {
 		webRuntimeBridge?.publishAssistantContent(chatHandler.streamingContent);
 	}, [webRuntimeBridge, chatHandler.streamingContent]);
+
+	React.useEffect(() => {
+		if (!webRuntimeBridge) {
+			return;
+		}
+
+		setWebToolLifecyclePublisher({
+			started: (id, name) => webRuntimeBridge.publishToolStarted(id, name),
+			finished: (id, name, ok) =>
+				webRuntimeBridge.publishToolFinished(id, name, ok),
+		});
+
+		return () => {
+			setWebToolLifecyclePublisher(null);
+		};
+	}, [webRuntimeBridge]);
 
 	// Apply a session resolved by cli.tsx from --continue/--resume <id> (or open
 	// the picker for a bare --resume), once on mount. Reuses the exact same

--- a/source/app/hooks/useGlobalHandlerQueues.tsx
+++ b/source/app/hooks/useGlobalHandlerQueues.tsx
@@ -11,10 +11,12 @@ import {
 	type PendingToolConfirmation,
 	setGlobalToolConfirmHandler,
 } from '@/utils/tool-confirm-queue';
+import type {WebRuntimeBridge} from '@/web/runtime-bridge';
 
 interface UseGlobalHandlerQueuesProps {
 	setPendingQuestion: (question: PendingQuestion | null) => void;
 	setIsQuestionMode: (mode: boolean) => void;
+	webRuntimeBridge?: WebRuntimeBridge;
 }
 
 interface GlobalHandlerQueues {
@@ -30,6 +32,9 @@ interface GlobalHandlerQueues {
  *  - question-queue (ask_question tool) drives the question prompt UI
  *  - tool-approval-queue (subagent tool calls) drives a parallel approval flow
  *
+ * During an active browser-owned turn, requests route through the web runtime
+ * bridge instead of the terminal Ink prompts so the browser can resolve them.
+ *
  * The tool-approval queue uses a dedicated state slot so it doesn't conflict
  * with the main agent's tool confirmation flow — a subagent's tool can need
  * approval while the parent agent is mid-conversation.
@@ -37,11 +42,23 @@ interface GlobalHandlerQueues {
 export function useGlobalHandlerQueues({
 	setPendingQuestion,
 	setIsQuestionMode,
+	webRuntimeBridge,
 }: UseGlobalHandlerQueuesProps): GlobalHandlerQueues {
 	const questionResolverRef = useRef<((answer: string) => void) | null>(null);
+	const webRuntimeBridgeRef = useRef(webRuntimeBridge);
+	webRuntimeBridgeRef.current = webRuntimeBridge;
 
 	useEffect(() => {
 		setGlobalQuestionHandler((question: PendingQuestion) => {
+			const bridge = webRuntimeBridgeRef.current;
+			if (bridge?.hasActiveBrowserTurn()) {
+				return bridge.requestQuestion({
+					question: question.question,
+					options: question.options,
+					allowFreeform: question.allowFreeform,
+				});
+			}
+
 			return new Promise<string>(resolve => {
 				questionResolverRef.current = resolve;
 				setPendingQuestion(question);
@@ -70,6 +87,15 @@ export function useGlobalHandlerQueues({
 
 	useEffect(() => {
 		setGlobalToolApprovalHandler((approval: PendingToolApproval) => {
+			const bridge = webRuntimeBridgeRef.current;
+			if (bridge?.hasActiveBrowserTurn()) {
+				return bridge.requestApproval({
+					toolName: approval.toolCall.function.name,
+					arguments: approval.toolCall.function.arguments,
+					context: `Subagent: ${approval.subagentName}`,
+				});
+			}
+
 			return new Promise<boolean>(resolve => {
 				toolApprovalResolverRef.current = resolve;
 				setPendingSubagentApproval(approval);
@@ -97,6 +123,14 @@ export function useGlobalHandlerQueues({
 
 	useEffect(() => {
 		setGlobalToolConfirmHandler((confirmation: PendingToolConfirmation) => {
+			const bridge = webRuntimeBridgeRef.current;
+			if (bridge?.hasActiveBrowserTurn()) {
+				return bridge.requestApproval({
+					toolName: confirmation.toolCall.function.name,
+					arguments: confirmation.toolCall.function.arguments,
+				});
+			}
+
 			return new Promise<boolean>(resolve => {
 				toolConfirmResolverRef.current = resolve;
 				setPendingToolConfirmation(confirmation);

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -603,6 +603,9 @@ async function main(): Promise<void> {
 			});
 			const webServer = await startLocalWebServer({
 				onClientEvent: webRuntimeBridge.handleClientEvent,
+				onAllClientsDisconnected: () => {
+					webRuntimeBridge?.handleDisconnect();
+				},
 			});
 			broadcastEvent = webServer.broadcastEvent;
 

--- a/source/hooks/chat-handler/conversation/tool-executor.tsx
+++ b/source/hooks/chat-handler/conversation/tool-executor.tsx
@@ -38,10 +38,20 @@ const executeOne = async (
 	toolCall: ToolCall;
 	result: ToolResult;
 }> => {
+	const {publishWebToolFinished, publishWebToolStarted} = await import(
+		'@/web/tool-lifecycle'
+	);
+	publishWebToolStarted(toolCall.id, toolCall.function.name);
 	try {
 		const result = await processToolUse(toolCall);
+		publishWebToolFinished(
+			toolCall.id,
+			toolCall.function.name,
+			!result.content.startsWith('Error: '),
+		);
 		return {toolCall, result};
 	} catch (error) {
+		publishWebToolFinished(toolCall.id, toolCall.function.name, false);
 		return {
 			toolCall,
 			result: {
@@ -90,7 +100,7 @@ export interface ToolDisplayOptions {
  * the validated registry handler. The single per-tool execution primitive
  * shared by the auto-execute batch and the (post-approval) confirmation path.
  */
-export const executeApprovedTool = (
+export const executeApprovedTool = async (
 	toolCall: ToolCall,
 	toolManager: ToolManager | null,
 	processToolUse: (toolCall: ToolCall) => Promise<ToolResult>,
@@ -98,12 +108,28 @@ export const executeApprovedTool = (
 	signal?: AbortSignal,
 ): Promise<StreamingBashRun | {toolCall: ToolCall; result: ToolResult}> => {
 	if (toolCall.function.name === 'execute_bash' && setLiveComponent) {
-		return executeBashStreaming(
-			toolCall,
-			toolManager,
-			setLiveComponent,
-			signal,
+		const {publishWebToolFinished, publishWebToolStarted} = await import(
+			'@/web/tool-lifecycle'
 		);
+		publishWebToolStarted(toolCall.id, toolCall.function.name);
+		try {
+			const execution = await executeBashStreaming(
+				toolCall,
+				toolManager,
+				setLiveComponent,
+				signal,
+			);
+			publishWebToolFinished(
+				toolCall.id,
+				toolCall.function.name,
+				!execution.result.content.startsWith('Error: ') &&
+					!execution.result.content.startsWith('⚒ Validation failed'),
+			);
+			return execution;
+		} catch (error) {
+			publishWebToolFinished(toolCall.id, toolCall.function.name, false);
+			throw error;
+		}
 	}
 	return executeOne(toolCall, processToolUse);
 };

--- a/source/web/page.spec.ts
+++ b/source/web/page.spec.ts
@@ -62,3 +62,29 @@ test('web mode renders streamed assistant output as safe markdown', t => {
 	t.true(page.includes('textElement.dataset.rawText = nextText'));
 	t.false(page.includes("appendMessage('assistant', '', 'Assistant output')"));
 });
+
+test('web mode renders actionable approval and question cards', t => {
+	const page = renderWebModePage();
+
+	t.true(page.includes('function renderApprovalCard(message)'));
+	t.true(page.includes('function renderQuestionCard(message)'));
+	t.true(page.includes("type: 'approval_response'"));
+	t.true(page.includes("type: 'question_response'"));
+	t.true(page.includes("approveButton.textContent = 'Approve'"));
+	t.true(page.includes("denyButton.textContent = 'Deny'"));
+	t.true(page.includes("message.allowFreeform"));
+	t.false(page.includes("appendMessage('system', message.reason, 'Approval required')"));
+	t.false(page.includes("appendMessage('system', message.question, 'Question required')"));
+});
+
+test('web mode shows live tool running and completed status', t => {
+	const page = renderWebModePage();
+
+	t.true(page.includes("'system tool-status', 'Running tool: ' + message.name"));
+	t.true(page.includes("'Tool finished: ' + message.name"));
+	t.true(
+		page.includes(
+			"'Provider and model stay in the terminal runtime. During a browser turn, approvals and questions are answered here.'",
+		),
+	);
+});

--- a/source/web/page.ts
+++ b/source/web/page.ts
@@ -350,6 +350,73 @@ export function renderWebModePage(): string {
 			background: rgba(8, 9, 11, 0.26);
 			color: #beb7c7;
 		}
+		.message.interaction {
+			align-self: stretch;
+			width: min(760px, 100%);
+			border-color: rgba(125, 207, 255, 0.28);
+			background: rgba(36, 40, 59, 0.92);
+		}
+		.interaction-card {
+			display: grid;
+			gap: 12px;
+		}
+		.interaction-card pre {
+			margin: 0;
+			overflow-x: auto;
+			border: 1px solid var(--tn-border);
+			border-radius: 8px;
+			background: #12131c;
+			padding: 12px 14px;
+			font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+			font-size: 13px;
+			white-space: pre-wrap;
+		}
+		.interaction-actions,
+		.question-options {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 10px;
+		}
+		.interaction-actions button,
+		.question-options button {
+			min-height: 36px;
+			padding: 0 14px;
+			border: 1px solid rgba(125, 207, 255, 0.28);
+			border-radius: 8px;
+			background: rgba(125, 207, 255, 0.12);
+			color: #f5f2eb;
+			cursor: pointer;
+			font-size: 14px;
+			font-weight: 650;
+		}
+		.interaction-actions button[data-approved="false"] {
+			border-color: rgba(247, 118, 142, 0.35);
+			background: rgba(247, 118, 142, 0.12);
+		}
+		.interaction-actions button:disabled,
+		.question-options button:disabled,
+		.question-freeform button:disabled {
+			opacity: 0.55;
+			cursor: default;
+		}
+		.question-freeform {
+			display: grid;
+			gap: 8px;
+			grid-template-columns: minmax(0, 1fr) auto;
+		}
+		.question-freeform input {
+			min-height: 36px;
+			padding: 0 12px;
+			border: 1px solid var(--tn-border);
+			border-radius: 8px;
+			background: rgba(8, 9, 11, 0.35);
+			color: #f5f2eb;
+		}
+		.message.tool-status {
+			align-self: center;
+			width: min(760px, 100%);
+			border-style: dashed;
+		}
 		.empty-state {
 			position: absolute;
 			z-index: 2;
@@ -1150,6 +1217,150 @@ export function renderWebModePage(): string {
 			return true;
 		}
 
+			function formatToolArguments(args) {
+				try {
+					return JSON.stringify(args ?? {}, null, 2);
+				} catch {
+					return '{}';
+				}
+			}
+
+			function disableInteractionCard(card) {
+				for (const control of card.querySelectorAll('button, input')) {
+					control.disabled = true;
+				}
+			}
+
+			function renderApprovalCard(message) {
+				hideEmptyState();
+				const messageElement = document.createElement('div');
+				messageElement.className = 'message system interaction';
+				const card = document.createElement('div');
+				card.className = 'interaction-card';
+
+				const title = document.createElement('strong');
+				title.textContent = 'Approve tool: ' + message.toolName;
+				card.append(title);
+
+				if (message.context) {
+					const context = document.createElement('div');
+					context.className = 'meta';
+					context.textContent = message.context;
+					card.append(context);
+				}
+
+				const args = document.createElement('pre');
+				args.textContent = formatToolArguments(message.arguments);
+				card.append(args);
+
+				const actions = document.createElement('div');
+				actions.className = 'interaction-actions';
+				const approveButton = document.createElement('button');
+				approveButton.type = 'button';
+				approveButton.dataset.approved = 'true';
+				approveButton.textContent = 'Approve';
+				const denyButton = document.createElement('button');
+				denyButton.type = 'button';
+				denyButton.dataset.approved = 'false';
+				denyButton.textContent = 'Deny';
+				actions.append(approveButton, denyButton);
+				card.append(actions);
+				messageElement.append(card);
+				messageList.append(messageElement);
+				messageList.scrollTop = messageList.scrollHeight;
+
+				const respond = (approved) => {
+					disableInteractionCard(card);
+					const meta = document.createElement('div');
+					meta.className = 'meta';
+					meta.textContent = approved ? 'Approved' : 'Denied';
+					messageElement.append(meta);
+					sendClientEvent({
+						type: 'approval_response',
+						id: message.id,
+						approved,
+					});
+				};
+
+				approveButton.addEventListener('click', () => respond(true));
+				denyButton.addEventListener('click', () => respond(false));
+			}
+
+			function renderQuestionCard(message) {
+				hideEmptyState();
+				const messageElement = document.createElement('div');
+				messageElement.className = 'message system interaction';
+				const card = document.createElement('div');
+				card.className = 'interaction-card';
+
+				const title = document.createElement('strong');
+				title.textContent = message.question;
+				card.append(title);
+
+				const options = document.createElement('div');
+				options.className = 'question-options';
+				for (const option of message.options || []) {
+					const optionButton = document.createElement('button');
+					optionButton.type = 'button';
+					optionButton.textContent = option;
+					optionButton.addEventListener('click', () => {
+						disableInteractionCard(card);
+						const meta = document.createElement('div');
+						meta.className = 'meta';
+						meta.textContent = 'Answered';
+						messageElement.append(meta);
+						sendClientEvent({
+							type: 'question_response',
+							id: message.id,
+							answer: option,
+						});
+					});
+					options.append(optionButton);
+				}
+				card.append(options);
+
+				if (message.allowFreeform) {
+					const freeform = document.createElement('div');
+					freeform.className = 'question-freeform';
+					const input = document.createElement('input');
+					input.type = 'text';
+					input.placeholder = 'Type a custom answer';
+					input.autocomplete = 'off';
+					const answerButton = document.createElement('button');
+					answerButton.type = 'button';
+					answerButton.textContent = 'Send answer';
+					const submitFreeform = () => {
+						const answer = input.value.trim();
+						if (!answer) {
+							return;
+						}
+						disableInteractionCard(card);
+						const meta = document.createElement('div');
+						meta.className = 'meta';
+						meta.textContent = 'Answered';
+						messageElement.append(meta);
+						sendClientEvent({
+							type: 'question_response',
+							id: message.id,
+							answer,
+						});
+					};
+					answerButton.addEventListener('click', submitFreeform);
+					input.addEventListener('keydown', event => {
+						if (event.key === 'Enter') {
+							event.preventDefault();
+							submitFreeform();
+						}
+					});
+					freeform.append(input, answerButton);
+					card.append(freeform);
+				}
+
+				messageElement.append(card);
+				messageList.append(messageElement);
+				messageList.scrollTop = messageList.scrollHeight;
+			}
+
 		function handleServerEvent(message) {
 			if (message.type === 'ready') {
 				setStatus('Connected', 'connected');
@@ -1176,22 +1387,26 @@ export function renderWebModePage(): string {
 			}
 
 			if (message.type === 'tool_started') {
-				appendMessage('system', 'Tool started: ' + message.name);
+				appendMessage('system tool-status', 'Running tool: ' + message.name, 'In progress');
 				return;
 			}
 
 			if (message.type === 'tool_finished') {
-				appendMessage('system', 'Tool finished: ' + message.name, message.ok ? 'Completed' : 'Failed');
+				appendMessage(
+					'system tool-status',
+					'Tool finished: ' + message.name,
+					message.ok ? 'Completed' : 'Failed',
+				);
 				return;
 			}
 
 			if (message.type === 'approval_required') {
-				appendMessage('system', message.reason, 'Approval required');
+				renderApprovalCard(message);
 				return;
 			}
 
 			if (message.type === 'question_required') {
-				appendMessage('system', message.question, 'Question required');
+				renderQuestionCard(message);
 				return;
 			}
 
@@ -1317,7 +1532,10 @@ export function renderWebModePage(): string {
 			});
 
 			settingsButton.addEventListener('click', () => {
-				addSystemNotice('Provider, model, tools, and approvals are still owned by the terminal runtime in this phase.', 'Session settings');
+				addSystemNotice(
+					'Provider and model stay in the terminal runtime. During a browser turn, approvals and questions are answered here.',
+					'Session settings',
+				);
 			});
 
 			threadSearchInput.addEventListener('input', () => {

--- a/source/web/protocol.spec.ts
+++ b/source/web/protocol.spec.ts
@@ -1,0 +1,79 @@
+import test from 'ava';
+import {parseWebClientEvent, WEB_PROTOCOL_VERSION} from './protocol.js';
+
+test('parseWebClientEvent accepts approval and question responses', t => {
+	t.deepEqual(
+		parseWebClientEvent(
+			JSON.stringify({
+				type: 'approval_response',
+				id: 'approval-1',
+				approved: true,
+			}),
+		),
+		{type: 'approval_response', id: 'approval-1', approved: true},
+	);
+
+	t.deepEqual(
+		parseWebClientEvent(
+			JSON.stringify({
+				type: 'question_response',
+				id: 'question-1',
+				answer: 'Use the existing bridge',
+			}),
+		),
+		{
+			type: 'question_response',
+			id: 'question-1',
+			answer: 'Use the existing bridge',
+		},
+	);
+});
+
+test('parseWebClientEvent still accepts the phase 4 handshake events', t => {
+	t.deepEqual(
+		parseWebClientEvent(
+			JSON.stringify({
+				type: 'hello',
+				protocolVersion: WEB_PROTOCOL_VERSION,
+			}),
+		),
+		{type: 'hello', protocolVersion: WEB_PROTOCOL_VERSION},
+	);
+
+	t.deepEqual(
+		parseWebClientEvent(
+			JSON.stringify({
+				type: 'user_message',
+				id: 'turn-1',
+				text: 'hello',
+			}),
+		),
+		{type: 'user_message', id: 'turn-1', text: 'hello'},
+	);
+});
+
+test('parseWebClientEvent rejects malformed interaction responses', t => {
+	t.throws(
+		() =>
+			parseWebClientEvent(
+				JSON.stringify({type: 'approval_response', id: 'a', approved: 'yes'}),
+			),
+		{message: 'Approval response approved flag is required.'},
+	);
+
+	t.throws(
+		() =>
+			parseWebClientEvent(
+				JSON.stringify({type: 'question_response', id: 'q', answer: 12}),
+			),
+		{message: 'Question response answer is required.'},
+	);
+
+	t.throws(
+		() =>
+			parseWebClientEvent(
+				JSON.stringify({type: 'approval_response', approved: false}),
+			),
+		{message: 'Approval response id is required.'},
+	);
+});

--- a/source/web/protocol.ts
+++ b/source/web/protocol.ts
@@ -3,7 +3,9 @@ export const WEB_PROTOCOL_VERSION = 1;
 export type WebClientEvent =
 	| {type: 'hello'; protocolVersion: typeof WEB_PROTOCOL_VERSION}
 	| {type: 'user_message'; id: string; text: string}
-	| {type: 'cancel'; id: string};
+	| {type: 'cancel'; id: string}
+	| {type: 'approval_response'; id: string; approved: boolean}
+	| {type: 'question_response'; id: string; answer: string};
 
 export type WebServerEvent =
 	| {type: 'ready'; protocolVersion: typeof WEB_PROTOCOL_VERSION}
@@ -11,8 +13,20 @@ export type WebServerEvent =
 	| {type: 'assistant_delta'; id: string; text: string}
 	| {type: 'tool_started'; id: string; name: string}
 	| {type: 'tool_finished'; id: string; name: string; ok: boolean}
-	| {type: 'approval_required'; id: string; reason: string}
-	| {type: 'question_required'; id: string; question: string}
+	| {
+			type: 'approval_required';
+			id: string;
+			toolName: string;
+			arguments: Record<string, unknown>;
+			context?: string;
+	  }
+	| {
+			type: 'question_required';
+			id: string;
+			question: string;
+			options: string[];
+			allowFreeform: boolean;
+	  }
 	| {type: 'turn_completed'; id: string}
 	| {type: 'error'; message: string};
 
@@ -60,6 +74,34 @@ export function parseWebClientEvent(rawMessage: string): WebClientEvent {
 			return {
 				type: 'cancel',
 				id: parsed.id,
+			};
+		case 'approval_response':
+			if (typeof parsed.id !== 'string' || parsed.id.length === 0) {
+				throw new Error('Approval response id is required.');
+			}
+
+			if (typeof parsed.approved !== 'boolean') {
+				throw new Error('Approval response approved flag is required.');
+			}
+
+			return {
+				type: 'approval_response',
+				id: parsed.id,
+				approved: parsed.approved,
+			};
+		case 'question_response':
+			if (typeof parsed.id !== 'string' || parsed.id.length === 0) {
+				throw new Error('Question response id is required.');
+			}
+
+			if (typeof parsed.answer !== 'string') {
+				throw new Error('Question response answer is required.');
+			}
+
+			return {
+				type: 'question_response',
+				id: parsed.id,
+				answer: parsed.answer,
 			};
 		default:
 			throw new Error(`Unsupported web event type: ${parsed.type}.`);

--- a/source/web/runtime-bridge.spec.ts
+++ b/source/web/runtime-bridge.spec.ts
@@ -145,3 +145,132 @@ test('web runtime bridge cleanup does not remove a newer handler binding', async
 
 	t.deepEqual(submittedMessages, ['second:hello']);
 });
+
+test('web runtime bridge resolves matching approval responses during a browser turn', async t => {
+	const events: WebServerEvent[] = [];
+	const bridge = createWebRuntimeBridge(event => {
+		events.push(event);
+	});
+	bridge.bindRuntimeHandlers({
+		submitMessage: () => new Promise<void>(() => {}),
+		cancel: () => {},
+	});
+
+	await bridge.handleClientEvent(userMessage('turn-1'));
+	const approvalPromise = bridge.requestApproval({
+		toolName: 'write_file',
+		arguments: {path: 'README.md'},
+		context: 'Subagent: researcher',
+	});
+
+	t.like(events.at(-1), {
+		type: 'approval_required',
+		toolName: 'write_file',
+		arguments: {path: 'README.md'},
+		context: 'Subagent: researcher',
+	});
+
+	const approvalEvent = events.at(-1);
+	if (!approvalEvent || approvalEvent.type !== 'approval_required') {
+		t.fail('expected approval_required event');
+		return;
+	}
+
+	await bridge.handleClientEvent({
+		type: 'approval_response',
+		id: approvalEvent.id,
+		approved: true,
+	});
+
+	t.true(await approvalPromise);
+	await t.throwsAsync(
+		bridge.handleClientEvent({
+			type: 'approval_response',
+			id: approvalEvent.id,
+			approved: false,
+		}),
+		{message: 'This approval response does not match a pending request.'},
+	);
+});
+
+test('web runtime bridge rejects stale question responses and clears on cancel', async t => {
+	const events: WebServerEvent[] = [];
+	let cancelCount = 0;
+	const bridge = createWebRuntimeBridge(event => {
+		events.push(event);
+	});
+	bridge.bindRuntimeHandlers({
+		submitMessage: () => new Promise<void>(() => {}),
+		cancel: () => {
+			cancelCount++;
+		},
+	});
+
+	await bridge.handleClientEvent(userMessage('turn-1'));
+	const questionPromise = bridge.requestQuestion({
+		question: 'Which approach?',
+		options: ['A', 'B'],
+		allowFreeform: true,
+	});
+
+	const questionEvent = events.at(-1);
+	if (!questionEvent || questionEvent.type !== 'question_required') {
+		t.fail('expected question_required event');
+		return;
+	}
+
+	await t.throwsAsync(
+		bridge.handleClientEvent({
+			type: 'question_response',
+			id: 'stale-id',
+			answer: 'A',
+		}),
+		{message: 'This question response does not match a pending request.'},
+	);
+
+	await bridge.handleClientEvent({type: 'cancel', id: 'turn-1'});
+	await t.throwsAsync(questionPromise, {
+		message: 'The browser turn was cancelled before the question was answered.',
+	});
+	t.is(cancelCount, 1);
+});
+
+test('web runtime bridge publishes tool lifecycle only during an active browser turn', async t => {
+	const events: WebServerEvent[] = [];
+	const bridge = createWebRuntimeBridge(event => {
+		events.push(event);
+	});
+	bridge.bindRuntimeHandlers({
+		submitMessage: () => new Promise<void>(() => {}),
+		cancel: () => {},
+	});
+
+	bridge.publishToolStarted('tool-1', 'read_file');
+	t.deepEqual(events, []);
+
+	await bridge.handleClientEvent(userMessage('turn-1'));
+	bridge.publishToolStarted('tool-1', 'read_file');
+	bridge.publishToolFinished('tool-1', 'read_file', true);
+
+	t.deepEqual(events, [
+		{type: 'tool_started', id: 'tool-1', name: 'read_file'},
+		{type: 'tool_finished', id: 'tool-1', name: 'read_file', ok: true},
+	]);
+});
+
+test('web runtime bridge denies pending approval on disconnect', async t => {
+	const bridge = createWebRuntimeBridge(() => {});
+	bridge.bindRuntimeHandlers({
+		submitMessage: () => new Promise<void>(() => {}),
+		cancel: () => {},
+	});
+
+	await bridge.handleClientEvent(userMessage('turn-1'));
+	const approvalPromise = bridge.requestApproval({
+		toolName: 'execute_bash',
+		arguments: {command: 'ls'},
+	});
+	bridge.handleDisconnect();
+
+	t.false(await approvalPromise);
+});

--- a/source/web/runtime-bridge.ts
+++ b/source/web/runtime-bridge.ts
@@ -5,13 +5,44 @@ export interface WebRuntimeHandlers {
 	cancel: () => void;
 }
 
+export interface WebApprovalRequest {
+	toolName: string;
+	arguments: Record<string, unknown>;
+	context?: string;
+}
+
+export interface WebQuestionRequest {
+	question: string;
+	options: string[];
+	allowFreeform: boolean;
+}
+
 export interface WebRuntimeBridge {
 	handleClientEvent: (event: WebClientEvent) => Promise<void>;
 	bindRuntimeHandlers: (handlers: WebRuntimeHandlers) => () => void;
 	publishAssistantContent: (content: string) => void;
+	publishToolStarted: (id: string, name: string) => void;
+	publishToolFinished: (id: string, name: string, ok: boolean) => void;
+	hasActiveBrowserTurn: () => boolean;
+	requestApproval: (request: WebApprovalRequest) => Promise<boolean>;
+	requestQuestion: (request: WebQuestionRequest) => Promise<string>;
 	completeTurn: () => void;
 	failTurn: (error: unknown) => void;
+	handleDisconnect: () => void;
 }
+
+type PendingInteraction =
+	| {
+			id: string;
+			kind: 'approval';
+			resolve: (approved: boolean) => void;
+	  }
+	| {
+			id: string;
+			kind: 'question';
+			resolve: (answer: string) => void;
+			reject: (error: Error) => void;
+	  };
 
 export function createWebRuntimeBridge(
 	broadcastEvent: (event: WebServerEvent) => void,
@@ -19,10 +50,41 @@ export function createWebRuntimeBridge(
 	let runtimeHandlers: WebRuntimeHandlers | null = null;
 	let activeTurnId: string | null = null;
 	let previousAssistantContent = '';
+	let pendingInteraction: PendingInteraction | null = null;
+	let interactionCounter = 0;
 
 	const clearActiveTurn = () => {
 		activeTurnId = null;
 		previousAssistantContent = '';
+	};
+
+	const settlePendingInteraction = (options: {
+		denyApprovals: boolean;
+		rejectQuestions: boolean;
+		questionMessage?: string;
+	}) => {
+		const pending = pendingInteraction;
+		pendingInteraction = null;
+		if (!pending) {
+			return;
+		}
+
+		if (pending.kind === 'approval') {
+			pending.resolve(false);
+			return;
+		}
+
+		if (options.rejectQuestions) {
+			pending.reject(
+				new Error(
+					options.questionMessage ??
+						'The browser question was cancelled before an answer arrived.',
+				),
+			);
+			return;
+		}
+
+		pending.resolve('');
 	};
 
 	const completeActiveTurn = (expectedTurnId?: string) => {
@@ -30,6 +92,12 @@ export function createWebRuntimeBridge(
 			return;
 		}
 
+		settlePendingInteraction({
+			denyApprovals: true,
+			rejectQuestions: true,
+			questionMessage:
+				'The browser turn completed before the question was answered.',
+		});
 		broadcastEvent({type: 'turn_completed', id: activeTurnId});
 		clearActiveTurn();
 	};
@@ -39,6 +107,12 @@ export function createWebRuntimeBridge(
 			return;
 		}
 
+		settlePendingInteraction({
+			denyApprovals: true,
+			rejectQuestions: true,
+			questionMessage:
+				'The browser turn failed before the question was answered.',
+		});
 		broadcastEvent({
 			type: 'error',
 			message:
@@ -47,6 +121,11 @@ export function createWebRuntimeBridge(
 					: 'Nanocoder could not complete this turn.',
 		});
 		clearActiveTurn();
+	};
+
+	const nextInteractionId = (kind: 'approval' | 'question') => {
+		interactionCounter += 1;
+		return `browser-${kind}-${interactionCounter}`;
 	};
 
 	return {
@@ -59,11 +138,59 @@ export function createWebRuntimeBridge(
 				throw new Error('Nanocoder runtime is still starting.');
 			}
 
+			if (event.type === 'approval_response') {
+				if (!activeTurnId) {
+					throw new Error('No browser turn is waiting for approval.');
+				}
+
+				if (
+					!pendingInteraction ||
+					pendingInteraction.kind !== 'approval' ||
+					pendingInteraction.id !== event.id
+				) {
+					throw new Error(
+						'This approval response does not match a pending request.',
+					);
+				}
+
+				const pending = pendingInteraction;
+				pendingInteraction = null;
+				pending.resolve(event.approved);
+				return;
+			}
+
+			if (event.type === 'question_response') {
+				if (!activeTurnId) {
+					throw new Error('No browser turn is waiting for a question answer.');
+				}
+
+				if (
+					!pendingInteraction ||
+					pendingInteraction.kind !== 'question' ||
+					pendingInteraction.id !== event.id
+				) {
+					throw new Error(
+						'This question response does not match a pending request.',
+					);
+				}
+
+				const pending = pendingInteraction;
+				pendingInteraction = null;
+				pending.resolve(event.answer);
+				return;
+			}
+
 			if (event.type === 'cancel') {
 				if (!activeTurnId || event.id !== activeTurnId) {
 					throw new Error('This browser turn is no longer active.');
 				}
 
+				settlePendingInteraction({
+					denyApprovals: true,
+					rejectQuestions: true,
+					questionMessage:
+						'The browser turn was cancelled before the question was answered.',
+				});
 				runtimeHandlers.cancel();
 				return;
 			}
@@ -92,6 +219,12 @@ export function createWebRuntimeBridge(
 
 			return () => {
 				if (runtimeHandlers === handlers) {
+					settlePendingInteraction({
+						denyApprovals: true,
+						rejectQuestions: true,
+						questionMessage:
+							'The browser runtime was unbound before the question was answered.',
+					});
 					runtimeHandlers = null;
 				}
 			};
@@ -121,6 +254,83 @@ export function createWebRuntimeBridge(
 			}
 		},
 
+		publishToolStarted(id, name) {
+			if (!activeTurnId) {
+				return;
+			}
+
+			broadcastEvent({type: 'tool_started', id, name});
+		},
+
+		publishToolFinished(id, name, ok) {
+			if (!activeTurnId) {
+				return;
+			}
+
+			broadcastEvent({type: 'tool_finished', id, name, ok});
+		},
+
+		hasActiveBrowserTurn() {
+			return activeTurnId !== null;
+		},
+
+		requestApproval(request) {
+			if (!activeTurnId) {
+				return Promise.resolve(false);
+			}
+
+			if (pendingInteraction) {
+				return Promise.resolve(false);
+			}
+
+			const id = nextInteractionId('approval');
+			return new Promise<boolean>(resolve => {
+				pendingInteraction = {
+					id,
+					kind: 'approval',
+					resolve,
+				};
+				broadcastEvent({
+					type: 'approval_required',
+					id,
+					toolName: request.toolName,
+					arguments: sanitizeJsonRecord(request.arguments),
+					...(request.context ? {context: request.context} : {}),
+				});
+			});
+		},
+
+		requestQuestion(request) {
+			if (!activeTurnId) {
+				return Promise.reject(
+					new Error('No browser turn is active for this question.'),
+				);
+			}
+
+			if (pendingInteraction) {
+				return Promise.reject(
+					new Error('Another browser interaction is already pending.'),
+				);
+			}
+
+			const id = nextInteractionId('question');
+			return new Promise<string>((resolve, reject) => {
+				pendingInteraction = {
+					id,
+					kind: 'question',
+					resolve,
+					reject,
+				};
+				broadcastEvent({
+					type: 'question_required',
+					id,
+					question: request.question,
+					options: [...request.options],
+					allowFreeform: request.allowFreeform,
+				});
+			});
+		},
+
 		completeTurn() {
 			completeActiveTurn();
 		},
@@ -128,5 +338,24 @@ export function createWebRuntimeBridge(
 		failTurn(error) {
 			failActiveTurn(error);
 		},
+
+		handleDisconnect() {
+			settlePendingInteraction({
+				denyApprovals: true,
+				rejectQuestions: true,
+				questionMessage:
+					'The browser disconnected before the question was answered.',
+			});
+		},
 	};
+}
+
+function sanitizeJsonRecord(
+	value: Record<string, unknown>,
+): Record<string, unknown> {
+	try {
+		return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
 }

--- a/source/web/server.ts
+++ b/source/web/server.ts
@@ -18,6 +18,7 @@ export interface LocalWebServerOptions {
 	token?: string;
 	openBrowser?: boolean;
 	onClientEvent?: (event: WebClientEvent) => void | Promise<void>;
+	onAllClientsDisconnected?: () => void;
 }
 
 export interface LocalWebServer {
@@ -111,6 +112,9 @@ export async function startLocalWebServer(
 
 		clientSocket.on('close', () => {
 			connectedClients.delete(clientSocket);
+			if (connectedClients.size === 0) {
+				options.onAllClientsDisconnected?.();
+			}
 		});
 	});
 

--- a/source/web/tool-lifecycle.ts
+++ b/source/web/tool-lifecycle.ts
@@ -1,0 +1,30 @@
+/**
+ * Optional publisher used by the conversation tool executor to surface
+ * tool start/finish events to an active browser turn. Terminal mode leaves
+ * this unset; web mode binds it through the runtime bridge.
+ */
+
+export interface WebToolLifecyclePublisher {
+	started: (id: string, name: string) => void;
+	finished: (id: string, name: string, ok: boolean) => void;
+}
+
+let publisher: WebToolLifecyclePublisher | null = null;
+
+export function setWebToolLifecyclePublisher(
+	next: WebToolLifecyclePublisher | null,
+): void {
+	publisher = next;
+}
+
+export function publishWebToolStarted(id: string, name: string): void {
+	publisher?.started(id, name);
+}
+
+export function publishWebToolFinished(
+	id: string,
+	name: string,
+	ok: boolean,
+): void {
+	publisher?.finished(id, name, ok);
+}


### PR DESCRIPTION
## Description

Completes the local web-mode interaction loop for [#628](https://github.com/Nano-Collective/nanocoder/issues/628) Phase 5.

Browser turns can now:
- approve/deny tools via actionable cards
- answer agent questions (options + freeform)
- see live tool running/completed status

Runtime policy still owns safety; the browser only presents requests and returns the user's choice. Pending interactions are cleared safely on cancel, failure, completion, unbind, and disconnect.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))