### PR TITLE
fix: summarize oversized git diffs

### DIFF
--- a/.changeset/quiet-git-diffs.md
+++ b/.changeset/quiet-git-diffs.md
@@ -2,4 +2,4 @@
 "@nanocollective/nanocoder": patch
 ---
 
-Summarized oversized `git_diff` results with a diffstat and guidance to request a specific file for details.
+Bound oversized multi-file `git_diff` results to a 20-entry diffstat while preserving the total file count, and kept file-scoped results as bounded head-and-tail patches.

--- a/.changeset/quiet-git-diffs.md
+++ b/.changeset/quiet-git-diffs.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Summarized oversized `git_diff` results with a diffstat and guidance to request a specific file for details.

--- a/source/tools/git/git-diff.spec.tsx
+++ b/source/tools/git/git-diff.spec.tsx
@@ -2,6 +2,10 @@
  * Git Diff Tool Tests
  */
 
+import {execSync} from 'node:child_process';
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import React from 'react';
 import test from 'ava';
 import {render} from 'ink-testing-library';
@@ -45,6 +49,42 @@ test('git_diff tool has AI SDK tool with execute', t => {
 
 test('git_diff tool has formatter function', t => {
 	t.is(typeof gitDiffTool.formatter, 'function');
+});
+
+test.serial('git_diff summarizes oversized diffs', async t => {
+	const dir = mkdtempSync(join(tmpdir(), 'nanocoder-git-diff-test-'));
+	const originalCwd = process.cwd();
+
+	try {
+		execSync('git init -q -b main', {cwd: dir});
+		execSync('git config user.email test@example.com', {cwd: dir});
+		execSync('git config user.name Test', {cwd: dir});
+
+		const file = join(dir, 'large.txt');
+		writeFileSync(file, 'baseline\n');
+		execSync('git add large.txt', {cwd: dir});
+		execSync('git commit -q -m baseline', {cwd: dir});
+		writeFileSync(
+			file,
+			`${Array.from({length: 600}, (_, index) => `line ${index + 1}`).join('\n')}\n`,
+		);
+
+		process.chdir(dir);
+		// biome-ignore lint/suspicious/noExplicitAny: Test accesses the AI SDK execute function.
+		const execute = (gitDiffTool.tool as any).execute as (
+			args: {stat?: boolean},
+		) => Promise<string>;
+		const result = await execute({});
+
+		t.regex(result, /large\.txt/);
+		t.regex(result, /files? changed/);
+		t.regex(result, /Diff is too large to return in full/);
+		t.regex(result, /file parameter/);
+		t.false(result.includes('diff --git'));
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(dir, {recursive: true, force: true});
+	}
 });
 
 // ============================================================================

--- a/source/tools/git/git-diff.spec.tsx
+++ b/source/tools/git/git-diff.spec.tsx
@@ -51,41 +51,93 @@ test('git_diff tool has formatter function', t => {
 	t.is(typeof gitDiffTool.formatter, 'function');
 });
 
-test.serial('git_diff summarizes oversized diffs', async t => {
-	const dir = mkdtempSync(join(tmpdir(), 'nanocoder-git-diff-test-'));
-	const originalCwd = process.cwd();
+test.serial(
+	'git_diff preserves bounded patch output for an oversized file-scoped diff',
+	async t => {
+		const dir = mkdtempSync(join(tmpdir(), 'nanocoder-git-diff-test-'));
+		const originalCwd = process.cwd();
 
-	try {
-		execSync('git init -q -b main', {cwd: dir});
-		execSync('git config user.email test@example.com', {cwd: dir});
-		execSync('git config user.name Test', {cwd: dir});
+		try {
+			execSync('git init -q -b main', {cwd: dir});
+			execSync('git config user.email test@example.com', {cwd: dir});
+			execSync('git config user.name Test', {cwd: dir});
 
-		const file = join(dir, 'large.txt');
-		writeFileSync(file, 'baseline\n');
-		execSync('git add large.txt', {cwd: dir});
-		execSync('git commit -q -m baseline', {cwd: dir});
-		writeFileSync(
-			file,
-			`${Array.from({length: 600}, (_, index) => `line ${index + 1}`).join('\n')}\n`,
-		);
+			const file = join(dir, 'large.txt');
+			writeFileSync(file, 'baseline\n');
+			execSync('git add large.txt', {cwd: dir});
+			execSync('git commit -q -m baseline', {cwd: dir});
+			writeFileSync(
+				file,
+				`${Array.from({length: 600}, (_, index) => `line ${index + 1}`).join('\n')}\n`,
+			);
 
-		process.chdir(dir);
-		// biome-ignore lint/suspicious/noExplicitAny: Test accesses the AI SDK execute function.
-		const execute = (gitDiffTool.tool as any).execute as (
-			args: {stat?: boolean},
-		) => Promise<string>;
-		const result = await execute({});
+			process.chdir(dir);
+			// biome-ignore lint/suspicious/noExplicitAny: Test accesses the AI SDK execute function.
+			const execute = (gitDiffTool.tool as any).execute as (
+				args: {file?: string; stat?: boolean},
+			) => Promise<string>;
+			const result = await execute({file: 'large.txt'});
 
-		t.regex(result, /large\.txt/);
-		t.regex(result, /files? changed/);
-		t.regex(result, /Diff is too large to return in full/);
-		t.regex(result, /file parameter/);
-		t.false(result.includes('diff --git'));
-	} finally {
-		process.chdir(originalCwd);
-		rmSync(dir, {recursive: true, force: true});
-	}
-});
+			t.regex(result, /diff --git a\/large\.txt b\/large\.txt/);
+			t.regex(result, /^\+line 1$/m);
+			t.regex(result, /^\+line 600$/m);
+			t.regex(result, /Diff truncated: showing first 250 and last 250/);
+			t.false(result.includes('Use the file parameter'));
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(dir, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
+	'git_diff caps oversized multi-file stats while preserving the total file count',
+	async t => {
+		const dir = mkdtempSync(join(tmpdir(), 'nanocoder-git-diff-test-'));
+		const originalCwd = process.cwd();
+
+		try {
+			execSync('git init -q -b main', {cwd: dir});
+			execSync('git config user.email test@example.com', {cwd: dir});
+			execSync('git config user.name Test', {cwd: dir});
+
+			for (let index = 1; index <= 25; index++) {
+				writeFileSync(
+					join(dir, `file-${String(index).padStart(2, '0')}.txt`),
+					'baseline\n',
+				);
+			}
+			execSync('git add .', {cwd: dir});
+			execSync('git commit -q -m baseline', {cwd: dir});
+
+			for (let index = 1; index <= 25; index++) {
+				writeFileSync(
+					join(dir, `file-${String(index).padStart(2, '0')}.txt`),
+					`${Array.from(
+						{length: 25},
+						(_, lineIndex) => `file ${index} line ${lineIndex + 1}`,
+					).join('\n')}\n`,
+				);
+			}
+
+			process.chdir(dir);
+			// biome-ignore lint/suspicious/noExplicitAny: Test accesses the AI SDK execute function.
+			const execute = (gitDiffTool.tool as any).execute as (
+				args: {stat?: boolean},
+			) => Promise<string>;
+			const result = await execute({});
+
+			t.regex(result, /file-01\.txt/);
+			t.regex(result, /file-20\.txt/);
+			t.false(result.includes('file-21.txt'));
+			t.regex(result, /25 files changed/);
+			t.regex(result, /Diff is too large to return in full/);
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(dir, {recursive: true, force: true});
+		}
+	},
+);
 
 // ============================================================================
 // Formatter Tests

--- a/source/tools/git/git-diff.tsx
+++ b/source/tools/git/git-diff.tsx
@@ -24,35 +24,40 @@ interface GitDiffInput {
 	stat?: boolean;
 }
 
+const MAX_DIFF_LINES = 500;
+
+function buildGitDiffArgs(
+	args: GitDiffInput,
+	includeStat = Boolean(args.stat),
+): string[] {
+	const gitArgs: string[] = ['diff'];
+
+	if (args.staged) {
+		gitArgs.push('--cached');
+	}
+
+	if (includeStat) {
+		gitArgs.push('--stat');
+	}
+
+	if (args.base) {
+		gitArgs.push(args.base);
+	}
+
+	if (args.file) {
+		gitArgs.push('--', args.file);
+	}
+
+	return gitArgs;
+}
+
 // ============================================================================
 // Execution
 // ============================================================================
 
 const executeGitDiff = async (args: GitDiffInput): Promise<string> => {
 	try {
-		const gitArgs: string[] = ['diff'];
-
-		// Add --cached for staged changes
-		if (args.staged) {
-			gitArgs.push('--cached');
-		}
-
-		// Add base reference (branch or commit)
-		if (args.base) {
-			gitArgs.push(args.base);
-		}
-
-		// Show stat only
-		if (args.stat) {
-			gitArgs.push('--stat');
-		}
-
-		// Specific file
-		if (args.file) {
-			gitArgs.push('--', args.file);
-		}
-
-		const output = await execGit(gitArgs);
+		const output = await execGit(buildGitDiffArgs(args));
 
 		if (!output.trim()) {
 			if (args.staged) {
@@ -64,11 +69,24 @@ const executeGitDiff = async (args: GitDiffInput): Promise<string> => {
 			return 'No unstaged changes.';
 		}
 
-		// Truncate if too long (unless stat mode which is already compact)
+		// Summarize oversized full diffs to avoid sending large patches to the model.
 		if (!args.stat) {
-			const {content, truncated, totalLines} = truncateDiff(output, 500);
+			const {content, truncated, totalLines} = truncateDiff(
+				output,
+				MAX_DIFF_LINES,
+			);
 			if (truncated) {
-				return `${content}\n\n[Total: ${totalLines} lines]`;
+				try {
+					const statOutput = await execGit(buildGitDiffArgs(args, true));
+					return (
+						`${statOutput}\n\n` +
+						`Diff is too large to return in full (${totalLines} lines). ` +
+						'Use the file parameter to request a specific path for detailed output.'
+					);
+				} catch {
+					// Keep the result bounded even if the summary command fails.
+					return content;
+				}
 			}
 		}
 

--- a/source/tools/git/git-diff.tsx
+++ b/source/tools/git/git-diff.tsx
@@ -37,7 +37,7 @@ function buildGitDiffArgs(
 	}
 
 	if (includeStat) {
-		gitArgs.push('--stat');
+		gitArgs.push('--stat-count=20', '--stat');
 	}
 
 	if (args.base) {
@@ -76,6 +76,11 @@ const executeGitDiff = async (args: GitDiffInput): Promise<string> => {
 				MAX_DIFF_LINES,
 			);
 			if (truncated) {
+				const filesChanged = output.match(/^diff --git /gm)?.length ?? 0;
+				if (filesChanged <= 1) {
+					return content;
+				}
+
 				try {
 					const statOutput = await execGit(buildGitDiffArgs(args, true));
 					return (

--- a/source/tools/git/utils.spec.ts
+++ b/source/tools/git/utils.spec.ts
@@ -14,6 +14,7 @@ import {
 	getCurrentBranchSync,
 	getDefaultBranchSync,
 	getGitStatusSummarySync,
+	truncateDiff,
 } from './utils';
 
 // ============================================================================
@@ -159,6 +160,36 @@ test('parseGitStatus ignores empty lines', t => {
 	const result = parseGitStatus(statusOutput);
 	t.is(result.staged.length, 1);
 	t.is(result.unstaged.length, 1);
+});
+
+// ============================================================================
+// truncateDiff Tests
+// ============================================================================
+
+test('truncateDiff leaves output unchanged below the limit', t => {
+	const diff = 'line 1\nline 2\nline 3';
+	const result = truncateDiff(diff, 3);
+
+	t.false(result.truncated);
+	t.is(result.totalLines, 3);
+	t.is(result.content, diff);
+});
+
+test('truncateDiff preserves the beginning and end of a large diff', t => {
+	const diff = Array.from({length: 10}, (_, index) => `line ${index + 1}`).join(
+		'\n',
+	);
+	const result = truncateDiff(diff, 4);
+
+	t.true(result.truncated);
+	t.is(result.totalLines, 10);
+	t.true(result.content.startsWith('line 1\nline 2'));
+	t.true(result.content.endsWith('line 9\nline 10'));
+	t.regex(
+		result.content,
+		/\[Diff truncated: showing first 2 and last 2 of 10 lines; 6 lines omitted\]/,
+	);
+	t.false(result.content.includes('line 3'));
 });
 
 // ============================================================================

--- a/source/tools/git/utils.ts
+++ b/source/tools/git/utils.ts
@@ -649,7 +649,10 @@ export async function getStashCount(): Promise<number> {
 // ============================================================================
 
 /**
- * Truncate diff output if too long
+ * Truncate diff output if too long while preserving both ends of the diff.
+ * The beginning usually contains the file headers and the end often contains
+ * the final hunks, so keeping both gives the caller useful context without
+ * returning the entire result.
  */
 export function truncateDiff(
 	diff: string,
@@ -666,11 +669,17 @@ export function truncateDiff(
 		return {content: diff, truncated: false, totalLines};
 	}
 
-	const truncatedContent = lines.slice(0, maxLines).join('\n');
+	const headLines = Math.ceil(maxLines / 2);
+	const tailLines = Math.floor(maxLines / 2);
+	const omittedLines = totalLines - headLines - tailLines;
+	const head = lines.slice(0, headLines).join('\n');
+	const tail = tailLines > 0 ? lines.slice(-tailLines).join('\n') : '';
+	const marker =
+		`... [Diff truncated: showing first ${headLines} and last ${tailLines} ` +
+		`of ${totalLines} lines; ${omittedLines} lines omitted]`;
+
 	return {
-		content:
-			truncatedContent +
-			`\n\n... [Diff truncated: showing ${maxLines} of ${totalLines} lines]`,
+		content: tail ? `${head}\n\n${marker}\n\n${tail}` : `${head}\n\n${marker}`,
 		truncated: true,
 		totalLines,
 	};


### PR DESCRIPTION
Closes #770
Part of #772

## Summary

- use a bounded `--stat-count=20 --stat` summary for oversized multi-file diffs
- return bounded head-and-tail patch content when an oversized diff is already scoped to one file
- keep recovery guidance actionable and preserve useful context from both ends
- add utility and integration regression tests plus a patch changeset

## Validation

- focused git utility and git-diff suites: 37 passed
- `pnpm run test:format`
- `pnpm run test:lint`
- `git diff --check`

Current type/build/unit CI failures are inherited from the ACP SDK regression on `main`; prerequisite fix: #830.