### PR TITLE
feat(cli): add token usage block to --json run report

### DIFF
--- a/.changeset/six-goats-rhyme.md
+++ b/.changeset/six-goats-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Add token usage block to the --plain --json run report. Downstream tooling consuming headless JSON output can now read input/output/total token counts per run, when the provider reports them. Closes #821.

--- a/source/plain/conversation.spec.ts
+++ b/source/plain/conversation.spec.ts
@@ -40,6 +40,7 @@ function makeFakeClient(options: FakeClientOptions): LLMClient {
 					{ message: { role: "assistant", content: "" } },
 				],
 				toolsDisabled: partial.toolsDisabled,
+				usage: partial.usage,
 			} as LLMChatResponse;
 		},
 	} as unknown as LLMClient;
@@ -636,6 +637,7 @@ function makeRecordingClient(
 					{ message: { role: "assistant", content: "" } },
 				],
 				toolsDisabled: partial.toolsDisabled,
+				usage: partial.usage,
 			} as LLMChatResponse;
 		},
 	} as unknown as LLMClient;
@@ -769,5 +771,104 @@ test.serial(
 		t.is(outcome.kind, "success");
 		t.is(handlerCalls, 0, "final-turn XML tool call must not execute");
 		t.is(calls.length, 1);
+	},
+);
+
+test.serial(
+	"accumulates token usage across multiple turns",
+	async (t) => {
+		const calls: RecordedCall[] = [];
+		const client = makeRecordingClient(
+			[
+				{
+					choices: [
+						{
+							message: {
+								role: "assistant",
+								content: "",
+								tool_calls: [
+									{
+										id: "call_1",
+										type: "function",
+										function: { name: "safe_tool", arguments: {} },
+									},
+								],
+							},
+						},
+					],
+					usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+				},
+				{
+					choices: [
+						{
+							message: {
+								role: "assistant",
+								content: "all done",
+							},
+						},
+					],
+					usage: { inputTokens: 150, outputTokens: 30, totalTokens: 180 },
+				},
+			],
+			calls,
+		);
+		const toolManager = makeFakeToolManager({
+			knownTools: new Set(["safe_tool"]),
+			needsApprovalByName: { safe_tool: false },
+		});
+		setToolRegistryGetter(() => ({
+			safe_tool: (async () => "tool-output") as ToolHandler,
+		}));
+
+		const outcome = await runPlainConversation({
+			client,
+			toolManager,
+			systemMessage: SYSTEM,
+			initialMessages: [USER],
+			developmentMode: "auto-accept",
+			nonInteractiveAlwaysAllow: [],
+			abortSignal: new AbortController().signal,
+		});
+
+		t.is(outcome.kind, "success");
+		t.deepEqual(outcome.usage, {
+			inputTokens: 250,
+			outputTokens: 50,
+			totalTokens: 300,
+		});
+	},
+);
+
+test.serial(
+	"omits usage property when no turn reports usage",
+	async (t) => {
+		const client = makeFakeClient({
+			responses: [
+				{
+					choices: [
+						{
+							message: {
+								role: "assistant",
+								content: "no usage here",
+							},
+						},
+					],
+				},
+			],
+		});
+		const toolManager = makeFakeToolManager();
+
+		const outcome = await runPlainConversation({
+			client,
+			toolManager,
+			systemMessage: SYSTEM,
+			initialMessages: [USER],
+			developmentMode: "auto-accept",
+			nonInteractiveAlwaysAllow: [],
+			abortSignal: new AbortController().signal,
+		});
+
+		t.is(outcome.kind, "success");
+		t.is(outcome.usage, undefined);
 	},
 );

--- a/source/plain/conversation.ts
+++ b/source/plain/conversation.ts
@@ -35,12 +35,19 @@ export interface RunPlainConversationOptions {
 	outputFormat?: 'text' | 'json';
 }
 
+export interface PlainConversationUsage {
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+}
+
 export type PlainConversationOutcome =
 	| {
 			kind: 'success';
 			finalText: string;
 			reasoning: string | null;
 			toolCalls: ToolCallLog[];
+			usage?: PlainConversationUsage;
 	  }
 	| {
 			kind: 'tool-approval-required';
@@ -48,6 +55,7 @@ export type PlainConversationOutcome =
 			finalText: string;
 			reasoning: string | null;
 			toolCalls: ToolCallLog[];
+			usage?: PlainConversationUsage;
 	  }
 	| {
 			kind: 'error';
@@ -55,6 +63,7 @@ export type PlainConversationOutcome =
 			finalText: string;
 			reasoning: string | null;
 			toolCalls: ToolCallLog[];
+			usage?: PlainConversationUsage;
 	  };
 
 // On the last allowed turn we strip tools and inject this so the model
@@ -98,6 +107,20 @@ export async function runPlainConversation(
 	let accumulatedReasoning = '';
 	const toolCallsLog: ToolCallLog[] = [];
 
+	let hasReportedUsage = false;
+	let accumulatedInputTokens = 0;
+	let accumulatedOutputTokens = 0;
+	let accumulatedTotalTokens = 0;
+
+	const getUsage = (): PlainConversationUsage | undefined => {
+		if (!hasReportedUsage) return undefined;
+		return {
+			inputTokens: accumulatedInputTokens,
+			outputTokens: accumulatedOutputTokens,
+			totalTokens: accumulatedTotalTokens,
+		};
+	};
+
 	const maxTurns =
 		getAppConfig().headless?.maxTurns ?? DEFAULT_HEADLESS_MAX_TURNS;
 
@@ -109,6 +132,7 @@ export async function runPlainConversation(
 				finalText: accumulatedFinalText,
 				reasoning: accumulatedReasoning || null,
 				toolCalls: toolCallsLog,
+				usage: getUsage(),
 			};
 		}
 
@@ -173,6 +197,13 @@ export async function runPlainConversation(
 			modeOverrides,
 		);
 
+		if (result?.usage) {
+			hasReportedUsage = true;
+			accumulatedInputTokens += result.usage.inputTokens ?? 0;
+			accumulatedOutputTokens += result.usage.outputTokens ?? 0;
+			accumulatedTotalTokens += result.usage.totalTokens ?? 0;
+		}
+
 		if (!isJson && (reasoningPrinted || contentStarted)) {
 			writeLine();
 		}
@@ -184,6 +215,7 @@ export async function runPlainConversation(
 				finalText: accumulatedFinalText,
 				reasoning: accumulatedReasoning || null,
 				toolCalls: toolCallsLog,
+				usage: getUsage(),
 			};
 		}
 
@@ -210,6 +242,7 @@ export async function runPlainConversation(
 				finalText: accumulatedFinalText,
 				reasoning: accumulatedReasoning || null,
 				toolCalls: toolCallsLog,
+				usage: getUsage(),
 			};
 		}
 
@@ -268,6 +301,7 @@ export async function runPlainConversation(
 					finalText: accumulatedFinalText,
 					reasoning: accumulatedReasoning || null,
 					toolCalls: toolCallsLog,
+					usage: getUsage(),
 				};
 			}
 			return {
@@ -275,6 +309,7 @@ export async function runPlainConversation(
 				finalText: accumulatedFinalText,
 				reasoning: accumulatedReasoning || null,
 				toolCalls: toolCallsLog,
+				usage: getUsage(),
 			};
 		}
 
@@ -302,6 +337,7 @@ export async function runPlainConversation(
 				finalText: accumulatedFinalText,
 				reasoning: accumulatedReasoning || null,
 				toolCalls: toolCallsLog,
+				usage: getUsage(),
 			};
 		}
 
@@ -352,6 +388,7 @@ export async function runPlainConversation(
 		finalText: accumulatedFinalText,
 		reasoning: accumulatedReasoning || null,
 		toolCalls: toolCallsLog,
+		usage: getUsage(),
 	};
 }
 

--- a/source/plain/shell.spec.ts
+++ b/source/plain/shell.spec.ts
@@ -93,6 +93,7 @@ function baseDeps(
 	return {
 		loadPreferences: () => ({ trustedDirectories: [] }) as never,
 		savePreferences: () => undefined,
+		getShutdownManager: makeFakeShutdownManager({ code: null }),
 		...overrides,
 	};
 }
@@ -129,6 +130,50 @@ test.serial(
 		t.is(report.finalText, "all done");
 		t.deepEqual(report.toolCalls, []);
 		t.deepEqual(report.filesChanged, []);
+		t.is(report.usage, undefined);
+		t.is(shutdown.code, 0);
+	},
+);
+
+test.serial(
+	"--json success outcome includes usage block when present in conversation outcome",
+	async (t) => {
+		const shutdown: CapturedShutdown = { code: null };
+		const stdout = capturingStdout();
+		try {
+			await runPlainShell({
+				prompt: "do the thing",
+				developmentMode: "auto-accept",
+				trustDirectory: true,
+				outputFormat: "json",
+				deps: baseDeps({
+					initializePlain: makeFakeInitializePlain(),
+					runPlainConversation: makeFakeRunPlainConversation({
+						kind: "success",
+						finalText: "all done",
+						reasoning: null,
+						toolCalls: [],
+						usage: {
+							inputTokens: 500,
+							outputTokens: 100,
+							totalTokens: 600,
+						},
+					}),
+					getShutdownManager: makeFakeShutdownManager(shutdown),
+				}),
+			});
+		} finally {
+			stdout.restore();
+		}
+
+		const report = JSON.parse(stdout.get());
+		t.is(report.kind, "success");
+		t.is(report.exitCode, 0);
+		t.deepEqual(report.usage, {
+			inputTokens: 500,
+			outputTokens: 100,
+			totalTokens: 600,
+		});
 		t.is(shutdown.code, 0);
 	},
 );

--- a/source/plain/shell.ts
+++ b/source/plain/shell.ts
@@ -223,6 +223,9 @@ export async function runPlainShell(
 			reasoning: outcome.reasoning ? sanitizeOutput(outcome.reasoning) : null,
 			toolCalls: formattedToolCalls,
 			filesChanged: Array.from(filesChangedSet),
+			...(outcome.usage && {
+				usage: outcome.usage,
+			}),
 			...(outcome.kind === 'error' && {
 				message: sanitizeOutput(outcome.message),
 			}),


### PR DESCRIPTION
## Description

While finalizing the NanoBench architecture, I identified a critical missing dependency: downstream evaluation harnesses have no way to programmatically track token consumption or diagnose API quota limits. 

Following up on the discussion in `Nano-Collective/docs#60`, I investigated issues #756 and #796. Both issues highlight a clear community need for token telemetry. After reviewing them, I found neither of those addresses the `--json` run report. NanoBench's orchestrator runs Nanocoder in `--plain --json` mode and reads structured stdout — that's a completely different code path from the interactive CLI footer or the VS Code ACP layer. 

So #796, as written, would not actually put a usage block into the payload NanoBench needs. It's adjacent (same underlying `ResponseUsage` concept, same provider-reported token data), but it doesn't close the gap mentioned in NanoBench: https://github.com/Nano-Collective/docs/issues/60#issue-5081496969

## What this PR does
This PR extends the headless `stdout` payload to expose total token consumption metrics when Nanocoder is run with the `--json` flag.

**Key Changes:**
* **Multi-Turn Accumulation:** Tracks and sums input, output, and total tokens across the entire conversation loop in `runPlainConversation`.
* **Schema Extension:** Injects a structured `usage` block into the final `--json` output.
* **Graceful Degradation:** Safely omits the `usage` property for local/unsupported models that don't report token metrics, preventing parser breaks.
* **Test Coverage:** Adds unit tests in `conversation.spec.ts` and `shell.spec.ts` to validate state tracking and payload generation.

It captures the usage data from the underlying AI SDK provider and appends a `usage` block to the final JSON report. The shape looks like this:

```json
{
  "kind": "run_completed",
  "exitCode": 0,
  "toolCalls": [...],
  "filesChanged": [...],
  "temperature": 0,
  "usage": {
    "inputTokens": 4520,
    "outputTokens": 850,
    "totalTokens": 5370
  }
}
```

## Type of Change

- [x] New feature


