### PR TITLE
Fix update checks, cache presence, and network error classification

### DIFF
--- a/.changeset/fix-update-cache-network-guards.md
+++ b/.changeset/fix-update-cache-network-guards.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed update checks incorrectly recording a successful check after a registry fetch failure, corrected `BoundedMap.has()` for entries whose value is `undefined`, and restored network-error classification for Node.js errno codes. Closes #739, #738, and #737.

--- a/source/utils/bounded-map.spec.ts
+++ b/source/utils/bounded-map.spec.ts
@@ -23,6 +23,15 @@ test('BoundedMap - has() method', t => {
 	t.false(map.has('nonexistent'));
 });
 
+test('BoundedMap - has() returns true for an existing undefined value', t => {
+	const map = new BoundedMap<string, undefined>();
+
+	map.set('key', undefined);
+
+	t.true(map.has('key'));
+	t.false(map.has('missing'));
+});
+
 test('BoundedMap - delete() method', t => {
 	const map = new BoundedMap<string, number>();
 

--- a/source/utils/bounded-map.ts
+++ b/source/utils/bounded-map.ts
@@ -90,7 +90,21 @@ export class BoundedMap<K, V> {
 	 * Check if key exists and is not expired
 	 */
 	has(key: K): boolean {
-		return this.get(key) !== undefined;
+		const entry = this.map.get(key);
+		if (!entry) {
+			return false;
+		}
+
+		// Check TTL if configured
+		if (this.ttl !== undefined && this.ttl > 0) {
+			const age = Date.now() - entry.timestamp;
+			if (age > this.ttl) {
+				this.map.delete(key);
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/source/utils/error-formatter.spec.ts
+++ b/source/utils/error-formatter.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {formatError} from './error-formatter';
+import {createErrorInfo, formatError} from './error-formatter';
 
 console.log(`\nerror-formatter.spec.ts`);
 
@@ -173,4 +173,25 @@ test('formatError - handles validation error object', t => {
 	};
 	const result = formatError(error);
 	t.is(result, 'email: Invalid email format');
+});
+
+test('createErrorInfo - recognizes Node network error codes', t => {
+	for (const code of ['ECONNREFUSED', 'ENOTFOUND', 'ECONNRESET']) {
+		const error = Object.assign(new Error('request failed'), {code});
+		const result = createErrorInfo(error);
+
+		t.true(result.isNetworkError);
+		t.is(result.code, code);
+	}
+});
+
+test('createErrorInfo - recognizes ETIMEDOUT as a network and timeout error', t => {
+	const error = Object.assign(new Error('request failed'), {
+		code: 'ETIMEDOUT',
+	});
+	const result = createErrorInfo(error);
+
+	t.true(result.isNetworkError);
+	t.true(result.isTimeoutError);
+	t.is(result.code, 'ETIMEDOUT');
 });

--- a/source/utils/error-formatter.ts
+++ b/source/utils/error-formatter.ts
@@ -140,13 +140,15 @@ export function createErrorInfo(
  * Check if error is a network-related error
  */
 function isNetworkError(error: Error): boolean {
+	const errorCode = (error as NodeJS.ErrnoException).code;
+
 	return (
 		error.name === 'NetworkError' ||
 		error.name === 'FetchError' ||
-		error.name === 'ECONNREFUSED' ||
-		error.name === 'ENOTFOUND' ||
-		error.name === 'ECONNRESET' ||
-		error.name === 'ETIMEDOUT' ||
+		errorCode === 'ECONNREFUSED' ||
+		errorCode === 'ENOTFOUND' ||
+		errorCode === 'ECONNRESET' ||
+		errorCode === 'ETIMEDOUT' ||
 		error.message.includes('network') ||
 		error.message.includes('fetch') ||
 		error.message.includes('connection')
@@ -157,9 +159,11 @@ function isNetworkError(error: Error): boolean {
  * Check if error is a timeout error
  */
 function isTimeoutError(error: Error): boolean {
+	const errorCode = (error as NodeJS.ErrnoException).code;
+
 	return (
 		error.name === 'TimeoutError' ||
-		error.name === 'ETIMEDOUT' ||
+		errorCode === 'ETIMEDOUT' ||
 		error.message.includes('timeout') ||
 		error.message.includes('timed out')
 	);

--- a/source/utils/update-checker.spec.ts
+++ b/source/utils/update-checker.spec.ts
@@ -1,7 +1,15 @@
-import {readFileSync} from 'fs';
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'fs';
 import {dirname, join} from 'path';
 import {fileURLToPath} from 'url';
+import {tmpdir} from 'os';
 import test from 'ava';
+import {resetPreferencesCache} from '@/config/preferences';
 import {checkForUpdates} from './update-checker';
 
 console.log(`\nupdate-checker.spec.ts`);
@@ -12,6 +20,11 @@ const __dirname = dirname(__filename);
 const packageJsonPath = join(__dirname, '../../package.json');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 const CURRENT_VERSION = packageJson.version as string;
+
+const originalConfigDir = process.env.NANOCODER_CONFIG_DIR;
+const testConfigDir = mkdtempSync(join(tmpdir(), 'nanocoder-update-checker-'));
+process.env.NANOCODER_CONFIG_DIR = testConfigDir;
+resetPreferencesCache();
 
 // Mock fetch globally for testing
 const originalFetch = globalThis.fetch;
@@ -47,6 +60,19 @@ test.afterEach(() => {
 	// Restore original fetch and env after each test
 	globalThis.fetch = originalFetch;
 	delete process.env.NANOCODER_INSTALL_METHOD;
+});
+
+test.after.always(() => {
+	if (existsSync(testConfigDir)) {
+		rmSync(testConfigDir, {recursive: true, force: true});
+	}
+
+	if (originalConfigDir === undefined) {
+		delete process.env.NANOCODER_CONFIG_DIR;
+	} else {
+		process.env.NANOCODER_CONFIG_DIR = originalConfigDir;
+	}
+	resetPreferencesCache();
 });
 
 // Version Comparison Tests
@@ -205,6 +231,27 @@ test('checkForUpdates: handles HTTP 500 error', async t => {
 
 	t.false(result.hasUpdate);
 	t.truthy(result.currentVersion);
+});
+
+test('checkForUpdates: preserves timestamp when version fetch fails', async t => {
+	const preferencesPath = join(testConfigDir, 'nanocoder-preferences.json');
+	const previousTimestamp = 1234567890;
+	writeFileSync(
+		preferencesPath,
+		JSON.stringify({lastUpdateCheck: previousTimestamp}),
+	);
+
+	globalThis.fetch = createMockFetch(503, {
+		error: 'Service unavailable',
+	});
+
+	const result = await checkForUpdates();
+	const preferences = JSON.parse(readFileSync(preferencesPath, 'utf-8')) as {
+		lastUpdateCheck?: number;
+	};
+
+	t.false(result.hasUpdate);
+	t.is(preferences.lastUpdateCheck, previousTimestamp);
 });
 
 test('checkForUpdates: handles timeout (via AbortSignal)', async t => {

--- a/source/utils/update-checker.ts
+++ b/source/utils/update-checker.ts
@@ -123,7 +123,9 @@ export async function checkForUpdates(): Promise<UpdateInfo> {
 
 	try {
 		const latestVersion = await fetchLatestVersion();
-		updateLastCheckTime();
+		if (latestVersion !== null) {
+			updateLastCheckTime();
+		}
 
 		if (!latestVersion) {
 			return {


### PR DESCRIPTION
## Summary

- Preserve `lastUpdateCheck` when the npm registry fetch fails.
- Make `BoundedMap.has()` report true for keys whose stored value is `undefined` while retaining TTL expiry behavior.
- Read Node.js errno codes from `error.code` for network and timeout classification.

## Issues

Closes #739  
Closes #738  
Closes #737

## Validation

- `pnpm exec ava source/utils/bounded-map.spec.ts source/utils/error-formatter.spec.ts source/utils/update-checker.spec.ts` - 73 tests passed
- `pnpm test:types`
- `pnpm test:format`
- `pnpm test:lint`
- `pnpm test:knip`
- `pnpm build`
- `pnpm exec ava source/cli-integration.spec.ts` - 7 tests passed

A full AVA run was also attempted. After building, the focused CLI integration tests passed; the full run still reports one unrelated settings-tabs assertion.
