### PR TITLE
fix: await rejectChange() in rejectAll() to avoid overlapping cleanup

### DIFF
--- a/.changeset/fix-vscode-reject-all-await.md
+++ b/.changeset/fix-vscode-reject-all-await.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed the VS Code extension's **Reject All** running rejection cleanups concurrently: `rejectAll()` fired the async `rejectChange()` without awaiting, so overlapping cleanups raced over shared editor state (stale tab snapshots in `closeEditors()`). Rejections now run sequentially, mirroring `applyAll()`. Thanks to @jmdlrg. Closes #725.

--- a/plugins/vscode/src/diff-manager.ts
+++ b/plugins/vscode/src/diff-manager.ts
@@ -321,10 +321,10 @@ export class DiffManager {
 	/**
 	 * Reject all pending changes
 	 */
-	rejectAll(): void {
+	async rejectAll(): Promise<void> {
 		const ids = Array.from(this.pendingChanges.keys());
 		for (const id of ids) {
-			this.rejectChange(id);
+			await this.rejectChange(id);
 		}
 	}
 


### PR DESCRIPTION
## Description

`rejectAll()` in the VS Code extension's diff manager fired the async `rejectChange()` without awaiting, so rejecting several pending diffs at once ran their cleanups concurrently. This makes `rejectAll()` await each rejection sequentially, mirroring how `applyAll()` already awaits `applyChange()`.

**On the issue's verification note** (whether concurrency was intentional): three signals say it wasn't — (1) `applyAll()`, the sibling method, already awaits sequentially; (2) concurrency buys nothing here since extension-host UI operations serialize anyway; (3) `closeEditors()` snapshots `vscode.window.tabGroups.all` and closes tabs against that snapshot, so concurrent rejections hold stale `Tab` references and race over shared editor state — the exact hazard the issue describes.

**Signature change** (`void` → `Promise<void>`): safe — neither `rejectAll()` nor `applyAll()` currently has callers in the repo.

**Possible follow-up (out of scope here):** `rejectChange()` has no `try/catch` (unlike `applyChange()`), so a failure now aborts the remaining rejections instead of becoming a silent unhandled rejection. Happy to address that in a separate PR if you want `rejectAll()` to keep going on per-change failures.

Fixes #725

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files — N/A (bug fix; the VS Code plugin has no test infrastructure)
- [ ] All existing tests pass (`pnpm test:all` completes successfully) — format, type and lint checks pass; 8 test failures in `cli-integration` and `settings-tabs` reproduce identically on a clean `main` checkout on my machine, so they're pre-existing and unrelated
- [ ] Tests cover both success and error scenarios — N/A

Verified the change with `pnpm run build:ext` (clean) and `tsc --noEmit` on the plugin (clean).

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

N/A — the fix is in the VS Code extension's diff manager and is provider-agnostic.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed) — N/A
- [x] No breaking changes (or clearly documented) — signature change documented above; no callers exist
- [ ] Appropriate logging added using structured logging — N/A, no logging paths touched