### PR TITLE
fix: drop toLocaleString() thousands separators from LLM-facing tool output

### DIFF
--- a/.changeset/tolocalestring-llm-payload.md
+++ b/.changeset/tolocalestring-llm-payload.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Dropped `toLocaleString()` thousands-separators from strings returned to the model (`read_file`'s metadata output and validator error, `list_directory`'s per-entry size, and `@file`-mention metadata). Comma separators cost extra tokens without adding meaning for the model. Left them in place in the terminal display components, where they're actually useful.

--- a/source/tools/list-directory.tsx
+++ b/source/tools/list-directory.tsx
@@ -158,9 +158,7 @@ const executeListDirectory = async (
 							? '@'
 							: '';
 				const displayPath = recursive ? entry.relativePath : entry.name;
-				const sizeStr = entry.size
-					? ` (${entry.size.toLocaleString()} bytes)`
-					: '';
+				const sizeStr = entry.size ? ` (${entry.size} bytes)` : '';
 				output += `${displayPath}${suffix}${sizeStr}\n`;
 			}
 		}

--- a/source/tools/read-file.spec.tsx
+++ b/source/tools/read-file.spec.tsx
@@ -585,7 +585,7 @@ test.serial(
 			t.false(result.valid);
 			if (!result.valid) {
 				t.regex(result.error, /minified or binary content/);
-				t.regex(result.error, /15,000 characters/);
+				t.regex(result.error, /15000 characters/);
 			}
 		} finally {
 			process.chdir(originalCwd);

--- a/source/tools/read-file.tsx
+++ b/source/tools/read-file.tsx
@@ -50,7 +50,7 @@ const executeReadFile = async (args: {
 			output += `${'='.repeat(50)}\n\n`;
 
 			output += `Type: ${type}\n`;
-			output += `Size: ${size.toLocaleString()} bytes\n`;
+			output += `Size: ${size} bytes\n`;
 			output += `Last Modified: ${lastModified}\n`;
 
 			// For regular files, try to get additional info
@@ -63,8 +63,8 @@ const executeReadFile = async (args: {
 					const lines = cached.lines;
 					const content = cached.content;
 
-					output += `Lines: ${lines.length.toLocaleString()}\n`;
-					output += `Estimated Tokens: ~${calculateTokens(content).toLocaleString()}\n`;
+					output += `Lines: ${lines.length}\n`;
+					output += `Estimated Tokens: ~${calculateTokens(content)}\n`;
 
 					// Detect file type from extension
 					const fileType = getFileType(absPath);
@@ -130,9 +130,9 @@ const executeReadFile = async (args: {
 
 			let output = `File: ${args.path}\n`;
 			output += `Type: ${fileType}\n`;
-			output += `Total lines: ${totalLines.toLocaleString()}\n`;
-			output += `Size: ${fileSize.toLocaleString()} bytes\n`;
-			output += `Estimated tokens: ~${estimatedTokens.toLocaleString()}\n\n`;
+			output += `Total lines: ${totalLines}\n`;
+			output += `Size: ${fileSize} bytes\n`;
+			output += `Estimated tokens: ~${estimatedTokens}\n\n`;
 
 			if (totalLines <= FILE_READ_CHUNKING_HINT_THRESHOLD_LINES) {
 				output += `[Medium file - To read specific sections, call read_file with start_line and end_line]\n`;
@@ -460,7 +460,7 @@ const readFileValidator = async (args: {
 				if (line && line.length > MAX_LINE_LENGTH_CHARS) {
 					return {
 						valid: false,
-						error: `File "${args.path}" contains minified or binary content (line ${i + 1} has ${line.length.toLocaleString()} characters). This file cannot be read as it would consume excessive tokens without providing useful information.`,
+						error: `File "${args.path}" contains minified or binary content (line ${i + 1} has ${line.length} characters). This file cannot be read as it would consume excessive tokens without providing useful information.`,
 					};
 				}
 			}

--- a/source/utils/file-content-loader.ts
+++ b/source/utils/file-content-loader.ts
@@ -54,7 +54,7 @@ export async function loadFileContent(
 			const metadataContent = [
 				`[Binary file: ${filePath}]`,
 				`Type: ${fileType}`,
-				`Size: ${fileStats.size.toLocaleString()} bytes (${formatBytes(fileStats.size)})`,
+				`Size: ${fileStats.size} bytes (${formatBytes(fileStats.size)})`,
 				`Last Modified: ${fileStats.mtime.toISOString()}`,
 				'',
 				'(Binary files cannot be included as text content)',
@@ -79,8 +79,8 @@ export async function loadFileContent(
 			const estimatedLines = Math.round(fileStats.size / 40);
 			const metadataContent = [
 				`[Large file: ${filePath}]`,
-				`Size: ${fileStats.size.toLocaleString()} bytes (${formatBytes(fileStats.size)})`,
-				`Lines: ~${estimatedLines.toLocaleString()}`,
+				`Size: ${fileStats.size} bytes (${formatBytes(fileStats.size)})`,
+				`Lines: ~${estimatedLines}`,
 				`Last Modified: ${fileStats.mtime.toISOString()}`,
 				'',
 				`(File exceeds ${formatBytes(MAX_FILE_TAG_SIZE_BYTES)} limit for inline tagging. Use @file:1-100 to tag specific line ranges)`,


### PR DESCRIPTION
## Summary

Fixes #768. `toLocaleString()` was leaking comma thousands-separators into strings returned to the model as tool results, not just into the terminal display. Comma separators cost extra tokens and carry no meaning for the model — this was flagged as good-first-issue material by the maintainer.

Fixed the LLM-facing (`execute`/`validator`) paths:
- `source/tools/read-file.tsx` — metadata output (size, lines, tokens), large-file metadata output, and the minified/binary-content validator error message
- `source/tools/list-directory.tsx` — per-entry byte size in the directory listing
- `source/utils/file-content-loader.ts` — binary-file and large-file metadata shown when a file is loaded via `@file` mention (this content is inlined into the chat message sent to the model)

Left `toLocaleString()` in place everywhere it's actually display-only, per the issue's own guidance (`Formatter` components vs `execute` functions):
- The Ink `<Text>` formatter components in `read-file.tsx`, `list-directory.tsx`, `search-file-contents.tsx`, `find-files.tsx` — these render to the terminal, never to the model
- `compact-handler.ts`, `context-max-handler.ts`, `auto-compact.ts` — checked these too since they also format token counts, but their formatted strings only go to `onAddToChatQueue` (local terminal display); the actual conversation array passed to the model (`setMessages(...)`) doesn't include them, so they're out of scope

## Test plan

- `pnpm run test:format`, `test:lint`, `test:types` — all clean
- `pnpm run test:ava` on the three affected spec files — 84 tests pass
- One existing test (`read-file.spec.tsx`, minified-content validator) asserted the old comma-formatted output (`/15,000 characters/`); updated it to match the fixed output (`/15000 characters/`) since that was testing the exact behavior this issue asks to remove