### PR TITLE
fix: format search_file_contents results grep-style, one line per match

### DIFF
--- a/.changeset/search-results-grep-format.md
+++ b/.changeset/search-results-grep-format.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+`search_file_contents` now formats results grep-style (`file:line:content`, one line per match) instead of spreading each match across three lines with a blank separator. Matches with `contextLines` still show the full multi-line context block, now with a `-` header separator matching grep's convention.

--- a/source/tools/search-file-contents.spec.tsx
+++ b/source/tools/search-file-contents.spec.tsx
@@ -763,10 +763,13 @@ test.serial(
 				// Count x's in result - should be 300 - 12 (searchTarget) = 288
 				const contentLine = result.split('\n').find(l => l.includes('searchTarget'));
 				t.truthy(contentLine, 'Should have content line');
-				// The trimmed content should be max 300 chars + ellipsis
-				const trimmedContent = contentLine!.trim();
+				// Content follows the `file:line:` prefix in grep-style output;
+				// strip it before checking the truncated length.
+				const contentMatch = contentLine!.match(/^.+?:\d+:(.*)$/);
+				t.truthy(contentMatch, 'Content line should be in file:line:content format');
+				const trimmedContent = contentMatch![1];
 				t.true(
-					trimmedContent.length <= 302, // 300 + ellipsis (1 char) + possible whitespace
+					trimmedContent.length <= 301, // 300 + ellipsis (1 char)
 					`Content should be truncated, got ${trimmedContent.length} chars`,
 				);
 			} finally {

--- a/source/tools/search-file-contents.tsx
+++ b/source/tools/search-file-contents.tsx
@@ -79,13 +79,20 @@ const executeSearchFileContents = async (
 			return `No matches found for "${args.query}"`;
 		}
 
-		// Format results with clear file:line format
+		// Format results grep-style: one line per match (`file:line:content`).
+		// Matches with context lines have multi-line content already prefixed
+		// per-line by the search itself, so those use `-` as the header
+		// separator (standard grep convention for context) and keep the block
+		// on its own lines instead of squeezing it onto one.
 		let output = `Found ${matches.length} match${matches.length === 1 ? '' : 'es'}${truncated ? ` (showing first ${maxResults})` : ''}:\n\n`;
 
-		for (const match of matches) {
-			output += `${match.file}:${match.line}\n`;
-			output += `  ${match.content}\n\n`;
-		}
+		output += matches
+			.map(match =>
+				match.content.includes('\n')
+					? `${match.file}:${match.line}-\n${match.content}`
+					: `${match.file}:${match.line}:${match.content}`,
+			)
+			.join('\n\n');
 
 		return output.trim();
 	} catch (error: unknown) {


### PR DESCRIPTION
## Summary

Fixes #766. `executeSearchFileContents` formatted each match across three output lines (a `file:line` header, an indented content line, and a blank separator), which costs tokens the model doesn't need — the newline, the 2-space indent, and the blank line between matches are pure formatting overhead.

Switched to standard grep format: `file:line:content`, one line per match.

Per the issue's note, `contextLines` produces multi-line `content` (already prefixed per-line with its own line number by the search itself), so a single `file:line:content` line doesn't work for that case. For those matches, the header uses `-` instead of `:` as the separator (standard grep convention for marking a context block vs. an exact match line) and the content block keeps its own lines rather than being squeezed onto one:

```
# no context
src/foo.ts:42:const x = 1

# contextLines: 1
src/foo.ts:42-
41: const before = 1
42: const x = 1
43: const after = 1
```

## Test plan

- `pnpm run test:format`, `test:lint`, `test:types` — all clean
- `pnpm run test:ava source/tools/search-file-contents.spec.tsx` — 56 tests pass, including the `contextLines` cases
- One existing test (`search_file_contents truncates very long matching lines to 300 chars`) located "the content line" and checked its raw length, assuming the old two-line-per-match layout where content had its own line. Updated it to strip the `file:line:` prefix before measuring, since that prefix now shares the line with content.