### PR TITLE
fix: truncate LLM-facing command output head+tail instead of head-only

### DIFF
--- a/.changeset/bash-output-truncation.md
+++ b/.changeset/bash-output-truncation.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+`execute_bash` and custom tools now truncate long output by keeping both the head and the tail (tail-weighted) instead of only the head, so the actionable part of compiler/test-runner output (error list, failure summary, exit status) — which usually lands at the end — isn't discarded.

--- a/source/custom-tools/handler.ts
+++ b/source/custom-tools/handler.ts
@@ -5,6 +5,7 @@ import {TRUNCATION_OUTPUT_LIMIT} from '@/constants';
 import {renderBody} from '@/custom-tools/template';
 import type {CustomToolMetadata} from '@/types/custom-tools';
 import type {ToolHandler} from '@/types/index';
+import {truncateHeadAndTail} from '@/utils/truncate-output';
 
 /**
  * Build a `ToolHandler` that renders the script body and runs it under the
@@ -97,8 +98,7 @@ export function runScript(
 }
 
 function truncate(text: string): string {
-	if (text.length <= TRUNCATION_OUTPUT_LIMIT) return text;
-	return text.slice(0, TRUNCATION_OUTPUT_LIMIT) + '\n... [Output truncated]';
+	return truncateHeadAndTail(text, TRUNCATION_OUTPUT_LIMIT);
 }
 
 /**

--- a/source/tools/execute-bash.tsx
+++ b/source/tools/execute-bash.tsx
@@ -9,6 +9,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {type BashExecutionState, bashExecutor} from '@/services/bash-executor';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
+import {truncateHeadAndTail} from '@/utils/truncate-output';
 
 /**
  * Execute a bash command using the bash executor service.
@@ -46,14 +47,10 @@ export function formatBashResultForLLM(result: BashExecutionState): string {
 		fullOutput = `Error: ${result.error}\n${fullOutput}`;
 	}
 
-	// Limit the context for LLM to prevent overwhelming the model
-	const llmContext =
-		fullOutput.length > TRUNCATION_OUTPUT_LIMIT
-			? fullOutput.substring(0, TRUNCATION_OUTPUT_LIMIT) +
-				'\n... [Output truncated. Use more specific commands to see full output]'
-			: fullOutput;
-
-	return llmContext;
+	// Limit the context for LLM to prevent overwhelming the model. Keeps both
+	// head and tail, since build/test tooling puts the actionable part (error
+	// list, failure summary, exit status) at the end.
+	return truncateHeadAndTail(fullOutput, TRUNCATION_OUTPUT_LIMIT);
 }
 
 /**

--- a/source/utils/truncate-output.spec.ts
+++ b/source/utils/truncate-output.spec.ts
@@ -1,0 +1,40 @@
+import test from 'ava';
+import {truncateHeadAndTail} from './truncate-output';
+
+test('returns original string if within the limit', t => {
+	t.is(truncateHeadAndTail('hello', 100), 'hello');
+});
+
+test('returns original string if exactly at the limit', t => {
+	const text = 'x'.repeat(100);
+	t.is(truncateHeadAndTail(text, 100), text);
+});
+
+test('keeps both head and tail when over the limit', t => {
+	const head = 'HEAD'.repeat(50); // 200 chars
+	const middle = 'M'.repeat(1000);
+	const tail = 'TAIL'.repeat(50); // 200 chars
+	const result = truncateHeadAndTail(head + middle + tail, 300);
+
+	t.true(result.startsWith(head.slice(0, 10)), 'Should keep the start of the head');
+	t.true(result.endsWith(tail.slice(-10)), 'Should keep the end of the tail');
+	t.true(result.includes('characters elided'), 'Should mark that content was elided');
+});
+
+test('gives the tail a larger share of the budget than the head', t => {
+	const text = 'x'.repeat(10_000);
+	const result = truncateHeadAndTail(text, 2000);
+
+	const parts = result.split(/\n\.\.\. \[Output truncated: \d+ characters elided\] \.\.\.\n/);
+	t.is(parts.length, 2, 'Should split cleanly into a head and a tail around the marker');
+	const [head, tail] = parts;
+
+	t.true(head.length < tail.length, 'Tail should be the larger share');
+	t.is(head.length, 800);
+	t.is(tail.length, 1200);
+});
+
+test('does not truncate output shorter than the limit even with unusual content', t => {
+	const text = 'a\nb\nc';
+	t.is(truncateHeadAndTail(text, 10), text);
+});

--- a/source/utils/truncate-output.ts
+++ b/source/utils/truncate-output.ts
@@ -1,0 +1,24 @@
+/**
+ * Truncate text for LLM consumption, keeping both the head and the tail
+ * instead of just the head. Compiler and test-runner output puts the
+ * actionable part (error list, failure summary, exit status) at the end,
+ * so a head-only cut throws away exactly what the model needs most and
+ * forces an extra round-trip with a narrower command to recover it.
+ *
+ * The tail gets the larger share of the budget, since that is where the
+ * actionable content usually is.
+ */
+export function truncateHeadAndTail(text: string, limit: number): string {
+	if (text.length <= limit) {
+		return text;
+	}
+
+	const headLength = Math.floor(limit * 0.4);
+	const tailLength = limit - headLength;
+	const elidedCount = text.length - headLength - tailLength;
+
+	const head = text.slice(0, headLength);
+	const tail = text.slice(text.length - tailLength);
+
+	return `${head}\n... [Output truncated: ${elidedCount} characters elided] ...\n${tail}`;
+}


### PR DESCRIPTION
## Summary

Fixes #764. `execute-bash.tsx` and `custom-tools/handler.ts` both truncated long output for the model by keeping only the first `TRUNCATION_OUTPUT_LIMIT` (2000) characters. Compiler and test-runner output puts the actionable part at the end — `tsc` prints its error list then the count, AVA prints passing output then the failure summary, most build tools print the exit digest last — so head-only truncation throws away exactly what the model needs from a `pnpm run test:types` or `pnpm run test:ava` run. It then has to re-run with a narrower command to recover information already in hand.

Added a shared helper, `source/utils/truncate-output.ts`, that keeps both the head and the tail within the same byte budget (40/60 split, tail-weighted since that's where the actionable content usually is), with a marker showing how many characters were elided in between. Used it at both LLM-facing call sites:

- `formatBashResultForLLM` in `execute-bash.tsx`
- `truncate()` in `custom-tools/handler.ts`

Left `bash-progress.tsx`'s head-only truncation alone — per the issue, that one only feeds a display-only token-count estimate for the live progress UI, not something the model sees.

## Test plan

- `pnpm run test:format`, `test:lint`, `test:types` — all clean
- New `source/utils/truncate-output.spec.ts` — 5 tests covering the under/at/over-limit cases, that both head and tail are kept, and the 40/60 split
- `pnpm run test:ava source/tools/execute-bash.spec.tsx source/custom-tools/handler.spec.ts` — 67 tests pass unmodified, including the existing truncation-length and truncation-marker assertions