### PR TITLE
feat: add provenance and warnings to semantic memory proposals

### DIFF
--- a/source/commands/memory.spec.tsx
+++ b/source/commands/memory.spec.tsx
@@ -144,6 +144,12 @@ test('memory command proposes durable memories from current messages', async t =
 			{
 				content: 'Auth uses Clerk.',
 				category: 'architecture',
+				sourceType: 'explicit-user',
+				evidence: {
+					userMessages: ['Refactor auth.'],
+					assistantMessages: [],
+				},
+				warnings: [],
 			},
 		]),
 	});

--- a/source/commands/memory.ts
+++ b/source/commands/memory.ts
@@ -72,12 +72,49 @@ export function createMemoryCommand(
 						);
 					}
 
-					return infoMsg(
-						proposals
-							.map(proposal => `[${proposal.category}] ${proposal.content}`)
-							.join('\n'),
-						'memory-propose',
+					proposals.sort((a, b) => {
+						const aWarns = a.warnings.length;
+						const bWarns = b.warnings.length;
+						if (aWarns === 0 && bWarns > 0) return -1;
+						if (aWarns > 0 && bWarns === 0) return 1;
+						return 0;
+					});
+
+					const lines: string[] = [];
+					for (let i = 0; i < proposals.length; i++) {
+						const proposal = proposals[i]!;
+						const hasWarnings = proposal.warnings.length > 0;
+						const header = `─────────────────────────────────\nProposal ${i + 1} of ${proposals.length}${hasWarnings ? '  ⚠ Review carefully' : ''}\n─────────────────────────────────`;
+						lines.push(header);
+						lines.push(`[${proposal.category}] ${proposal.content}\n`);
+						lines.push(`Source:   ${proposal.sourceType}`);
+
+						const evidenceLines: string[] = [];
+						for (const m of proposal.evidence.userMessages) {
+							evidenceLines.push(`User: "${m}"`);
+						}
+						for (const m of proposal.evidence.assistantMessages) {
+							evidenceLines.push(`Assistant: "${m}"`);
+						}
+
+						if (evidenceLines.length > 0) {
+							lines.push(`Evidence: ${evidenceLines[0]}`);
+							for (let j = 1; j < evidenceLines.length; j++) {
+								lines.push(`          ${evidenceLines[j]}`);
+							}
+						}
+
+						for (const w of proposal.warnings) {
+							lines.push(`⚠ ${w}`);
+						}
+						lines.push('');
+					}
+
+					lines.push(
+						'─────────────────────────────────\nRun /remember <content> to save any of the above.',
 					);
+
+					return infoMsg(lines.join('\n'), 'memory-propose');
 				}
 
 				return errorMsg(USAGE, 'memory-error');

--- a/source/memory/summarizer-service.spec.ts
+++ b/source/memory/summarizer-service.spec.ts
@@ -114,16 +114,32 @@ test('SummarizerService proposes durable memories from messages', t => {
 			{
 				content: 'Use the existing provider abstraction for model changes.',
 				category: 'architecture',
+				sourceType: 'explicit-user',
+				evidence: {
+					userMessages: [
+						'Use the existing provider abstraction for model changes.',
+					],
+					assistantMessages: [],
+				},
+				warnings: [],
 			},
 			{
 				content: 'Fixed the queued input regression by restoring drafts.',
 				category: 'bugFix',
+				sourceType: 'conversation-inferred',
+				evidence: {
+					userMessages: [],
+					assistantMessages: [
+						'Fixed the queued input regression by restoring drafts.',
+					],
+				},
+				warnings: ['Inferred from conversation, no explicit user statement.'],
 			},
 		] satisfies MemoryProposal[],
 	);
 });
 
-test('SummarizerService dedupes proposed memories', t => {
+test('SummarizerService dedupes proposed memories and user takes precedence', t => {
 	const service = new SummarizerService();
 
 	t.deepEqual(
@@ -141,6 +157,85 @@ test('SummarizerService dedupes proposed memories', t => {
 			{
 				content: 'Refactor the storage path later.',
 				category: 'refactor',
+				sourceType: 'explicit-user',
+				evidence: {
+					userMessages: ['Refactor the storage path later.'],
+					assistantMessages: ['Refactor the storage path later.'],
+				},
+				warnings: [],
+			},
+		],
+	);
+});
+
+test('SummarizerService detects assistant position reversal', t => {
+	const service = new SummarizerService();
+
+	t.deepEqual(
+		service.proposeMemoriesFromMessages([
+			{
+				role: 'user',
+				content: "Actually, generic exceptions look cleaner, you'd agree right?",
+			},
+			{
+				role: 'assistant',
+				content: "You're right. I will use generic exceptions formatting.",
+			},
+		]),
+		[
+			{
+				content: "You're right. I will use generic exceptions formatting.",
+				category: 'codingStyle',
+				sourceType: 'conversation-inferred',
+				evidence: {
+					userMessages: [],
+					assistantMessages: ["You're right. I will use generic exceptions formatting."],
+				},
+				warnings: [
+					'Possible assistant position reversal.',
+					'Inferred from conversation, no explicit user statement.',
+				],
+			},
+		],
+	);
+});
+
+test('SummarizerService guards false positive on reversal when user provides path/code/error', t => {
+	const service = new SummarizerService();
+
+	t.deepEqual(
+		service.proposeMemoriesFromMessages([
+			{
+				role: 'user',
+				content: 'That path is wrong, it should be /src/auth/style.ts',
+			},
+			{
+				role: 'assistant',
+				content: "You're right. The style convention is updated.",
+			},
+		]),
+		[
+			{
+				content: 'That path is wrong, it should be /src/auth/style.ts',
+				category: 'codingStyle',
+				sourceType: 'explicit-user',
+				evidence: {
+					userMessages: ['That path is wrong, it should be /src/auth/style.ts'],
+					assistantMessages: [],
+				},
+				warnings: [],
+			},
+			{
+				content: "You're right. The style convention is updated.",
+				category: 'codingStyle',
+				sourceType: 'conversation-inferred',
+				evidence: {
+					userMessages: [],
+					assistantMessages: ["You're right. The style convention is updated."],
+				},
+				warnings: [
+					'Inferred from conversation, no explicit user statement.',
+				],
 			},
 		],
 	);
@@ -164,6 +259,12 @@ test('SummarizerService proposals do not save memories automatically', async t =
 		{
 			content: 'TODO delete obsolete project memory later.',
 			category: 'todo',
+			sourceType: 'explicit-user',
+			evidence: {
+				userMessages: ['TODO delete obsolete project memory later.'],
+				assistantMessages: [],
+			},
+			warnings: [],
 		},
 	]);
 	t.deepEqual(await manager.listMemories(), []);

--- a/source/memory/summarizer-service.ts
+++ b/source/memory/summarizer-service.ts
@@ -10,9 +10,20 @@ export interface RememberMemoryInput {
 	sourceSessionId?: string;
 }
 
+export type MemorySourceType =
+	| 'explicit-remember'
+	| 'explicit-user'
+	| 'conversation-inferred';
+
 export interface MemoryProposal {
 	content: string;
 	category: string;
+	sourceType: MemorySourceType;
+	evidence: {
+		userMessages: string[];
+		assistantMessages: string[];
+	};
+	warnings: string[];
 }
 
 const CATEGORY_RULES: Array<{category: string; pattern: RegExp}> = [
@@ -59,10 +70,22 @@ export class SummarizerService {
 	}
 
 	proposeMemoriesFromMessages(messages: Message[]): MemoryProposal[] {
-		const proposals = new Map<string, MemoryProposal>();
+		const proposals = new Map<
+			string,
+			{
+				content: string;
+				category: string;
+				sourceRole: 'user' | 'assistant';
+				userTurns: string[];
+				assistantTurns: string[];
+				warnings: string[];
+			}
+		>();
 
-		for (const message of messages) {
-			if (message.role !== 'user' && message.role !== 'assistant') continue;
+		for (let i = 0; i < messages.length; i++) {
+			const message = messages[i];
+			if (!message || (message.role !== 'user' && message.role !== 'assistant'))
+				continue;
 
 			for (const candidate of splitMemoryCandidates(message.content)) {
 				const category = inferMemoryCategory(candidate);
@@ -70,12 +93,104 @@ export class SummarizerService {
 
 				const key = candidate.toLowerCase();
 				if (!proposals.has(key)) {
-					proposals.set(key, {content: candidate, category});
+					proposals.set(key, {
+						content: candidate,
+						category,
+						sourceRole: message.role,
+						userTurns: [],
+						assistantTurns: [],
+						warnings: [],
+					});
+				}
+
+				const entry = proposals.get(key)!;
+				if (message.role === 'user') {
+					entry.userTurns.push(message.content);
+					entry.sourceRole = 'user';
+				} else {
+					entry.assistantTurns.push(message.content);
+				}
+
+				if (message.role === 'assistant' && entry.sourceRole !== 'user') {
+					if (this.isAssistantReversal(messages, i)) {
+						if (
+							!entry.warnings.includes('Possible assistant position reversal.')
+						) {
+							entry.warnings.push('Possible assistant position reversal.');
+						}
+					}
 				}
 			}
 		}
 
-		return [...proposals.values()];
+		return [...proposals.values()].map(entry => {
+			const sourceType: MemorySourceType =
+				entry.sourceRole === 'user' ? 'explicit-user' : 'conversation-inferred';
+			const warnings = [...entry.warnings];
+
+			if (sourceType === 'conversation-inferred') {
+				if (
+					!warnings.includes(
+						'Inferred from conversation, no explicit user statement.',
+					)
+				) {
+					warnings.push(
+						'Inferred from conversation, no explicit user statement.',
+					);
+				}
+			}
+
+			return {
+				content: entry.content,
+				category: entry.category,
+				sourceType,
+				evidence: {
+					userMessages: entry.userTurns,
+					assistantMessages: entry.assistantTurns,
+				},
+				warnings,
+			};
+		});
+	}
+
+	private isAssistantReversal(
+		messages: Message[],
+		assistantIndex: number,
+	): boolean {
+		const assistantMsg = messages[assistantIndex];
+		if (!assistantMsg) return false;
+
+		const agreementOpenerPattern =
+			/^\s*[^a-z0-9]*(you're right|good point|fair enough|that makes sense|you're correct|fair point)/i;
+		if (!agreementOpenerPattern.test(assistantMsg.content)) {
+			return false;
+		}
+
+		let userMsg: Message | undefined;
+		for (let i = assistantIndex - 1; i >= 0; i--) {
+			const m = messages[i];
+			if (!m) continue;
+			if (m.role === 'user') {
+				userMsg = m;
+				break;
+			}
+			if (m.role === 'assistant') {
+				return false;
+			}
+		}
+
+		if (!userMsg) return false;
+
+		const userContent = userMsg.content;
+		const hasCodeBlock = /```/.test(userContent);
+		const hasFilePath = /[/]|\.(ts|js|jsx|tsx|py|json|md|html|css)\b/i.test(
+			userContent,
+		);
+		const hasErrorOutput = /\b(error:|exception|traceback|stack trace)\b/i.test(
+			userContent,
+		);
+
+		return !(hasCodeBlock || hasFilePath || hasErrorOutput);
 	}
 }
 


### PR DESCRIPTION
## Description

This PR enhances the continuous semantic memory system by adding provenance tracking and diagnostic warnings to memory proposals. #619

Previously, all extracted memories looked identical regardless of whether they were explicitly stated by the user or casually inferred from a conversation where the assistant simply agreed with the user.

Now, the `/memory propose` command:
- Tracks the `sourceType` of every memory (e.g., `explicit-user` vs `conversation-inferred`).
- Stores the exact message history as `evidence` to show exactly where the proposed memory came from.
- Employs a lightweight heuristic to detect potential "assistant position reversals" (where the AI blindly agrees with a user's ungrounded preference) and flags them with a warning.
- Sorts the output so that clean, trusted proposals appear at the top, and flagged, inferred proposals are pushed to the bottom.

### Screen Shot
<img width="1320" height="628" alt="image" src="https://github.com/user-attachments/assets/4a5951f4-b614-4c56-95ae-479225e58130" />


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
