### PR TITLE
fix: stop echoing full file contents back after write_file

### DIFF
--- a/.changeset/write-file-echo.md
+++ b/.changeset/write-file-echo.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+`write_file` no longer echoes the full file contents back after writing. The model already authored that content as the tool call arguments, so returning it again was pure duplication that scaled with file size and got re-sent on every later step of the agent loop. The confirmation message (line/char/token counts) is unchanged.

--- a/source/tools/file-ops/write-file.spec.tsx
+++ b/source/tools/file-ops/write-file.spec.tsx
@@ -115,7 +115,6 @@ test('write_file: create new file', async t => {
 	const content = await readFile(filePath, 'utf-8');
 	t.is(content, 'Hello World\n');
 	t.true(result.includes('File written successfully'));
-	t.true(result.includes('File contents after write:'));
 });
 
 test('write_file: overwrite existing file', async t => {
@@ -129,7 +128,6 @@ test('write_file: overwrite existing file', async t => {
 	const content = await readFile(filePath, 'utf-8');
 	t.is(content, 'New content\n');
 	t.true(result.includes('File overwritten successfully'));
-	t.true(result.includes('File contents after write:'));
 });
 
 test('write_file: write empty file', async t => {
@@ -192,7 +190,7 @@ test('write_file: preserves exact content including whitespace', async t => {
 // Read-After-Write Verification Tests
 // ============================================================================
 
-test('write_file: returns file contents after write', async t => {
+test('write_file: reports accurate stats without echoing content back', async t => {
 	const filePath = join(testDir, 'verify.txt');
 
 	const result = await executeWriteFile({
@@ -200,11 +198,12 @@ test('write_file: returns file contents after write', async t => {
 		content: 'Test content\nLine 2',
 	});
 
-	// Check that result includes the actual file contents
-	t.true(result.includes('File contents after write:'));
-	t.true(result.includes('Test content'));
-	t.true(result.includes('Line 2'));
+	// The read-back verifies the write succeeded and produces accurate stats,
+	// but the model already has this content (it just sent it as the tool
+	// call arguments), so it should not be echoed back in the result.
 	t.true(result.includes('2 lines'));
+	t.false(result.includes('Test content'));
+	t.false(result.includes('File contents after write:'));
 });
 
 test('write_file: detects token count', async t => {

--- a/source/tools/file-ops/write-file.tsx
+++ b/source/tools/file-ops/write-file.tsx
@@ -45,23 +45,16 @@ const executeWriteFile = async (args: {
 	// follow-up edit or rewrite is not blind.
 	markFileSeen(absPath);
 
-	// Read back to verify and show actual content
+	// Read back to verify the write succeeded (but don't echo the content back
+	// to the model — it just sent us that exact content as the tool call
+	// arguments, so returning it again is pure duplication).
 	const actualContent = await readFile(absPath, 'utf-8');
-	const lines = actualContent.split('\n');
-	const lineCount = lines.length;
+	const lineCount = actualContent.split('\n').length;
 	const charCount = actualContent.length;
 	const estimatedTokens = calculateTokens(actualContent);
 
-	// Generate full file contents to show the model the current file state
-	let fileContext = '\n\nFile contents after write:\n';
-	for (let i = 0; i < lines.length; i++) {
-		const lineNumStr = String(i + 1).padStart(4, ' ');
-		const line = lines[i] || '';
-		fileContext += `${lineNumStr}: ${line}\n`;
-	}
-
 	const action = fileExists ? 'overwritten' : 'written';
-	return `File ${action} successfully (${lineCount} lines, ${charCount} characters, ~${estimatedTokens} tokens).${fileContext}`;
+	return `File ${action} successfully (${lineCount} lines, ${charCount} characters, ~${estimatedTokens} tokens).`;
 };
 
 const writeFileCoreTool = tool({


### PR DESCRIPTION
## Summary

Fixes #762. `executeWriteFile` read the file back after writing and appended every line, number-prefixed, to the tool result. That's pure duplication: the model just sent that exact content as the tool call arguments, so returning it again costs tokens (with an extra ~6 chars/line for the prefix) without adding information the model didn't already have. There's no cap, so it scales linearly with file size — the issue measured ~8,500 tokens on `source/app/App.tsx` (791 lines) in this repo — and since tool results stay in the conversation, that cost is re-sent on every subsequent agent step.

Kept the read-back itself (per the issue: it verifies the write succeeded, and its line/char/token counts already feed the existing confirmation message), just stopped appending the line-numbered content dump.

## Test plan

- `pnpm run test:format`, `test:lint`, `test:types` — all clean
- `pnpm run test:ava source/tools/file-ops/write-file.spec.tsx` — 43 tests pass
- Updated the three existing tests that asserted the echoed content:
  - `write_file: create new file` / `write_file: overwrite existing file` — dropped the `'File contents after write:'` assertion
  - `write_file: returns file contents after write` → renamed to `write_file: reports accurate stats without echoing content back`, now asserts the line count is still accurate while the raw content and the `'File contents after write:'` marker are absent