### PR TITLE
feat(voice):  Add push-to-talk voice pipeline and VoiceStatusBar integration (PR 3/6)

### DIFF
--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -16,6 +16,7 @@ import {useTerminalRows} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
 import {UIStateProvider} from '@/hooks/useUIState';
 import type {useUserMessageQueue} from '@/hooks/useUserMessageQueue';
+import {useVoice} from '@/hooks/useVoice';
 import type {useVSCodeServer} from '@/hooks/useVSCodeServer';
 import type {ImageAttachment} from '@/types/core';
 import type {RestoredInputDraft, SubmittedInputDraft} from '@/types/hooks';
@@ -82,6 +83,12 @@ export function InteractiveApp({
 		React.useState<SubmittedInputDraft | null>(null);
 	const [restoredDraft, setRestoredDraft] =
 		React.useState<RestoredInputDraft | null>(null);
+
+	const {state: voiceState, startStopRecording} = useVoice({
+		handleUserSubmit,
+		messages: appState.messages,
+		addToChatQueue: appState.addToChatQueue,
+	});
 
 	const handleToggleCompactDisplay = () => {
 		const expanding = appState.compactToolDisplay;
@@ -257,13 +264,14 @@ export function InteractiveApp({
 		pendingSubagentApproval === null &&
 		pendingToolConfirmation === null;
 
-	// Push-to-talk keybinding stub (Ctrl+T)
-	// This PR (PR1) only scaffolds the handler. Audio capture is not yet wired.
+	// Push-to-talk keybinding (Ctrl+T)
+	// IMPORTANT: Push-to-talk in this PR is an INTERNAL VALIDATION MECHANISM ONLY.
+	// The actual v1 goal is hands-free (VAD-driven) voice, landing in PR4.
+	// This exists here purely to prove the STT → pipeline → TTS loop works end-to-end.
 	useInput(
 		(input, key) => {
 			if (key.ctrl && input === 't') {
-				// Stub: Log or no-op until audio pipeline is wired in later PRs
-				// console.debug('Push-to-talk triggered');
+				void startStopRecording();
 			}
 		},
 		{isActive: isVoiceInputAppropriate},
@@ -425,7 +433,7 @@ export function InteractiveApp({
 					!appState.isSettingsMode &&
 					!appState.planReviewState?.show &&
 					voicePref.enabled && (
-						<VoiceStatusBar state="idle" theme={currentTheme} />
+						<VoiceStatusBar state={voiceState} theme={currentTheme} />
 					)}
 			</Box>
 		</Box>

--- a/source/commands/voice.spec.tsx
+++ b/source/commands/voice.spec.tsx
@@ -48,5 +48,4 @@ test('voice command toggles state and renders InfoMessage', async t => {
 	
 	t.truthy(output);
 	t.regex(output!, /Voice mode (enabled|disabled)/);
-	t.regex(output!, /audio not yet wired — scaffolding only/);
 });

--- a/source/commands/voice.tsx
+++ b/source/commands/voice.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import {InfoMessage} from '@/components/message-box';
 import {getVoicePreference, updateVoicePreference} from '@/config/preferences';
+import type {VoicePlugin} from '@/hooks/useVoice';
 import {generateKey} from '@/session/key-generator';
 import type {Command} from '@/types/index';
 
 export const voiceCommand: Command = {
 	name: 'voice',
-	description: 'Toggle realtime voice mode (scaffolding only)',
+	description: 'Toggle voice input',
 	handler: async () => {
 		const currentConfig = getVoicePreference();
 		const newState = !currentConfig.enabled;
@@ -16,11 +17,20 @@ export const voiceCommand: Command = {
 			enabled: newState,
 		});
 
+		try {
+			const plugin = (await import(
+				'@nanocollective/nanocoder-voice'
+			)) as VoicePlugin;
+			await plugin.playPhrase(
+				newState ? 'Voice mode activated' : 'Voice mode deactivated',
+			);
+		} catch (_error) {
+			// Audio is a nice-to-have addition here, never a requirement for the command to succeed
+		}
+
 		return React.createElement(InfoMessage, {
 			key: generateKey('voice-toggle'),
-			message: `Voice mode ${
-				newState ? 'enabled' : 'disabled'
-			} (audio not yet wired — scaffolding only).`,
+			message: `Voice mode ${newState ? 'enabled' : 'disabled'}.`,
 		});
 	},
 };

--- a/source/components/voice-status-bar.tsx
+++ b/source/components/voice-status-bar.tsx
@@ -42,7 +42,7 @@ export const VoiceStatusBar = memo(function VoiceStatusBar({
 				return '♪ Speaking...';
 			case 'idle':
 			default:
-				return '○ Idle (Hold Ctrl+T to talk)';
+				return '○ Idle (Press Ctrl+T to talk)';
 		}
 	};
 

--- a/source/hooks/useVoice.spec.tsx
+++ b/source/hooks/useVoice.spec.tsx
@@ -1,66 +1,307 @@
 import test from 'ava';
 import React from 'react';
-import { render } from 'ink-testing-library';
-import { useVoice, UseVoiceProps } from './useVoice.js';
-import type { VoiceState } from '@/components/voice-status-bar';
+import {render} from 'ink-testing-library';
+import type {UseVoiceProps, VoicePlugin} from './useVoice.js';
+import {useVoice} from './useVoice.js';
+import type {VoiceState} from '@/components/voice-status-bar.js';
+import type {Message} from '@/types/core.js';
 
-// Helper component to test the hook
-function TestComponent({
-	handleUserSubmit,
-	messages,
-	addToChatQueue,
-}: UseVoiceProps & {
+/** Build a complete mock plugin; any method not overridden resolves immediately. */
+function makeMockPlugin(overrides: Partial<VoicePlugin> = {}): VoicePlugin {
+	return {
+		recordAudio: async () => {},
+		transcribeAudio: async () => 'hello world',
+		synthesizeSpeech: async () => {},
+		playAudio: async () => {},
+		playPhrase: async () => {},
+		...overrides,
+	};
+}
+
+/**
+ * Minimal test harness. Keeps messages as React state so the deferred-TTS
+ * useEffect in useVoice fires correctly when handleUserSubmit appends a reply.
+ * The `simulateReply` flag controls whether handleUserSubmit adds an assistant
+ * message (mimicking what the real app does).
+ */
+function VoiceHarness({
+	loadPlugin,
+	onStateChange,
+	triggerRef,
+	queueRef,
+	simulateReply = true,
+}: {
+	loadPlugin: UseVoiceProps['loadPlugin'];
 	onStateChange?: (state: VoiceState) => void;
-	triggerRef?: React.MutableRefObject<(() => void) | null>;
+	triggerRef: React.MutableRefObject<(() => void) | null>;
+	queueRef: React.MutableRefObject<React.ReactNode[]>;
+	simulateReply?: boolean;
 }) {
-	const { state, startStopRecording } = useVoice({
+	const [messages, setMessages] = React.useState<Message[]>([]);
+
+	const handleUserSubmit = React.useCallback(async () => {
+		if (simulateReply) {
+			setMessages(prev => [
+				...prev,
+				{role: 'assistant' as const, content: 'Test reply.'},
+			]);
+		}
+	}, [simulateReply]);
+
+	const stableOnStateChange = React.useCallback(
+		(s: VoiceState) => {
+			onStateChange?.(s);
+		},
+		[onStateChange],
+	);
+
+	const {state, startStopRecording} = useVoice({
 		handleUserSubmit,
 		messages,
-		addToChatQueue,
+		addToChatQueue: comp => {
+			queueRef.current.push(comp);
+		},
+		loadPlugin,
 	});
 
 	React.useEffect(() => {
-		// eslint-disable-next-line react/prop-types
-		if (arguments[0].onStateChange) {
-			// eslint-disable-next-line react/prop-types
-			arguments[0].onStateChange(state);
-		}
-	}, [state]);
+		stableOnStateChange(state);
+	}, [state, stableOnStateChange]);
 
 	React.useEffect(() => {
-		// eslint-disable-next-line react/prop-types
-		if (arguments[0].triggerRef) {
-			// eslint-disable-next-line react/prop-types
-			arguments[0].triggerRef.current = startStopRecording;
-		}
-	}, [startStopRecording]);
+		triggerRef.current = startStopRecording;
+	}, [startStopRecording, triggerRef]);
 
 	return <></>;
 }
 
-// Since dynamic imports are hard to mock natively in Ava without proxyquire or similar,
-// we will just ensure that if the plugin is not installed, it degrades gracefully.
-// And we can write a test for graceful degradation.
-
-test('gracefully handles missing voice plugin', async t => {
-	const triggerRef = { current: null as (() => void) | null };
-	const queue: React.ReactNode[] = [];
-
-	render(
-		<TestComponent
-			handleUserSubmit={async () => {}}
-			messages={[]}
-			addToChatQueue={(comp) => queue.push(comp)}
-			triggerRef={triggerRef}
-		/>
-	);
-
-	if (triggerRef.current) {
-		await triggerRef.current();
+/**
+ * Flush microtasks and macrotask ticks so async state updates and React
+ * effects settle between test steps.
+ */
+async function flush(ticks = 3) {
+	for (let i = 0; i < 4; i++) {
+		await Promise.resolve();
 	}
 
-	// We expect the queue to contain an ErrorMessage because the plugin import will fail in the test environment
-	t.true(queue.length > 0);
-	// In a real mock environment, we would use proxyquire or similar to mock @nanocollective/nanocoder-voice
-	t.pass();
+	for (let i = 0; i < ticks; i++) {
+		await new Promise<void>(r => setTimeout(r, 0));
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('gracefully handles missing voice plugin', async t => {
+	const triggerRef = {current: null as (() => void) | null};
+	const queueRef = {current: [] as React.ReactNode[]};
+
+	render(
+		<VoiceHarness
+			loadPlugin={async () => {
+				throw new Error('Module not found');
+			}}
+			triggerRef={triggerRef}
+			queueRef={queueRef}
+		/>,
+	);
+
+	await flush();
+	await triggerRef.current!();
+	await flush();
+
+	t.is(queueRef.current.length, 1, 'should queue exactly one error message');
+
+	const queued = queueRef.current[0] as React.ReactElement<{message: string}>;
+	t.true(
+		queued.props.message.includes(
+			'Voice plugin not available. Please ensure @nanocollective/nanocoder-voice is installed.',
+		),
+		'error message should identify the missing plugin',
+	);
+});
+
+test('full successful cycle: completes without error and ends at idle', async t => {
+	// React 19 automatic batching merges rapid setState calls within the same
+	// async tick, so we cannot rely on observing every intermediate state
+	// (listening/processing/speaking) as distinct renders through a useEffect.
+	// We assert the observable outcomes instead: no errors queued, state returns
+	// to idle, and all plugin methods were called exactly once.
+	const triggerRef = {current: null as (() => void) | null};
+	const queueRef = {current: [] as React.ReactNode[]};
+
+	const calls = {
+		recordAudio: 0,
+		transcribeAudio: 0,
+		synthesizeSpeech: 0,
+		playAudio: 0,
+	};
+
+	const finalStates: VoiceState[] = [];
+
+	render(
+		<VoiceHarness
+			loadPlugin={async () =>
+				makeMockPlugin({
+					recordAudio: async () => {
+						calls.recordAudio++;
+					},
+					transcribeAudio: async () => {
+						calls.transcribeAudio++;
+						return 'hello world';
+					},
+					synthesizeSpeech: async () => {
+						calls.synthesizeSpeech++;
+					},
+					playAudio: async () => {
+						calls.playAudio++;
+					},
+				})
+			}
+			onStateChange={s => {
+				finalStates.push(s);
+			}}
+			triggerRef={triggerRef}
+			queueRef={queueRef}
+		/>,
+	);
+
+	await flush();
+	await triggerRef.current!();
+	await flush(5); // let the deferred TTS useEffect fire and TTS chain complete
+
+	t.is(finalStates.at(-1), 'idle', 'state should be idle after full cycle');
+	t.is(queueRef.current.length, 0, 'no error messages should be queued');
+	t.is(calls.recordAudio, 1, 'recordAudio called once');
+	t.is(calls.transcribeAudio, 1, 'transcribeAudio called once');
+	t.is(calls.synthesizeSpeech, 1, 'synthesizeSpeech called once');
+	t.is(calls.playAudio, 1, 'playAudio called once');
+});
+
+test('graceful failure when recordAudio throws', async t => {
+	const states: VoiceState[] = [];
+	const triggerRef = {current: null as (() => void) | null};
+	const queueRef = {current: [] as React.ReactNode[]};
+
+	render(
+		<VoiceHarness
+			loadPlugin={async () =>
+				makeMockPlugin({
+					recordAudio: async () => {
+						throw new Error('Microphone access denied');
+					},
+				})
+			}
+			onStateChange={s => {
+				states.push(s);
+			}}
+			triggerRef={triggerRef}
+			queueRef={queueRef}
+		/>,
+	);
+
+	await flush();
+	await triggerRef.current!();
+	await flush();
+
+	t.is(states.at(-1), 'idle', 'should return to idle after recordAudio failure');
+	t.is(queueRef.current.length, 1, 'should queue exactly one error message');
+
+	const queued = queueRef.current[0] as React.ReactElement<{message: string}>;
+	t.true(
+		queued.props.message.includes('Voice pipeline error'),
+		'error message should identify a pipeline error',
+	);
+});
+
+test('graceful failure when transcribeAudio throws', async t => {
+	const states: VoiceState[] = [];
+	const triggerRef = {current: null as (() => void) | null};
+	const queueRef = {current: [] as React.ReactNode[]};
+
+	render(
+		<VoiceHarness
+			loadPlugin={async () =>
+				makeMockPlugin({
+					transcribeAudio: async () => {
+						throw new Error('Whisper timed out');
+					},
+				})
+			}
+			onStateChange={s => {
+				states.push(s);
+			}}
+			triggerRef={triggerRef}
+			queueRef={queueRef}
+		/>,
+	);
+
+	await flush();
+	await triggerRef.current!();
+	await flush();
+
+	t.is(
+		states.at(-1),
+		'idle',
+		'should return to idle after transcribeAudio failure',
+	);
+	t.is(queueRef.current.length, 1, 'should queue exactly one error message');
+
+	const queued = queueRef.current[0] as React.ReactElement<{message: string}>;
+	t.true(
+		queued.props.message.includes('Voice pipeline error'),
+		'error message should identify a pipeline error',
+	);
+});
+
+test('manual abort mid-recording returns cleanly to idle', async t => {
+	const states: VoiceState[] = [];
+	const triggerRef = {current: null as (() => void) | null};
+	const queueRef = {current: [] as React.ReactNode[]};
+
+	// recordAudio hangs until the AbortSignal fires, then rejects with AbortError
+	const mockPlugin = makeMockPlugin({
+		recordAudio: async (_path, _duration, signal) =>
+			new Promise<void>((_resolve, reject) => {
+				const onAbort = () => {
+					const err = Object.assign(new Error('The operation was aborted.'), {
+						name: 'AbortError',
+					});
+					reject(err);
+				};
+
+				if (signal?.aborted) {
+					onAbort();
+					return;
+				}
+
+				signal?.addEventListener('abort', onAbort);
+			}),
+	});
+
+	render(
+		<VoiceHarness
+			loadPlugin={async () => mockPlugin}
+			onStateChange={s => {
+				states.push(s);
+			}}
+			triggerRef={triggerRef}
+			queueRef={queueRef}
+		/>,
+	);
+
+	await flush();
+
+	// First press — start recording (do not await; the function is hanging)
+	const done = triggerRef.current!();
+	await flush(); // let state settle to 'listening' and triggerRef update
+
+	t.is(states.at(-1), 'listening', 'should be listening after first press');
+
+	// Second press — abort the recording
+	triggerRef.current!();
+	await done; // wait for the first startStopRecording call to exit cleanly
+	await flush();
+
+	t.is(states.at(-1), 'idle', 'should return to idle after abort');
+	t.is(queueRef.current.length, 0, 'no error messages should be queued');
 });

--- a/source/hooks/useVoice.spec.tsx
+++ b/source/hooks/useVoice.spec.tsx
@@ -1,0 +1,66 @@
+import test from 'ava';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { useVoice, UseVoiceProps } from './useVoice.js';
+import type { VoiceState } from '@/components/voice-status-bar';
+
+// Helper component to test the hook
+function TestComponent({
+	handleUserSubmit,
+	messages,
+	addToChatQueue,
+}: UseVoiceProps & {
+	onStateChange?: (state: VoiceState) => void;
+	triggerRef?: React.MutableRefObject<(() => void) | null>;
+}) {
+	const { state, startStopRecording } = useVoice({
+		handleUserSubmit,
+		messages,
+		addToChatQueue,
+	});
+
+	React.useEffect(() => {
+		// eslint-disable-next-line react/prop-types
+		if (arguments[0].onStateChange) {
+			// eslint-disable-next-line react/prop-types
+			arguments[0].onStateChange(state);
+		}
+	}, [state]);
+
+	React.useEffect(() => {
+		// eslint-disable-next-line react/prop-types
+		if (arguments[0].triggerRef) {
+			// eslint-disable-next-line react/prop-types
+			arguments[0].triggerRef.current = startStopRecording;
+		}
+	}, [startStopRecording]);
+
+	return <></>;
+}
+
+// Since dynamic imports are hard to mock natively in Ava without proxyquire or similar,
+// we will just ensure that if the plugin is not installed, it degrades gracefully.
+// And we can write a test for graceful degradation.
+
+test('gracefully handles missing voice plugin', async t => {
+	const triggerRef = { current: null as (() => void) | null };
+	const queue: React.ReactNode[] = [];
+
+	render(
+		<TestComponent
+			handleUserSubmit={async () => {}}
+			messages={[]}
+			addToChatQueue={(comp) => queue.push(comp)}
+			triggerRef={triggerRef}
+		/>
+	);
+
+	if (triggerRef.current) {
+		await triggerRef.current();
+	}
+
+	// We expect the queue to contain an ErrorMessage because the plugin import will fail in the test environment
+	t.true(queue.length > 0);
+	// In a real mock environment, we would use proxyquire or similar to mock @nanocollective/nanocoder-voice
+	t.pass();
+});

--- a/source/hooks/useVoice.ts
+++ b/source/hooks/useVoice.ts
@@ -42,6 +42,11 @@ export interface UseVoiceProps {
 	) => Promise<void>;
 	messages: Message[];
 	addToChatQueue: (component: React.ReactNode) => void;
+	/**
+	 * Injectable plugin loader; defaults to the real dynamic import.
+	 * Override in tests to supply a mock without touching the module registry.
+	 */
+	loadPlugin?: () => Promise<VoicePlugin>;
 }
 
 export interface UseVoiceReturn {
@@ -53,6 +58,8 @@ export function useVoice({
 	handleUserSubmit,
 	messages,
 	addToChatQueue,
+	loadPlugin = async () =>
+		(await import('@nanocollective/nanocoder-voice')) as unknown as VoicePlugin,
 }: UseVoiceProps): UseVoiceReturn {
 	const [state, setState] = React.useState<VoiceState>('idle');
 
@@ -60,21 +67,87 @@ export function useVoice({
 	const recordingAudioPromiseRef = React.useRef<Promise<void> | null>(null);
 	const activeFileRef = React.useRef<string | null>(null);
 
-	const messagesRef = React.useRef(messages);
-	React.useEffect(() => {
-		messagesRef.current = messages;
-	}, [messages]);
+	// Deferred TTS state: armed just before handleUserSubmit is awaited so the
+	// messages-watching useEffect below can drive the TTS step on the next render.
+	//
+	// Why not read messages immediately after `await handleUserSubmit`?
+	//
+	// handleUserSubmit (→ handleChatMessage → processAssistantResponse) fully
+	// awaits the entire LLM response and calls React's setMessages() before its
+	// promise resolves. However setMessages() only *schedules* a React state
+	// update — the updated messages array is NOT reflected in this hook's
+	// `messages` prop (or any ref driven by useEffect) until after the next
+	// render cycle. Arming these refs and letting a useEffect drive the speaking
+	// → idle transition is the correct, race-free pattern here.
+	const pluginRef = React.useRef<VoicePlugin | null>(null);
+	const pendingTTSRef = React.useRef(false);
 
 	const cleanupActiveFile = React.useCallback(() => {
 		if (activeFileRef.current && existsSync(activeFileRef.current)) {
 			try {
 				unlinkSync(activeFileRef.current);
 			} catch {
-				// Best effort
+				// Best effort — temp file cleanup should never fail the pipeline
 			}
+
 			activeFileRef.current = null;
 		}
 	}, []);
+
+	// Abort and clean up temp files on unmount to avoid stale operations
+	React.useEffect(() => {
+		return () => {
+			if (abortControllerRef.current) {
+				abortControllerRef.current.abort();
+				abortControllerRef.current = null;
+			}
+
+			pendingTTSRef.current = false;
+			pluginRef.current = null;
+			cleanupActiveFile();
+		};
+	}, [cleanupActiveFile]);
+
+	// Deferred TTS: fires after React commits the updated messages prop.
+	// pendingTTSRef is armed in startStopRecording before handleUserSubmit is
+	// awaited, so this effect is guaranteed to run with the assistant reply in
+	// `messages` regardless of how React schedules the re-render.
+	React.useEffect(() => {
+		if (!pendingTTSRef.current || !pluginRef.current) return;
+
+		const lastMsg = messages[messages.length - 1];
+		if (!lastMsg || lastMsg.role !== 'assistant') return;
+
+		const plugin = pluginRef.current;
+		const formattedText = formatForSpeech(lastMsg.content);
+		pendingTTSRef.current = false;
+		pluginRef.current = null;
+
+		if (formattedText.trim() === '') {
+			setState('idle');
+			return;
+		}
+
+		setState('speaking');
+		const ttsFile = join(tmpdir(), `nanocoder-tts-${randomUUID()}.wav`);
+		activeFileRef.current = ttsFile;
+
+		plugin
+			.synthesizeSpeech(formattedText, ttsFile)
+			.then(async () => plugin.playAudio(ttsFile))
+			.catch(() => {
+				addToChatQueue(
+					React.createElement(ErrorMessage, {
+						key: generateKey('voice-audio-error'),
+						message: 'Failed to synthesize or play speech response.',
+					}),
+				);
+			})
+			.finally(() => {
+				cleanupActiveFile();
+				setState('idle');
+			});
+	}, [messages, addToChatQueue, cleanupActiveFile]);
 
 	const startStopRecording = React.useCallback(async () => {
 		if (state === 'listening') {
@@ -82,6 +155,7 @@ export function useVoice({
 				abortControllerRef.current.abort();
 				abortControllerRef.current = null;
 			}
+
 			return;
 		}
 
@@ -91,7 +165,7 @@ export function useVoice({
 
 		let plugin: VoicePlugin;
 		try {
-			plugin = (await import('@nanocollective/nanocoder-voice')) as VoicePlugin;
+			plugin = await loadPlugin();
 		} catch (_error) {
 			addToChatQueue(
 				React.createElement(ErrorMessage, {
@@ -124,17 +198,20 @@ export function useVoice({
 			try {
 				await audioPromise;
 			} catch (err) {
-				// Aborting the recording is expected behavior for a toggle, it rejects with AbortError
+				// Aborting the recording is expected for toggle-to-stop. A proper
+				// AbortError (name === 'AbortError') propagates to the outer catch
+				// where it is handled gracefully. Only rethrow non-abort errors.
 				if (!(err instanceof Error) || !err.message?.includes('AbortError')) {
 					throw err;
 				}
 			}
+
 			recordingAudioPromiseRef.current = null;
 
 			setState('processing');
 			const transcribedText = await plugin.transcribeAudio(
 				recordingFile,
-				60000,
+				60_000,
 			);
 
 			cleanupActiveFile();
@@ -150,36 +227,20 @@ export function useVoice({
 				return;
 			}
 
+			// Arm deferred TTS BEFORE awaiting handleUserSubmit. By the time the
+			// promise resolves the LLM reply is in the pipeline, but React hasn't
+			// re-rendered yet. The messages useEffect above drives the
+			// processing → speaking → idle transition once the messages prop updates.
+			pendingTTSRef.current = true;
+			pluginRef.current = plugin;
+
 			await handleUserSubmit(transcribedText, transcribedText);
-
-			const currentMessages = messagesRef.current;
-			const lastMessage = currentMessages[currentMessages.length - 1];
-
-			if (lastMessage && lastMessage.role === 'assistant') {
-				setState('speaking');
-				const formattedText = formatForSpeech(lastMessage.content);
-
-				if (formattedText.trim() !== '') {
-					const ttsFile = join(tmpdir(), `nanocoder-tts-${randomUUID()}.wav`);
-					activeFileRef.current = ttsFile;
-					try {
-						await plugin.synthesizeSpeech(formattedText, ttsFile);
-						await plugin.playAudio(ttsFile);
-					} catch (_audioErr) {
-						addToChatQueue(
-							React.createElement(ErrorMessage, {
-								key: generateKey('voice-audio-error'),
-								message: 'Failed to synthesize or play speech response.',
-							}),
-						);
-					} finally {
-						cleanupActiveFile();
-					}
-				}
-			}
-
-			setState('idle');
+			// Intentionally no setState here — the deferred TTS useEffect owns the
+			// remaining state transitions.
 		} catch (error) {
+			// Reset deferred TTS in case it was armed before the error occurred
+			pendingTTSRef.current = false;
+			pluginRef.current = null;
 			setState('idle');
 			recordingAudioPromiseRef.current = null;
 			abortControllerRef.current = null;
@@ -196,7 +257,7 @@ export function useVoice({
 				}),
 			);
 		}
-	}, [state, handleUserSubmit, addToChatQueue, cleanupActiveFile]);
+	}, [state, handleUserSubmit, addToChatQueue, cleanupActiveFile, loadPlugin]);
 
 	return {
 		state,

--- a/source/hooks/useVoice.ts
+++ b/source/hooks/useVoice.ts
@@ -81,6 +81,14 @@ export function useVoice({
 	// → idle transition is the correct, race-free pattern here.
 	const pluginRef = React.useRef<VoicePlugin | null>(null);
 	const pendingTTSRef = React.useRef(false);
+	// Safety net: if handleUserSubmit resolves but no assistant message ever
+	// lands (e.g. the conversation loop gives up after empty turns and returns
+	// without writing a role==='assistant' entry), pendingTTSRef would stay true
+	// and state would be stuck on 'processing' forever. This timeout resets both
+	// unconditionally after 90 s so the UI always recovers.
+	const ttsTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
 
 	const cleanupActiveFile = React.useCallback(() => {
 		if (activeFileRef.current && existsSync(activeFileRef.current)) {
@@ -102,6 +110,11 @@ export function useVoice({
 				abortControllerRef.current = null;
 			}
 
+			if (ttsTimeoutRef.current) {
+				clearTimeout(ttsTimeoutRef.current);
+				ttsTimeoutRef.current = null;
+			}
+
 			pendingTTSRef.current = false;
 			pluginRef.current = null;
 			cleanupActiveFile();
@@ -117,6 +130,12 @@ export function useVoice({
 
 		const lastMsg = messages[messages.length - 1];
 		if (!lastMsg || lastMsg.role !== 'assistant') return;
+
+		// Assistant reply arrived — cancel the safety timeout
+		if (ttsTimeoutRef.current) {
+			clearTimeout(ttsTimeoutRef.current);
+			ttsTimeoutRef.current = null;
+		}
 
 		const plugin = pluginRef.current;
 		const formattedText = formatForSpeech(lastMsg.content);
@@ -234,11 +253,32 @@ export function useVoice({
 			pendingTTSRef.current = true;
 			pluginRef.current = plugin;
 
+			// Safety timeout: some conversation-loop exit paths (empty-turn give-up,
+			// malformed-tool give-up, etc.) call `return` without ever appending an
+			// assistant message. handleUserSubmit resolves successfully in those cases
+			// but no assistant message ever lands, so the messages useEffect never
+			// clears pendingTTSRef and state stays stuck on 'processing' forever.
+			// This timeout guarantees recovery within 90 s regardless of how the
+			// conversation loop exits.
+			ttsTimeoutRef.current = setTimeout(() => {
+				if (pendingTTSRef.current) {
+					pendingTTSRef.current = false;
+					pluginRef.current = null;
+					ttsTimeoutRef.current = null;
+					setState('idle');
+				}
+			}, 90_000);
+
 			await handleUserSubmit(transcribedText, transcribedText);
 			// Intentionally no setState here — the deferred TTS useEffect owns the
 			// remaining state transitions.
 		} catch (error) {
 			// Reset deferred TTS in case it was armed before the error occurred
+			if (ttsTimeoutRef.current) {
+				clearTimeout(ttsTimeoutRef.current);
+				ttsTimeoutRef.current = null;
+			}
+
 			pendingTTSRef.current = false;
 			pluginRef.current = null;
 			setState('idle');

--- a/source/hooks/useVoice.ts
+++ b/source/hooks/useVoice.ts
@@ -1,0 +1,205 @@
+import {randomUUID} from 'node:crypto';
+import {existsSync, unlinkSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import React from 'react';
+import {ErrorMessage, InfoMessage} from '@/components/message-box';
+import type {VoiceState} from '@/components/voice-status-bar';
+import {generateKey} from '@/session/key-generator';
+import type {ImageAttachment, Message} from '@/types/core';
+import {formatForSpeech} from '@/utils/format-for-speech';
+
+export interface VoicePlugin {
+	recordAudio: (
+		filePath: string,
+		durationMs?: number,
+		signal?: AbortSignal,
+	) => Promise<void>;
+	transcribeAudio: (
+		filePath: string,
+		timeoutMs?: number,
+		signal?: AbortSignal,
+	) => Promise<string>;
+	synthesizeSpeech: (
+		text: string,
+		outputPath: string,
+		timeoutMs?: number,
+		signal?: AbortSignal,
+	) => Promise<void>;
+	playAudio: (
+		filePath: string,
+		timeoutMs?: number,
+		signal?: AbortSignal,
+	) => Promise<void>;
+	playPhrase: (phrase: string) => Promise<void>;
+}
+
+export interface UseVoiceProps {
+	handleUserSubmit: (
+		message: string,
+		displayValue: string,
+		images?: ImageAttachment[],
+	) => Promise<void>;
+	messages: Message[];
+	addToChatQueue: (component: React.ReactNode) => void;
+}
+
+export interface UseVoiceReturn {
+	state: VoiceState;
+	startStopRecording: () => void;
+}
+
+export function useVoice({
+	handleUserSubmit,
+	messages,
+	addToChatQueue,
+}: UseVoiceProps): UseVoiceReturn {
+	const [state, setState] = React.useState<VoiceState>('idle');
+
+	const abortControllerRef = React.useRef<AbortController | null>(null);
+	const recordingAudioPromiseRef = React.useRef<Promise<void> | null>(null);
+	const activeFileRef = React.useRef<string | null>(null);
+
+	const messagesRef = React.useRef(messages);
+	React.useEffect(() => {
+		messagesRef.current = messages;
+	}, [messages]);
+
+	const cleanupActiveFile = React.useCallback(() => {
+		if (activeFileRef.current && existsSync(activeFileRef.current)) {
+			try {
+				unlinkSync(activeFileRef.current);
+			} catch {
+				// Best effort
+			}
+			activeFileRef.current = null;
+		}
+	}, []);
+
+	const startStopRecording = React.useCallback(async () => {
+		if (state === 'listening') {
+			if (abortControllerRef.current) {
+				abortControllerRef.current.abort();
+				abortControllerRef.current = null;
+			}
+			return;
+		}
+
+		if (state !== 'idle') {
+			return;
+		}
+
+		let plugin: VoicePlugin;
+		try {
+			plugin = (await import('@nanocollective/nanocoder-voice')) as VoicePlugin;
+		} catch (_error) {
+			addToChatQueue(
+				React.createElement(ErrorMessage, {
+					key: generateKey('voice-error'),
+					message:
+						'Voice plugin not available. Please ensure @nanocollective/nanocoder-voice is installed.',
+				}),
+			);
+			return;
+		}
+
+		setState('listening');
+		const abortController = new AbortController();
+		abortControllerRef.current = abortController;
+
+		const recordingFile = join(
+			tmpdir(),
+			`nanocoder-recording-${randomUUID()}.wav`,
+		);
+		activeFileRef.current = recordingFile;
+
+		try {
+			const audioPromise = plugin.recordAudio(
+				recordingFile,
+				undefined,
+				abortController.signal,
+			);
+			recordingAudioPromiseRef.current = audioPromise;
+
+			try {
+				await audioPromise;
+			} catch (err) {
+				// Aborting the recording is expected behavior for a toggle, it rejects with AbortError
+				if (!(err instanceof Error) || !err.message?.includes('AbortError')) {
+					throw err;
+				}
+			}
+			recordingAudioPromiseRef.current = null;
+
+			setState('processing');
+			const transcribedText = await plugin.transcribeAudio(
+				recordingFile,
+				60000,
+			);
+
+			cleanupActiveFile();
+
+			if (!transcribedText || transcribedText.trim() === '') {
+				addToChatQueue(
+					React.createElement(InfoMessage, {
+						key: generateKey('voice-info'),
+						message: 'No speech detected.',
+					}),
+				);
+				setState('idle');
+				return;
+			}
+
+			await handleUserSubmit(transcribedText, transcribedText);
+
+			const currentMessages = messagesRef.current;
+			const lastMessage = currentMessages[currentMessages.length - 1];
+
+			if (lastMessage && lastMessage.role === 'assistant') {
+				setState('speaking');
+				const formattedText = formatForSpeech(lastMessage.content);
+
+				if (formattedText.trim() !== '') {
+					const ttsFile = join(tmpdir(), `nanocoder-tts-${randomUUID()}.wav`);
+					activeFileRef.current = ttsFile;
+					try {
+						await plugin.synthesizeSpeech(formattedText, ttsFile);
+						await plugin.playAudio(ttsFile);
+					} catch (_audioErr) {
+						addToChatQueue(
+							React.createElement(ErrorMessage, {
+								key: generateKey('voice-audio-error'),
+								message: 'Failed to synthesize or play speech response.',
+							}),
+						);
+					} finally {
+						cleanupActiveFile();
+					}
+				}
+			}
+
+			setState('idle');
+		} catch (error) {
+			setState('idle');
+			recordingAudioPromiseRef.current = null;
+			abortControllerRef.current = null;
+			cleanupActiveFile();
+
+			if (error instanceof Error && error.name === 'AbortError') {
+				return;
+			}
+
+			addToChatQueue(
+				React.createElement(ErrorMessage, {
+					key: generateKey('voice-error'),
+					message: `Voice pipeline error: ${error instanceof Error ? error.message : String(error)}`,
+				}),
+			);
+		}
+	}, [state, handleUserSubmit, addToChatQueue, cleanupActiveFile]);
+
+	return {
+		state,
+		startStopRecording,
+	};
+}

--- a/source/utils/format-for-speech.spec.ts
+++ b/source/utils/format-for-speech.spec.ts
@@ -1,0 +1,55 @@
+import test from 'ava';
+import { formatForSpeech } from './format-for-speech.js';
+
+test('strips ANSI escape codes', (t) => {
+	const input = 'Hello \x1B[31mWorld\x1B[0m!';
+	const result = formatForSpeech(input);
+	t.is(result, 'Hello World!');
+});
+
+test('collapses fenced code blocks > 3 lines', (t) => {
+	const input = 'Here is some code:\n```typescript\nconst a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\n```\nDone.';
+	const result = formatForSpeech(input);
+	t.is(result, 'Here is some code:\n[code block, 4 lines]\nDone.');
+});
+
+test('keeps fenced code blocks <= 3 lines', (t) => {
+	const input = 'Here is some code:\n```typescript\nconst a = 1;\nconst b = 2;\n```\nDone.';
+	const result = formatForSpeech(input);
+	t.is(result, 'Here is some code:\nconst a = 1;\nconst b = 2;\nDone.');
+});
+
+test('collapses stack traces', (t) => {
+	const input = 'An error occurred:\nTypeError: something went wrong\n    at Object.<anonymous> (/file.js:1:1)\n    at Module._compile (module.js:1:1)\nAnd that is it.';
+	const result = formatForSpeech(input);
+	t.is(result, 'An error occurred:\nTypeError: something went wrong\n[stack trace, 2 frames]\nAnd that is it.');
+});
+
+test('strips markdown headings, bold, italic, links, blockquotes, and lists', (t) => {
+	const input = '# Heading 1\n## Heading 2\nThis is **bold** and *italic*.\nHere is a [link](https://example.com).\n> Blockquote\n- Item 1\n* Item 2\n1. Item 3';
+	const result = formatForSpeech(input);
+	t.is(result, 'Heading 1\nHeading 2\nThis is bold and italic.\nHere is a link.\nBlockquote\nItem 1\nItem 2\nItem 3');
+});
+
+test('abbreviates long absolute file paths', (t) => {
+	const inputPosix = 'File is at /users/ronak/projects/nanocoder/src/index.ts';
+	const resultPosix = formatForSpeech(inputPosix);
+	t.is(resultPosix, 'File is at /users/.../index.ts');
+
+	const inputWindows = 'File is at C:\\Users\\ronak\\projects\\nanocoder\\src\\index.ts';
+	const resultWindows = formatForSpeech(inputWindows);
+	t.is(resultWindows, 'File is at C:\\Users\\...\\index.ts');
+});
+
+test('normalizes whitespace', (t) => {
+	const input = 'Hello   world.\n\n\nHow are you?';
+	const result = formatForSpeech(input);
+	t.is(result, 'Hello world.\nHow are you?');
+});
+
+test('truncates to max length', (t) => {
+	const input = 'A'.repeat(600);
+	const result = formatForSpeech(input, { maxLength: 500 });
+	t.true(result.startsWith('A'.repeat(500)));
+	t.true(result.includes('characters omitted]'));
+});

--- a/source/utils/format-for-speech.spec.ts
+++ b/source/utils/format-for-speech.spec.ts
@@ -32,11 +32,11 @@ test('strips markdown headings, bold, italic, links, blockquotes, and lists', (t
 });
 
 test('abbreviates long absolute file paths', (t) => {
-	const inputPosix = 'File is at /users/ronak/projects/nanocoder/src/index.ts';
+	const inputPosix = 'File is at /users/username/projects/nanocoder/src/index.ts';
 	const resultPosix = formatForSpeech(inputPosix);
 	t.is(resultPosix, 'File is at /users/.../index.ts');
 
-	const inputWindows = 'File is at C:\\Users\\ronak\\projects\\nanocoder\\src\\index.ts';
+	const inputWindows = 'File is at C:\\Users\\username\\projects\\nanocoder\\src\\index.ts';
 	const resultWindows = formatForSpeech(inputWindows);
 	t.is(resultWindows, 'File is at C:\\Users\\...\\index.ts');
 });

--- a/source/utils/format-for-speech.ts
+++ b/source/utils/format-for-speech.ts
@@ -1,0 +1,97 @@
+export interface FormatForSpeechOptions {
+	maxLength?: number;
+}
+
+export function formatForSpeech(
+	text: string,
+	options: FormatForSpeechOptions = {},
+): string {
+	const {maxLength = 500} = options;
+
+	let result = text;
+
+	// 1. Strip ANSI escape codes
+	// eslint-disable-next-line no-control-regex
+	result = result.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+
+	// 2. Collapse fenced code blocks
+	// We'll replace blocks with more than 3 lines of code with a summary.
+	result = result.replace(/```(?:[^\n]*\n)([\s\S]*?)```/g, (match, code) => {
+		const lines = code.trim().split('\n');
+		if (lines.length > 3) {
+			return `[code block, ${lines.length} lines]`;
+		}
+		return code.trim();
+	});
+
+	// 3. Collapse stack traces (look for "Error: ..." followed by "    at ...")
+	result = result.replace(
+		/([^\n]*Error[^\n]*\n)((?:(?:\s+at\s+)[^\n]+\n?)+)/g,
+		(match, firstLine, frames) => {
+			const frameLines = frames.trim().split('\n');
+			if (frameLines.length > 0) {
+				return `${firstLine.trim()}\n[stack trace, ${frameLines.length} frames]\n`;
+			}
+			return match;
+		},
+	);
+
+	// 4. Strip markdown syntax
+	// Headings
+	result = result.replace(/^#{1,6}\s+(.*)$/gm, '$1');
+	// Bold/Italic (**, *, __, _)
+	result = result.replace(/(\*\*|__)(.*?)\1/g, '$2');
+	result = result.replace(/(\*|_)(.*?)\1/g, '$2');
+	// Links: [text](url) -> text
+	result = result.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+	// Blockquotes
+	result = result.replace(/^>\s+(.*)$/gm, '$1');
+	// List markers (-, *, +, 1.)
+	result = result.replace(/^(\s*)([-*+]|\d+\.)\s+/gm, '$1');
+
+	// 5. Abbreviate long absolute file paths
+	// Find strings like /foo/bar/baz/qux.ts or C:\foo\bar\baz.ts
+	result = result.replace(
+		/(?:[a-zA-Z]:\\|\/)(?:[^\\\/\n]+[\\\/])+[^\\\/\n]+/g,
+		match => {
+			const sep = match.includes('\\') ? '\\' : '/';
+			const parts = match.split(sep);
+			// Keep first 2 and last 2, replace middle with ...
+			// E.g., /a/b/c/d/e.ts -> /a/.../e.ts
+			if (parts.length > 4) {
+				// parts[0] is drive letter or empty string, parts[1] is first dir
+				const start = 2;
+				// just keep first folder and last file
+				return `${parts.slice(0, start).join(sep)}${sep}...${sep}${parts[parts.length - 1]}`;
+			}
+			return match;
+		},
+	);
+
+	// 6. Normalize whitespace
+	// Collapse multiple newlines into a single space, or maybe just two newlines into one.
+	// We want it to sound continuous but keep some breaks.
+	// Actually, for speech, collapsing multiple newlines to a single space or period-space is good.
+	// We'll replace 2+ newlines with a single newline or space. Let's just use single newlines,
+	// and multiple spaces to single spaces.
+	result = result.replace(/\n{2,}/g, '\n');
+	result = result.replace(/ {2,}/g, ' ');
+	result = result.trim();
+
+	// 7. Truncate
+	if (result.length > maxLength) {
+		const truncated = result.slice(0, maxLength);
+		// Try to cut at a word boundary
+		const lastSpace = truncated.lastIndexOf(' ');
+		if (lastSpace > maxLength * 0.8) {
+			result =
+				truncated.slice(0, lastSpace) +
+				`... [${result.length - lastSpace} characters omitted]`;
+		} else {
+			result =
+				truncated + `... [${result.length - maxLength} characters omitted]`;
+		}
+	}
+
+	return result;
+}


### PR DESCRIPTION
## Description
This is PR 3 of 6 for Realtime Voice Mode (see #622 for the full plan). PR1 gave 
us the settings and UI. PR2 gave us the local recording/speech tools as a standalone plugin. This PR connects them together for the first time - this is the first PR where voice mode actually does something real.

## Type of Change

- [x] New feature

## Changes

- Hold `Ctrl+T` to talk: records your voice, turns it into text, sends it into 
  the chat exactly like you'd typed it, then reads the AI's reply back out loud.
- `/voice` now plays a short "Voice mode activated / deactivated" sound when you 
  toggle it, not just a text message.
- The little voice status box now shows real states (Idle / Listening / 
  Processing / Speaking) instead of always saying "Idle."
- If the voice plugin isn't installed, or recording/speech fails for any reason, 
  the app shows a clear error and keeps working normally -  it never crashes or 
  gets stuck.

## Important note

`Ctrl+T` push-to-talk here is meant as an internal way to prove the whole voice 
pipeline actually works end-to-end. It's not the final experience - the real goal 
is fully hands-free voice (no button needed), which is coming in PR4.
