### PR TITLE
fix(mcp): don't leave a server connected when tool discovery fails

### DIFF
--- a/.changeset/fix-mcp-failed-tool-discovery.md
+++ b/.changeset/fix-mcp-failed-tool-discovery.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed an MCP server staying visible as connected when its initial `tools/list` call failed. `connectToServer()` now registers the client, transport, and config only after tool discovery succeeds, and closes the partially-established client on failure so its transport/child process doesn't leak.

--- a/source/mcp/mcp-client.spec.ts
+++ b/source/mcp/mcp-client.spec.ts
@@ -1065,3 +1065,79 @@ test('callTool sanitizes object arguments to strings when schema expects a strin
 		t.is(typeof capturedArgs.path, 'string', 'Path should remain a string');
 	}
 });
+
+// ============================================================================
+// Regression Tests for connectToServer lifecycle (failed tool discovery)
+// ============================================================================
+
+// Subclass exposing the createClient() seam so we can drive the connect path
+// with a fake client and no real transport/network.
+class SeamMCPClient extends MCPClient {
+	constructor(private readonly injected: any) {
+		super();
+	}
+	protected createClient(): any {
+		return this.injected;
+	}
+}
+
+const httpServer = {
+	name: 'seam-server',
+	transport: 'http' as const,
+	url: 'http://localhost:1/mcp',
+};
+
+test('MCPClient.connectToServer: does not leave the server registered when listTools fails', async t => {
+	let closed = false;
+	const failingClient = {
+		async connect() {},
+		async listTools() {
+			throw new Error('tools/list failed');
+		},
+		async close() {
+			closed = true;
+		},
+	};
+
+	const client = new SeamMCPClient(failingClient);
+
+	await t.throwsAsync(async () => await client.connectToServer(httpServer), {
+		message: /tools\/list failed/,
+	});
+
+	// The failed server must not linger as connected for the rest of the session.
+	t.false(client.isServerConnected('seam-server'));
+	t.is(client.getServerInfo('seam-server'), undefined);
+	t.is(client.getConnectedServers().length, 0);
+	t.is(client.getServerTools('seam-server').length, 0);
+
+	// The partially-established client must be closed so its transport/child
+	// process doesn't leak.
+	t.true(closed, 'client.close() should be called after a failed connect');
+});
+
+test('MCPClient.connectToServer: registers the server once tool discovery succeeds', async t => {
+	const okClient = {
+		async connect() {},
+		async listTools() {
+			return {
+				tools: [
+					{
+						name: 'ok_tool',
+						description: 'A working tool',
+						inputSchema: {type: 'object', properties: {}},
+					},
+				],
+			};
+		},
+		async close() {},
+	};
+
+	const client = new SeamMCPClient(okClient);
+
+	await t.notThrowsAsync(async () => await client.connectToServer(httpServer));
+
+	t.true(client.isServerConnected('seam-server'));
+	t.is(client.getServerTools('seam-server').length, 1);
+	t.is(client.getServerInfo('seam-server')?.connected, true);
+});

--- a/source/mcp/mcp-client.ts
+++ b/source/mcp/mcp-client.ts
@@ -72,6 +72,15 @@ export class MCPClient {
 		return server;
 	}
 
+	// Overridable seam so tests can supply a client with a failing listTools()
+	// without standing up a real transport.
+	protected createClient(): Client {
+		return new Client({
+			name: 'nanocoder-mcp-client',
+			version: '1.0.0',
+		});
+	}
+
 	async connectToServer(server: MCPServer): Promise<void> {
 		const correlationId = generateCorrelationId();
 		const metrics = startMetrics();
@@ -106,6 +115,7 @@ export class MCPClient {
 				);
 			}
 
+			let client: Client | undefined;
 			try {
 				// Create transport using the factory
 				const transport = TransportFactory.createTransport(normalizedServer);
@@ -116,10 +126,7 @@ export class MCPClient {
 				});
 
 				// Create and connect client
-				const client = new Client({
-					name: 'nanocoder-mcp-client',
-					version: '1.0.0',
-				});
+				client = this.createClient();
 
 				this.logger.debug('MCP client created, attempting connection', {
 					serverName: normalizedServer.name,
@@ -149,12 +156,9 @@ export class MCPClient {
 					transport: normalizedServer.transport,
 				});
 
-				// Store client, transport, and server config
-				this.clients.set(normalizedServer.name, client);
-				this.transports.set(normalizedServer.name, transport);
-				this.serverConfigs.set(normalizedServer.name, normalizedServer);
-
-				// List available tools from this server
+				// List available tools from this server. Do this before registering
+				// the server so a failed tools/list doesn't leave it visible as
+				// connected — the maps are populated only once discovery succeeds.
 				const toolsResult = await client.listTools();
 				const tools: MCPTool[] = toolsResult.tools.map(tool => ({
 					name: tool.name,
@@ -167,6 +171,11 @@ export class MCPClient {
 					serverName: normalizedServer.name,
 				}));
 
+				// Store client, transport, config, and tools together only after
+				// connection and tool discovery have both succeeded.
+				this.clients.set(normalizedServer.name, client);
+				this.transports.set(normalizedServer.name, transport);
+				this.serverConfigs.set(normalizedServer.name, normalizedServer);
 				this.serverTools.set(normalizedServer.name, tools);
 
 				const finalMetrics = endMetrics(metrics);
@@ -181,6 +190,20 @@ export class MCPClient {
 					correlationId,
 				});
 			} catch (error) {
+				// Best-effort cleanup: close the client so a partially-established
+				// connection (e.g. handshake ok but tools/list failed) doesn't leak
+				// its transport / child process. Nothing was registered yet.
+				if (client) {
+					try {
+						await client.close();
+					} catch (closeError) {
+						this.logger.debug('Error closing MCP client after failed connect', {
+							serverName: normalizedServer.name,
+							error: formatError(closeError),
+						});
+					}
+				}
+
 				const finalMetrics = endMetrics(metrics);
 				this.logger.error('Failed to connect to MCP server', {
 					serverName: normalizedServer.name,


### PR DESCRIPTION
Closes #787.

`connectToServer()` registered the client, transport, and config in its internal maps right after the handshake but *before* calling `listTools()`. So when a server connects fine but its initial `tools/list` fails, the rejection propagates as expected — but the server is left registered: `isServerConnected()` returns true, `getServerInfo()` reports `connected: true` with zero tools, and the stdio child stays alive for the rest of the session.

Moved the map registration to after `listTools()` succeeds, so a server only becomes visible once both connection and tool discovery are done. The catch now also closes the partially-established client best-effort, so its transport / child process doesn't leak when discovery fails.

Added two AVA tests around the connect lifecycle — one for the failed `listTools()` path (rejects, nothing registered, client closed) and one confirming the success path still registers. They use a small `createClient()` seam so the test can inject a client without standing up a real transport.