### PR TITLE
fix: clarify refusal message when only metadata was read (#761)

### DIFF
--- a/.changeset/wacky-tables-shout.md
+++ b/.changeset/wacky-tables-shout.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Clarify read-before-edit refusal messages to specify that files over 300 lines need a ranged read

--- a/source/tools/file-ops/diff-edit.tsx
+++ b/source/tools/file-ops/diff-edit.tsx
@@ -339,7 +339,7 @@ const diffEditValidator = async (
 	if (!hasSeenFile(absPath)) {
 		return {
 			valid: false,
-			error: `You must read "${args.path}" before editing it. Call read_file on it first, then retry diff_edit with SEARCH blocks copied from the file.`,
+			error: `You must read "${args.path}" before editing it. Call read_file on it first — if the file is over 300 lines, specify start_line and end_line to read its actual content, not just metadata — then retry diff_edit with SEARCH blocks copied from the file.`,
 		};
 	}
 

--- a/source/tools/file-ops/string-replace.tsx
+++ b/source/tools/file-ops/string-replace.tsx
@@ -214,7 +214,7 @@ const stringReplaceValidator = async (
 	if (!hasSeenFile(absPath)) {
 		return {
 			valid: false,
-			error: `You must read "${path}" before editing it. Call read_file on it first, then retry string_replace with old_str copied exactly from the file.`,
+			error: `You must read "${path}" before editing it. Call read_file on it first — if the file is over 300 lines, specify start_line and end_line to read its actual content, not just metadata — then retry string_replace with old_str copied exactly from the file.`,
 		};
 	}
 

--- a/source/tools/file-ops/write-file.tsx
+++ b/source/tools/file-ops/write-file.tsx
@@ -271,7 +271,7 @@ const writeFileValidator = async (args: {
 	if (existsSync(absPath) && !hasSeenFile(absPath)) {
 		return {
 			valid: false,
-			error: `"${args.path}" already exists and you have not read it this session. Call read_file on it first (so you don't discard existing content), then retry. For small changes, prefer string_replace over a full overwrite.`,
+			error: `"${args.path}" already exists and you have not read it this session. Call read_file on it first — if the file is over 300 lines, specify start_line and end_line to read its actual content, not just metadata — so you don't discard existing content, then retry. For small changes, prefer string_replace over a full overwrite.`,
 		};
 	}
 


### PR DESCRIPTION
Closes #761

## Description
`read_file`'s metadata-only response (files over 300 lines with no
line range) correctly does not call `markFileSeen`, since the model
hasn't actually seen the file's contents. However, the refusal
messages in `diff_edit`, `string_replace`, and `write_file` (which
check `hasSeenFile`) didn't explain *why* the edit was refused after
a metadata read, or what to do about it.

Per the maintainer's noted judgment call in the issue: kept the
metadata-response behavior as-is (not marking seen), and instead
made all three refusal messages explicit that files over 300 lines
require specifying `start_line`/`end_line` on `read_file` to read
actual content — so the model (or contributor) can recover in one
step instead of guessing why the edit was blocked.

Updated all three call sites for consistency, not just the one
implied by the issue's reproduction steps, since all three tools
share the same `hasSeenFile` guard and refusal pattern.

## Type of Change
- [x] Bug fix

## Changeset
- [x] Added a changeset (`pnpm changeset`)

## Testing
### Automated Tests
- [x] All existing tests pass (`bash scripts/test.sh`)

Verified against `main` directly: both show the same 63 pre-existing
failures unrelated to this change (coverage threshold issues in
`fetch-models.ts` and others); this change introduces none.

### Manual Testing
Reviewed the change against the reported repro steps in #761 —
message wording verified for accuracy in all three files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes