### PR TITLE
fix: address review feedback on semantic memory

### DIFF
--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -43,6 +43,8 @@ Type `/` in the chat input to see available commands. All commands start with `/
 | `/explorer` | Interactive file browser to navigate, preview, and select files for context |
 | `/tune` | Configure runtime model behaviour — tool profiles, compaction, native tools, model parameters (see [Tune](tune.md)) |
 | `/ide` | Connect to an IDE for live integration (e.g., VS Code diff previews) |
+| `/remember` | Save a durable project memory (see [Semantic Memory](semantic-memory.md)) |
+| `/memory` | List, delete, propose, and accept project memories (see [Semantic Memory](semantic-memory.md)) |
 
 ## Special Input Syntax
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -235,6 +235,7 @@ Extend Nanocoder's capabilities by connecting [MCP (Model Context Protocol) serv
 | [Checkpointing](checkpointing.md) | Saving and restoring conversation snapshots |
 | [Session Management](session-management.md) | Automatic session saving and resumption |
 | [Task Management](task-management.md) | Tracking multi-step work |
+| [Semantic Memory](semantic-memory.md) | Save durable project facts and recall them automatically across sessions |
 | [File Explorer](file-explorer.md) | Interactive file browser for context selection |
 | [Image Attachments](image-attachments.md) | Send screenshots and images to vision-capable models |
 | [VS Code Extension](vscode-extension.md) | Editor integration with live diff previews |

--- a/docs/features/semantic-memory.md
+++ b/docs/features/semantic-memory.md
@@ -1,0 +1,63 @@
+---
+title: "Semantic Memory"
+description: "Save durable project facts and recall them automatically across sessions"
+sidebar_order: 13
+---
+
+# Semantic Memory
+
+Semantic memory lets you save durable facts about a project — architectural decisions, conventions, known issues, rejected approaches — so you don't have to re-explain them every session. Relevant memories are automatically recalled and injected into the system prompt as project context.
+
+Memory creation is always manual and explicit. Nothing is ever saved automatically after a session; you decide what's worth remembering.
+
+## Commands
+
+- `/remember [--category <name>] <content>` — Save a memory directly
+- `/memory list` — List all saved memories with their IDs and categories
+- `/memory delete <id>` — Delete a specific memory
+- `/memory clear` — Delete all memories for the current project
+- `/memory propose` — Scan the current conversation for durable-sounding facts and print them as numbered proposals for review
+- `/memory accept <n>` — Save proposal `n` from the most recent `/memory propose` output
+
+### Example
+
+```
+/remember The auth module uses Clerk and avoids middleware in the edge runtime.
+/remember --category codingStyle Use camelCase for all variable names.
+
+/memory list
+/memory propose
+/memory accept 2
+```
+
+## Categories
+
+Memories are grouped into: `architecture`, `bugFix`, `refactor`, `todo`, `codingStyle`, or `project` (the default, for anything that doesn't match a more specific category). `/remember` infers a category automatically from the content unless you pass `--category`.
+
+## Recall
+
+When you send a message, Nanocoder ranks saved memories by relevance to that message (keyword overlap, with common words filtered out) and injects the most relevant ones into the system prompt under a `## Project Context` heading, up to a token budget. Low-relevance memories are dropped rather than injected as noise.
+
+Recall works the same way across every interface: the interactive TUI, `nanocoder run` / `--plain`, and `--acp`. Each surface shows a `Recalling N project memories...` notice when memories are injected.
+
+Retrieval is keyword-based, not a true embeddings/vector search — the "semantic" in the name refers to the kind of facts stored (durable project knowledge), not the matching technique.
+
+## Proposals
+
+`/memory propose` looks back through the conversation for lines that read like durable facts (matched against the category keywords above) and prints them with their source (`explicit-user` or `conversation-inferred`) and a short evidence snippet. Nothing is saved until you run `/memory accept <n>`.
+
+Proposals inferred purely from assistant text carry an `Inferred from conversation, no explicit user statement.` warning. If the assistant appears to be capitulating to pushback rather than stating a fact (opens with "you're right", "fair enough", etc., in response to a non-technical user message), the proposal is also flagged `Possible assistant position reversal.` — this catches the case where a model agreeing with a user's stylistic preference gets summarized into a "project convention" that was never actually decided. If you explicitly restate the same line yourself, the reversal warning is cleared, since your own statement is what actually resolves the ambiguity.
+
+## Turning It Off
+
+Semantic memory is on by default. Toggle it from `/settings` → **Semantic Memory**. Turning it off disables both recall (memories are no longer injected into prompts) and writes (`/remember` and `/memory accept` are refused while it's off).
+
+## Storage and Scope
+
+Memories are stored per-repository in a local JSON file under your app data directory, keyed by a hash of the repository's `git remote origin.url` (or its absolute path, for non-git directories). This means:
+
+- All branches, worktrees, and local clones that share the same `origin` remote share one memory pool.
+- Forks with a different `origin` get their own, separate pool.
+- This scope isn't currently configurable — if you work across branches with genuinely divergent conventions in the same repository, they'll share memories.
+
+Files are written atomically (temp file + rename) with restrictive permissions (`0600` on the file, `0700` on the directory), and nothing ever leaves your machine.

--- a/source/acp/acp-agent.spec.ts
+++ b/source/acp/acp-agent.spec.ts
@@ -7,6 +7,7 @@ import {
 	setToolRegistryGetter,
 	setToolManagerGetter,
 } from '@/message-handler';
+import {SemanticMemoryManager} from '@/memory/semantic-memory-manager';
 
 console.log('\nacp-agent.spec.ts');
 
@@ -276,6 +277,38 @@ test('AcpAgent.prompt - returns response for valid session', async t => {
 		prompt: [{type: 'text', text: 'Hello!'}],
 	});
 	t.truthy(result.stopReason);
+});
+
+test('AcpAgent.prompt - recalls relevant project memories scoped to the session cwd, without accumulating across turns', async t => {
+	await new SemanticMemoryManager({cwd: '/tmp'}).addMemory({
+		content: 'Auth uses Clerk and avoids middleware.',
+	});
+
+	const capturedSystemPrompts: string[] = [];
+	const conn = createMockConn();
+	const initContext = createMockInitContext();
+	initContext.client = {
+		...initContext.client,
+		chat: async (messages: Array<{content: string}>) => {
+			capturedSystemPrompts.push(messages[0]?.content ?? '');
+			return {choices: [{message: {content: 'Test response'}}]};
+		},
+	} as any;
+	const agent = new AcpAgent(initContext, conn);
+	const session = await agent.newSession({cwd: '/tmp'});
+
+	await agent.prompt({
+		sessionId: session.sessionId,
+		prompt: [{type: 'text', text: 'refactor auth middleware handling'}],
+	});
+	await agent.prompt({
+		sessionId: session.sessionId,
+		prompt: [{type: 'text', text: 'unrelated question about docs'}],
+	});
+
+	t.true(capturedSystemPrompts[0]?.includes('## Project Context'));
+	t.true(capturedSystemPrompts[0]?.includes('Auth uses Clerk'));
+	t.false(capturedSystemPrompts[1]?.includes('## Project Context'));
 });
 
 // ============================================================================

--- a/source/acp/acp-agent.ts
+++ b/source/acp/acp-agent.ts
@@ -33,8 +33,14 @@ import {AcpSession} from '@/acp/acp-session';
 import type {AcpInitContext} from '@/acp/acp-types';
 import {appendToolDefinitionsToPrompt} from '@/ai-sdk-client/tools/system-prompt-assembler';
 import {getAppConfig} from '@/config/index';
-import {loadPreferences, updateLastUsed} from '@/config/preferences';
+import {
+	getSemanticMemoryEnabled,
+	loadPreferences,
+	updateLastUsed,
+} from '@/config/preferences';
 import {resolveTune} from '@/config/tune';
+import {appendRelevantProjectContextWithCount} from '@/memory/project-context';
+import {SemanticMemoryManager} from '@/memory/semantic-memory-manager';
 import {getTuneToolMode} from '@/types/config';
 import {getLogger} from '@/utils/logging';
 import {buildSystemPrompt, setLastBuiltPrompt} from '@/utils/prompt-builder';
@@ -148,6 +154,25 @@ export class AcpAgent implements Agent {
 				...(images.length > 0 ? {images} : {}),
 			},
 		];
+
+		if (session.baseSystemMessage) {
+			const projectContext = await appendRelevantProjectContextWithCount(
+				session.baseSystemMessage.content,
+				userText,
+				new SemanticMemoryManager({cwd: session.cwd}),
+				{semanticMemoryEnabled: getSemanticMemoryEnabled()},
+			);
+			session.systemMessage = {
+				role: 'system',
+				content: projectContext.systemPrompt,
+			};
+			setLastBuiltPrompt(projectContext.systemPrompt);
+			if (projectContext.memoryCount > 0) {
+				logger.info(
+					`ACP recall: session=${params.sessionId} count=${projectContext.memoryCount}`,
+				);
+			}
+		}
 
 		const config = getAppConfig();
 		const nonInteractiveAlwaysAllow = config.alwaysAllow ?? [];
@@ -344,7 +369,8 @@ export class AcpAgent implements Agent {
 		);
 		setLastBuiltPrompt(systemContent);
 
-		session.systemMessage = {role: 'system', content: systemContent};
+		session.baseSystemMessage = {role: 'system', content: systemContent};
+		session.systemMessage = session.baseSystemMessage;
 	}
 }
 

--- a/source/acp/acp-session.ts
+++ b/source/acp/acp-session.ts
@@ -12,6 +12,7 @@ export class AcpSession {
 
 	messages: Message[] = [];
 	systemMessage?: Message;
+	baseSystemMessage?: Message;
 	abortController = new AbortController();
 	developmentMode: DevelopmentMode;
 	/** True while a prompt turn is being processed, to reject overlapping prompts. */

--- a/source/commands/memory.spec.tsx
+++ b/source/commands/memory.spec.tsx
@@ -35,10 +35,24 @@ class FakeMemoryManager {
 }
 
 class FakeSummarizerService {
+	accepted: Array<Pick<MemoryProposal, 'content' | 'category'>> = [];
+
 	constructor(private readonly proposals: MemoryProposal[]) {}
 
 	proposeMemoriesFromMessages(messages: Message[]): MemoryProposal[] {
 		return messages.length === 0 ? [] : this.proposals;
+	}
+
+	async acceptProposal(
+		proposal: Pick<MemoryProposal, 'content' | 'category'>,
+	): Promise<SemanticMemory> {
+		this.accepted.push({content: proposal.content, category: proposal.category});
+		return {
+			id: `accepted-${this.accepted.length}`,
+			content: proposal.content,
+			category: proposal.category,
+			timestamp: '2026-08-05T00:00:00.000Z',
+		};
 	}
 }
 
@@ -182,6 +196,65 @@ test('memory command reports when no proposals are found', async t => {
 	const {lastFrame} = renderWithTheme(result as React.ReactElement);
 
 	t.true((lastFrame() ?? '').includes('No durable memory proposals found.'));
+});
+
+test('memory command accepts a proposal by index after propose', async t => {
+	const manager = new FakeMemoryManager();
+	const summarizerService = new FakeSummarizerService([
+		{
+			content: 'Auth uses Clerk.',
+			category: 'architecture',
+			sourceType: 'explicit-user',
+			evidence: {userMessages: ['Refactor auth.'], assistantMessages: []},
+			warnings: [],
+		},
+	]);
+	const command = createMemoryCommand({memoryManager: manager, summarizerService});
+
+	await command.handler(['propose'], [{role: 'user', content: 'Refactor auth.'}], testMetadata);
+	const result = await command.handler(['accept', '1'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true((lastFrame() ?? '').includes('Saved architecture memory: Auth uses Clerk.'));
+	t.deepEqual(summarizerService.accepted, [
+		{content: 'Auth uses Clerk.', category: 'architecture'},
+	]);
+});
+
+test('memory command rejects accept with no prior proposals', async t => {
+	const manager = new FakeMemoryManager();
+	const command = createMemoryCommand({
+		memoryManager: manager,
+		summarizerService: new FakeSummarizerService([]),
+	});
+
+	const result = await command.handler(['accept', '1'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true(
+		(lastFrame() ?? '').includes('No proposals to accept. Run /memory propose first.'),
+	);
+});
+
+test('memory command rejects accept with an out-of-range index', async t => {
+	const manager = new FakeMemoryManager();
+	const summarizerService = new FakeSummarizerService([
+		{
+			content: 'Auth uses Clerk.',
+			category: 'architecture',
+			sourceType: 'explicit-user',
+			evidence: {userMessages: ['Refactor auth.'], assistantMessages: []},
+			warnings: [],
+		},
+	]);
+	const command = createMemoryCommand({memoryManager: manager, summarizerService});
+
+	await command.handler(['propose'], [{role: 'user', content: 'Refactor auth.'}], testMetadata);
+	const result = await command.handler(['accept', '5'], [], testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+
+	t.true((lastFrame() ?? '').includes('Usage: /memory accept <1-1>'));
+	t.deepEqual(summarizerService.accepted, []);
 });
 
 test('lazy registry exposes /memory', t => {

--- a/source/commands/memory.ts
+++ b/source/commands/memory.ts
@@ -1,4 +1,5 @@
 import {SemanticMemoryManager} from '@/memory/semantic-memory-manager';
+import type {MemoryProposal} from '@/memory/summarizer-service';
 import {SummarizerService} from '@/memory/summarizer-service';
 import type {Command} from '@/types/commands';
 import {formatError} from '@/utils/error-formatter';
@@ -9,11 +10,14 @@ interface MemoryCommandOptions {
 		SemanticMemoryManager,
 		'listMemories' | 'deleteMemory' | 'clearMemories'
 	>;
-	summarizerService?: Pick<SummarizerService, 'proposeMemoriesFromMessages'>;
+	summarizerService?: Pick<
+		SummarizerService,
+		'proposeMemoriesFromMessages' | 'acceptProposal'
+	>;
 }
 
 const USAGE =
-	'Usage: /memory list | /memory delete <id> | /memory clear | /memory propose';
+	'Usage: /memory list | /memory delete <id> | /memory clear | /memory propose | /memory accept <n>';
 
 export function createMemoryCommand(
 	options: MemoryCommandOptions = {},
@@ -21,6 +25,7 @@ export function createMemoryCommand(
 	const memoryManager = options.memoryManager ?? new SemanticMemoryManager();
 	const summarizerService =
 		options.summarizerService ?? new SummarizerService();
+	let lastProposals: MemoryProposal[] = [];
 
 	return {
 		name: 'memory',
@@ -66,6 +71,7 @@ export function createMemoryCommand(
 					const proposals =
 						summarizerService.proposeMemoriesFromMessages(messages);
 					if (proposals.length === 0) {
+						lastProposals = [];
 						return infoMsg(
 							'No durable memory proposals found.',
 							'memory-propose',
@@ -79,6 +85,7 @@ export function createMemoryCommand(
 						if (aWarns > 0 && bWarns === 0) return 1;
 						return 0;
 					});
+					lastProposals = proposals;
 
 					const lines: string[] = [];
 					for (let i = 0; i < proposals.length; i++) {
@@ -111,10 +118,38 @@ export function createMemoryCommand(
 					}
 
 					lines.push(
-						'─────────────────────────────────\nRun /remember <content> to save any of the above.',
+						`─────────────────────────────────\nRun /memory accept <1-${proposals.length}> to save one of the above.`,
 					);
 
 					return infoMsg(lines.join('\n'), 'memory-propose');
+				}
+
+				if (subcommand === 'accept') {
+					if (lastProposals.length === 0) {
+						return errorMsg(
+							'No proposals to accept. Run /memory propose first.',
+							'memory-error',
+						);
+					}
+
+					const index = Number.parseInt(args[1] ?? '', 10);
+					const proposal = Number.isInteger(index)
+						? lastProposals[index - 1]
+						: undefined;
+					if (!proposal) {
+						return errorMsg(
+							`Usage: /memory accept <1-${lastProposals.length}>`,
+							'memory-error',
+						);
+					}
+
+					const memory = await summarizerService.acceptProposal(proposal);
+					lastProposals = lastProposals.filter((_, i) => i !== index - 1);
+
+					return successMsg(
+						`Saved ${memory.category} memory: ${memory.content}`,
+						'memory-accept',
+					);
 				}
 
 				return errorMsg(USAGE, 'memory-error');

--- a/source/memory/project-context.spec.ts
+++ b/source/memory/project-context.spec.ts
@@ -24,7 +24,7 @@ test('formatProjectContext formats memories as project context', t => {
 			memory('Auth uses Clerk.'),
 			memory('Avoid middleware.\nUse adapters.'),
 		]),
-		'## Project Context\n\n- Auth uses Clerk.\n- Avoid middleware. Use adapters.',
+		'## Project Context\n\n```\n- Auth uses Clerk.\n- Avoid middleware. Use adapters.\n```',
 	);
 });
 
@@ -37,9 +37,9 @@ test('formatProjectContext respects token budget', t => {
 					'This second memory is intentionally long enough to exceed the tiny test budget.',
 				),
 			],
-			{tokenBudget: 12},
+			{tokenBudget: 14},
 		),
-		'## Project Context\n\n- Use existing hooks.',
+		'## Project Context\n\n```\n- Use existing hooks.\n```',
 	);
 });
 
@@ -47,7 +47,7 @@ test('formatProjectContext returns empty string when budget is too small', t => 
 	t.is(formatProjectContext([memory('Use existing hooks.')], {tokenBudget: 1}), '');
 });
 
-test('formatProjectContext skips oversized memories within budget', t => {
+test('formatProjectContext stops at the first memory that would exceed the remaining budget, in relevance order', t => {
 	t.is(
 		formatProjectContext(
 			[
@@ -58,7 +58,7 @@ test('formatProjectContext skips oversized memories within budget', t => {
 			],
 			{tokenBudget: 10},
 		),
-		'## Project Context\n\n- Use adapters.',
+		'',
 	);
 });
 
@@ -69,7 +69,7 @@ test('appendProjectContext returns original prompt without memories', t => {
 test('appendProjectContext appends formatted memories', t => {
 	t.is(
 		appendProjectContext('base prompt', [memory('Use existing provider.')]),
-		'base prompt\n\n## Project Context\n\n- Use existing provider.',
+		'base prompt\n\n## Project Context\n\n```\n- Use existing provider.\n```',
 	);
 });
 
@@ -82,7 +82,7 @@ test('appendRelevantProjectContext appends relevant memories', async t => {
 		},
 	});
 
-	t.is(prompt, 'base prompt\n\n## Project Context\n\n- Auth uses Clerk.');
+	t.is(prompt, 'base prompt\n\n## Project Context\n\n```\n- Auth uses Clerk.\n```');
 });
 
 test('appendRelevantProjectContextWithCount reports injected memory count', async t => {

--- a/source/memory/project-context.ts
+++ b/source/memory/project-context.ts
@@ -36,12 +36,13 @@ function formatProjectContextWithCount(
 
 	const tokenBudget = options.tokenBudget ?? DEFAULT_TOKEN_BUDGET;
 	const bullets: string[] = [];
-	let usedTokens = estimateTokens('## Project Context\n\n');
+	let usedTokens =
+		estimateTokens('## Project Context\n\n') + estimateTokens('```\n\n```');
 
 	for (const memory of memories) {
 		const bullet = `- ${memory.content.replaceAll(/\s+/gu, ' ').trim()}`;
 		const bulletTokens = estimateTokens(`${bullet}\n`);
-		if (usedTokens + bulletTokens > tokenBudget) continue;
+		if (usedTokens + bulletTokens > tokenBudget) break;
 
 		bullets.push(bullet);
 		usedTokens += bulletTokens;
@@ -50,7 +51,7 @@ function formatProjectContextWithCount(
 	if (bullets.length === 0) return {content: '', memoryCount: 0};
 
 	return {
-		content: `## Project Context\n\n${bullets.join('\n')}`,
+		content: `## Project Context\n\n\`\`\`\n${bullets.join('\n')}\n\`\`\``,
 		memoryCount: bullets.length,
 	};
 }

--- a/source/memory/semantic-memory-manager.spec.ts
+++ b/source/memory/semantic-memory-manager.spec.ts
@@ -113,6 +113,47 @@ test('SemanticMemoryManager includes category matches in relevance ranking', asy
 	]);
 });
 
+test('SemanticMemoryManager filters out stopword-only matches on an unrelated query', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+
+	await manager.addMemory({
+		content: 'The auth module uses Clerk and we avoid middleware in the edge runtime.',
+	});
+	await manager.addMemory({
+		content:
+			'The flaky test in the payments suite is a known failure and we should fix it later.',
+	});
+	const style = await manager.addMemory({
+		content: 'Use tabs not spaces in the settings form styling.',
+	});
+
+	const results = await manager.findRelevantMemories(
+		'can you add a new field to the user profile page in the settings form',
+		5,
+	);
+
+	t.deepEqual(results, [style]);
+});
+
+test('SemanticMemoryManager serializes concurrent writes so none are lost', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+
+	await Promise.all(
+		Array.from({length: 10}, (_, i) =>
+			manager.addMemory({content: `Memory number ${i}.`}),
+		),
+	);
+
+	const memories = await manager.listMemories();
+	t.is(memories.length, 10);
+});
+
 test('SemanticMemoryManager rejects empty memory content', async t => {
 	const dir = await createTempDir();
 	const cwd = path.join(dir, 'repo');

--- a/source/memory/semantic-memory-manager.ts
+++ b/source/memory/semantic-memory-manager.ts
@@ -61,12 +61,135 @@ function hashScope(scope: string): string {
 	return crypto.createHash('sha256').update(scope).digest('hex').slice(0, 32);
 }
 
+const STOPWORDS = new Set([
+	'a',
+	'about',
+	'after',
+	'again',
+	'all',
+	'am',
+	'an',
+	'and',
+	'any',
+	'are',
+	'as',
+	'at',
+	'be',
+	'been',
+	'being',
+	'but',
+	'by',
+	'can',
+	'could',
+	'did',
+	'do',
+	'does',
+	'doing',
+	'down',
+	'during',
+	'each',
+	'few',
+	'for',
+	'from',
+	'further',
+	'had',
+	'has',
+	'have',
+	'having',
+	'he',
+	'her',
+	'here',
+	'hers',
+	'herself',
+	'him',
+	'himself',
+	'his',
+	'how',
+	'if',
+	'in',
+	'into',
+	'is',
+	'it',
+	'its',
+	'itself',
+	'just',
+	'me',
+	'more',
+	'most',
+	'my',
+	'myself',
+	'no',
+	'nor',
+	'not',
+	'now',
+	'of',
+	'off',
+	'on',
+	'once',
+	'only',
+	'or',
+	'other',
+	'our',
+	'ours',
+	'ourselves',
+	'out',
+	'over',
+	'own',
+	'same',
+	'she',
+	'should',
+	'so',
+	'some',
+	'such',
+	'than',
+	'that',
+	'the',
+	'their',
+	'theirs',
+	'them',
+	'themselves',
+	'then',
+	'there',
+	'these',
+	'they',
+	'this',
+	'those',
+	'through',
+	'to',
+	'too',
+	'under',
+	'until',
+	'up',
+	'very',
+	'was',
+	'we',
+	'were',
+	'what',
+	'when',
+	'where',
+	'which',
+	'while',
+	'who',
+	'whom',
+	'why',
+	'will',
+	'with',
+	'would',
+	'you',
+	'your',
+	'yours',
+	'yourself',
+	'yourselves',
+]);
+
+const MIN_RELEVANCE_RATIO = 0.1;
+
 function tokenize(value: string): Set<string> {
 	return new Set(
 		value
 			.toLowerCase()
 			.split(/[^a-z0-9]+/u)
-			.filter(part => part.length > 1),
+			.filter(part => part.length > 1 && !STOPWORDS.has(part)),
 	);
 }
 
@@ -74,10 +197,20 @@ export class SemanticMemoryManager {
 	private readonly memoryDir: string;
 	private readonly cwd: string;
 	private memoryFilePath?: string;
+	private writeQueue: Promise<unknown> = Promise.resolve();
 
 	constructor(options: SemanticMemoryManagerOptions = {}) {
 		this.memoryDir = options.memoryDir ?? path.join(getAppDataPath(), 'memory');
 		this.cwd = options.cwd ?? process.cwd();
+	}
+
+	private mutate<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.writeQueue.then(operation, operation);
+		this.writeQueue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
 	}
 
 	async addMemory(input: CreateMemoryInput): Promise<SemanticMemory> {
@@ -97,10 +230,12 @@ export class SemanticMemoryManager {
 				: {}),
 		};
 
-		const memories = await this.listMemories();
-		memories.push(memory);
-		await this.writeMemories(memories);
-		return memory;
+		return this.mutate(async () => {
+			const memories = await this.listMemories();
+			memories.push(memory);
+			await this.writeMemories(memories);
+			return memory;
+		});
 	}
 
 	async listMemories(): Promise<SemanticMemory[]> {
@@ -123,18 +258,20 @@ export class SemanticMemoryManager {
 	}
 
 	async deleteMemory(id: string): Promise<boolean> {
-		const memories = await this.listMemories();
-		const filtered = memories.filter(memory => memory.id !== id);
-		if (filtered.length === memories.length) {
-			return false;
-		}
+		return this.mutate(async () => {
+			const memories = await this.listMemories();
+			const filtered = memories.filter(memory => memory.id !== id);
+			if (filtered.length === memories.length) {
+				return false;
+			}
 
-		await this.writeMemories(filtered);
-		return true;
+			await this.writeMemories(filtered);
+			return true;
+		});
 	}
 
 	async clearMemories(): Promise<void> {
-		await this.writeMemories([]);
+		await this.mutate(() => this.writeMemories([]));
 	}
 
 	async findRelevantMemories(
@@ -153,9 +290,15 @@ export class SemanticMemoryManager {
 					if (memoryTerms.has(term)) score++;
 					if (categoryTerms.has(term)) score++;
 				}
-				return {memory, score};
+				const vocabularySize = memoryTerms.size + categoryTerms.size;
+				const relevanceRatio =
+					vocabularySize === 0 ? 0 : score / vocabularySize;
+				return {memory, score, relevanceRatio};
 			})
-			.filter(result => result.score > 0)
+			.filter(
+				result =>
+					result.score > 0 && result.relevanceRatio >= MIN_RELEVANCE_RATIO,
+			)
 			.sort((a, b) => {
 				if (a.score !== b.score) return b.score - a.score;
 				return b.memory.timestamp.localeCompare(a.memory.timestamp);

--- a/source/memory/summarizer-service.spec.ts
+++ b/source/memory/summarizer-service.spec.ts
@@ -19,7 +19,7 @@ test('SummarizerService stores a manual memory', async t => {
 	const cwd = path.join(dir, 'repo');
 	await fs.mkdir(cwd);
 	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
-	const service = new SummarizerService(manager);
+	const service = new SummarizerService(manager, () => true);
 
 	const memory = await service.remember({
 		content: '  Use the existing provider abstraction for model changes.  ',
@@ -38,6 +38,7 @@ test('SummarizerService rejects empty manual memory content', async t => {
 	await fs.mkdir(cwd);
 	const service = new SummarizerService(
 		new SemanticMemoryManager({memoryDir: dir, cwd}),
+		() => true,
 	);
 
 	await t.throwsAsync(service.remember({content: '   '}), {
@@ -51,6 +52,7 @@ test('SummarizerService uses explicit camelCase category', async t => {
 	await fs.mkdir(cwd);
 	const service = new SummarizerService(
 		new SemanticMemoryManager({memoryDir: dir, cwd}),
+		() => true,
 	);
 
 	const memory = await service.remember({
@@ -200,6 +202,32 @@ test('SummarizerService detects assistant position reversal', t => {
 	);
 });
 
+test('SummarizerService clears the reversal warning once the user later explicitly restates the same line', t => {
+	const service = new SummarizerService();
+
+	const proposals = service.proposeMemoriesFromMessages([
+		{
+			role: 'user',
+			content: 'Actually, generic exceptions look cleaner, do not you think.',
+		},
+		{
+			role: 'assistant',
+			content: "You're right. I will use generic exceptions formatting.",
+		},
+		{
+			role: 'user',
+			content: "You're right. I will use generic exceptions formatting.",
+		},
+	]);
+
+	const restated = proposals.find(
+		p => p.content === "You're right. I will use generic exceptions formatting.",
+	);
+	t.truthy(restated);
+	t.is(restated?.sourceType, 'explicit-user');
+	t.deepEqual(restated?.warnings, []);
+});
+
 test('SummarizerService guards false positive on reversal when user provides path/code/error', t => {
 	const service = new SummarizerService();
 
@@ -241,6 +269,59 @@ test('SummarizerService guards false positive on reversal when user provides pat
 	);
 });
 
+test('SummarizerService drops uncategorized assistant chatter but keeps uncategorized user statements', t => {
+	const service = new SummarizerService();
+
+	t.deepEqual(
+		service.proposeMemoriesFromMessages([
+			{
+				role: 'assistant',
+				content: 'The project name shows up in the welcome banner.',
+			},
+			{
+				role: 'user',
+				content: 'The project name is Nanocoder, not nano-coder.',
+			},
+		]),
+		[
+			{
+				content: 'The project name is Nanocoder, not nano-coder.',
+				category: 'project',
+				sourceType: 'explicit-user',
+				evidence: {
+					userMessages: ['The project name is Nanocoder, not nano-coder.'],
+					assistantMessages: [],
+				},
+				warnings: [],
+			},
+		],
+	);
+});
+
+test('SummarizerService caps candidates per message and truncates evidence snippets', t => {
+	const service = new SummarizerService();
+	const longSuffix = 'x'.repeat(200);
+	const longMessage = [
+		`Fix the provider retry storage schema bug one. ${longSuffix}`,
+		'Fix the provider retry storage schema bug two.',
+		'Fix the provider retry storage schema bug three.',
+		'Fix the provider retry storage schema bug four.',
+		'Fix the provider retry storage schema bug five.',
+	].join('\n');
+
+	const proposals = service.proposeMemoriesFromMessages([
+		{role: 'assistant', content: longMessage},
+	]);
+
+	t.is(proposals.length, 3);
+	for (const proposal of proposals) {
+		for (const evidence of proposal.evidence.assistantMessages) {
+			t.true(evidence.length <= 161);
+		}
+	}
+	t.true(proposals[0]!.evidence.assistantMessages[0]!.endsWith('…'));
+});
+
 test('SummarizerService proposals do not save memories automatically', async t => {
 	const dir = await createTempDir();
 	const cwd = path.join(dir, 'repo');
@@ -268,4 +349,40 @@ test('SummarizerService proposals do not save memories automatically', async t =
 		},
 	]);
 	t.deepEqual(await manager.listMemories(), []);
+});
+
+test('SummarizerService blocks writes when semantic memory is disabled', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+	const service = new SummarizerService(manager, () => false);
+
+	await t.throwsAsync(service.remember({content: 'Use tabs not spaces.'}), {
+		message: 'Semantic memory is turned off. Enable it in /settings to save memories.',
+	});
+	await t.throwsAsync(
+		service.acceptProposal({content: 'Use tabs not spaces.', category: 'codingStyle'}),
+		{
+			message: 'Semantic memory is turned off. Enable it in /settings to save memories.',
+		},
+	);
+	t.deepEqual(await manager.listMemories(), []);
+});
+
+test('SummarizerService acceptProposal saves a proposal without re-deriving its category', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({memoryDir: dir, cwd});
+	const service = new SummarizerService(manager, () => true);
+
+	const memory = await service.acceptProposal(
+		{content: 'Fixed the queued input regression by restoring drafts.', category: 'bugFix'},
+		'session-1',
+	);
+
+	t.is(memory.category, 'bugFix');
+	t.is(memory.sourceSessionId, 'session-1');
+	t.deepEqual(await manager.listMemories(), [memory]);
 });

--- a/source/memory/summarizer-service.ts
+++ b/source/memory/summarizer-service.ts
@@ -1,3 +1,4 @@
+import {getSemanticMemoryEnabled} from '@/config/preferences';
 import type {Message} from '@/types/core';
 import {
 	type SemanticMemory,
@@ -10,10 +11,7 @@ export interface RememberMemoryInput {
 	sourceSessionId?: string;
 }
 
-export type MemorySourceType =
-	| 'explicit-remember'
-	| 'explicit-user'
-	| 'conversation-inferred';
+export type MemorySourceType = 'explicit-user' | 'conversation-inferred';
 
 export interface MemoryProposal {
 	content: string;
@@ -24,6 +22,15 @@ export interface MemoryProposal {
 		assistantMessages: string[];
 	};
 	warnings: string[];
+}
+
+const MAX_CANDIDATES_PER_MESSAGE = 3;
+const MAX_EVIDENCE_LENGTH = 160;
+
+function truncateEvidence(content: string): string {
+	const collapsed = content.replaceAll(/\s+/gu, ' ').trim();
+	if (collapsed.length <= MAX_EVIDENCE_LENGTH) return collapsed;
+	return `${collapsed.slice(0, MAX_EVIDENCE_LENGTH)}…`;
 }
 
 const CATEGORY_RULES: Array<{category: string; pattern: RegExp}> = [
@@ -52,9 +59,14 @@ const CATEGORY_RULES: Array<{category: string; pattern: RegExp}> = [
 ];
 
 export class SummarizerService {
-	constructor(private readonly memoryManager = new SemanticMemoryManager()) {}
+	constructor(
+		private readonly memoryManager = new SemanticMemoryManager(),
+		private readonly isMemoryEnabled: () => boolean = getSemanticMemoryEnabled,
+	) {}
 
 	async remember(input: RememberMemoryInput): Promise<SemanticMemory> {
+		this.assertMemoryWritesEnabled();
+
 		const content = input.content.trim();
 		if (!content) {
 			throw new Error('Memory content cannot be empty');
@@ -67,6 +79,27 @@ export class SummarizerService {
 				: inferMemoryCategory(content),
 			sourceSessionId: input.sourceSessionId,
 		});
+	}
+
+	async acceptProposal(
+		proposal: Pick<MemoryProposal, 'content' | 'category'>,
+		sourceSessionId?: string,
+	): Promise<SemanticMemory> {
+		this.assertMemoryWritesEnabled();
+
+		return this.memoryManager.addMemory({
+			content: proposal.content,
+			category: proposal.category,
+			sourceSessionId,
+		});
+	}
+
+	private assertMemoryWritesEnabled(): void {
+		if (!this.isMemoryEnabled()) {
+			throw new Error(
+				'Semantic memory is turned off. Enable it in /settings to save memories.',
+			);
+		}
 	}
 
 	proposeMemoriesFromMessages(messages: Message[]): MemoryProposal[] {
@@ -87,9 +120,14 @@ export class SummarizerService {
 			if (!message || (message.role !== 'user' && message.role !== 'assistant'))
 				continue;
 
-			for (const candidate of splitMemoryCandidates(message.content)) {
+			const candidates = splitMemoryCandidates(message.content).slice(
+				0,
+				MAX_CANDIDATES_PER_MESSAGE,
+			);
+
+			for (const candidate of candidates) {
 				const category = inferMemoryCategory(candidate);
-				if (category === 'project') continue;
+				if (category === 'project' && message.role === 'assistant') continue;
 
 				const key = candidate.toLowerCase();
 				if (!proposals.has(key)) {
@@ -104,11 +142,15 @@ export class SummarizerService {
 				}
 
 				const entry = proposals.get(key)!;
+				const snippet = truncateEvidence(message.content);
 				if (message.role === 'user') {
-					entry.userTurns.push(message.content);
+					entry.userTurns.push(snippet);
 					entry.sourceRole = 'user';
+					entry.warnings = entry.warnings.filter(
+						warning => warning !== 'Possible assistant position reversal.',
+					);
 				} else {
-					entry.assistantTurns.push(message.content);
+					entry.assistantTurns.push(snippet);
 				}
 
 				if (message.role === 'assistant' && entry.sourceRole !== 'user') {
@@ -222,5 +264,7 @@ function splitMemoryCandidates(content: string): string[] {
 	return content
 		.split(/\n+/u)
 		.map(part => part.trim())
-		.filter(part => part.length >= 12 && part.length <= 300);
+		.filter(
+			part => part.length >= 12 && part.length <= 300 && !part.endsWith('?'),
+		);
 }

--- a/source/plain/shell.spec.ts
+++ b/source/plain/shell.spec.ts
@@ -479,6 +479,86 @@ test.serial(
 );
 
 test.serial(
+	"text mode recalls relevant project memories and surfaces the count on stderr",
+	async (t) => {
+		const shutdown: CapturedShutdown = { code: null };
+		const stdout = capturingStdout();
+		const stderr = capturingStderr();
+		const calls: Array<{ systemPrompt: string; query: string }> = [];
+		try {
+			await runPlainShell({
+				prompt: "refactor the auth module",
+				developmentMode: "auto-accept",
+				trustDirectory: true,
+				outputFormat: "text",
+				deps: baseDeps({
+					initializePlain: makeFakeInitializePlain(),
+					runPlainConversation: makeFakeRunPlainConversation({
+						kind: "success",
+						finalText: "all done",
+						reasoning: null,
+						toolCalls: [],
+					}),
+					getShutdownManager: makeFakeShutdownManager(shutdown),
+					appendRelevantProjectContextWithCount: async (systemPrompt, query) => {
+						calls.push({ systemPrompt, query });
+						return {
+							systemPrompt: `${systemPrompt}\n\n## Project Context\n\n- Auth uses Clerk.`,
+							memoryCount: 2,
+						};
+					},
+				}),
+			});
+		} finally {
+			stdout.restore();
+			stderr.restore();
+		}
+
+		t.is(calls.length, 1);
+		t.is(calls[0]?.query, "refactor the auth module");
+		t.regex(stderr.get(), /Recalling 2 project memories\.\.\./);
+		t.is(shutdown.code, 0);
+	},
+);
+
+test.serial(
+	"text mode stays silent when no relevant memories are recalled",
+	async (t) => {
+		const shutdown: CapturedShutdown = { code: null };
+		const stdout = capturingStdout();
+		const stderr = capturingStderr();
+		try {
+			await runPlainShell({
+				prompt: "do the thing",
+				developmentMode: "auto-accept",
+				trustDirectory: true,
+				outputFormat: "text",
+				deps: baseDeps({
+					initializePlain: makeFakeInitializePlain(),
+					runPlainConversation: makeFakeRunPlainConversation({
+						kind: "success",
+						finalText: "all done",
+						reasoning: null,
+						toolCalls: [],
+					}),
+					getShutdownManager: makeFakeShutdownManager(shutdown),
+					appendRelevantProjectContextWithCount: async (systemPrompt) => ({
+						systemPrompt,
+						memoryCount: 0,
+					}),
+				}),
+			});
+		} finally {
+			stdout.restore();
+			stderr.restore();
+		}
+
+		t.false(stderr.get().includes("Recalling"));
+		t.is(shutdown.code, 0);
+	},
+);
+
+test.serial(
 	"text error outcome writes the error message to stderr with exit code 1",
 	async (t) => {
 		const shutdown: CapturedShutdown = { code: null };

--- a/source/plain/shell.ts
+++ b/source/plain/shell.ts
@@ -3,6 +3,8 @@ import {appendToolDefinitionsToPrompt} from '@/ai-sdk-client/tools/system-prompt
 import {getAppConfig} from '@/config/index';
 import {loadPreferences, savePreferences} from '@/config/preferences';
 import {resolveTune} from '@/config/tune';
+import {appendRelevantProjectContextWithCount} from '@/memory/project-context';
+import {SemanticMemoryManager} from '@/memory/semantic-memory-manager';
 import {runPlainConversation} from '@/plain/conversation';
 import {initializePlain} from '@/plain/initialize';
 import {
@@ -42,6 +44,7 @@ export interface RunPlainShellDeps {
 	getShutdownManager: typeof getShutdownManager;
 	loadPreferences: typeof loadPreferences;
 	savePreferences: typeof savePreferences;
+	appendRelevantProjectContextWithCount: typeof appendRelevantProjectContextWithCount;
 }
 
 const defaultDeps: RunPlainShellDeps = {
@@ -50,6 +53,7 @@ const defaultDeps: RunPlainShellDeps = {
 	getShutdownManager,
 	loadPreferences,
 	savePreferences,
+	appendRelevantProjectContextWithCount,
 };
 
 /**
@@ -152,12 +156,28 @@ export async function runPlainShell(
 	const toolsForPrompt = toolsDisabled
 		? toolManager.getFilteredTools(availableNames)
 		: {};
-	const systemContent = appendToolDefinitionsToPrompt(
+	const toolPrompt = appendToolDefinitionsToPrompt(
 		basePrompt,
 		toolsDisabled,
 		fallbackToolFormat,
 		toolsForPrompt,
 	);
+
+	const projectContext = await deps.appendRelevantProjectContextWithCount(
+		toolPrompt,
+		prompt,
+		new SemanticMemoryManager(),
+		{
+			semanticMemoryEnabled:
+				deps.loadPreferences().semanticMemoryEnabled ?? true,
+		},
+	);
+	const systemContent = projectContext.systemPrompt;
+	if (projectContext.memoryCount > 0) {
+		writeStatus(
+			`Recalling ${projectContext.memoryCount} project memor${projectContext.memoryCount === 1 ? 'y' : 'ies'}...`,
+		);
+	}
 	setLastBuiltPrompt(systemContent);
 
 	const systemMessage: Message = {role: 'system', content: systemContent};


### PR DESCRIPTION
## Description


- Retrieval: added a stopword list and a minimum relevance-ratio threshold to `findRelevantMemories` so incidental word overlap (e.g. "the", "in") no longer scores as relevant
- `/memory propose`: capped candidates per message and truncated evidence to snippets instead of full messages; explicit user statements can now be proposed even without matching one of the five keyword categories, while uncategorized assistant chatter is still filtered out
- Added `/memory accept <n>` to save a proposal directly instead of retyping it into `/remember`
- Wired project-memory recall into `--plain` and `--acp`, matching what the TUI already did (previously memories saved on those surfaces were never recalled)
- The `semanticMemoryEnabled` setting now gates writes (`/remember`, `/memory accept`), not just recall
- Added `docs/features/semantic-memory.md` and `/remember`/`/memory` entries in `commands.md`
- Non-blocking cleanups: fixed a read-modify-write race in `SemanticMemoryManager`, fixed the token-budget loop silently reordering memories by size, fenced the injected memory content in the system prompt, removed a dead `MemorySourceType` value, fixed an order-dependent warning on accepted proposals

Closes #619 

## Type of Change

- [x] Bug fix

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))