### PR TITLE
fix(prompt-history): return null at navigation end

### DIFF
--- a/.changeset/fix-prompt-history-end.md
+++ b/.changeset/fix-prompt-history-end.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed prompt history navigation returning an invalid value after reaching the end of the history. `getNextString()` now returns `null`, matching the behavior of the other history navigation methods.

--- a/source/prompt-history.spec.ts
+++ b/source/prompt-history.spec.ts
@@ -269,7 +269,7 @@ test('getNextString returns string value', t => {
 	t.is(nextString, 'command two', 'Should return string value');
 });
 
-test('getNextString returns empty string at end', t => {
+test('getNextString returns null at end', t => {
 	const history = createTestHistory();
 
 	history.addPrompt('command one');
@@ -279,8 +279,8 @@ test('getNextString returns empty string at end', t => {
 	const nextString = history.getNextString();
 	t.is(
 		nextString,
-		'',
-		'Should return empty string when reaching end (legacy behavior)',
+		null,
+		'Should return null when reaching end',
 	);
 });
 
@@ -531,7 +531,7 @@ test('backwards compatibility - getPreviousString vs getPrevious', t => {
 	t.is(stringValue, 'test');
 });
 
-test('backwards compatibility - getNextString returns empty string at end', t => {
+test('backwards compatibility - getNextString returns null at end', t => {
 	const history = createTestHistory();
 
 	history.addPrompt('test');
@@ -540,8 +540,8 @@ test('backwards compatibility - getNextString returns empty string at end', t =>
 	const nextString = history.getNextString();
 	t.is(
 		nextString,
-		'',
-		'Legacy method should return empty string, not null',
+		null,
+		'Legacy method should return null, matching getNext',
 	);
 });
 

--- a/source/prompt-history.ts
+++ b/source/prompt-history.ts
@@ -151,7 +151,7 @@ export class PromptHistory {
 
 	getNextString(): string | null {
 		const result = this.getNext();
-		return result?.displayValue ?? '';
+		return result?.displayValue ?? null;
 	}
 
 	resetIndex(): void {


### PR DESCRIPTION
## Summary

- return `null` from `getNextString()` when prompt history navigation reaches the end
- align both legacy string-returning tests with the declared `string | null` contract
- keep behavior consistent with `getNext()` and `getPreviousString()`

Fixes #721

## Validation

Passed:
- `corepack pnpm exec ava source/prompt-history.spec.ts` — 41 tests passed
- `corepack pnpm run test:types`
- `corepack pnpm run format:check`
- `corepack pnpm run test:lint`
- `corepack pnpm run test:knip`
- TypeScript compile via `corepack pnpm exec tsc` and Windows-equivalent artifact copy
- `git diff --check`
- pre-commit lint-staged hook

Environment limitations:
- `pnpm run test:all` cannot invoke `./scripts/test.sh` from PowerShell on Windows.
- Full `pnpm run test:ava` was attempted for 5 minutes; it did not complete and was terminated by the command timeout near existing `execute-bash.spec.tsx` tests. The reporter then emitted EPIPE during shutdown.
- `pnpm test:audit` cannot reach the configured `npmmirror.com` audit endpoint, and its `--ignore-unfixable` option is unsupported by pnpm 11.
- Semgrep was not installed, so it was skipped as the repository test script specifies.
