### PR TITLE
fix: preserve multibyte input in alternate-screen TUI

### DIFF
--- a/.changeset/fix-korean-terminal-input.md
+++ b/.changeset/fix-korean-terminal-input.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed multibyte terminal input being corrupted when an alternate-screen stdin chunk split a UTF-8 character, which could affect Korean and other IME input.

--- a/source/app/components/settings-tabs.spec.tsx
+++ b/source/app/components/settings-tabs.spec.tsx
@@ -97,7 +97,7 @@ test.beforeEach(() => {
 	resetPreferencesCache();
 });
 
-test('renders all four category tabs with Appearance selected first', async t => {
+test('renders all category tabs with Appearance selected first', async t => {
 	const {lastFrame, unmount} = renderWithTheme(
 		<SettingsSelector onCancel={() => {}} />,
 	);
@@ -106,7 +106,8 @@ test('renders all four category tabs with Appearance selected first', async t =>
 	t.truthy(output);
 	t.truthy(output!.includes('Appearance'));
 	t.truthy(output!.includes('Input'));
-	t.truthy(output!.includes('Display'));
+	t.truthy(output!.includes('Behavior'));
+	t.truthy(output!.includes('Providers'));
 	t.truthy(output!.includes('Advanced'));
 	// The selected tab is marked by the user's TitleShape system, not a
 	// literal bracket string (ANSI escapes also contain '[', so compare

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -544,13 +544,13 @@ async function main(): Promise<void> {
 			// filtered proxy stream: mouse reports are stripped, wheel ticks
 			// are re-emitted on the wheelEvents bus for the chat viewport.
 			const {PassThrough} = await import('node:stream');
-			const {stripMouseSequences, wheelEvents} = await import(
-				'@/utils/terminal-mouse'
-			);
+			const {createUtf8InputDecoder, stripMouseSequences, wheelEvents} =
+				await import('@/utils/terminal-mouse');
 			const filtered = new PassThrough();
+			const decodeInput = createUtf8InputDecoder();
 			let carry = '';
 			const forwardInput = (chunk: Buffer | string) => {
-				const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+				const text = decodeInput(chunk);
 				const result = stripMouseSequences(text, carry);
 				carry = result.carry;
 				for (const direction of result.wheel) {

--- a/source/utils/terminal-mouse.spec.ts
+++ b/source/utils/terminal-mouse.spec.ts
@@ -1,5 +1,19 @@
 import test from 'ava';
-import {stripMouseSequences} from './terminal-mouse.js';
+import {
+	createUtf8InputDecoder,
+	stripMouseSequences,
+} from './terminal-mouse.js';
+
+test('preserves multibyte text split across stdin chunks', t => {
+	const decode = createUtf8InputDecoder();
+	const input = Buffer.from('너는 누구니?', 'utf8');
+
+	// Split inside the first Korean character (너), as a terminal data event
+	// can do when an IME emits bytes faster than stdin is drained.
+	t.is(decode(input.subarray(0, 1)), '');
+	t.is(decode(input.subarray(1, 3)), '너');
+	t.is(decode(input.subarray(3)), '는 누구니?');
+});
 
 test('passes plain text through untouched', t => {
 	const r = stripMouseSequences('hello world');

--- a/source/utils/terminal-mouse.ts
+++ b/source/utils/terminal-mouse.ts
@@ -1,4 +1,5 @@
 import {EventEmitter} from 'node:events';
+import {StringDecoder} from 'node:string_decoder';
 
 /**
  * SGR mouse reporting (DECSET 1000 + 1006) support for the fullscreen TUI.
@@ -15,6 +16,21 @@ export type WheelDirection = 'up' | 'down';
 
 /** Singleton bus: cli.tsx publishes wheel ticks, ChatHistory subscribes. */
 export const wheelEvents = new EventEmitter();
+
+/**
+ * Decode stdin bytes without losing a multibyte character split across
+ * separate data events. TTY input is usually delivered as Buffers, and the
+ * default Buffer#toString('utf8') replaces an incomplete trailing sequence
+ * immediately instead of waiting for the next chunk.
+ */
+export function createUtf8InputDecoder(): (chunk: Buffer | string) => string {
+	const decoder = new StringDecoder('utf8');
+
+	return chunk =>
+		decoder.write(
+			typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk,
+		);
+}
 
 // ESC [ < button ; column ; row, terminated by M (press) or m (release).
 const SGR_MOUSE_RE = /\x1b\[<(\d+);\d+;\d+[Mm]/g;


### PR DESCRIPTION
## Summary

- Decode alternate-screen stdin with a stateful UTF-8 decoder so multibyte characters are preserved across `data` chunk boundaries.
- Keep the existing mouse-sequence filtering and wheel-event handling unchanged after decoding.
- Add regression coverage that splits Korean input inside a character, plus the current settings-tab contract needed by the upstream test suite.

Closes #532

## Root cause

The alternate-screen input proxy converted every `Buffer` chunk with `Buffer#toString('utf8')`. When a terminal or IME split a multibyte character across chunks, the incomplete byte sequence was replaced before the next chunk arrived. The decoder now retains incomplete sequences and emits the character only after all bytes are available.

## Validation

- `pnpm exec ava source/utils/terminal-mouse.spec.ts source/app/components/settings-tabs.spec.tsx`
- `pnpm test:ava` (6,255 passed, 1 skipped)
- `pnpm test:format`
- `pnpm test:lint`
- `pnpm test:types`
- `pnpm build`
