### PR TITLE
fix: drop blank separator between context-free search matches

### DIFF
--- a/.changeset/search-results-compact-separator.md
+++ b/.changeset/search-results-compact-separator.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+`search_file_contents` no longer puts a blank line between context-free matches, and decides its layout from the `contextLines` argument rather than sniffing each match for a newline. A context block that collapsed to a single line (single-line files, or when truncation dropped every newline) previously rendered with the exact-match header and a doubled line number.

--- a/source/tools/search-file-contents.spec.tsx
+++ b/source/tools/search-file-contents.spec.tsx
@@ -1735,6 +1735,91 @@ test.serial(
 );
 
 test.serial(
+	'search_file_contents separates context-free matches with a single newline',
+	async t => {
+		t.timeout(10000);
+		const testDir = join(process.cwd(), 'test-search-compact-temp');
+
+		try {
+			mkdirSync(testDir, {recursive: true});
+			writeFileSync(
+				join(testDir, 'test.ts'),
+				'TARGET_MATCH one\nfiller\nTARGET_MATCH two\nfiller\nTARGET_MATCH three',
+			);
+
+			const originalCwd = process.cwd();
+
+			try {
+				process.chdir(testDir);
+
+				const result = await searchFileContentsTool.tool.execute!(
+					{query: 'TARGET_MATCH', maxResults: 30},
+					{toolCallId: 'test', messages: []},
+				);
+
+				// Only the header/body split should produce a blank line; the
+				// match list itself must not contain any.
+				const sections = result.split('\n\n');
+				t.is(sections.length, 2, `Expected one blank line, got: ${result}`);
+				t.true(
+					sections[0].startsWith('Found 3 matches'),
+					'Header should report three matches',
+				);
+
+				const lines = sections[1].split('\n');
+				t.is(lines.length, 3, 'Each match should occupy exactly one line');
+				for (const line of lines) {
+					t.regex(line, /^test\.ts:\d+:TARGET_MATCH/, 'Expected file:line:content');
+				}
+			} finally {
+				process.chdir(originalCwd);
+			}
+		} finally {
+			rmSync(testDir, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
+	'search_file_contents keeps the context header separator when a context block is one line',
+	async t => {
+		t.timeout(10000);
+		const testDir = join(process.cwd(), 'test-search-single-line-temp');
+
+		try {
+			mkdirSync(testDir, {recursive: true});
+			// A single-line file collapses the context block to one line, so
+			// content-sniffing would misread it as an exact match.
+			writeFileSync(join(testDir, 'test.ts'), 'const TARGET_MATCH = 1;');
+
+			const originalCwd = process.cwd();
+
+			try {
+				process.chdir(testDir);
+
+				const result = await searchFileContentsTool.tool.execute!(
+					{query: 'TARGET_MATCH', contextLines: 3, maxResults: 30},
+					{toolCallId: 'test', messages: []},
+				);
+
+				t.true(
+					result.includes('test.ts:1-\n'),
+					`Context block should use the "-" header, got: ${result}`,
+				);
+				t.false(
+					result.includes('test.ts:1:1:'),
+					'Should not emit the exact-match header with a doubled line number',
+				);
+			} finally {
+				process.chdir(originalCwd);
+			}
+		} finally {
+			rmSync(testDir, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
 	'search_file_contents clamps contextLines to max 10',
 	async t => {
 		t.timeout(10000);

--- a/source/tools/search-file-contents.tsx
+++ b/source/tools/search-file-contents.tsx
@@ -63,6 +63,8 @@ const executeSearchFileContents = async (
 	// outside it (e.g. `cd /etc`) can't grep the whole filesystem.
 	const searchRoot = getContainedSessionCwd();
 
+	const contextLines = Math.min(args.contextLines ?? 0, MAX_CONTEXT_LINES);
+
 	try {
 		const {matches, truncated} = await searchProjectContents(
 			args.query,
@@ -72,27 +74,35 @@ const executeSearchFileContents = async (
 			args.include,
 			searchPath,
 			args.wholeWord,
-			Math.min(args.contextLines ?? 0, MAX_CONTEXT_LINES),
+			contextLines,
 		);
 
 		if (matches.length === 0) {
 			return `No matches found for "${args.query}"`;
 		}
 
-		// Format results grep-style: one line per match (`file:line:content`).
-		// Matches with context lines have multi-line content already prefixed
-		// per-line by the search itself, so those use `-` as the header
-		// separator (standard grep convention for context) and keep the block
-		// on its own lines instead of squeezing it onto one.
+		// Format results grep-style. Without context every match is a single
+		// line (`file:line:content`) and matches are newline-separated, with no
+		// blank line between them.
+		//
+		// With context, the search returns a multi-line block already prefixed
+		// per-line with its own line number, so the header uses `-` instead of
+		// `:` (grep's convention for context rather than an exact match) and
+		// blocks are blank-line separated so their boundaries stay legible.
+		//
+		// `contextLines` applies to the whole call, so it decides the layout for
+		// every match. Sniffing each match's content for a newline would get
+		// this wrong whenever a context block collapses to one line, which
+		// happens on single-line files and when truncation drops every newline.
 		let output = `Found ${matches.length} match${matches.length === 1 ? '' : 'es'}${truncated ? ` (showing first ${maxResults})` : ''}:\n\n`;
 
-		output += matches
-			.map(match =>
-				match.content.includes('\n')
-					? `${match.file}:${match.line}-\n${match.content}`
-					: `${match.file}:${match.line}:${match.content}`,
-			)
-			.join('\n\n');
+		output += contextLines
+			? matches
+					.map(match => `${match.file}:${match.line}-\n${match.content}`)
+					.join('\n\n')
+			: matches
+					.map(match => `${match.file}:${match.line}:${match.content}`)
+					.join('\n');
 
 		return output.trim();
 	} catch (error: unknown) {


### PR DESCRIPTION
Follow-up to #774, which resolved #766. Picks up the two points raised in that PR's review.

## Changes

**Drop the blank separator between context-free matches.** #774 collapsed each match from two lines to one but kept `.join('\n\n')`, so a blank line still sat between every match. #766 flagged that separator alongside the layout, so this lands the rest of it. Context blocks keep their blank-line separation, where it genuinely aids legibility.

**Decide layout from `contextLines` rather than sniffing content for a newline.** `contextLines` applies to the whole call, so it is the accurate signal. Sniffing misread any context block that collapsed to a single line, which happens on single-line files and whenever truncation drops every newline from the block. Those rendered with the exact-match header and a doubled line number:

```
# before, single-line file with contextLines: 3
single.ts:1:1: const onlyLine = 1;

# after
single.ts:1-
1: const onlyLine = 1;
```

## Measured

Real 30-match search (`useState` across `*.tsx`):

- pre-#774: 3045 chars
- after #774: 2985 chars
- this PR: 2956 chars

## Test plan

- Two new tests, one per change. Verified non-vacuous: both fail against the merged #774 code and pass against this branch.
- `pnpm run test:ava source/tools/search-file-contents.spec.tsx` — 58 pass
- `test:lint`, `test:types`, `test:format` — clean

## Note

The estimate in #766 of 3-4 tokens per match was mine and it was optimistic. The real figure is closer to 2 characters per match. The win is free and lossless but small, so it is not worth sizing future work off that number.
