### PR TITLE
fix: normalize Atlas Cloud GPT-5.6 model IDs

### DIFF
--- a/.changeset/bright-models-fix.md
+++ b/.changeset/bright-models-fix.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+Fixed the Atlas Cloud wizard to store provider-qualified GPT-5.6 model IDs, while preserving compatibility with existing shorthand configurations. Thanks to @RealBhupesh. Closes #803.

--- a/source/ai-sdk-client/ai-sdk-client.spec.ts
+++ b/source/ai-sdk-client/ai-sdk-client.spec.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import type {AIProviderConfig} from '@/types/index';
 import {AISDKClient} from './ai-sdk-client.js';
+import type {TaggedProvider} from './providers/provider-factory.js';
 
 test('AISDKClient constructor initializes with config', t => {
 	const config: AIProviderConfig = {
@@ -114,4 +115,33 @@ test('AISDKClient handles config without models', t => {
 
 	const client = new AISDKClient(config);
 	t.is(client.getCurrentModel(), '');
+});
+
+test('AISDKClient sends the normalized Atlas model to its provider', async t => {
+	const config: AIProviderConfig = {
+		name: 'Atlas Cloud',
+		type: 'openai',
+		models: ['gpt-5.6-sol'],
+		config: {
+			baseURL: 'https://api.atlascloud.ai/v1',
+			apiKey: 'test-key',
+		},
+	};
+	const client = new AISDKClient(config);
+	let receivedModel: string | undefined;
+	const provider = ((model: string): never => {
+		receivedModel = model;
+		throw new Error('model captured');
+	}) as unknown as Extract<
+		TaggedProvider,
+		{kind: 'openai-compatible'}
+	>['provider'];
+	(client as unknown as {provider: TaggedProvider}).provider = {
+		kind: 'openai-compatible',
+		provider,
+	};
+
+	await t.throwsAsync(client.chat([], {}, {}), {message: 'model captured'});
+
+	t.is(receivedModel, 'openai/gpt-5.6-sol');
 });

--- a/source/ai-sdk-client/ai-sdk-client.ts
+++ b/source/ai-sdk-client/ai-sdk-client.ts
@@ -17,6 +17,7 @@ import type {
 import {getLogger} from '@/utils/logging';
 import {isLocalURL} from '@/utils/url-utils';
 import {handleChat} from './chat/chat-handler.js';
+import {normalizeModelIdForRequest} from './model-id.js';
 import {
 	createProvider,
 	type TaggedProvider,
@@ -169,6 +170,12 @@ export class AISDKClient implements LLMClient {
 						? this.provider.provider.responses(this.currentModel)
 						: this.provider.provider.chat(this.currentModel);
 				case 'openai-compatible':
+					return this.provider.provider(
+						normalizeModelIdForRequest(
+							this.providerConfig.config.baseURL,
+							this.currentModel,
+						),
+					) as LanguageModel;
 				case 'anthropic':
 				case 'google':
 					return this.provider.provider(this.currentModel) as LanguageModel;

--- a/source/ai-sdk-client/model-id.spec.ts
+++ b/source/ai-sdk-client/model-id.spec.ts
@@ -1,0 +1,46 @@
+import test from 'ava';
+import {normalizeModelIdForRequest} from './model-id.js';
+
+test('normalizes unqualified Atlas Cloud GPT-5.6 model IDs', t => {
+	t.is(
+		normalizeModelIdForRequest(
+			'https://api.atlascloud.ai/v1',
+			'gpt-5.6-sol',
+		),
+		'openai/gpt-5.6-sol',
+	);
+
+	t.is(
+		normalizeModelIdForRequest(
+			'https://api.atlascloud.ai/v1',
+			'GPT-5.6-TERRA',
+		),
+		'openai/gpt-5.6-terra',
+	);
+});
+
+test('preserves already-qualified Atlas Cloud and unrelated model IDs', t => {
+	t.is(
+		normalizeModelIdForRequest(
+			'https://api.atlascloud.ai/v1',
+			'openai/gpt-5.6-sol',
+		),
+		'openai/gpt-5.6-sol',
+	);
+	t.is(
+		normalizeModelIdForRequest(
+			'https://api.atlascloud.ai/v1',
+			'deepseek-v3',
+		),
+		'deepseek-v3',
+	);
+	t.is(
+		normalizeModelIdForRequest('https://api.openai.com/v1', 'gpt-5.6-sol'),
+		'gpt-5.6-sol',
+	);
+});
+
+test('does not throw for missing or malformed base URLs', t => {
+	t.is(normalizeModelIdForRequest(undefined, 'gpt-5.6-sol'), 'gpt-5.6-sol');
+	t.is(normalizeModelIdForRequest('not a URL', 'gpt-5.6-sol'), 'gpt-5.6-sol');
+});

--- a/source/ai-sdk-client/model-id.ts
+++ b/source/ai-sdk-client/model-id.ts
@@ -1,0 +1,28 @@
+const ATLAS_CLOUD_HOST = 'api.atlascloud.ai';
+const ATLAS_GPT_MODEL_PATTERN = /^gpt-5\.6-(sol|terra|luna)$/i;
+
+function isAtlasCloudBaseUrl(baseURL: string | undefined): boolean {
+	if (!baseURL) return false;
+
+	try {
+		return new URL(baseURL).hostname.toLowerCase() === ATLAS_CLOUD_HOST;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Older Atlas Cloud wizard versions stored unqualified GPT-5.6 model IDs.
+ * Normalize those legacy aliases at request time so existing configurations
+ * continue working after the wizard starts writing provider-qualified IDs.
+ */
+export function normalizeModelIdForRequest(
+	baseURL: string | undefined,
+	model: string,
+): string {
+	if (!isAtlasCloudBaseUrl(baseURL) || !ATLAS_GPT_MODEL_PATTERN.test(model)) {
+		return model;
+	}
+
+	return `openai/${model.toLowerCase()}`;
+}

--- a/source/wizards/templates/provider-templates.spec.ts
+++ b/source/wizards/templates/provider-templates.spec.ts
@@ -658,7 +658,7 @@ test('major providers have correct default models', t => {
 		'chatgpt-codex': 'gpt-5.3-codex',
 		'github-copilot': 'gpt-5.6-sol',
 		'poe': 'gpt-5.6-sol',
-		'atlas-cloud': 'gpt-5.6-sol',
+		'atlas-cloud': 'openai/gpt-5.6-sol',
 		'together': 'deepseek-ai/DeepSeek-V4-Pro',
 	};
 
@@ -674,4 +674,3 @@ test('major providers have correct default models', t => {
 		);
 	}
 });
-

--- a/source/wizards/templates/provider-templates.ts
+++ b/source/wizards/templates/provider-templates.ts
@@ -550,7 +550,7 @@ export const PROVIDER_TEMPLATES: ProviderTemplate[] = [
 		name: 'Atlas Cloud',
 		baseUrl: 'https://api.atlascloud.ai/v1',
 		apiKeyPrompt: 'API Key (from atlascloud.ai/developer)',
-		modelDefault: 'gpt-5.6-sol',
+		modelDefault: 'openai/gpt-5.6-sol',
 	}),
 	apiKeyTemplate({
 		id: 'together',


### PR DESCRIPTION
## Summary

- change the Atlas Cloud wizard default to the provider-qualified `openai/gpt-5.6-sol` model ID
- normalize legacy unqualified GPT-5.6 Atlas configs only at the OpenAI-compatible request boundary
- preserve qualified IDs, unrelated models, and other providers
- add template, normalization, and provider-wiring regression coverage plus a patch changeset

## Root-cause status

Atlas documents the model as `openai/gpt-5.6-sol`, while NanoCoder's wizard previously stored `gpt-5.6-sol`. The template mismatch is confirmed in the repository and fixed here. An authenticated two-request Atlas API comparison is still pending, so this PR does not claim the endpoint rejection is independently confirmed yet.

Closes #803

## Validation

- focused template, model-ID, and AI SDK client suites: 51 passed
- regression mutation: the provider-wiring test fails when the raw model is restored
- format and diff checks pass
- full branch CI is temporarily blocked by the ACP SDK regression on current `main`; prerequisite fix: #830