### PR TITLE
fix: bound string_replace result context

### DIFF
--- a/.changeset/bounded-string-replace-results.md
+++ b/.changeset/bounded-string-replace-results.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Bound `string_replace` results to a context window around the edited range.

--- a/source/tools/file-ops/string-replace.spec.tsx
+++ b/source/tools/file-ops/string-replace.spec.tsx
@@ -338,6 +338,71 @@ test('string_replace: works with large replacements', async t => {
 	t.true(result.includes('Successfully replaced'));
 });
 
+test('string_replace: returns only a bounded context window around the edit', async t => {
+	const filePath = await createTestFile(
+		'large-context.txt',
+		Array.from({length: 100}, (_, i) => `line ${i + 1}`).join('\n'),
+	);
+
+	const result = await executeStringReplace({
+		path: filePath,
+		old_str: 'line 50',
+		new_str: 'changed line 50',
+	});
+
+	t.regex(result, /Updated file context \(lines 30-70 of 100\)/);
+	t.true(result.includes('[... lines 1-29 omitted ...]'));
+	t.true(result.includes('  30: line 30'));
+	t.true(result.includes('  50: changed line 50'));
+	t.true(result.includes('  70: line 70'));
+	t.true(result.includes('[... lines 71-100 omitted ...]'));
+	t.false(result.includes('  29: line 29'));
+	t.false(result.includes('  71: line 71'));
+});
+
+test('string_replace: clamps context windows at the file boundaries', async t => {
+	const filePath = await createTestFile(
+		'boundary-context.txt',
+		Array.from(
+			{length: 45},
+			(_, i) => `line ${String(i + 1).padStart(3, '0')}`,
+		).join('\n'),
+	);
+
+	const startResult = await executeStringReplace({
+		path: filePath,
+		old_str: 'line 001',
+		new_str: 'changed line 001',
+	});
+	const endResult = await executeStringReplace({
+		path: filePath,
+		old_str: 'line 045',
+		new_str: 'changed line 045',
+	});
+
+	t.regex(startResult, /Updated file context \(lines 1-21 of 45\)/);
+	t.false(startResult.includes('[... lines 1-'));
+	t.true(startResult.includes('[... lines 22-45 omitted ...]'));
+	t.regex(endResult, /Updated file context \(lines 25-45 of 45\)/);
+	t.true(endResult.includes('[... lines 1-24 omitted ...]'));
+	t.false(endResult.includes('[... lines 46-'));
+});
+
+test('string_replace: reports the line for inline matches', async t => {
+	const filePath = await createTestFile(
+		'inline-match.txt',
+		'prefix target suffix\nnext line\n',
+	);
+
+	const result = await executeStringReplace({
+		path: filePath,
+		old_str: 'target',
+		new_str: 'replacement',
+	});
+
+	t.regex(result, /Successfully replaced content at line 1 \(now line 1\)/);
+});
+
 // ============================================================================
 // Validator Tests
 // ============================================================================
@@ -964,4 +1029,3 @@ test('string_replace formatter: normalizes tabs to 2 spaces', async t => {
 	t.regex(output!, /string_replace/);
 	t.regex(output!, /Path:/);
 });
-

--- a/source/tools/file-ops/string-replace.tsx
+++ b/source/tools/file-ops/string-replace.tsx
@@ -25,6 +25,40 @@ interface StringReplaceArgs {
 	new_str: string;
 }
 
+const STRING_REPLACE_CONTEXT_LINES = 20;
+
+function formatUpdatedFileContext(
+	content: string,
+	startLine: number,
+	endLine: number,
+): string {
+	const lines = content.split('\n');
+	const contextStartLine = Math.max(
+		1,
+		startLine - STRING_REPLACE_CONTEXT_LINES,
+	);
+	const contextEndLine = Math.min(
+		lines.length,
+		endLine + STRING_REPLACE_CONTEXT_LINES,
+	);
+
+	let fileContext = `\n\nUpdated file context (lines ${contextStartLine}-${contextEndLine} of ${lines.length}):\n`;
+	if (contextStartLine > 1) {
+		fileContext += `[... lines 1-${contextStartLine - 1} omitted ...]\n`;
+	}
+
+	for (let i = contextStartLine - 1; i < contextEndLine; i++) {
+		const lineNumStr = String(i + 1).padStart(4, ' ');
+		fileContext += `${lineNumStr}: ${lines[i] || ''}\n`;
+	}
+
+	if (contextEndLine < lines.length) {
+		fileContext += `[... lines ${contextEndLine + 1}-${lines.length} omitted ...]\n`;
+	}
+
+	return fileContext;
+}
+
 const executeStringReplace = async (
 	args: StringReplaceArgs,
 ): Promise<string> => {
@@ -61,32 +95,14 @@ const executeStringReplace = async (
 	// not blind.
 	markFileSeen(absPath);
 
-	const beforeLines = fileContent.split('\n');
 	const oldStrLines = old_str.split('\n');
 	const newStrLines = new_str.split('\n');
 
-	let startLine = 0;
-	let searchIndex = 0;
-	for (let i = 0; i < beforeLines.length; i++) {
-		const lineWithNewline =
-			beforeLines[i] + (i < beforeLines.length - 1 ? '\n' : '');
-		if (fileContent.indexOf(old_str, searchIndex) === searchIndex) {
-			startLine = i + 1;
-			break;
-		}
-		searchIndex += lineWithNewline.length;
-	}
+	const matchIndex = fileContent.indexOf(old_str);
+	const startLine = fileContent.slice(0, matchIndex).split('\n').length;
 
 	const endLine = startLine + oldStrLines.length - 1;
 	const newEndLine = startLine + newStrLines.length - 1;
-
-	const newLines = newContent.split('\n');
-	let fileContext = '\n\nUpdated file contents:\n';
-	for (let i = 0; i < newLines.length; i++) {
-		const lineNumStr = String(i + 1).padStart(4, ' ');
-		const line = newLines[i] || '';
-		fileContext += `${lineNumStr}: ${line}\n`;
-	}
 
 	const rangeDesc =
 		startLine === endLine
@@ -97,12 +113,12 @@ const executeStringReplace = async (
 			? `line ${startLine}`
 			: `lines ${startLine}-${newEndLine}`;
 
-	return `Successfully replaced content at ${rangeDesc} (now ${newRangeDesc}).${fileContext}`;
+	return `Successfully replaced content at ${rangeDesc} (now ${newRangeDesc}).${formatUpdatedFileContext(newContent, startLine, newEndLine)}`;
 };
 
 const stringReplaceCoreTool = tool({
 	description:
-		'Replace exact string content in a file. IMPORTANT: Provide exact content including whitespace and surrounding context. For unique matching, include 2-3 lines before/after the change. Break large changes into multiple small replacements.',
+		'Replace exact string content in a file. IMPORTANT: Provide exact content including whitespace and surrounding context. For unique matching, include 2-3 lines before/after the change. Break large changes into multiple small replacements. Successful edits return a bounded context window around the changed range, not the entire file.',
 	inputSchema: jsonSchema<StringReplaceArgs>({
 		type: 'object',
 		properties: {


### PR DESCRIPTION
## Summary

- Bound successful `string_replace` results to a 20-line context window on each side of the edited range.
- Added explicit line ranges and omitted-range markers so the model can still orient itself without receiving the whole file.
- Corrected line-number detection for inline matches and added large-file and boundary regression tests.
- Added a patch changeset.

## Validation

- `pnpm run test:ava source/tools/file-ops/string-replace.spec.tsx` (42 passed)
- `pnpm run test:format`
- `pnpm run test:lint`
- `pnpm run test:types`
- `pnpm run test:knip`
- `pnpm run test:audit`

The full AVA suite has one unrelated existing failure in `source/app/components/settings-tabs.spec.tsx:109`, where the test expects `Display` but the rendered output does not include it.

Fixes #763
