### PR TITLE
feat(commands): add /commit command

### DIFF
--- a/.changeset/chubby-books-behave.md
+++ b/.changeset/chubby-books-behave.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added a /commit slash command that generates Conventional Commit messages from staged Git diffs using the active LLM client. Thanks to @DeepamJha. Closes #757.

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -31,6 +31,7 @@ Type `/` in the chat input to see available commands. All commands start with `/
 | `/exit` | Exit the application |
 | `/export` | Export current session to markdown file |
 | `/copy` | Copy the last assistant response to the system clipboard |
+| `/commit` | Generate a Conventional Commit message from staged Git changes |
 | `/doctor` | Show environment health report for bug reports |
 | `/update` | Update Nanocoder to the latest version |
 | `/usage` | Get current model context usage visually |

--- a/source/commands/commit.spec.tsx
+++ b/source/commands/commit.spec.tsx
@@ -1,0 +1,131 @@
+import test from 'ava';
+import React from 'react';
+import clipboard from 'clipboardy';
+import {renderWithTheme} from '@/test-utils/render-with-theme';
+import type {Message} from '@/types/core';
+import {commitCommand} from '@/commands/commit';
+// In a CI/Linux sandbox clipboardy.write may not have a backing binary
+// installed (it shells out to xclip/xsel/pbcopy/clip.exe). For tests we
+// stub the write method directly on the default export object — this is
+// the same monkey-patching approach export.spec.tsx uses for fs.writeFile.
+const originalWrite = clipboard.write;
+let lastWritten: string | null = null;
+let writeImpl: (text: string) => Promise<void> = async text => {
+	lastWritten = text;
+};
+
+test.beforeEach(() => {
+	lastWritten = null;
+	writeImpl = async text => {
+		lastWritten = text;
+	};
+	(clipboard as {write: (text: string) => Promise<void>}).write = text =>
+		writeImpl(text);
+});
+
+test.afterEach(() => {
+	(clipboard as {write: (text: string) => Promise<void>}).write = originalWrite;
+});
+
+const testMetadata = {
+	provider: 'test-provider',
+	model: 'test-model',
+	tokens: 0,
+	getMessageTokens: (m: Message) => m.content.length,
+};
+
+const baseMessages: Message[] = [
+	{role: 'user', content: 'Tell me a joke'},
+	{role: 'assistant', content: 'Why did the chicken cross the road?'},
+	{role: 'user', content: 'I don\'t know, why?'},
+	{role: 'assistant', content: 'To get to the other side.'},
+];
+
+test('copyCommand has correct name and description', t => {
+	t.is(copyCommand.name, 'copy');
+	t.is(
+		copyCommand.description,
+		'Copy the last assistant response to the clipboard',
+	);
+});
+
+test('copyCommand writes the last assistant content to the clipboard', async t => {
+	await commitCommand.handler([], baseMessages, testMetadata);
+
+	t.is(lastWritten, 'To get to the other side.');
+});
+
+test('copyCommand returns a React success message on success', async t => {
+	const result = await copyCommand.handler(
+		[],
+		baseMessages,
+		testMetadata,
+	);
+	t.truthy(React.isValidElement(result));
+
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+
+	t.true(output.includes('Copied last response to clipboard'));
+	// The success message should NOT include the copied content itself
+	// (the user just ran /copy — they already know what they copied).
+	t.false(output.includes('To get to the other side'));
+});
+
+test('copyCommand warns when no assistant response exists', async t => {
+	const messages: Message[] = [
+		{role: 'user', content: 'Hello?'},
+		{role: 'system', content: 'You are a helpful assistant'},
+	];
+
+	const result = await copyCommand.handler([], messages, testMetadata);
+	t.truthy(React.isValidElement(result));
+
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+
+	t.true(output.includes('No assistant response to copy yet'));
+	t.is(lastWritten, null);
+});
+
+test('copyCommand warns when last assistant message has empty content', async t => {
+	const messages: Message[] = [
+		{role: 'user', content: 'Hello?'},
+		{role: 'assistant', content: ''},
+	];
+
+	const result = await copyCommand.handler([], messages, testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+
+	t.true(output.includes('No assistant response to copy yet'));
+	t.is(lastWritten, null);
+});
+
+test('copyCommand returns an error message when clipboard write fails', async t => {
+	writeImpl = async () => {
+		throw new Error('no clipboard tool available');
+	};
+
+	const result = await copyCommand.handler([], baseMessages, testMetadata);
+	t.truthy(React.isValidElement(result));
+
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+
+	t.true(output.includes('Failed to copy to clipboard'));
+	t.true(output.includes('no clipboard tool available'));
+});
+
+test('copyCommand ignores trailing non-assistant messages', async t => {
+	// Even if there are tool/system messages after the assistant, the
+	// last assistant content should still be the one copied.
+	const messages: Message[] = [
+		...baseMessages,
+		{role: 'tool', name: 'echo', content: 'noise'},
+		{role: 'system', content: 'system note'},
+	];
+
+	await copyCommand.handler([], messages, testMetadata);
+	t.is(lastWritten, 'To get to the other side.');
+});

--- a/source/commands/commit.spec.tsx
+++ b/source/commands/commit.spec.tsx
@@ -1,31 +1,12 @@
 import test from 'ava';
 import React from 'react';
-import clipboard from 'clipboardy';
 import {renderWithTheme} from '@/test-utils/render-with-theme';
 import type {Message} from '@/types/core';
-import {commitCommand} from '@/commands/commit';
-// In a CI/Linux sandbox clipboardy.write may not have a backing binary
-// installed (it shells out to xclip/xsel/pbcopy/clip.exe). For tests we
-// stub the write method directly on the default export object — this is
-// the same monkey-patching approach export.spec.tsx uses for fs.writeFile.
-const originalWrite = clipboard.write;
-let lastWritten: string | null = null;
-let writeImpl: (text: string) => Promise<void> = async text => {
-	lastWritten = text;
-};
+import {createCommitCommand} from './commit';
 
-test.beforeEach(() => {
-	lastWritten = null;
-	writeImpl = async text => {
-		lastWritten = text;
-	};
-	(clipboard as {write: (text: string) => Promise<void>}).write = text =>
-		writeImpl(text);
-});
-
-test.afterEach(() => {
-	(clipboard as {write: (text: string) => Promise<void>}).write = originalWrite;
-});
+const baseMessages: Message[] = [
+	{role: 'user', content: 'Generate a commit message'},
+];
 
 const testMetadata = {
 	provider: 'test-provider',
@@ -34,98 +15,162 @@ const testMetadata = {
 	getMessageTokens: (m: Message) => m.content.length,
 };
 
-const baseMessages: Message[] = [
-	{role: 'user', content: 'Tell me a joke'},
-	{role: 'assistant', content: 'Why did the chicken cross the road?'},
-	{role: 'user', content: 'I don\'t know, why?'},
-	{role: 'assistant', content: 'To get to the other side.'},
-];
+function createClient(response: string) {
+	return {
+		chat: async () => ({
+			choices: [
+				{
+					message: {
+						content: response,
+					},
+				},
+			],
+		}),
+	};
+}
 
-test('copyCommand has correct name and description', t => {
-	t.is(copyCommand.name, 'copy');
+test('commitCommand has correct name and description', t => {
+	const command = createCommitCommand({
+		hasStagedChanges: async () => false,
+		execGit: async () => '',
+	});
+
+	t.is(command.name, 'commit');
 	t.is(
-		copyCommand.description,
-		'Copy the last assistant response to the clipboard',
+		command.description,
+		'Generate a conventional commit message from staged changes',
 	);
 });
 
-test('copyCommand writes the last assistant content to the clipboard', async t => {
-	await commitCommand.handler([], baseMessages, testMetadata);
+test('commit warns when no staged changes exist', async t => {
+	const command = createCommitCommand({
+		hasStagedChanges: async () => false,
+		execGit: async () => {
+			throw new Error('execGit should not be called');
+		},
+	});
 
-	t.is(lastWritten, 'To get to the other side.');
-});
+	const result = await command.handler([], baseMessages, testMetadata);
 
-test('copyCommand returns a React success message on success', async t => {
-	const result = await copyCommand.handler(
-		[],
-		baseMessages,
-		testMetadata,
-	);
 	t.truthy(React.isValidElement(result));
 
 	const {lastFrame} = renderWithTheme(result as React.ReactElement);
 	const output = lastFrame() || '';
 
-	t.true(output.includes('Copied last response to clipboard'));
-	// The success message should NOT include the copied content itself
-	// (the user just ran /copy — they already know what they copied).
-	t.false(output.includes('To get to the other side'));
+	t.true(output.includes('No staged changes to commit'));
 });
 
-test('copyCommand warns when no assistant response exists', async t => {
-	const messages: Message[] = [
-		{role: 'user', content: 'Hello?'},
-		{role: 'system', content: 'You are a helpful assistant'},
-	];
+test('commit returns an error when no client is available', async t => {
+	const command = createCommitCommand({
+		hasStagedChanges: async () => true,
+		execGit: async () => 'diff --git a/file.ts b/file.ts',
+	});
 
-	const result = await copyCommand.handler([], messages, testMetadata);
+	const result = await command.handler([], baseMessages, {
+		...testMetadata,
+		client: undefined,
+	});
+
 	t.truthy(React.isValidElement(result));
 
 	const {lastFrame} = renderWithTheme(result as React.ReactElement);
 	const output = lastFrame() || '';
 
-	t.true(output.includes('No assistant response to copy yet'));
-	t.is(lastWritten, null);
+	t.true(output.includes('No active LLM client available'));
 });
 
-test('copyCommand warns when last assistant message has empty content', async t => {
-	const messages: Message[] = [
-		{role: 'user', content: 'Hello?'},
-		{role: 'assistant', content: ''},
-	];
+test('commit generates a message from the staged diff', async t => {
+	let receivedMessages: Message[] = [];
 
-	const result = await copyCommand.handler([], messages, testMetadata);
-	const {lastFrame} = renderWithTheme(result as React.ReactElement);
-	const output = lastFrame() || '';
+	const command = createCommitCommand({
+		hasStagedChanges: async () => true,
+		execGit: async args => {
+			t.deepEqual(args, [
+				'diff',
+				'--cached',
+				'--no-ext-diff',
+				'--no-color',
+			]);
 
-	t.true(output.includes('No assistant response to copy yet'));
-	t.is(lastWritten, null);
-});
+			return 'diff --git a/file.ts b/file.ts\n+const value = 1;';
+		},
+	});
 
-test('copyCommand returns an error message when clipboard write fails', async t => {
-	writeImpl = async () => {
-		throw new Error('no clipboard tool available');
+	const client = {
+		chat: async (messages: Message[]) => {
+			receivedMessages = messages;
+
+			return {
+				choices: [
+					{
+						message: {
+							content: 'feat: add value constant',
+						},
+					},
+				],
+			};
+		},
 	};
 
-	const result = await copyCommand.handler([], baseMessages, testMetadata);
+	const result = await command.handler([], baseMessages, {
+		...testMetadata,
+		client,
+	});
+
 	t.truthy(React.isValidElement(result));
 
 	const {lastFrame} = renderWithTheme(result as React.ReactElement);
 	const output = lastFrame() || '';
 
-	t.true(output.includes('Failed to copy to clipboard'));
-	t.true(output.includes('no clipboard tool available'));
+	t.true(output.includes('feat: add value constant'));
+	t.is(receivedMessages[0]?.role, 'system');
+	t.is(receivedMessages[1]?.role, 'user');
+	t.is(
+	receivedMessages[1]?.content,
+	'diff --git a/file.ts b/file.ts\n+const value = 1;',
+);
 });
 
-test('copyCommand ignores trailing non-assistant messages', async t => {
-	// Even if there are tool/system messages after the assistant, the
-	// last assistant content should still be the one copied.
-	const messages: Message[] = [
-		...baseMessages,
-		{role: 'tool', name: 'echo', content: 'noise'},
-		{role: 'system', content: 'system note'},
-	];
+test('commit warns when the model returns an empty response', async t => {
+	const command = createCommitCommand({
+		hasStagedChanges: async () => true,
+		execGit: async () => 'staged diff',
+	});
 
-	await copyCommand.handler([], messages, testMetadata);
-	t.is(lastWritten, 'To get to the other side.');
+	const result = await command.handler([], baseMessages, {
+		...testMetadata,
+		client: createClient(''),
+	});
+
+	t.truthy(React.isValidElement(result));
+
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+
+	t.true(output.includes('Model returned an empty commit message'));
+});
+
+test('commit returns an error when the LLM request fails', async t => {
+	const command = createCommitCommand({
+		hasStagedChanges: async () => true,
+		execGit: async () => 'staged diff',
+	});
+
+	const client = {
+		chat: async () => {
+			throw new Error('LLM request failed');
+		},
+	};
+
+	const result = await command.handler([], baseMessages, {
+		...testMetadata,
+		client,
+	});
+
+	t.truthy(React.isValidElement(result));
+
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+
+	t.true(output.includes('LLM request failed'));
 });

--- a/source/commands/commit.ts
+++ b/source/commands/commit.ts
@@ -1,0 +1,59 @@
+import {execGit, hasStagedChanges} from '@/tools/git/utils';
+import type {Command} from '@/types/commands';
+import type {Message} from '@/types/core';
+import {formatError} from '@/utils/error-formatter';
+import {errorMsg, successMsg, warningMsg} from '@/utils/message-factory';
+
+const COMMIT_SYSTEM_PROMPT = `You write Git commit messages using the Conventional Commits specification.
+
+Rules:
+- Output ONLY the commit message.
+- No markdown.
+- No explanation.
+- Use types like feat, fix, chore, docs, refactor, test, style, perf, build, ci.
+- Base the message only on the provided staged diff.`;
+
+export const commitCommand: Command = {
+	name: 'commit',
+	description: 'Generate a conventional commit message from staged changes',
+	handler: async (_args, _messages, metadata) => {
+		const hasChanges = await hasStagedChanges();
+
+		if (!hasChanges) {
+			return warningMsg('No staged changes to commit.', 'commit');
+		}
+
+		const diff = await execGit(['diff', '--cached']);
+
+		const client = metadata.client;
+
+		if (!client) {
+			return errorMsg('No active LLM client available.', 'commit');
+		}
+
+		const commitMessages: Message[] = [
+			{
+				role: 'system',
+				content: COMMIT_SYSTEM_PROMPT,
+			},
+			{
+				role: 'user',
+				content: diff,
+			},
+		];
+
+		try {
+			const response = await client.chat(commitMessages, {}, {});
+
+			const commitMessage = response?.choices?.[0]?.message?.content?.trim();
+
+			if (!commitMessage) {
+				return warningMsg('Model returned an empty commit message.', 'commit');
+			}
+
+			return successMsg(commitMessage, 'commit');
+		} catch (error) {
+			return errorMsg(formatError(error), 'commit');
+		}
+	},
+};

--- a/source/commands/commit.ts
+++ b/source/commands/commit.ts
@@ -1,4 +1,4 @@
-import {execGit, hasStagedChanges} from '@/tools/git/utils';
+import {execGit, hasStagedChanges, truncateDiff} from '@/tools/git/utils';
 import type {Command} from '@/types/commands';
 import type {Message} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
@@ -7,53 +7,81 @@ import {errorMsg, successMsg, warningMsg} from '@/utils/message-factory';
 const COMMIT_SYSTEM_PROMPT = `You write Git commit messages using the Conventional Commits specification.
 
 Rules:
+
 - Output ONLY the commit message.
 - No markdown.
 - No explanation.
 - Use types like feat, fix, chore, docs, refactor, test, style, perf, build, ci.
 - Base the message only on the provided staged diff.`;
 
-export const commitCommand: Command = {
-	name: 'commit',
-	description: 'Generate a conventional commit message from staged changes',
-	handler: async (_args, _messages, metadata) => {
-		const hasChanges = await hasStagedChanges();
+type CommitDependencies = {
+	hasStagedChanges: () => Promise<boolean>;
+	execGit: (args: string[]) => Promise<string>;
+};
 
-		if (!hasChanges) {
-			return warningMsg('No staged changes to commit.', 'commit');
-		}
+const defaultDependencies: CommitDependencies = {
+	hasStagedChanges,
+	execGit,
+};
 
-		const diff = await execGit(['diff', '--cached']);
+export function createCommitCommand(
+	dependencies: CommitDependencies = defaultDependencies,
+): Command {
+	return {
+		name: 'commit',
+		description: 'Generate a conventional commit message from staged changes',
+		handler: async (_args, _messages, metadata) => {
+			const hasChanges = await dependencies.hasStagedChanges();
 
-		const client = metadata.client;
-
-		if (!client) {
-			return errorMsg('No active LLM client available.', 'commit');
-		}
-
-		const commitMessages: Message[] = [
-			{
-				role: 'system',
-				content: COMMIT_SYSTEM_PROMPT,
-			},
-			{
-				role: 'user',
-				content: diff,
-			},
-		];
-
-		try {
-			const response = await client.chat(commitMessages, {}, {});
-
-			const commitMessage = response?.choices?.[0]?.message?.content?.trim();
-
-			if (!commitMessage) {
-				return warningMsg('Model returned an empty commit message.', 'commit');
+			if (!hasChanges) {
+				return warningMsg('No staged changes to commit.', 'commit');
 			}
 
-			return successMsg(commitMessage, 'commit');
-		} catch (error) {
-			return errorMsg(formatError(error), 'commit');
-		}
-	},
-};
+			const diff = truncateDiff(
+				await dependencies.execGit([
+					'diff',
+					'--cached',
+					'--no-ext-diff',
+					'--no-color',
+				]),
+				500,
+			);
+
+			const client = metadata.client;
+
+			if (!client) {
+				return errorMsg('No active LLM client available.', 'commit');
+			}
+
+			const commitMessages: Message[] = [
+				{
+					role: 'system',
+					content: COMMIT_SYSTEM_PROMPT,
+				},
+				{
+					role: 'user',
+					content: diff.content,
+				},
+			];
+
+			try {
+				const response = await client.chat(commitMessages, {}, {});
+
+				const commitMessage = response?.choices?.[0]?.message?.content?.trim();
+
+				if (!commitMessage) {
+					return warningMsg(
+						'Model returned an empty commit message.',
+						'commit',
+					);
+				}
+
+				return successMsg(commitMessage, 'commit');
+			} catch (error) {
+				return errorMsg(formatError(error), 'commit');
+			}
+		},
+	};
+}
+
+export const commitCommand = createCommitCommand();

--- a/source/commands/lazy-registry.ts
+++ b/source/commands/lazy-registry.ts
@@ -68,6 +68,11 @@ export const lazyCommands: LazyCommand[] = [
 		load: () => import('@/commands/copy').then(m => m.copyCommand),
 	},
 	{
+		name: 'commit',
+		description: 'Generate a conventional commit message from staged changes',
+		load: () => import('@/commands/commit').then(m => m.commitCommand),
+	},
+	{
 		name: 'doctor',
 		description: 'Show environment health report for bug reports',
 		load: () => import('@/commands/doctor').then(m => m.doctorCommand),


### PR DESCRIPTION
Closes #757

## Description

Adds a new `/commit` slash command that generates a Conventional Commit
message from the currently staged Git diff.

The implementation follows the approach discussed in #757:

- Checks for staged changes before making an LLM request.
- Reads the staged diff using `git diff --cached`.
- Reuses the active conversation LLM client (`metadata.client`) instead of
  creating a new client.
- Uses a dedicated system prompt to generate only a Conventional Commit
  message.
- Returns the generated message without automatically executing
  `git commit`.
- Handles missing staged changes, empty model responses, and LLM errors
  using the existing message factory.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this feature for the changelog.

## Testing

### Automated Tests

- [x] Added `commit.spec.tsx`
- [x] `pnpm build`
- [x] `pnpm test`
- [x] `pnpm test:lint`

### Manual Testing

- [x] Tested with OpenRouter

Verified that:

- `/commit` warns when no changes are staged.
- `/commit` generates a Conventional Commit message from the staged diff.
- Model errors are surfaced through the existing error message flow.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes
- [x] Appropriate logging added using structured logging (see CONTRIBUTING.md#logging)

(No additional logging was required for this command.)