### PR TITLE
fix: bound diff_edit result context

### DIFF
--- a/.changeset/calm-diffs-shrink.md
+++ b/.changeset/calm-diffs-shrink.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+Fixed `diff_edit` returning the entire modified file by limiting results to changed-region previews. Thanks to @RealBhupesh. Closes #795.

--- a/source/tools/file-ops/diff-edit.spec.tsx
+++ b/source/tools/file-ops/diff-edit.spec.tsx
@@ -170,17 +170,96 @@ test('diff_edit rejects duplicate search blocks and leaves file unchanged', asyn
 	t.is(await readFile(filePath, 'utf-8'), 'alpha\n');
 });
 
-test('diff_edit returns updated file contents for the model', async t => {
-	const filePath = await createTestFile('test.ts', 'alpha\n');
+test('diff_edit returns bounded context around the changed region', async t => {
+	const filePath = await createTestFile(
+		'large-context.txt',
+		Array.from({length: 100}, (_, index) => `line ${index + 1}`).join('\n'),
+	);
 
 	const result = await executeDiffEdit({
 		path: filePath,
-		diff: diffBlock('alpha', 'beta'),
+		diff: diffBlock('line 50', 'changed line 50'),
 	});
 
 	t.regex(result, /Successfully applied 1 diff block/);
-	t.regex(result, /Updated file contents:/);
-	t.regex(result, /1: beta/);
+	t.regex(result, /Updated file context \(lines 47-53 of 100\)/);
+	t.true(result.includes('[... lines 1-46 omitted ...]'));
+	t.true(result.includes('  47: line 47'));
+	t.true(result.includes('  50: changed line 50'));
+	t.true(result.includes('  53: line 53'));
+	t.true(result.includes('[... lines 54-100 omitted ...]'));
+	t.false(result.includes('  46: line 46'));
+	t.false(result.includes('  54: line 54'));
+});
+
+test('diff_edit caps previews for unusually large changed lines', async t => {
+	const filePath = await createTestFile('long-line.txt', 'before\ntarget\nafter');
+	const replacement = `replacement-start-${'x'.repeat(8000)}-replacement-end`;
+
+	const result = await executeDiffEdit({
+		path: filePath,
+		diff: diffBlock('target', replacement),
+	});
+
+	t.true(result.length <= 4000);
+	t.true(result.includes('replacement-start-'));
+	t.true(result.includes('-replacement-end'));
+	t.regex(result, /preview truncated/i);
+});
+
+test('diff_edit includes each separated changed region without middle-file noise', async t => {
+	const filePath = await createTestFile(
+		'multiple-regions.txt',
+		Array.from(
+			{length: 100},
+			(_, index) => `line ${String(index + 1).padStart(3, '0')}`,
+		).join('\n'),
+	);
+
+	const result = await executeDiffEdit({
+		path: filePath,
+		diff: [
+			diffBlock('line 090', 'changed line 090'),
+			diffBlock('line 010', 'changed line 010'),
+		].join('\n\n'),
+	});
+
+	t.regex(result, /Updated file context \(lines 7-13 of 100\)/);
+	t.regex(result, /Updated file context \(lines 87-93 of 100\)/);
+	t.true(result.includes('Changed regions: lines 10, 90.'));
+	t.true(result.includes('[... lines 1-6 omitted ...]'));
+	t.true(result.includes('[... lines 14-86 omitted ...]'));
+	t.true(result.includes('[... lines 94-100 omitted ...]'));
+	t.false(result.includes('[... lines 14-100 omitted ...]'));
+	t.false(result.includes('[... lines 1-86 omitted ...]'));
+	t.true(result.includes('  10: changed line 010'));
+	t.true(result.includes('  90: changed line 090'));
+	t.false(result.includes('  50: line 050'));
+});
+
+test('diff_edit keeps a summary of every changed region when the preview is capped', async t => {
+	const filePath = await createTestFile(
+		'capped-multiple-regions.txt',
+		Array.from(
+			{length: 100},
+			(_, index) => `line ${String(index + 1).padStart(3, '0')}`,
+		).join('\n'),
+	);
+	const largeReplacement = (lineNumber: number) =>
+		`changed line ${lineNumber}-${'x'.repeat(3000)}`;
+
+	const result = await executeDiffEdit({
+		path: filePath,
+		diff: [
+			diffBlock('line 010', largeReplacement(10)),
+			diffBlock('line 050', largeReplacement(50)),
+			diffBlock('line 090', largeReplacement(90)),
+		].join('\n\n'),
+	});
+
+	t.true(result.length <= 4000);
+	t.true(result.includes('Changed regions: lines 10, 50, 90.'));
+	t.regex(result, /preview truncated/i);
 });
 
 test('diff_edit rejects missing search content and leaves file unchanged', async t => {

--- a/source/tools/file-ops/diff-edit.tsx
+++ b/source/tools/file-ops/diff-edit.tsx
@@ -32,6 +32,19 @@ export interface DiffEditBlock {
 const SEARCH_MARKER = '<<<<<<< SEARCH';
 const SEPARATOR_MARKER = '=======';
 const REPLACE_MARKER = '>>>>>>> REPLACE';
+const DIFF_EDIT_CONTEXT_LINES = 3;
+const MAX_DIFF_EDIT_RESULT_CHARS = 4000;
+
+function capDiffEditResult(content: string): string {
+	if (content.length <= MAX_DIFF_EDIT_RESULT_CHARS) return content;
+
+	const marker = `\n... [Preview truncated: ${content.length} characters; use read_file with a narrow range to inspect omitted content] ...\n`;
+	const remainingLength = MAX_DIFF_EDIT_RESULT_CHARS - marker.length;
+	const headLength = Math.floor(remainingLength / 2);
+	const tailLength = remainingLength - headLength;
+
+	return `${content.slice(0, headLength)}${marker}${content.slice(-tailLength)}`;
+}
 
 function stripSingleBoundaryNewline(value: string): string {
 	if (value.startsWith('\r\n')) return value.slice(2);
@@ -155,17 +168,83 @@ function applyBlocks(fileContent: string, blocks: DiffEditBlock[]): string {
 	return newContent;
 }
 
-function formatUpdatedFileContext(content: string): string {
-	const lines = content.split('\n');
-	let fileContext = '\n\nUpdated file contents:\n';
+function formatUpdatedFileContext(
+	originalContent: string,
+	updatedContent: string,
+	blocks: DiffEditBlock[],
+): string {
+	const lines = updatedContent.split('\n');
+	let cumulativeOffset = 0;
+	const changedRanges = blocks
+		.map(block => ({
+			block,
+			originalIndex: originalContent.indexOf(block.search),
+		}))
+		.sort((a, b) => a.originalIndex - b.originalIndex)
+		.map(({block, originalIndex}) => {
+			const updatedIndex = originalIndex + cumulativeOffset;
+			const changedStart = updatedContent
+				.slice(0, updatedIndex)
+				.split('\n').length;
+			const replacementLineCount = Math.max(
+				1,
+				block.replace.split('\n').length,
+			);
+			const changedEnd = Math.min(
+				lines.length,
+				changedStart + replacementLineCount - 1,
+			);
 
-	for (let i = 0; i < lines.length; i++) {
-		const lineNumStr = String(i + 1).padStart(4, ' ');
-		const line = lines[i] || '';
-		fileContext += `${lineNumStr}: ${line}\n`;
-	}
+			cumulativeOffset += block.replace.length - block.search.length;
+			return {
+				changedStart,
+				changedEnd,
+				start: Math.max(1, changedStart - DIFF_EDIT_CONTEXT_LINES),
+				end: Math.min(lines.length, changedEnd + DIFF_EDIT_CONTEXT_LINES),
+			};
+		});
+	const changedRegionSummary = changedRanges
+		.map(({changedStart, changedEnd}) =>
+			changedStart === changedEnd
+				? String(changedStart)
+				: `${changedStart}-${changedEnd}`,
+		)
+		.join(', ');
 
-	return fileContext;
+	const contextWindows = changedRanges.reduce<
+		Array<{start: number; end: number}>
+	>((windows, range) => {
+		const previous = windows.at(-1);
+		if (previous && range.start <= previous.end + 1) {
+			previous.end = Math.max(previous.end, range.end);
+		} else {
+			windows.push({...range});
+		}
+		return windows;
+	}, []);
+
+	return (
+		`\n\nChanged regions: lines ${changedRegionSummary}.` +
+		contextWindows
+			.map(({start, end}, index) => {
+				let context = `\n\nUpdated file context (lines ${start}-${end} of ${lines.length}):\n`;
+				const previousEnd = contextWindows[index - 1]?.end ?? 0;
+				if (start > previousEnd + 1) {
+					context += `[... lines ${previousEnd + 1}-${start - 1} omitted ...]\n`;
+				}
+
+				for (let lineNumber = start; lineNumber <= end; lineNumber++) {
+					const lineNumStr = String(lineNumber).padStart(4, ' ');
+					context += `${lineNumStr}: ${lines[lineNumber - 1] || ''}\n`;
+				}
+
+				if (index === contextWindows.length - 1 && end < lines.length) {
+					context += `[... lines ${end + 1}-${lines.length} omitted ...]\n`;
+				}
+				return context;
+			})
+			.join('')
+	);
 }
 
 const executeDiffEdit = async (args: DiffEditArgs): Promise<string> => {
@@ -183,12 +262,14 @@ const executeDiffEdit = async (args: DiffEditArgs): Promise<string> => {
 	markFileSeen(absPath);
 
 	const blockLabel = blocks.length === 1 ? 'block' : 'blocks';
-	return `Successfully applied ${blocks.length} diff ${blockLabel}.${formatUpdatedFileContext(newContent)}`;
+	return capDiffEditResult(
+		`Successfully applied ${blocks.length} diff ${blockLabel}.${formatUpdatedFileContext(fileContent, newContent, blocks)}`,
+	);
 };
 
 const diffEditCoreTool = tool({
 	description:
-		'Apply one or more SEARCH/REPLACE edit blocks to a file. Use this for weak local models when exact string_replace arguments are hard to produce. Every SEARCH block must match the file exactly once. Format: <<<<<<< SEARCH, old content, =======, new content, >>>>>>> REPLACE. Do not wrap the diff in a markdown code fence.',
+		'Apply one or more SEARCH/REPLACE edit blocks to a file. Use this for weak local models when exact string_replace arguments are hard to produce. Every SEARCH block must match the file exactly once. Format: <<<<<<< SEARCH, old content, =======, new content, >>>>>>> REPLACE. Do not wrap the diff in a markdown code fence. Successful edits return bounded context around changed regions instead of the entire file.',
 	inputSchema: jsonSchema<DiffEditArgs>({
 		type: 'object',
 		properties: {


### PR DESCRIPTION
## Summary

- replace `diff_edit`'s full-file response with three lines of context around each changed region
- merge nearby context windows and report accurate omitted-line ranges
- cap unusually large previews at 4,000 characters while retaining a summary of every changed region
- add regression coverage for large files, separated and out-of-order blocks, and oversized multi-block edits

## Why

`diff_edit` returned the entire modified file after a successful edit. On large files this duplicated content already present in the conversation, consumed unnecessary context, and increased latency. The tool now returns only the information needed to verify the edit and directs the model to `read_file` with a narrow range when more context is needed.

Closes #795

## Validation

- `pnpm exec ava source/tools/file-ops/diff-edit.spec.tsx` (19 tests passed)
- `pnpm run test:all` (6,258 tests passed, 1 skipped)
- Type checking, lint, formatting, Knip, and dependency audit passed as part of the full suite
- `pnpm exec changeset status`
- `git diff --check`

Note: Semgrep was not installed locally, so the repository's optional Semgrep step was skipped by its test script.
