### PR TITLE
feat: make list_directory file sizes opt-in via showSizes

### DIFF
--- a/.changeset/list-directory-show-sizes.md
+++ b/.changeset/list-directory-show-sizes.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+`list_directory` no longer emits per-entry byte sizes by default. Sizes cost tokens on every entry and are rarely load-bearing when the model is just orienting itself in a directory, and they forced an extra `lstat` call per file. Pass `showSizes: true` to opt back in. Closes #767.

--- a/source/tools/list-directory.spec.tsx
+++ b/source/tools/list-directory.spec.tsx
@@ -102,6 +102,25 @@ test('ListDirectoryFormatter shows tree format indicator', t => {
 	t.regex(output!, /tree/);
 });
 
+test('ListDirectoryFormatter shows sizes info', t => {
+	const formatter = listDirectoryTool.formatter;
+	if (!formatter) {
+		t.fail('Formatter is not defined');
+		return;
+	}
+
+	const element = formatter(
+		{path: '.', showSizes: true},
+		'Directory contents for ".":\n\nfile.ts (1000 bytes)',
+	);
+	const {lastFrame} = render(<TestThemeProvider>{element}</TestThemeProvider>);
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Sizes:/);
+	t.regex(output!, /shown/);
+});
+
 test('ListDirectoryFormatter handles error results gracefully', t => {
 	const formatter = listDirectoryTool.formatter;
 	if (!formatter) {
@@ -209,7 +228,31 @@ test.serial('list_directory shows files and directories', async t => {
 	}
 });
 
-test.serial('list_directory shows file sizes', async t => {
+test.serial('list_directory does not show file sizes by default', async t => {
+	t.timeout(10000);
+	const originalCwd = process.cwd();
+
+	try {
+		const testDir = join(process.cwd(), 'test-listdir-sizes-default-temp');
+		mkdirSync(testDir, {recursive: true});
+		writeFileSync(join(testDir, 'largefile.txt'), 'x'.repeat(1000));
+
+		process.chdir(testDir);
+
+		const result = await listDirectoryTool.tool.execute!(
+			{},
+			{toolCallId: 'test', messages: []},
+		);
+
+		t.true(result.includes('largefile.txt'));
+		t.false(result.includes('bytes'));
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(join(originalCwd, 'test-listdir-sizes-default-temp'), {recursive: true, force: true});
+	}
+});
+
+test.serial('list_directory shows file sizes when showSizes=true', async t => {
 	t.timeout(10000);
 	const originalCwd = process.cwd();
 
@@ -221,12 +264,13 @@ test.serial('list_directory shows file sizes', async t => {
 		process.chdir(testDir);
 
 		const result = await listDirectoryTool.tool.execute!(
-			{},
+			{showSizes: true},
 			{toolCallId: 'test', messages: []},
 		);
 
-		// Should show file size in bytes
-		t.true(result.includes('bytes') || result.includes('1,000'));
+		// Should show file size as a plain number (no thousands separators)
+		t.true(result.includes('(1000 bytes)'));
+		t.false(result.includes('1,000'));
 	} finally {
 		process.chdir(originalCwd);
 		rmSync(join(originalCwd, 'test-listdir-sizes-temp'), {recursive: true, force: true});

--- a/source/tools/list-directory.tsx
+++ b/source/tools/list-directory.tsx
@@ -17,6 +17,7 @@ interface ListDirectoryArgs {
 	recursive?: boolean;
 	maxDepth?: number;
 	tree?: boolean;
+	showSizes?: boolean;
 	showHiddenFiles?: boolean;
 }
 
@@ -34,6 +35,7 @@ const executeListDirectory = async (
 	const recursive = args.recursive ?? false;
 	const maxDepth = args.maxDepth ?? 3;
 	const tree = args.tree ?? false;
+	const showSizes = args.showSizes ?? false;
 	const showHiddenFiles = args.showHiddenFiles ?? false;
 
 	// Validate path
@@ -90,9 +92,9 @@ const executeListDirectory = async (
 
 					const relativePath = join(relativeTo, item.name);
 
-					// Only get stats for files (to get size)
+					// Only get stats for files (to get size) when explicitly requested
 					let size: number | undefined;
-					if (type === 'file') {
+					if (showSizes && type === 'file') {
 						try {
 							const stats = await lstat(fullPath);
 							size = stats.size;
@@ -158,9 +160,7 @@ const executeListDirectory = async (
 							? '@'
 							: '';
 				const displayPath = recursive ? entry.relativePath : entry.name;
-				const sizeStr = entry.size
-					? ` (${entry.size.toLocaleString()} bytes)`
-					: '';
+				const sizeStr = showSizes && entry.size ? ` (${entry.size} bytes)` : '';
 				output += `${displayPath}${suffix}${sizeStr}\n`;
 			}
 		}
@@ -185,7 +185,7 @@ const executeListDirectory = async (
 
 const listDirectoryCoreTool = tool({
 	description:
-		'List directory contents with file sizes. Use this INSTEAD OF bash ls/ls -la/ls -R commands. Use recursive=true with maxDepth for nested exploration. Use tree=true for flat paths (easier to parse). Best for: exploring unknown directories, seeing file sizes, understanding project structure. For finding specific files by pattern, use find_files instead.',
+		'List directory contents. Use this INSTEAD OF bash ls/ls -la/ls -R commands. Use recursive=true with maxDepth for nested exploration. Use tree=true for flat paths (easier to parse). Use showSizes=true to include per-entry byte sizes. Best for: exploring unknown directories, seeing file sizes, understanding project structure. For finding specific files by pattern, use find_files instead.',
 	inputSchema: jsonSchema<ListDirectoryArgs>({
 		type: 'object',
 		properties: {
@@ -208,6 +208,11 @@ const listDirectoryCoreTool = tool({
 				type: 'boolean',
 				description:
 					'If true, show flat paths output (one per line) instead of formatted tree. Great for LLM to see project structure.',
+			},
+			showSizes: {
+				type: 'boolean',
+				description:
+					'If true, include per-entry byte sizes (default: false). Requires an extra stat call per file and costs tokens; use only when file size is relevant.',
 			},
 			showHiddenFiles: {
 				type: 'boolean',
@@ -288,6 +293,13 @@ const ListDirectoryFormatter = React.memo(
 					<Box>
 						<Text color={colors.secondary}>Format: </Text>
 						<Text color={colors.text}>tree</Text>
+					</Box>
+				)}
+
+				{args.showSizes && (
+					<Box>
+						<Text color={colors.secondary}>Sizes: </Text>
+						<Text color={colors.text}>shown</Text>
 					</Box>
 				)}
 


### PR DESCRIPTION
## Description

Closes #767. `list_directory` used to append a byte size to every file
entry unconditionally, which cost roughly 8-10 tokens per entry and an
extra `lstat` syscall per file, for information that's rarely useful when
the model is just orienting itself in a folder.

Plain listings are now the default. Pass `showSizes: true` to opt back in.

Beyond the base fix:
- Sizes print as plain `(1000 bytes)` instead of `(1,000 bytes)`. The
  thousands separator wastes tokens and is locale-dependent.
- The CLI tool card shows a `Sizes: shown` indicator when the flag is on,
  matching the existing recursive/tree indicators.
- Tool description and schema updated to match.

Note: PR #778 proposes the same opt-in flag. This one is a superset
(plain-number sizes, formatter indicator, and a changeset). If #778
merges first, feel free to close this.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [x] Tested MCP integration (if applicable) — n/a, tool-level change only

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))