### PR TITLE
feat: make list_directory file sizes opt-in via showSizes

### DIFF
--- a/.changeset/list-directory-opt-in-sizes.md
+++ b/.changeset/list-directory-opt-in-sizes.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+`list_directory` no longer includes file sizes by default — they cost an `lstat` syscall per file plus output tokens for information that's rarely needed just to orient in a directory. Pass `showSizes=true` to opt back in, or use `read_file` with `metadata_only=true` for a single file's size.

--- a/source/tools/list-directory.spec.tsx
+++ b/source/tools/list-directory.spec.tsx
@@ -209,7 +209,7 @@ test.serial('list_directory shows files and directories', async t => {
 	}
 });
 
-test.serial('list_directory shows file sizes', async t => {
+test.serial('list_directory hides file sizes by default', async t => {
 	t.timeout(10000);
 	const originalCwd = process.cwd();
 
@@ -225,11 +225,35 @@ test.serial('list_directory shows file sizes', async t => {
 			{toolCallId: 'test', messages: []},
 		);
 
-		// Should show file size in bytes
-		t.true(result.includes('bytes') || result.includes('1,000'));
+		t.true(result.includes('largefile.txt'));
+		t.false(result.includes('bytes'));
 	} finally {
 		process.chdir(originalCwd);
 		rmSync(join(originalCwd, 'test-listdir-sizes-temp'), {recursive: true, force: true});
+	}
+});
+
+test.serial('list_directory shows file sizes when showSizes=true', async t => {
+	t.timeout(10000);
+	const originalCwd = process.cwd();
+
+	try {
+		const testDir = join(process.cwd(), 'test-listdir-sizes-opt-in-temp');
+		mkdirSync(testDir, {recursive: true});
+		writeFileSync(join(testDir, 'largefile.txt'), 'x'.repeat(1000));
+
+		process.chdir(testDir);
+
+		const result = await listDirectoryTool.tool.execute!(
+			{showSizes: true},
+			{toolCallId: 'test', messages: []},
+		);
+
+		// Should show file size in bytes
+		t.true(result.includes('bytes') || result.includes('1000') || result.includes('1,000'));
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(join(originalCwd, 'test-listdir-sizes-opt-in-temp'), {recursive: true, force: true});
 	}
 });
 

--- a/source/tools/list-directory.tsx
+++ b/source/tools/list-directory.tsx
@@ -18,6 +18,7 @@ interface ListDirectoryArgs {
 	maxDepth?: number;
 	tree?: boolean;
 	showHiddenFiles?: boolean;
+	showSizes?: boolean;
 }
 
 interface DirectoryEntry {
@@ -35,6 +36,7 @@ const executeListDirectory = async (
 	const maxDepth = args.maxDepth ?? 3;
 	const tree = args.tree ?? false;
 	const showHiddenFiles = args.showHiddenFiles ?? false;
+	const showSizes = args.showSizes ?? false;
 
 	// Validate path
 	const cwd = getSafeSessionCwd();
@@ -90,9 +92,11 @@ const executeListDirectory = async (
 
 					const relativePath = join(relativeTo, item.name);
 
-					// Only get stats for files (to get size)
+					// Only get stats for files (to get size), and only when sizes
+					// were requested — lstat is a syscall per file, not worth
+					// paying for on every listing.
 					let size: number | undefined;
-					if (type === 'file') {
+					if (type === 'file' && showSizes) {
 						try {
 							const stats = await lstat(fullPath);
 							size = stats.size;
@@ -185,7 +189,7 @@ const executeListDirectory = async (
 
 const listDirectoryCoreTool = tool({
 	description:
-		'List directory contents with file sizes. Use this INSTEAD OF bash ls/ls -la/ls -R commands. Use recursive=true with maxDepth for nested exploration. Use tree=true for flat paths (easier to parse). Best for: exploring unknown directories, seeing file sizes, understanding project structure. For finding specific files by pattern, use find_files instead.',
+		"List directory contents. Use this INSTEAD OF bash ls/ls -la/ls -R commands. Use recursive=true with maxDepth for nested exploration. Use tree=true for flat paths (easier to parse). Use showSizes=true to include file sizes (off by default; use read_file with metadata_only=true for a single file's size instead). Best for: exploring unknown directories, understanding project structure. For finding specific files by pattern, use find_files instead.",
 	inputSchema: jsonSchema<ListDirectoryArgs>({
 		type: 'object',
 		properties: {
@@ -213,6 +217,11 @@ const listDirectoryCoreTool = tool({
 				type: 'boolean',
 				description:
 					'If true, include hidden files and directories (default: false). Use with caution to avoid exposing sensitive files like .env.',
+			},
+			showSizes: {
+				type: 'boolean',
+				description:
+					"If true, include each file's size in bytes (default: false). Rarely needed just to orient in a directory; costs an extra stat call per file plus output tokens.",
 			},
 		},
 		required: [],


### PR DESCRIPTION
## Summary

Fixes #767. `list_directory` appended a byte size to every file entry unconditionally — roughly 8-10 tokens per entry for information that's rarely load-bearing when the model is just orienting itself in a directory (400-500 tokens on a 50-entry listing, more on recursive listings). It also cost an `lstat` syscall per file purely to get that size.

Added a `showSizes` boolean to `ListDirectoryArgs` and the tool schema, defaulting to `false`:
- Gated the `lstat` call on `showSizes` (skipped entirely when not requested)
- The existing `entry.size ? ... : ''` size-string logic already handles `size` being `undefined` correctly, so no change needed there
- Updated the tool description, which claimed "List directory contents with file sizes" — now mentions `showSizes=true` as opt-in, and points to `read_file`'s `metadata_only` for a single file's size

## Test plan

- `pnpm run test:format`, `test:lint`, `test:types` — all clean
- `pnpm run test:ava source/tools/list-directory.spec.tsx` — 30 tests pass
- Updated `list_directory shows file sizes` → `list_directory hides file sizes by default` (asserts no `bytes` in output) and added `list_directory shows file sizes when showSizes=true` to cover the opt-in path explicitly