### PR TITLE
fix: hoist fs/path requires to top-level imports in chat-webview-provider

### DIFF
--- a/plugins/vscode/src/chat-webview-provider.ts
+++ b/plugins/vscode/src/chat-webview-provider.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import { WebviewToExtensionMessage, ExtensionToWebviewMessage } from './webview-protocol';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import { NanocoderAcpClient } from './acp-client';
 import { DiffManager } from './diff-manager';
@@ -236,10 +238,7 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 		}
 	}
 
-	private _getHtmlForWebview(webview: vscode.Webview) {
-		const fs = require('fs');
-		const path = require('path');
-		
+	private _getHtmlForWebview(webview: vscode.Webview) { 
 		const htmlPath = path.join(this._extensionUri.fsPath, 'media', 'chat-panel.html');
 		let html = fs.readFileSync(htmlPath, 'utf8');
 


### PR DESCRIPTION
Closes #724

## Description
Hoists `require('fs')` and `require('path')` out of `_getHtmlForWebview`
in `plugins/vscode/src/chat-webview-provider.ts` into top-level ES module
imports, matching the existing import style in the file. No runtime
behavior change — purely a maintainability cleanup as described in #724.

Note: on current `main`, this file doesn't have separate
`requestPathInfo`/`requestOpenDialog` handlers as mentioned in the issue —
`_getHtmlForWebview` is the only place with the duplicated inline
`require()` calls, so that's the single location fixed here.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset
- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

This is an internal chore (no user-facing behavior change), so I ran
`pnpm changeset --empty` instead of a real changeset.

## Testing
### Automated Tests
- [ ] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

(No new tests added — this is a non-functional refactor of an existing
code path with no behavior change, so no new `.spec.ts` coverage applies.)

### Manual Testing
- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

(N/A — change is isolated to webview HTML loading, unrelated to provider/model integration.)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see CONTRIBUTING.md#logging)

(No logging changes needed — this touches only import statements, not runtime logic.)