### PR TITLE
fix: resolve infinite loading problem caused by syntax error

### DIFF
--- a/plugins/vscode/media/chat-panel.js
+++ b/plugins/vscode/media/chat-panel.js
@@ -608,6 +608,9 @@
 						// If we don't mess with it too much, let's just do exactly what Will said.
 						return p2;
 					}
+					return u;
+				});
+
 			paths.forEach(p => vscode.postMessage({ type: 'requestPathInfo', path: p }));
 		}, true);
 	}


### PR DESCRIPTION
## Description

This PR fixes a critical infinite loading state bug in the VS Code extension's chat panel where the Provider, Model, and Mode dropdowns would remain stuck on "Loading..." and the main chat view would not render.

**Why this happened:**
During a previous merge/refactor for file attachment logic, a `map` callback in `chat-panel.js` was accidentally left missing its closing bracket and parenthesis (`});`). 
1. This caused a `SyntaxError: missing ) after argument list` when the webview attempted to evaluate the JavaScript. 
2. Because the script execution halted, the webview never sent the `{ type: 'ready' }` message to the extension host.
3. Without receiving the `ready` signal, the extension host withheld the `syncState` payload. 
4. The frontend UI was left infinitely waiting for state, resulting in blank dropdowns and a missing chat history.

This PR simply restores the missing `});` to fix the syntax error, allowing the script to parse and the initialization handshake to complete successfully.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [x] Tested with Ollama
- [x] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
