### PR TITLE
fix: preview very large files before ranged reads

### DIFF
--- a/.changeset/tough-poems-read.md
+++ b/.changeset/tough-poems-read.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Return a useful preview before requiring ranged reads for very large files

--- a/source/app/prompts/sections/file-editing.md
+++ b/source/app/prompts/sections/file-editing.md
@@ -2,7 +2,7 @@
 
 **Reading files**:
 - Always read a file before editing it. Never blindly suggest edits.
-- Large files (>300 lines) return metadata first — use `start_line`/`end_line` for specific sections.
+- Very large files (>1500 lines) return a 250-line preview with a continuation hint — use `start_line`/`end_line` for specific sections or to continue the preview.
 - Use `metadata_only=true` to check file size without reading content.
 
 **Editing tools** (always read first):

--- a/source/constants.ts
+++ b/source/constants.ts
@@ -51,9 +51,10 @@ export const DEFAULT_TERMINAL_WIDTH = 200;
 export const DEFAULT_TERMINAL_COLUMNS = 80;
 
 // === FILE READING ===
-export const FILE_READ_METADATA_THRESHOLD_LINES = 300;
-export const FILE_READ_CHUNKING_HINT_THRESHOLD_LINES = 500;
-export const FILE_READ_CHUNK_SIZE_LINES = 250;
+// Files at or below this size are returned in full. Larger files get a bounded
+// preview so the first read still gives the model useful context.
+export const FILE_READ_PREVIEW_THRESHOLD_LINES = 1500;
+export const FILE_READ_PREVIEW_LINES = 250;
 
 // === @-FILE MENTION INLINING (prompt-processor) ===
 // Files at or under this many lines are inlined in full when @-mentioned.

--- a/source/tools/read-file.spec.tsx
+++ b/source/tools/read-file.spec.tsx
@@ -14,6 +14,10 @@ import {readFileTool} from './read-file';
 
 console.log(`\nread-file.spec.tsx – ${React.version}`);
 
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping terminal styling before text-only assertions.
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (value: string) => value.replace(ANSI_RE, '');
+
 // Create a mock theme provider for tests
 function TestThemeProvider({children}: {children: React.ReactNode}) {
 	const themeContextValue = {
@@ -91,7 +95,7 @@ test('ReadFileFormatter shows truncated preview range', async t => {
 		const output = lastFrame();
 		t.truthy(output);
 		t.notRegex(output!, /metadata\s+only/);
-		t.regex(output!, /Lines:\s+1 - 250 of 1600/);
+		t.regex(stripAnsi(output!), /Lines:\s+1 - 250 of 1600/);
 	} finally {
 		rmSync(testDir, {recursive: true, force: true});
 	}

--- a/source/tools/read-file.spec.tsx
+++ b/source/tools/read-file.spec.tsx
@@ -4,7 +4,7 @@ import test from 'ava';
 import {render} from 'ink-testing-library';
 import React from 'react';
 import {themes} from '../config/themes';
-import {EMPTY_CONTENT_MARKER} from '../constants';
+import {EMPTY_CONTENT_MARKER, FILE_READ_PREVIEW_LINES} from '../constants';
 import {ThemeContext} from '../hooks/useTheme';
 import {readFileTool} from './read-file';
 
@@ -64,12 +64,14 @@ test('ReadFileFormatter renders with path', async t => {
 	}
 });
 
-test('ReadFileFormatter shows metadata only indicator', async t => {
-	const testDir = join(process.cwd(), 'test-read-metadata-temp');
+test('ReadFileFormatter shows truncated preview range', async t => {
+	const testDir = join(process.cwd(), 'test-read-preview-temp');
 
 	try {
 		mkdirSync(testDir, {recursive: true});
-		const content = 'line\n'.repeat(400); // Over 300 lines
+		const content = Array.from({length: 1600}, (_, index) =>
+			`line-${index + 1}`,
+		).join('\n');
 		writeFileSync(join(testDir, 'large.ts'), content);
 
 		const formatter = readFileTool.formatter;
@@ -80,7 +82,7 @@ test('ReadFileFormatter shows metadata only indicator', async t => {
 
 		const element = await formatter(
 			{path: join(testDir, 'large.ts')},
-			'File: large.ts\nType: TypeScript\nTotal lines: 400',
+			`line-1\nline-${FILE_READ_PREVIEW_LINES}\n[Truncated at line ${FILE_READ_PREVIEW_LINES} of 1600. Use read_file with start_line: ${FILE_READ_PREVIEW_LINES + 1} and end_line to continue.]`,
 		);
 		const {lastFrame} = render(
 			<TestThemeProvider>{element}</TestThemeProvider>,
@@ -88,7 +90,8 @@ test('ReadFileFormatter shows metadata only indicator', async t => {
 
 		const output = lastFrame();
 		t.truthy(output);
-		t.regex(output!, /metadata\s+only/);
+		t.notRegex(output!, /metadata\s+only/);
+		t.regex(output!, /Lines:\s+1 - 250 of 1600/);
 	} finally {
 		rmSync(testDir, {recursive: true, force: true});
 	}
@@ -149,7 +152,7 @@ test('ReadFileFormatter displays line range for partial reads', async t => {
 // ============================================================================
 
 test.serial(
-	'read_file returns content directly for small files (<300 lines)',
+	'read_file returns content directly for files below the preview threshold',
 	async t => {
 		t.timeout(10000);
 		const testDir = join(process.cwd(), 'test-read-small-temp');
@@ -178,28 +181,29 @@ test.serial(
 );
 
 test.serial(
-	'read_file returns metadata for files >300 lines without ranges',
+	'read_file returns content for files below the preview threshold',
 	async t => {
 		t.timeout(10000);
-		const testDir = join(process.cwd(), 'test-read-metadata-only-temp');
+		const testDir = join(process.cwd(), 'test-read-below-preview-temp');
 
 		try {
 			mkdirSync(testDir, {recursive: true});
-			const content = 'line\n'.repeat(400);
-			writeFileSync(join(testDir, 'large.ts'), content);
+			const content = Array.from({length: 400}, (_, index) =>
+				`line-${index + 1}`,
+			).join('\n');
+			writeFileSync(join(testDir, 'medium.ts'), content);
 
 			const result = await readFileTool.tool.execute!(
 				{
-					path: join(testDir, 'large.ts'),
+					path: join(testDir, 'medium.ts'),
 				},
 				{toolCallId: 'test', messages: []},
 			);
 
-			// Should return metadata, not content
-			t.regex(result, /File:/);
-			t.regex(result, /Type: TypeScript/);
-			t.regex(result, /Total lines: \d+/); // Don't check exact number
-			t.regex(result, /Estimated tokens:/);
+			// Files below the preview threshold should be returned in full.
+			t.true(result.includes('line-1'));
+			t.true(result.includes('line-400'));
+			t.false(result.includes('[Truncated'));
 		} finally {
 			rmSync(testDir, {recursive: true, force: true});
 		}
@@ -237,41 +241,15 @@ test.serial(
 	},
 );
 
-test.serial(
-	'read_file provides progressive read suggestions for medium files',
-	async t => {
-		t.timeout(10000);
-		const testDir = join(process.cwd(), 'test-read-medium-temp');
-
-		try {
-			mkdirSync(testDir, {recursive: true});
-			const content = 'line\n'.repeat(350);
-			writeFileSync(join(testDir, 'medium.ts'), content);
-
-			const result = await readFileTool.tool.execute!(
-				{
-					path: join(testDir, 'medium.ts'),
-				},
-				{toolCallId: 'test', messages: []},
-			);
-
-			// Should suggest progressive reading
-			t.regex(result, /Medium file/);
-			t.regex(result, /start_line: 1, end_line: 250/);
-			t.regex(result, /start_line: 251/);
-		} finally {
-			rmSync(testDir, {recursive: true, force: true});
-		}
-	},
-);
-
-test.serial('read_file provides chunk suggestions for large files', async t => {
+test.serial('read_file returns a preview for very large files', async t => {
 	t.timeout(10000);
-	const testDir = join(process.cwd(), 'test-read-chunks-temp');
+	const testDir = join(process.cwd(), 'test-read-preview-content-temp');
 
 	try {
 		mkdirSync(testDir, {recursive: true});
-		const content = 'line\n'.repeat(1000);
+		const content = Array.from({length: 1600}, (_, index) =>
+			`line-${index + 1}`,
+		).join('\n');
 		writeFileSync(join(testDir, 'large.ts'), content);
 
 		const result = await readFileTool.tool.execute!(
@@ -281,11 +259,18 @@ test.serial('read_file provides chunk suggestions for large files', async t => {
 			{toolCallId: 'test', messages: []},
 		);
 
-		// Should suggest chunked reading
-		t.regex(result, /Large file/);
-		t.regex(result, /Targeted read/);
-		t.regex(result, /Progressive read/);
-		t.regex(result, /Example chunks/);
+		// The first read should contain usable content and a concise continuation
+		// hint instead of generated chunk calls.
+		t.true(result.startsWith('line-1\n'));
+		t.true(result.includes(`line-${FILE_READ_PREVIEW_LINES}`));
+		t.false(result.includes('line-251'));
+		t.regex(
+			result,
+			new RegExp(
+				`\\[Truncated at line ${FILE_READ_PREVIEW_LINES} of 1600\\. Use read_file with start_line: ${FILE_READ_PREVIEW_LINES + 1}`,
+			),
+		);
+		t.false(result.includes('Example chunks'));
 	} finally {
 		rmSync(testDir, {recursive: true, force: true});
 	}
@@ -437,6 +422,7 @@ test.serial('read_file detects common file types', async t => {
 			const result = await readFileTool.tool.execute!(
 				{
 					path: join(testDir, filename),
+					metadata_only: true,
 				},
 				{toolCallId: 'test', messages: []},
 			);
@@ -892,9 +878,10 @@ test.serial('read_file handles files without extension', async t => {
 			{toolCallId: 'test', messages: []},
 		);
 
-		// Should still provide metadata
-		t.regex(result, /File: .*Makefile/);
-		t.regex(result, /Total lines: \d+/); // Don't check exact number
+		// Files below the preview threshold return their content regardless of
+		// whether they have a recognized extension.
+		t.true(result.includes('line'));
+		t.false(result.includes('[Truncated'));
 	} finally {
 		rmSync(testDir, {recursive: true, force: true});
 	}

--- a/source/tools/read-file.tsx
+++ b/source/tools/read-file.tsx
@@ -6,9 +6,8 @@ import React from 'react';
 import ToolMessage from '@/components/tool-message';
 import {
 	EMPTY_CONTENT_MARKER,
-	FILE_READ_CHUNK_SIZE_LINES,
-	FILE_READ_CHUNKING_HINT_THRESHOLD_LINES,
-	FILE_READ_METADATA_THRESHOLD_LINES,
+	FILE_READ_PREVIEW_LINES,
+	FILE_READ_PREVIEW_THRESHOLD_LINES,
 	MAX_LINE_LENGTH_CHARS,
 } from '@/constants';
 import {ThemeContext} from '@/hooks/useTheme';
@@ -114,49 +113,24 @@ const executeReadFile = async (args: {
 
 		const lines = cached.lines;
 		const totalLines = lines.length;
-		const fileSize = content.length;
-		const estimatedTokens = calculateTokens(content);
 
-		// Progressive disclosure: metadata first for files >300 lines
-		// Small files can be read directly without ranges
+		// Return a bounded preview only for very large files. Most files can be
+		// understood and edited after a single read; truly large files still have
+		// an explicit, recoverable path to the remaining content.
 		if (
 			args.start_line === undefined &&
 			args.end_line === undefined &&
-			totalLines > FILE_READ_METADATA_THRESHOLD_LINES
+			totalLines > FILE_READ_PREVIEW_THRESHOLD_LINES
 		) {
-			// Return metadata only for medium/large files
-			// Detect file type from extension
-			const fileType = getFileType(absPath);
+			const previewEndLine = Math.min(FILE_READ_PREVIEW_LINES, totalLines);
+			const preview = lines.slice(0, previewEndLine).join('\n');
 
-			let output = `File: ${args.path}\n`;
-			output += `Type: ${fileType}\n`;
-			output += `Total lines: ${totalLines}\n`;
-			output += `Size: ${fileSize} bytes\n`;
-			output += `Estimated tokens: ~${estimatedTokens}\n\n`;
+			// The model has received real content, even though the rest is omitted.
+			// Marking it seen keeps the read-before-edit guard aligned with the
+			// content that was actually returned, just like a ranged read.
+			markFileSeen(absPath);
 
-			if (totalLines <= FILE_READ_CHUNKING_HINT_THRESHOLD_LINES) {
-				output += `[Medium file - To read specific sections, call read_file with start_line and end_line]\n`;
-				output += `[To read entire file progressively, make multiple calls:]\n`;
-				output += `  - read_file({path: "${args.path}", start_line: 1, end_line: ${FILE_READ_CHUNK_SIZE_LINES}})\n`;
-				output += `  - read_file({path: "${args.path}", start_line: ${FILE_READ_CHUNK_SIZE_LINES + 1}, end_line: ${totalLines}})\n`;
-			} else {
-				output += `[Large file - Choose one approach:]\n`;
-				output += `[1. Targeted read: Use search_files to find code, then read specific ranges]\n`;
-				output += `[2. Progressive read: Read file in chunks (recommended chunk size: 200-300 lines)]\n`;
-				output += `   Example chunks for ${totalLines} lines:\n`;
-				const chunkSize = FILE_READ_CHUNK_SIZE_LINES;
-				const numChunks = Math.ceil(totalLines / chunkSize);
-				for (let i = 0; i < Math.min(numChunks, 3); i++) {
-					const start = i * chunkSize + 1;
-					const end = Math.min((i + 1) * chunkSize, totalLines);
-					output += `   - read_file({path: "${args.path}", start_line: ${start}, end_line: ${end}})\n`;
-				}
-				if (numChunks > 3) {
-					output += `   ... and ${numChunks - 3} more chunks to complete the file\n`;
-				}
-			}
-
-			return output;
+			return `${preview}\n\n[Truncated at line ${previewEndLine} of ${totalLines}. Use read_file with start_line: ${previewEndLine + 1} and end_line to continue.]`;
 		}
 
 		// Line ranges specified - read and return content
@@ -191,7 +165,7 @@ const executeReadFile = async (args: {
 
 const readFileCoreTool = tool({
 	description:
-		'Read file contents. Use this INSTEAD OF bash cat/head/tail/less commands. PROGRESSIVE DISCLOSURE: Files ≤300 lines return content directly. Files >300 lines return metadata first - then call again with start_line/end_line to read specific sections. Use metadata_only=true for file info (size, lines, type) without reading content.',
+		'Read file contents. Use this INSTEAD OF bash cat/head/tail/less commands. PROGRESSIVE DISCLOSURE: Files ≤1500 lines return content directly. Larger files return a 250-line preview with a continuation hint - use start_line/end_line to read additional sections. Use metadata_only=true for file info (size, lines, type) without reading content.',
 	inputSchema: jsonSchema<{
 		path: string;
 		start_line?: number;
@@ -207,12 +181,12 @@ const readFileCoreTool = tool({
 			start_line: {
 				type: 'number',
 				description:
-					'Optional: Line number to start reading from (1-indexed). Required for files >300 lines. Use with end_line to read specific range.',
+					'Optional: Line number to start reading from (1-indexed). Use with end_line to read a specific range or continue a large-file preview.',
 			},
 			end_line: {
 				type: 'number',
 				description:
-					'Optional: Line number to stop reading at (inclusive). Required for files >300 lines. Use with start_line to read specific range.',
+					'Optional: Line number to stop reading at (inclusive). Use with start_line to read a specific range or continue a large-file preview.',
 			},
 			metadata_only: {
 				type: 'boolean',
@@ -250,9 +224,11 @@ const ReadFileFormatter = React.memo(
 		fileInfo: {
 			totalLines: number;
 			readLines: number;
+			readEndLine: number;
 			tokens: number;
 			isPartialRead: boolean;
 			isMetadataOnly: boolean;
+			isTruncated: boolean;
 		};
 	}) => {
 		const themeContext = React.useContext(ThemeContext);
@@ -295,7 +271,8 @@ const ReadFileFormatter = React.memo(
 						<Box>
 							<Text color={colors.secondary}>Lines: </Text>
 							<Text color={colors.text}>
-								{args.start_line || 1} - {args.end_line || fileInfo.totalLines}
+								{args.start_line || 1} - {args.end_line || fileInfo.readEndLine}
+								{fileInfo.isTruncated ? ` of ${fileInfo.totalLines}` : ''}
 							</Text>
 						</Box>
 					</>
@@ -333,9 +310,11 @@ const readFileFormatter = async (
 	let fileInfo = {
 		totalLines: 0,
 		readLines: 0,
+		readEndLine: 0,
 		tokens: 0,
 		isPartialRead: false,
 		isMetadataOnly: false,
+		isTruncated: false,
 	};
 
 	try {
@@ -352,13 +331,16 @@ const readFileFormatter = async (
 				(result?.startsWith('File:') ?? false) &&
 				!args.start_line &&
 				!args.end_line &&
-				totalLines > FILE_READ_METADATA_THRESHOLD_LINES;
+				totalLines > FILE_READ_PREVIEW_THRESHOLD_LINES;
+			const isTruncated = result?.includes('[Truncated at line ') ?? false;
 
 			// Calculate what was actually read
 			const startLine = args.start_line || 1;
-			const endLine = args.end_line || totalLines;
-			const readLines = endLine - startLine + 1;
-			const isPartialRead = startLine > 1 || endLine < totalLines;
+			const readEndLine = isTruncated
+				? Math.min(FILE_READ_PREVIEW_LINES, totalLines)
+				: args.end_line || totalLines;
+			const readLines = readEndLine - startLine + 1;
+			const isPartialRead = startLine > 1 || readEndLine < totalLines;
 
 			// Calculate tokens
 			let tokens: number;
@@ -373,9 +355,11 @@ const readFileFormatter = async (
 			fileInfo = {
 				totalLines,
 				readLines,
+				readEndLine,
 				tokens,
 				isPartialRead,
 				isMetadataOnly,
+				isTruncated,
 			};
 		}
 	} catch {


### PR DESCRIPTION
## Summary

Fixes #760.

- return files up to 1,500 lines in full
- preview the first 250 lines of larger files with a precise continuation hint
- remove generated multi-chunk boilerplate
- retain `metadata_only=true` for explicit metadata requests
- update prompt guidance, formatter behavior, and focused tests

The branch is rebased onto current `main`, merge conflicts are resolved, and an unrelated settings-tabs test edit has been removed.

## Validation

- feature-specific large-file preview cases pass
- formatter assertions are ANSI-safe
- `pnpm run test:format`
- `pnpm run test:lint`
- `git diff --check`

Current type/build/unit CI failures are inherited from the ACP SDK regression on `main`; prerequisite fix: #830.