### PR TITLE
fix(tools): stop prefixing edit tool responses with line numbers

### DIFF
--- a/.changeset/ten-clouds-show.md
+++ b/.changeset/ten-clouds-show.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed string_replace and write_file tool responses to return raw file contents instead of line-number-prefixed output, making them consistent with read_file and preventing follow-up edit mismatches. Thanks to @Pixie-19. Closes #765.

--- a/source/tools/file-ops/string-replace.tsx
+++ b/source/tools/file-ops/string-replace.tsx
@@ -80,13 +80,7 @@ const executeStringReplace = async (
 	const endLine = startLine + oldStrLines.length - 1;
 	const newEndLine = startLine + newStrLines.length - 1;
 
-	const newLines = newContent.split('\n');
-	let fileContext = '\n\nUpdated file contents:\n';
-	for (let i = 0; i < newLines.length; i++) {
-		const lineNumStr = String(i + 1).padStart(4, ' ');
-		const line = newLines[i] || '';
-		fileContext += `${lineNumStr}: ${line}\n`;
-	}
+	const fileContext = `\n\nUpdated file contents:\n${newContent}`;
 
 	const rangeDesc =
 		startLine === endLine

--- a/source/tools/file-ops/write-file.tsx
+++ b/source/tools/file-ops/write-file.tsx
@@ -47,18 +47,10 @@ const executeWriteFile = async (args: {
 
 	// Read back to verify and show actual content
 	const actualContent = await readFile(absPath, 'utf-8');
-	const lines = actualContent.split('\n');
-	const lineCount = lines.length;
+	const fileContext = `\n\nFile contents after write:\n${actualContent}`;
+	const lineCount = actualContent.split('\n').length;
 	const charCount = actualContent.length;
 	const estimatedTokens = calculateTokens(actualContent);
-
-	// Generate full file contents to show the model the current file state
-	let fileContext = '\n\nFile contents after write:\n';
-	for (let i = 0; i < lines.length; i++) {
-		const lineNumStr = String(i + 1).padStart(4, ' ');
-		const line = lines[i] || '';
-		fileContext += `${lineNumStr}: ${line}\n`;
-	}
 
 	const action = fileExists ? 'overwritten' : 'written';
 	return `File ${action} successfully (${lineCount} lines, ${charCount} characters, ~${estimatedTokens} tokens).${fileContext}`;


### PR DESCRIPTION
## Description

Fixes #765.

This PR removes line-number prefixes from the responses returned by the `string_replace` and `write_file` tools.

Previously these tools returned file contents like:

    1: import ...
    2: const x = ...

while `read_file` returned raw file contents without numbered prefixes. This inconsistency could cause follow-up edits to fail because `string_replace` expects the exact file contents.

The tools now return the raw file contents, making their output consistent with `read_file`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] Existing TypeScript compilation passes (`npm run test:types`)
- [x] Biome lint and format checks run successfully (schema version warning only)

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes