### PR TITLE
fix(fetch-url): block IPv6 loopback in the SSRF guard

### DIFF
--- a/.changeset/fix-fetch-url-ipv6-loopback.md
+++ b/.changeset/fix-fetch-url-ipv6-loopback.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Block IPv6 loopback in the `fetch_url` SSRF guard. The validator rejected `127.0.0.1` but let `http://[::1]:8080` through, so the loopback protection could be bypassed over IPv6. It now also rejects `[::1]` (and its expanded/IPv4-mapped spellings) and the `[::]` unspecified address. Closes #734.

--- a/source/tools/fetch-url.spec.tsx
+++ b/source/tools/fetch-url.spec.tsx
@@ -141,6 +141,36 @@ test('validator rejects 127.0.0.1 URLs', async t => {
 	}
 });
 
+test('validator rejects IPv6 loopback [::1] URLs', async t => {
+	if (!fetchUrlTool) {
+		t.pass('Skipping test - fetch-url module not available');
+		return;
+	}
+	const result = await fetchUrlTool.validator!({
+		url: 'http://[::1]:8080',
+	});
+
+	t.false(result.valid);
+	if (!result.valid) {
+		t.true(result.error.includes('internal/private network'));
+	}
+});
+
+test('validator rejects expanded and IPv4-mapped IPv6 loopback URLs', async t => {
+	if (!fetchUrlTool) {
+		t.pass('Skipping test - fetch-url module not available');
+		return;
+	}
+	for (const url of [
+		'http://[0:0:0:0:0:0:0:1]',
+		'http://[::ffff:127.0.0.1]',
+		'http://[::]',
+	]) {
+		const result = await fetchUrlTool.validator!({url});
+		t.false(result.valid, `expected ${url} to be rejected`);
+	}
+});
+
 test('validator rejects 192.168.x.x URLs', async t => {
 	if (!fetchUrlTool) {
 		t.pass('Skipping test - fetch-url module not available');

--- a/source/tools/fetch-url.tsx
+++ b/source/tools/fetch-url.tsx
@@ -153,6 +153,11 @@ const fetchUrlValidator = (
 			hostname === 'localhost' ||
 			hostname === '127.0.0.1' ||
 			hostname === '0.0.0.0' ||
+			// IPv6 loopback/unspecified. The URL parser normalizes every spelling
+			// (`[::1]`, expanded, IPv4-mapped `[::ffff:127.0.0.1]`) to these forms.
+			hostname === '[::1]' ||
+			hostname === '[::ffff:7f00:1]' ||
+			hostname === '[::]' ||
 			hostname.startsWith('192.168.') ||
 			hostname.startsWith('10.') ||
 			hostname.match(/^172\.(1[6-9]|2[0-9]|3[0-1])\./)


### PR DESCRIPTION
Closes #734. The `fetch_url` validator blocks `localhost`/`127.0.0.1`/`0.0.0.0` but not IPv6 loopback, so `http://[::1]:8080` sailed past the guard and could reach local services.

Added `[::1]`, the IPv4-mapped form `[::ffff:7f00:1]`, and the unspecified `[::]` to the same blocklist. The URL parser already normalizes every loopback spelling (`[::1]`, fully expanded, `[::ffff:127.0.0.1]`) to those canonical hostnames, so exact matches cover the variants — the added tests check the expanded and mapped forms too, and fail on `main` without the fix.