### PR TITLE
fix: use shared connection timeout constant in websocket client

### DIFF
--- a/plugins/vscode/src/websocket-client.ts
+++ b/plugins/vscode/src/websocket-client.ts
@@ -6,6 +6,7 @@ import {
 	PROTOCOL_VERSION,
 	DEFAULT_PORT,
 } from './protocol';
+import {TIMEOUT_PROVIDER_CONNECTION_MS} from '../../../source/constants';
 
 export type MessageHandler = (message: ServerMessage) => void;
 
@@ -75,7 +76,7 @@ export class WebSocketClient {
 						this.ws?.close();
 						resolve(false);
 					}
-				}, 5000);
+				}, TIMEOUT_PROVIDER_CONNECTION_MS);
 			} catch (error) {
 				this.isConnecting = false;
 				this.outputChannel.appendLine(`Connection failed: ${error}`);


### PR DESCRIPTION
## Summary

Replaces the hardcoded `5000` ms connection attempt timeout in `WebSocketClient.connect()` with the shared `TIMEOUT_PROVIDER_CONNECTION_MS` constant from `source/constants.ts`.

This keeps timeout values consistent across the codebase — future changes only need to happen in one place.

## Changes

- Imported `TIMEOUT_PROVIDER_CONNECTION_MS` from `../../../source/constants`
- Replaced the magic number `5000` on line 78 with the named constant

## Verification

- [x] `tsc --noEmit -p plugins/vscode/tsconfig.json` — passes
- [x] `esbuild` bundle — builds successfully
- [x] Biome pre-commit hooks — pass

Closes #723