### PR TITLE
fix: address web mode review feedback

### DIFF
--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -500,11 +500,13 @@ export default function App({
 		isGenerating: chatHandler.isGenerating,
 		submitMessage: appHandlers.handleMessageSubmit,
 		cancel: appHandlers.handleCancel,
+		resetSession: appHandlers.clearMessages,
 	});
 	webRuntimeStateRef.current = {
 		isGenerating: chatHandler.isGenerating,
 		submitMessage: appHandlers.handleMessageSubmit,
 		cancel: appHandlers.handleCancel,
+		resetSession: appHandlers.clearMessages,
 	};
 
 	React.useEffect(() => {
@@ -526,6 +528,15 @@ export default function App({
 				return webRuntimeStateRef.current.submitMessage(message);
 			},
 			cancel: () => webRuntimeStateRef.current.cancel(),
+			resetSession: () => {
+				if (webRuntimeStateRef.current.isGenerating) {
+					throw new Error(
+						'Cannot start a new chat while Nanocoder is processing a turn.',
+					);
+				}
+
+				return webRuntimeStateRef.current.resetSession();
+			},
 		});
 	}, [
 		webRuntimeBridge,

--- a/source/web/page.spec.ts
+++ b/source/web/page.spec.ts
@@ -1,10 +1,77 @@
 import test from 'ava';
-import {nanocoderLogoSvg, renderWebModePage} from './page.js';
+import {createPageNonce, nanocoderLogoSvg, renderWebModePage} from './page.js';
 
 test('web mode page renders the Nanocoder logo asset markup', t => {
 	t.true(nanocoderLogoSvg.includes('aria-label="Nanocoder"'));
 	t.true(nanocoderLogoSvg.includes('viewBox="0 0 64 64"'));
 	t.true(nanocoderLogoSvg.includes('#7dcfff'));
+});
+
+test('web mode page gives icon, thread, and send buttons a visible keyboard focus state', t => {
+	const page = renderWebModePage();
+
+	t.true(page.includes('.icon-button:hover,\n\t\t.icon-button:focus-visible {'));
+	t.true(page.includes('.thread-item:hover,\n\t\t.thread-item:focus-visible {'));
+	t.true(
+		page.includes(
+			'.send-button:not(:disabled):hover,\n\t\t.send-button:not(:disabled):focus-visible {',
+		),
+	);
+});
+
+test('web mode page styles the sidebar and message scrollbars instead of using the browser default', t => {
+	const page = renderWebModePage();
+
+	t.true(page.includes('.thread-list::-webkit-scrollbar {'));
+	t.true(page.includes('.messages::-webkit-scrollbar {'));
+	t.true(page.includes('scrollbar-width: thin;'));
+});
+
+test('web mode page tells the backend to reset the session when starting a new chat', t => {
+	const page = renderWebModePage();
+
+	t.true(
+		page.includes(
+			"sendClientEvent({type: 'reset_session', id: 'browser-reset-' + Date.now()});",
+		),
+	);
+	const newChatHandlerIndex = page.indexOf("newChatButton.addEventListener('click'");
+	const resetEventIndex = page.indexOf("type: 'reset_session'");
+	t.true(newChatHandlerIndex >= 0 && resetEventIndex > newChatHandlerIndex);
+});
+
+test('web mode page restores a rejected message into the composer instead of losing it', t => {
+	const page = renderWebModePage();
+
+	t.true(page.includes('const pendingMessageElement = message.id'));
+	t.true(page.includes("pendingMessageElement.querySelector('.message-content').textContent"));
+	t.true(page.includes("updateMessageMeta(pendingMessageElement, 'Not sent — ' + message.message)"));
+	t.true(page.includes('pendingMessages.delete(message.id)'));
+	t.true(page.includes('setPromptText(failedText)'));
+});
+
+test('web mode page reconnects the WebSocket with backoff instead of requiring a manual refresh', t => {
+	const page = renderWebModePage();
+
+	t.true(page.includes('function connectSocket() {'));
+	t.true(page.includes('function scheduleReconnect() {'));
+	t.true(page.includes('scheduleReconnect();'));
+	t.true(page.includes('reconnectDelayMs = Math.min(reconnectDelayMs * 2, maxReconnectDelayMs);'));
+	t.true(page.includes("setStatus('Reconnecting…', '');"));
+	t.false(page.includes("setStatus('Disconnected', 'disconnected');"));
+});
+
+test('web mode page links the favicon and scopes inline style/script to the given nonce', t => {
+	const nonce = createPageNonce();
+	const page = renderWebModePage(nonce);
+
+	t.true(
+		page.includes(
+			'<link rel="icon" type="image/svg+xml" href="/assets/nanocoder-icon.svg">',
+		),
+	);
+	t.true(page.includes(`<style nonce="${nonce}">`));
+	t.true(page.includes(`<script nonce="${nonce}">`));
 });
 
 test('web mode page renders prompt controls as real buttons', t => {

--- a/source/web/page.ts
+++ b/source/web/page.ts
@@ -1,3 +1,5 @@
+import {randomBytes} from 'node:crypto';
+
 export const nanocoderLogoSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Nanocoder">
 <rect width="64" height="64" rx="12" fill="#02191d"/>
 <path fill="#bb9af7" d="M8 17h7v30H8zM26 17h7v30h-7zM15 22h6v8h-6zM20 28h7v8h-7zM24 35h6v8h-6z"/>
@@ -6,14 +8,19 @@ export const nanocoderLogoSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox
 <rect x="46" y="40" width="11" height="7" fill="#7dcfff"/>
 </svg>`;
 
-export function renderWebModePage(): string {
+export function createPageNonce(): string {
+	return randomBytes(16).toString('base64');
+}
+
+export function renderWebModePage(nonce: string = createPageNonce()): string {
 	return `<!doctype html>
 <html lang="en">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Nanocoder Web Mode</title>
-	<style>
+	<link rel="icon" type="image/svg+xml" href="/assets/nanocoder-icon.svg">
+	<style nonce="${nonce}">
 		:root {
 			color-scheme: light dark;
 			font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -90,8 +97,10 @@ export function renderWebModePage(): string {
 			color: #d8d0df;
 			transition: background 140ms ease, transform 140ms ease;
 		}
-		.icon-button:hover {
+		.icon-button:hover,
+		.icon-button:focus-visible {
 			background: rgba(245, 242, 235, 0.11);
+			outline: 0;
 			transform: translateY(-1px);
 		}
 		.new-chat {
@@ -136,6 +145,18 @@ export function renderWebModePage(): string {
 			min-height: 0;
 			overflow-y: auto;
 			padding-top: 2px;
+			scrollbar-width: thin;
+			scrollbar-color: rgba(245, 242, 235, 0.18) transparent;
+		}
+		.thread-list::-webkit-scrollbar {
+			width: 8px;
+		}
+		.thread-list::-webkit-scrollbar-thumb {
+			background: rgba(245, 242, 235, 0.18);
+			border-radius: 8px;
+		}
+		.thread-list::-webkit-scrollbar-thumb:hover {
+			background: rgba(245, 242, 235, 0.3);
 		}
 		.thread-item {
 			display: flex;
@@ -155,9 +176,11 @@ export function renderWebModePage(): string {
 			background: rgba(245, 242, 235, 0.08);
 			color: #f5f2eb;
 		}
-		.thread-item:hover {
+		.thread-item:hover,
+		.thread-item:focus-visible {
 			background: rgba(245, 242, 235, 0.055);
 			color: #f5f2eb;
+			outline: 0;
 		}
 		.sidebar-footer {
 			display: flex;
@@ -257,6 +280,18 @@ export function renderWebModePage(): string {
 			pointer-events: none;
 			padding: 28px clamp(18px, 10vw, 160px) 160px;
 			scroll-behavior: smooth;
+			scrollbar-width: thin;
+			scrollbar-color: rgba(245, 242, 235, 0.18) transparent;
+		}
+		.messages::-webkit-scrollbar {
+			width: 10px;
+		}
+		.messages::-webkit-scrollbar-thumb {
+			background: rgba(245, 242, 235, 0.18);
+			border-radius: 8px;
+		}
+		.messages::-webkit-scrollbar-thumb:hover {
+			background: rgba(245, 242, 235, 0.3);
 		}
 		.message {
 			display: grid;
@@ -584,15 +619,18 @@ export function renderWebModePage(): string {
 			color: #0d1114;
 			transition: transform 120ms ease, opacity 120ms ease;
 		}
-		.send-button:not(:disabled):hover {
+		.send-button:not(:disabled):hover,
+		.send-button:not(:disabled):focus-visible {
 			transform: translateY(-1px);
 			background: #6ee7a1;
+			outline: 0;
 		}
 		.send-button.is-cancel {
 			background: #ff7675;
 			color: #08090b;
 		}
-		.send-button.is-cancel:not(:disabled):hover {
+		.send-button.is-cancel:not(:disabled):hover,
+		.send-button.is-cancel:not(:disabled):focus-visible {
 			background: #ff9493;
 		}
 		.send-button:disabled,
@@ -710,7 +748,8 @@ export function renderWebModePage(): string {
 			background: rgba(192, 202, 245, 0.08);
 			color: var(--tn-text);
 		}
-		.icon-button:hover {
+		.icon-button:hover,
+		.icon-button:focus-visible {
 			background: rgba(125, 207, 255, 0.14);
 		}
 		.new-chat {
@@ -743,6 +782,7 @@ export function renderWebModePage(): string {
 		}
 		.thread-item.active,
 		.thread-item:hover,
+		.thread-item:focus-visible,
 		.mode-pill,
 		.prompt-button:hover {
 			background: rgba(125, 207, 255, 0.1);
@@ -823,7 +863,8 @@ export function renderWebModePage(): string {
 			background: var(--tn-tool);
 			color: var(--tn-base);
 		}
-		.send-button:not(:disabled):hover {
+		.send-button:not(:disabled):hover,
+		.send-button:not(:disabled):focus-visible {
 			background: #9de1ff;
 		}
 	</style>
@@ -878,13 +919,13 @@ export function renderWebModePage(): string {
 			</form>
 		</main>
 	</div>
-	<script>
-		const statusElement = document.querySelector('#connectionStatus');
-		const messageList = document.querySelector('#messageList');
+	<script nonce="${nonce}">
+			const statusElement = document.querySelector('#connectionStatus');
+			const messageList = document.querySelector('#messageList');
 			const emptyState = document.querySelector('#emptyState');
-				const messageForm = document.querySelector('#messageForm');
-				const composerElement = document.querySelector('.composer');
-				const messageInput = document.querySelector('#messageInput');
+			const messageForm = document.querySelector('#messageForm');
+			const composerElement = document.querySelector('.composer');
+			const messageInput = document.querySelector('#messageInput');
 			const sendButton = document.querySelector('#sendButton');
 			const newChatButton = document.querySelector('#newChatButton');
 			const sessionMenuButton = document.querySelector('#sessionMenuButton');
@@ -916,11 +957,15 @@ export function renderWebModePage(): string {
 			let storedMessages = [];
 			let activeTurnId = null;
 			let isConnected = false;
+			let socket = null;
+			let reconnectTimer = null;
+			let reconnectDelayMs = 1000;
+			const maxReconnectDelayMs = 15000;
 
-		function setStatus(text, state) {
-			statusElement.textContent = text;
-			statusElement.className = 'status' + (state ? ' ' + state : '');
-		}
+			function setStatus(text, state) {
+				statusElement.textContent = text;
+				statusElement.className = 'status' + (state ? ' ' + state : '');
+			}
 
 			function setComposerEnabled(isEnabled) {
 				isConnected = isEnabled;
@@ -972,147 +1017,147 @@ export function renderWebModePage(): string {
 				window.localStorage.setItem(storageKey, JSON.stringify(storedMessages));
 			}
 
-		function setEmptyState(title, detail, includePrompts = false) {
-			emptyState.innerHTML = '';
-			const titleElement = document.createElement('strong');
-			titleElement.textContent = title;
-			emptyState.append(titleElement);
+			function setEmptyState(title, detail, includePrompts = false) {
+				emptyState.innerHTML = '';
+				const titleElement = document.createElement('strong');
+				titleElement.textContent = title;
+				emptyState.append(titleElement);
 
-			if (includePrompts) {
-				const modePills = document.createElement('div');
-				modePills.className = 'mode-pills';
-				for (const [label, prompt] of modePrompts) {
-					const pill = document.createElement('button');
-					pill.className = 'mode-pill';
-					pill.type = 'button';
-					pill.textContent = label;
-					pill.dataset.action = 'fill';
-					pill.dataset.prompt = prompt;
-					modePills.append(pill);
-				}
-				emptyState.append(modePills);
+				if (includePrompts) {
+					const modePills = document.createElement('div');
+					modePills.className = 'mode-pills';
+					for (const [label, prompt] of modePrompts) {
+						const pill = document.createElement('button');
+						pill.className = 'mode-pill';
+						pill.type = 'button';
+						pill.textContent = label;
+						pill.dataset.action = 'fill';
+						pill.dataset.prompt = prompt;
+						modePills.append(pill);
+					}
+					emptyState.append(modePills);
 
-				const promptList = document.createElement('div');
-				promptList.className = 'prompt-list';
-				for (const prompt of promptSuggestions) {
-					const promptButton = document.createElement('button');
-					promptButton.className = 'prompt-button';
-					promptButton.type = 'button';
-					promptButton.textContent = prompt;
-					promptButton.dataset.action = 'submit';
-					promptButton.dataset.prompt = prompt;
-					promptList.append(promptButton);
+					const promptList = document.createElement('div');
+					promptList.className = 'prompt-list';
+					for (const prompt of promptSuggestions) {
+						const promptButton = document.createElement('button');
+						promptButton.className = 'prompt-button';
+						promptButton.type = 'button';
+						promptButton.textContent = prompt;
+						promptButton.dataset.action = 'submit';
+						promptButton.dataset.prompt = prompt;
+						promptList.append(promptButton);
+					}
+					emptyState.append(promptList);
+					emptyState.hidden = false;
+					return;
 				}
-				emptyState.append(promptList);
+
+				const detailElement = document.createElement('span');
+				detailElement.textContent = detail;
+				emptyState.append(detailElement);
 				emptyState.hidden = false;
-				return;
 			}
 
-			const detailElement = document.createElement('span');
-			detailElement.textContent = detail;
-			emptyState.append(detailElement);
-			emptyState.hidden = false;
-		}
-
-		function hideEmptyState() {
-			emptyState.hidden = true;
-		}
-
-		function appendInlineMarkdown(element, text) {
-			const inlineCodeMarker = String.fromCharCode(96);
-			let remainingText = text;
-
-			while (remainingText) {
-				const strongIndex = remainingText.indexOf('**');
-				const codeIndex = remainingText.indexOf(inlineCodeMarker);
-				const markerIndexes = [strongIndex, codeIndex].filter(index => index >= 0);
-
-				if (markerIndexes.length === 0) {
-					element.append(document.createTextNode(remainingText));
-					return;
-				}
-
-				const markerIndex = Math.min(...markerIndexes);
-				if (markerIndex > 0) {
-					element.append(document.createTextNode(remainingText.slice(0, markerIndex)));
-					remainingText = remainingText.slice(markerIndex);
-				}
-
-				const marker = remainingText.startsWith('**') ? '**' : inlineCodeMarker;
-				const closingIndex = remainingText.indexOf(marker, marker.length);
-				if (closingIndex < 0) {
-					element.append(document.createTextNode(remainingText));
-					return;
-				}
-
-				const inlineElement = document.createElement(marker === '**' ? 'strong' : 'code');
-				inlineElement.textContent = remainingText.slice(marker.length, closingIndex);
-				element.append(inlineElement);
-				remainingText = remainingText.slice(closingIndex + marker.length);
+			function hideEmptyState() {
+				emptyState.hidden = true;
 			}
-		}
 
-		function renderAssistantText(element, text) {
-			element.replaceChildren();
-			const codeFence = String.fromCharCode(96).repeat(3);
-			let codeElement = null;
-			let listElement = null;
+			function appendInlineMarkdown(element, text) {
+				const inlineCodeMarker = String.fromCharCode(96);
+				let remainingText = text;
 
-			for (const line of text.split('\\n')) {
-				if (line.trim().startsWith(codeFence)) {
+				while (remainingText) {
+					const strongIndex = remainingText.indexOf('**');
+					const codeIndex = remainingText.indexOf(inlineCodeMarker);
+					const markerIndexes = [strongIndex, codeIndex].filter(index => index >= 0);
+
+					if (markerIndexes.length === 0) {
+						element.append(document.createTextNode(remainingText));
+						return;
+					}
+
+					const markerIndex = Math.min(...markerIndexes);
+					if (markerIndex > 0) {
+						element.append(document.createTextNode(remainingText.slice(0, markerIndex)));
+						remainingText = remainingText.slice(markerIndex);
+					}
+
+					const marker = remainingText.startsWith('**') ? '**' : inlineCodeMarker;
+					const closingIndex = remainingText.indexOf(marker, marker.length);
+					if (closingIndex < 0) {
+						element.append(document.createTextNode(remainingText));
+						return;
+					}
+
+					const inlineElement = document.createElement(marker === '**' ? 'strong' : 'code');
+					inlineElement.textContent = remainingText.slice(marker.length, closingIndex);
+					element.append(inlineElement);
+					remainingText = remainingText.slice(closingIndex + marker.length);
+				}
+			}
+
+			function renderAssistantText(element, text) {
+				element.replaceChildren();
+				const codeFence = String.fromCharCode(96).repeat(3);
+				let codeElement = null;
+				let listElement = null;
+
+				for (const line of text.split('\\n')) {
+					if (line.trim().startsWith(codeFence)) {
+						if (codeElement) {
+							codeElement = null;
+						} else {
+							const preElement = document.createElement('pre');
+							codeElement = document.createElement('code');
+							preElement.append(codeElement);
+							element.append(preElement);
+						}
+						listElement = null;
+						continue;
+					}
+
 					if (codeElement) {
-						codeElement = null;
-					} else {
-						const preElement = document.createElement('pre');
-						codeElement = document.createElement('code');
-						preElement.append(codeElement);
-						element.append(preElement);
+						codeElement.textContent += (codeElement.textContent ? '\\n' : '') + line;
+						continue;
 					}
-					listElement = null;
-					continue;
-				}
 
-				if (codeElement) {
-					codeElement.textContent += (codeElement.textContent ? '\\n' : '') + line;
-					continue;
-				}
-
-				if (!line.trim()) {
-					listElement = null;
-					continue;
-				}
-
-				const headingMatch = /^(#{1,3})\\s+(.*)$/.exec(line);
-				const unorderedMatch = /^[-*]\\s+(.*)$/.exec(line);
-				const orderedMatch = /^\\d+\\.\\s+(.*)$/.exec(line);
-
-				if (headingMatch) {
-					const headingElement = document.createElement('h' + headingMatch[1].length);
-					appendInlineMarkdown(headingElement, headingMatch[2]);
-					element.append(headingElement);
-					listElement = null;
-					continue;
-				}
-
-				const listMatch = unorderedMatch ?? orderedMatch;
-				if (listMatch) {
-					const listTag = unorderedMatch ? 'UL' : 'OL';
-					if (!listElement || listElement.tagName !== listTag) {
-						listElement = document.createElement(listTag.toLowerCase());
-						element.append(listElement);
+					if (!line.trim()) {
+						listElement = null;
+						continue;
 					}
-					const itemElement = document.createElement('li');
-					appendInlineMarkdown(itemElement, listMatch[1]);
-					listElement.append(itemElement);
-					continue;
-				}
 
-				const paragraphElement = document.createElement('p');
-				appendInlineMarkdown(paragraphElement, line);
-				element.append(paragraphElement);
-				listElement = null;
+					const headingMatch = /^(#{1,3})\\s+(.*)$/.exec(line);
+					const unorderedMatch = /^[-*]\\s+(.*)$/.exec(line);
+					const orderedMatch = /^\\d+\\.\\s+(.*)$/.exec(line);
+
+					if (headingMatch) {
+						const headingElement = document.createElement('h' + headingMatch[1].length);
+						appendInlineMarkdown(headingElement, headingMatch[2]);
+						element.append(headingElement);
+						listElement = null;
+						continue;
+					}
+
+					const listMatch = unorderedMatch ?? orderedMatch;
+					if (listMatch) {
+						const listTag = unorderedMatch ? 'UL' : 'OL';
+						if (!listElement || listElement.tagName !== listTag) {
+							listElement = document.createElement(listTag.toLowerCase());
+							element.append(listElement);
+						}
+						const itemElement = document.createElement('li');
+						appendInlineMarkdown(itemElement, listMatch[1]);
+						listElement.append(itemElement);
+						continue;
+					}
+
+					const paragraphElement = document.createElement('p');
+					appendInlineMarkdown(paragraphElement, line);
+					element.append(paragraphElement);
+					listElement = null;
+				}
 			}
-		}
 
 			function appendMessage(role, text, metaText, shouldStore = true) {
 				hideEmptyState();
@@ -1129,12 +1174,12 @@ export function renderWebModePage(): string {
 				}
 				messageElement.append(textElement);
 
-			if (metaText) {
-				const metaElement = document.createElement('div');
-				metaElement.className = 'meta';
-				metaElement.textContent = metaText;
-				messageElement.append(metaElement);
-			}
+				if (metaText) {
+					const metaElement = document.createElement('div');
+					metaElement.className = 'meta';
+					metaElement.textContent = metaText;
+					messageElement.append(metaElement);
+				}
 
 				messageList.append(messageElement);
 				messageList.scrollTop = messageList.scrollHeight;
@@ -1147,15 +1192,15 @@ export function renderWebModePage(): string {
 				return messageElement;
 			}
 
-		function updateMessageMeta(messageElement, metaText) {
-			let metaElement = messageElement.querySelector('.meta');
-			if (!metaElement) {
-				metaElement = document.createElement('div');
-				metaElement.className = 'meta';
-				messageElement.append(metaElement);
-			}
-				metaElement.textContent = metaText;
-			}
+			function updateMessageMeta(messageElement, metaText) {
+				let metaElement = messageElement.querySelector('.meta');
+				if (!metaElement) {
+					metaElement = document.createElement('div');
+					metaElement.className = 'meta';
+					messageElement.append(metaElement);
+				}
+					metaElement.textContent = metaText;
+				}
 
 			function restoreStoredMessages() {
 				storedMessages = readStoredMessages();
@@ -1179,33 +1224,33 @@ export function renderWebModePage(): string {
 				messageInput.focus();
 			}
 
-				function setPromptText(text) {
-					messageInput.value = text;
-					composerElement.classList.add('is-attention');
-					window.setTimeout(() => {
-						composerElement.classList.remove('is-attention');
-					}, 900);
-					messageForm.scrollIntoView({block: 'center', behavior: 'smooth'});
-					messageInput.focus();
-				}
+			function setPromptText(text) {
+				messageInput.value = text;
+				composerElement.classList.add('is-attention');
+				window.setTimeout(() => {
+					composerElement.classList.remove('is-attention');
+				}, 900);
+				messageForm.scrollIntoView({block: 'center', behavior: 'smooth'});
+				messageInput.focus();
+			}
 
 			function addSystemNotice(text, metaText = 'Local UI') {
 				appendMessage('system', text, metaText);
 			}
 
-		function appendAssistantDelta(id, text) {
-			let messageElement = assistantMessages.get(id);
-			if (!messageElement) {
-				messageElement = appendMessage('assistant', '');
-				assistantMessages.set(id, messageElement);
-			}
+			function appendAssistantDelta(id, text) {
+				let messageElement = assistantMessages.get(id);
+				if (!messageElement) {
+					messageElement = appendMessage('assistant', '');
+					assistantMessages.set(id, messageElement);
+				}
 
-			const textElement = messageElement.firstElementChild;
-			const nextText = (textElement.dataset.rawText ?? '') + text;
-			textElement.dataset.rawText = nextText;
-			renderAssistantText(textElement, nextText);
-			messageList.scrollTop = messageList.scrollHeight;
-		}
+				const textElement = messageElement.firstElementChild;
+				const nextText = (textElement.dataset.rawText ?? '') + text;
+				textElement.dataset.rawText = nextText;
+				renderAssistantText(textElement, nextText);
+				messageList.scrollTop = messageList.scrollHeight;
+			}
 
 			function sendClientEvent(event) {
 				if (socket.readyState !== WebSocket.OPEN) {
@@ -1213,9 +1258,9 @@ export function renderWebModePage(): string {
 					return false;
 				}
 
-			socket.send(JSON.stringify(event));
-			return true;
-		}
+				socket.send(JSON.stringify(event));
+				return true;
+			}
 
 			function formatToolArguments(args) {
 				try {
@@ -1361,68 +1406,79 @@ export function renderWebModePage(): string {
 				messageList.scrollTop = messageList.scrollHeight;
 			}
 
-		function handleServerEvent(message) {
-			if (message.type === 'ready') {
-				setStatus('Connected', 'connected');
-				setComposerEnabled(true);
-				if (storedMessages.length === 0) {
-					setEmptyState('How can I help you?', '', true);
-				}
-				messageInput.focus();
-				return;
-			}
-
-			if (message.type === 'ack') {
-				const messageElement = pendingMessages.get(message.id);
-				if (messageElement) {
-					updateMessageMeta(messageElement, 'Delivered to local session');
-					pendingMessages.delete(message.id);
-				}
-				return;
-			}
-
-			if (message.type === 'assistant_delta') {
-				appendAssistantDelta(message.id, message.text);
-				return;
-			}
-
-			if (message.type === 'tool_started') {
-				appendMessage('system tool-status', 'Running tool: ' + message.name, 'In progress');
-				return;
-			}
-
-			if (message.type === 'tool_finished') {
-				appendMessage(
-					'system tool-status',
-					'Tool finished: ' + message.name,
-					message.ok ? 'Completed' : 'Failed',
-				);
-				return;
-			}
-
-			if (message.type === 'approval_required') {
-				renderApprovalCard(message);
-				return;
-			}
-
-			if (message.type === 'question_required') {
-				renderQuestionCard(message);
-				return;
-			}
-
-			if (message.type === 'turn_completed') {
-				if (message.id === activeTurnId) {
-					setActiveTurn(null);
+			function handleServerEvent(message) {
+				if (message.type === 'ready') {
+					setStatus('Connected', 'connected');
+					setComposerEnabled(true);
+					if (storedMessages.length === 0) {
+						setEmptyState('How can I help you?', '', true);
+					}
 					messageInput.focus();
+					return;
 				}
-				return;
-			}
 
-			if (message.type === 'error') {
-				setActiveTurn(null);
-				appendMessage('system error', message.message);
-				return;
-			}
+				if (message.type === 'ack') {
+					const messageElement = pendingMessages.get(message.id);
+					if (messageElement) {
+						updateMessageMeta(messageElement, 'Delivered to local session');
+						pendingMessages.delete(message.id);
+					}
+					return;
+				}
+
+				if (message.type === 'assistant_delta') {
+					appendAssistantDelta(message.id, message.text);
+					return;
+				}
+
+				if (message.type === 'tool_started') {
+					appendMessage('system tool-status', 'Running tool: ' + message.name, 'In progress');
+					return;
+				}
+
+				if (message.type === 'tool_finished') {
+					appendMessage(
+						'system tool-status',
+						'Tool finished: ' + message.name,
+						message.ok ? 'Completed' : 'Failed',
+					);
+					return;
+				}
+
+				if (message.type === 'approval_required') {
+					renderApprovalCard(message);
+					return;
+				}
+
+				if (message.type === 'question_required') {
+					renderQuestionCard(message);
+					return;
+				}
+
+				if (message.type === 'turn_completed') {
+					if (message.id === activeTurnId) {
+						setActiveTurn(null);
+						messageInput.focus();
+					}
+					return;
+				}
+
+				if (message.type === 'error') {
+					setActiveTurn(null);
+					const pendingMessageElement = message.id
+						? pendingMessages.get(message.id)
+						: undefined;
+					if (pendingMessageElement) {
+						const failedText =
+							pendingMessageElement.querySelector('.message-content').textContent;
+						updateMessageMeta(pendingMessageElement, 'Not sent — ' + message.message);
+						pendingMessages.delete(message.id);
+						setPromptText(failedText);
+					} else {
+						appendMessage('system error', message.message);
+					}
+					return;
+				}
 
 				appendMessage('system', 'Received an unsupported local session event.');
 			}
@@ -1465,33 +1521,52 @@ export function renderWebModePage(): string {
 				setPromptText(prompt);
 			});
 
-			const socket = new WebSocket(eventsUrl);
+			function connectSocket() {
+				socket = new WebSocket(eventsUrl);
+
+				socket.addEventListener('open', () => {
+					reconnectDelayMs = 1000;
+					setStatus('Connecting', '');
+					sendClientEvent({type: 'hello', protocolVersion: 1});
+				});
+				socket.addEventListener('message', event => {
+					try {
+						const message = JSON.parse(event.data);
+						handleServerEvent(message);
+					} catch {
+						appendMessage('system error', 'Received an invalid local session event.');
+					}
+				});
+				socket.addEventListener('close', () => {
+					setActiveTurn(null);
+					setComposerEnabled(false);
+					setStatus('Reconnecting…', '');
+					setEmptyState(
+						'Reconnecting…',
+						'Trying to reach the local Nanocoder server again.',
+					);
+					scheduleReconnect();
+				});
+				socket.addEventListener('error', () => {
+					setActiveTurn(null);
+					setComposerEnabled(false);
+				});
+			}
+
+			function scheduleReconnect() {
+				if (reconnectTimer !== null) {
+					return;
+				}
+				reconnectTimer = window.setTimeout(() => {
+					reconnectTimer = null;
+					connectSocket();
+				}, reconnectDelayMs);
+				reconnectDelayMs = Math.min(reconnectDelayMs * 2, maxReconnectDelayMs);
+			}
+
 			setEmptyState('How can I help you?', '', true);
 			restoreStoredMessages();
-			socket.addEventListener('open', () => {
-				setStatus('Connecting', '');
-				sendClientEvent({type: 'hello', protocolVersion: 1});
-		});
-		socket.addEventListener('message', event => {
-			try {
-				const message = JSON.parse(event.data);
-				handleServerEvent(message);
-			} catch {
-				appendMessage('system error', 'Received an invalid local session event.');
-			}
-		});
-		socket.addEventListener('close', () => {
-			setActiveTurn(null);
-			setStatus('Disconnected', 'disconnected');
-			setComposerEnabled(false);
-			setEmptyState('Disconnected', 'Restart nanocoder --web to open a fresh local session.');
-		});
-		socket.addEventListener('error', () => {
-			setActiveTurn(null);
-			setStatus('Connection failed', 'failed');
-			setComposerEnabled(false);
-			setEmptyState('Connection failed', 'The browser could not reach the local Nanocoder server.');
-		});
+			connectSocket();
 
 			messageForm.addEventListener('submit', event => {
 				event.preventDefault();
@@ -1513,12 +1588,16 @@ export function renderWebModePage(): string {
 			});
 
 			newChatButton.addEventListener('click', () => {
+				sendClientEvent({type: 'reset_session', id: 'browser-reset-' + Date.now()});
 				clearLocalSession();
 				addSystemNotice('Started a fresh local browser session.', 'Stored only in this browser');
 			});
 
 			sessionMenuButton.addEventListener('click', () => {
-				addSystemNotice('This session is served from localhost and protected by the private URL token.', 'Session menu');
+				addSystemNotice(
+					'This session is served from localhost and protected by the private URL token. The live connection uses ws:// rather than wss:// because it never leaves your machine.',
+					'Session menu',
+				);
 			});
 
 			historyButton.addEventListener('click', () => {

--- a/source/web/protocol.spec.ts
+++ b/source/web/protocol.spec.ts
@@ -52,6 +52,23 @@ test('parseWebClientEvent still accepts the phase 4 handshake events', t => {
 	);
 });
 
+test('parseWebClientEvent accepts a reset_session event', t => {
+	t.deepEqual(
+		parseWebClientEvent(
+			JSON.stringify({
+				type: 'reset_session',
+				id: 'browser-reset-1',
+			}),
+		),
+		{type: 'reset_session', id: 'browser-reset-1'},
+	);
+
+	t.throws(
+		() => parseWebClientEvent(JSON.stringify({type: 'reset_session'})),
+		{message: 'Reset session id is required.'},
+	);
+});
+
 test('parseWebClientEvent rejects malformed interaction responses', t => {
 	t.throws(
 		() =>

--- a/source/web/protocol.ts
+++ b/source/web/protocol.ts
@@ -5,7 +5,8 @@ export type WebClientEvent =
 	| {type: 'user_message'; id: string; text: string}
 	| {type: 'cancel'; id: string}
 	| {type: 'approval_response'; id: string; approved: boolean}
-	| {type: 'question_response'; id: string; answer: string};
+	| {type: 'question_response'; id: string; answer: string}
+	| {type: 'reset_session'; id: string};
 
 export type WebServerEvent =
 	| {type: 'ready'; protocolVersion: typeof WEB_PROTOCOL_VERSION}
@@ -28,7 +29,7 @@ export type WebServerEvent =
 			allowFreeform: boolean;
 	  }
 	| {type: 'turn_completed'; id: string}
-	| {type: 'error'; message: string};
+	| {type: 'error'; message: string; id?: string};
 
 export function parseWebClientEvent(rawMessage: string): WebClientEvent {
 	let parsed: unknown;
@@ -102,6 +103,15 @@ export function parseWebClientEvent(rawMessage: string): WebClientEvent {
 				type: 'question_response',
 				id: parsed.id,
 				answer: parsed.answer,
+			};
+		case 'reset_session':
+			if (typeof parsed.id !== 'string' || parsed.id.length === 0) {
+				throw new Error('Reset session id is required.');
+			}
+
+			return {
+				type: 'reset_session',
+				id: parsed.id,
 			};
 		default:
 			throw new Error(`Unsupported web event type: ${parsed.type}.`);

--- a/source/web/runtime-bridge.spec.ts
+++ b/source/web/runtime-bridge.spec.ts
@@ -29,6 +29,7 @@ test('web runtime bridge accepts one browser turn without waiting for completion
 			return submission;
 		},
 		cancel: () => {},
+		resetSession: () => {},
 	});
 
 	await bridge.handleClientEvent(userMessage('turn-1', 'from browser'));
@@ -54,6 +55,7 @@ test('web runtime bridge publishes assistant deltas and completion for the activ
 	bridge.bindRuntimeHandlers({
 		submitMessage: () => submission,
 		cancel: () => {},
+		resetSession: () => {},
 	});
 
 	await bridge.handleClientEvent(userMessage('turn-1'));
@@ -83,6 +85,7 @@ test('web runtime bridge cancels only the matching active browser turn', async t
 		cancel: () => {
 			cancelCount++;
 		},
+		resetSession: () => {},
 	});
 
 	await bridge.handleClientEvent(userMessage('turn-1'));
@@ -109,6 +112,7 @@ test('web runtime bridge reports asynchronous submission failures and clears the
 			}
 		},
 		cancel: () => {},
+		resetSession: () => {},
 	});
 
 	await bridge.handleClientEvent(userMessage('turn-1', 'fail'));
@@ -131,12 +135,14 @@ test('web runtime bridge cleanup does not remove a newer handler binding', async
 			submittedMessages.push(`first:${text}`);
 		},
 		cancel: () => {},
+		resetSession: () => {},
 	});
 	bridge.bindRuntimeHandlers({
 		submitMessage: text => {
 			submittedMessages.push(`second:${text}`);
 		},
 		cancel: () => {},
+		resetSession: () => {},
 	});
 
 	releaseFirstBinding();
@@ -154,6 +160,7 @@ test('web runtime bridge resolves matching approval responses during a browser t
 	bridge.bindRuntimeHandlers({
 		submitMessage: () => new Promise<void>(() => {}),
 		cancel: () => {},
+		resetSession: () => {},
 	});
 
 	await bridge.handleClientEvent(userMessage('turn-1'));
@@ -204,6 +211,7 @@ test('web runtime bridge rejects stale question responses and clears on cancel',
 		cancel: () => {
 			cancelCount++;
 		},
+		resetSession: () => {},
 	});
 
 	await bridge.handleClientEvent(userMessage('turn-1'));
@@ -243,6 +251,7 @@ test('web runtime bridge publishes tool lifecycle only during an active browser 
 	bridge.bindRuntimeHandlers({
 		submitMessage: () => new Promise<void>(() => {}),
 		cancel: () => {},
+		resetSession: () => {},
 	});
 
 	bridge.publishToolStarted('tool-1', 'read_file');
@@ -258,11 +267,48 @@ test('web runtime bridge publishes tool lifecycle only during an active browser 
 	]);
 });
 
+test('web runtime bridge resets the session when no browser turn is active', async t => {
+	let resetCount = 0;
+	const bridge = createWebRuntimeBridge(() => {});
+	bridge.bindRuntimeHandlers({
+		submitMessage: () => new Promise<void>(() => {}),
+		cancel: () => {},
+		resetSession: () => {
+			resetCount++;
+		},
+	});
+
+	await bridge.handleClientEvent({type: 'reset_session', id: 'reset-1'});
+
+	t.is(resetCount, 1);
+});
+
+test('web runtime bridge refuses to reset the session while a browser turn is active', async t => {
+	let resetCount = 0;
+	const bridge = createWebRuntimeBridge(() => {});
+	bridge.bindRuntimeHandlers({
+		submitMessage: () => new Promise<void>(() => {}),
+		cancel: () => {},
+		resetSession: () => {
+			resetCount++;
+		},
+	});
+
+	await bridge.handleClientEvent(userMessage('turn-1'));
+	await t.throwsAsync(
+		bridge.handleClientEvent({type: 'reset_session', id: 'reset-1'}),
+		{message: 'Cannot start a new chat while a browser turn is active.'},
+	);
+
+	t.is(resetCount, 0);
+});
+
 test('web runtime bridge denies pending approval on disconnect', async t => {
 	const bridge = createWebRuntimeBridge(() => {});
 	bridge.bindRuntimeHandlers({
 		submitMessage: () => new Promise<void>(() => {}),
 		cancel: () => {},
+		resetSession: () => {},
 	});
 
 	await bridge.handleClientEvent(userMessage('turn-1'));

--- a/source/web/runtime-bridge.ts
+++ b/source/web/runtime-bridge.ts
@@ -3,6 +3,7 @@ import type {WebClientEvent, WebServerEvent} from './protocol.js';
 export interface WebRuntimeHandlers {
 	submitMessage: (text: string) => void | Promise<void>;
 	cancel: () => void;
+	resetSession: () => void | Promise<void>;
 }
 
 export interface WebApprovalRequest {
@@ -192,6 +193,17 @@ export function createWebRuntimeBridge(
 						'The browser turn was cancelled before the question was answered.',
 				});
 				runtimeHandlers.cancel();
+				return;
+			}
+
+			if (event.type === 'reset_session') {
+				if (activeTurnId) {
+					throw new Error(
+						'Cannot start a new chat while a browser turn is active.',
+					);
+				}
+
+				await runtimeHandlers.resetSession();
 				return;
 			}
 

--- a/source/web/server.spec.ts
+++ b/source/web/server.spec.ts
@@ -84,6 +84,50 @@ test('local web server serves Nanocoder icon asset', async t => {
 	t.true(body.includes('aria-label="Nanocoder"'));
 });
 
+test('local web server redirects /favicon.ico to the Nanocoder icon asset', async t => {
+	const webServer = await startLocalWebServer({openBrowser: false});
+	t.teardown(() => {
+		return webServer.close();
+	});
+
+	const response = await fetch(
+		`http://127.0.0.1:${webServer.port}/favicon.ico`,
+		{redirect: 'manual'},
+	);
+
+	t.is(response.status, 302);
+	t.is(response.headers.get('location'), '/assets/nanocoder-icon.svg');
+});
+
+test('local web server sets security headers, including a CSP scoped to the page nonce', async t => {
+	const webServer = await startLocalWebServer({
+		openBrowser: false,
+		token: 'test-token',
+	});
+	t.teardown(() => {
+		return webServer.close();
+	});
+
+	const response = await fetch(`${webServer.url}`);
+	const body = await response.text();
+
+	t.is(response.headers.get('x-content-type-options'), 'nosniff');
+	t.is(response.headers.get('x-frame-options'), 'DENY');
+
+	const csp = response.headers.get('content-security-policy');
+	t.truthy(csp);
+	t.regex(csp ?? '', /script-src 'self' 'nonce-[^']+'/);
+	t.regex(csp ?? '', /style-src 'self' 'nonce-[^']+'/);
+	t.true(
+		(csp ?? '').includes(`connect-src 'self' ws://127.0.0.1:${webServer.port}`),
+	);
+
+	const [, scriptNonce] = /<script nonce="([^"]+)">/.exec(body) ?? [];
+	const [, cspNonce] = /'nonce-([^']+)'/.exec(csp ?? '') ?? [];
+	t.truthy(scriptNonce);
+	t.is(scriptNonce, cspNonce);
+});
+
 test('local web server rejects placeholder page without valid token', async t => {
 	const webServer = await startLocalWebServer({
 		openBrowser: false,
@@ -274,6 +318,7 @@ test('local web server reports client event handler failures without acknowledgi
 
 	t.deepEqual(event, {
 		type: 'error',
+		id: 'message-1',
 		message: 'Browser event handler failed.',
 	});
 });

--- a/source/web/server.ts
+++ b/source/web/server.ts
@@ -3,7 +3,7 @@ import {randomBytes} from 'node:crypto';
 import {createServer, type Server} from 'node:http';
 import type {Duplex} from 'node:stream';
 import {WebSocket, WebSocketServer} from 'ws';
-import {nanocoderLogoSvg, renderWebModePage} from './page.js';
+import {createPageNonce, nanocoderLogoSvg, renderWebModePage} from './page.js';
 import {
 	parseWebClientEvent,
 	serializeWebServerEvent,
@@ -45,6 +45,9 @@ export async function startLocalWebServer(
 	const token = options.token ?? createLocalWebToken();
 
 	const server = createServer((request, response) => {
+		response.setHeader('x-content-type-options', 'nosniff');
+		response.setHeader('x-frame-options', 'DENY');
+
 		const requestUrl = new URL(request.url ?? '/', `http://${host}`);
 
 		if (requestUrl.pathname === '/health') {
@@ -62,6 +65,12 @@ export async function startLocalWebServer(
 			return;
 		}
 
+		if (requestUrl.pathname === '/favicon.ico') {
+			response.writeHead(302, {location: '/assets/nanocoder-icon.svg'});
+			response.end();
+			return;
+		}
+
 		if (requestUrl.pathname !== '/' && requestUrl.pathname !== '/index.html') {
 			response.writeHead(404, {'content-type': 'text/plain; charset=utf-8'});
 			response.end('Not found');
@@ -74,8 +83,12 @@ export async function startLocalWebServer(
 			return;
 		}
 
-		response.writeHead(200, {'content-type': 'text/html; charset=utf-8'});
-		response.end(renderWebModePage());
+		const nonce = createPageNonce();
+		response.writeHead(200, {
+			'content-type': 'text/html; charset=utf-8',
+			'content-security-policy': buildContentSecurityPolicy(host, port, nonce),
+		});
+		response.end(renderWebModePage(nonce));
 	});
 	const webSocketServer = new WebSocketServer({noServer: true});
 	const connectedClients = new Set<WebSocket>();
@@ -188,6 +201,7 @@ async function handleClientMessage(
 	} catch (error) {
 		sendServerEvent(clientSocket, {
 			type: 'error',
+			id: event.id,
 			message:
 				error instanceof Error
 					? error.message
@@ -208,6 +222,23 @@ function sendServerEvent(clientSocket: WebSocket, event: WebServerEvent): void {
 	}
 
 	clientSocket.send(serializeWebServerEvent(event));
+}
+
+function buildContentSecurityPolicy(
+	host: string,
+	port: number,
+	nonce: string,
+): string {
+	return [
+		"default-src 'self'",
+		`script-src 'self' 'nonce-${nonce}'`,
+		`style-src 'self' 'nonce-${nonce}'`,
+		"img-src 'self' data:",
+		`connect-src 'self' ws://${host}:${port}`,
+		"base-uri 'none'",
+		"form-action 'none'",
+		"frame-ancestors 'none'",
+	].join('; ');
 }
 
 function rejectWebSocketUpgrade(socket: Duplex): void {


### PR DESCRIPTION

## Description


- Security headers: nonce-scoped `Content-Security-Policy`, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`
- Favicon: `<link rel="icon">` + `/favicon.ico` redirect to the existing icon asset route
- `ws://` explained in the session-menu notice (expected for a localhost-only server)
- New Chat now resets the real backend conversation via a new `reset_session` protocol event (reuses the same `clearMessages` handler `/clear` uses), not just browser `localStorage`
- A message rejected because another turn is already active (e.g. two browser tabs against the same server) now gets restored into the composer instead of silently lost
- WebSocket auto-reconnects with exponential backoff (capped at 15s) instead of requiring a manual page refresh
- `:focus-visible` extended to the sidebar icon buttons, thread rows, and send button
- Custom themed scrollbars on the sidebar and message list
- Fixed several inline-script indentation bugs in `page.ts` found by direct inspection (not a blanket reformat)

One review item (the `\n` markdown-split "bug") was investigated and found to be a false alarm — verified by evaluating `renderWebModePage()` directly; the code was already correct.

Closes #628 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))