### PR TITLE
fix(daemon): Handle macOS daemon socket path length limits

### DIFF
--- a/.changeset/macos-socket-path-length-limit.md
+++ b/.changeset/macos-socket-path-length-limit.md
@@ -2,8 +2,4 @@
 "@nanocollective/nanocoder": patch
 ---
 
----
-"@nanocollective/nanocoder": patch
----
-
 Fixed daemon startup on macOS when the project-local socket path is too long. Nanocoder now checks the full socket path against macOS' Unix socket path limit and falls back to a stable hashed socket name in the system temp directory, avoiding libuv's documented Unix socket path truncation behavior.

--- a/.changeset/macos-socket-path-length-limit.md
+++ b/.changeset/macos-socket-path-length-limit.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Handle macOS socket path length limit

--- a/.changeset/macos-socket-path-length-limit.md
+++ b/.changeset/macos-socket-path-length-limit.md
@@ -2,4 +2,8 @@
 "@nanocollective/nanocoder": patch
 ---
 
-Handle macOS socket path length limit
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed daemon startup on macOS when the project-local socket path is too long. Nanocoder now checks the full socket path against macOS' Unix socket path limit and falls back to a stable hashed socket name in the system temp directory, avoiding libuv's documented Unix socket path truncation behavior.

--- a/source/daemon/lockfile.spec.ts
+++ b/source/daemon/lockfile.spec.ts
@@ -144,6 +144,22 @@ test('getSocketPath on macOS uses project dir for short paths and temp dir for l
 	const shortRoot = '/tmp/short';
 	const shortSock = getSocketPath(shortRoot);
 	t.is(shortSock, join(shortRoot, '.nanocoder', 'daemon.sock'));
+
+	// The final socket path includes /.nanocoder/daemon.sock, so a root
+	// that is safe by itself can still exceed macOS' 104-byte limit.
+	const borderlineRoot = '/tmp/' + 'a'.repeat(85);
+	const borderlineProjectSock = join(
+		borderlineRoot,
+		'.nanocoder',
+		'daemon.sock',
+	);
+	const borderlineSock = getSocketPath(borderlineRoot);
+	t.is(Buffer.byteLength(borderlineRoot), 90);
+	t.true(Buffer.byteLength(borderlineProjectSock) >= 104);
+	t.true(borderlineSock.startsWith(tmpdir()));
+	t.regex(borderlineSock, /nanocoder-daemon-[a-f0-9]{10}\.sock$/);
+	t.not(borderlineSock, borderlineProjectSock);
+
 	// Long path (>104 bytes) should use temp directory with hash
 	const longRoot = '/tmp/' + 'a'.repeat(200);
 	const longSock = getSocketPath(longRoot);

--- a/source/daemon/lockfile.spec.ts
+++ b/source/daemon/lockfile.spec.ts
@@ -135,6 +135,23 @@ test('getSocketPath returns a project-local .sock file on non-Windows', t => {
 	t.is(sock, join(root, '.nanocoder', 'daemon.sock'));
 });
 
+test('getSocketPath on macOS uses project dir for short paths and temp dir for long paths', t => {
+	if (process.platform !== 'darwin') {
+		t.pass('skipped: macOS-only assertion');
+		return;
+	}
+	// Short path should use project-local socket
+	const shortRoot = '/tmp/short';
+	const shortSock = getSocketPath(shortRoot);
+	t.is(shortSock, join(shortRoot, '.nanocoder', 'daemon.sock'));
+	// Long path (>104 bytes) should use temp directory with hash
+	const longRoot = '/tmp/' + 'a'.repeat(200);
+	const longSock = getSocketPath(longRoot);
+	t.true(longSock.startsWith(tmpdir()));
+	t.regex(longSock, /nanocoder-daemon-[a-f0-9]{10}\.sock$/);
+	t.not(longSock, join(longRoot, '.nanocoder', 'daemon.sock'));
+});
+
 test('getSocketPath returns a named pipe path on Windows', t => {
 	if (process.platform !== 'win32') {
 		t.pass('skipped: Windows-only assertion');

--- a/source/daemon/lockfile.ts
+++ b/source/daemon/lockfile.ts
@@ -15,6 +15,7 @@
 import {createHash, randomBytes} from 'node:crypto';
 import {existsSync, mkdirSync} from 'node:fs';
 import {readFile, rename, unlink, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
 import {dirname, join} from 'node:path';
 
 export interface DaemonLock {
@@ -44,6 +45,22 @@ export function getSocketPath(projectRoot: string): string {
 			.digest('hex')
 			.slice(0, 10);
 		return `\\\\.\\pipe\\nanocoder-daemon-${hash}`;
+	}
+
+	// On macOS, the socket path must be shorter than 104 bytes.
+	const DARWIN_SOCKET_PATH_CAPACITY = 104;
+	if (
+		process.platform === 'darwin' &&
+		Buffer.byteLength(projectRoot) > DARWIN_SOCKET_PATH_CAPACITY
+	) {
+		// Use a hash of the project root to keep and create a unique socket path in macOS temporary directory.
+		//
+		const hash = createHash('sha256')
+			.update(projectRoot)
+			.digest('hex')
+			.slice(0, 10)
+			.toLowerCase();
+		return join(tmpdir(), `nanocoder-daemon-${hash}.sock`);
 	}
 	return join(projectRoot, '.nanocoder', 'daemon.sock');
 }

--- a/source/daemon/lockfile.ts
+++ b/source/daemon/lockfile.ts
@@ -47,22 +47,28 @@ export function getSocketPath(projectRoot: string): string {
 		return `\\\\.\\pipe\\nanocoder-daemon-${hash}`;
 	}
 
-	// On macOS, the socket path must be shorter than 104 bytes.
-	const DARWIN_SOCKET_PATH_CAPACITY = 104;
+	const projectSock = join(projectRoot, '.nanocoder', 'daemon.sock');
+
+	const DARWIN_SOCKET_PATH_CAPACITY = 104; // sockaddr_un.sun_path on macOS
 	if (
 		process.platform === 'darwin' &&
-		Buffer.byteLength(projectRoot) > DARWIN_SOCKET_PATH_CAPACITY
+		Buffer.byteLength(projectSock) >= DARWIN_SOCKET_PATH_CAPACITY
 	) {
-		// Use a hash of the project root to keep and create a unique socket path in macOS temporary directory.
-		//
+		// Fall back to os.tmpdir() after the project-local path exceeds the
+		// macOS socket limit. This is not relying on a documented max length
+		// for /var/folders; the important part is that we stop carrying the
+		// unbounded projectRoot into the socket path. macOS temp dirs normally
+		// look like /var/folders/.../T, and with the fixed-length hash filename
+		// the resulting path stays below sockaddr_un.sun_path's 104-byte limit
+		// in normal environments. The hash keeps the fallback stable and
+		// distinct for each project.
 		const hash = createHash('sha256')
 			.update(projectRoot)
 			.digest('hex')
-			.slice(0, 10)
-			.toLowerCase();
+			.slice(0, 10);
 		return join(tmpdir(), `nanocoder-daemon-${hash}.sock`);
 	}
-	return join(projectRoot, '.nanocoder', 'daemon.sock');
+	return projectSock;
 }
 
 export async function readLockfile(


### PR DESCRIPTION
## Description

Fixes macOS daemon socket handling when the project-local socket path exceeds the platform's Unix socket path length limit.

Nanocoder now checks the full socket path before handing it to libuv. If the project-local path is too long, it falls back to a stable hashed socket name in the system temp directory.

macOS limits Unix socket paths via `sockaddr_un.sun_path`. With long project paths, the daemon socket path can exceed that limit after appending `.nanocoder/daemon.sock`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
