### PR TITLE
fix: restore ACP provider discovery

### DIFF
--- a/.changeset/restore-acp-provider-identifiers.md
+++ b/.changeset/restore-acp-provider-identifiers.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed ACP provider discovery after the SDK 1.3 update by including the required provider identifier.

--- a/source/acp/acp-agent.spec.ts
+++ b/source/acp/acp-agent.spec.ts
@@ -3,6 +3,7 @@ import {join} from 'node:path';
 import test from 'ava';
 import {AcpAgent} from '@/acp/acp-agent';
 import type {AcpInitContext} from '@/acp/acp-types';
+import {clearAppConfig} from '@/config';
 import {
 	setToolRegistryGetter,
 	setToolManagerGetter,
@@ -101,6 +102,38 @@ test('AcpAgent.initialize - returns empty auth methods', async t => {
 	const {agent} = createAgent();
 	const result = await agent.initialize({protocolVersion: 1});
 	t.deepEqual(result.authMethods, []);
+});
+
+test.serial('AcpAgent.unstable_listProviders - returns ACP provider identifiers', async t => {
+	const previousProviders = process.env.NANOCODER_PROVIDERS;
+	process.env.NANOCODER_PROVIDERS = JSON.stringify([
+		{
+			name: 'Atlas Cloud',
+			baseUrl: 'https://api.atlascloud.ai/v1',
+			models: ['openai/gpt-5.6-sol'],
+		},
+	]);
+	clearAppConfig();
+	try {
+		const {agent} = createAgent();
+		const result = await agent.unstable_listProviders({});
+
+		t.deepEqual(result.providers, [
+			{
+				id: 'Atlas Cloud',
+				providerId: 'Atlas Cloud',
+				required: false,
+				supported: ['openai'],
+			},
+		]);
+	} finally {
+		if (previousProviders === undefined) {
+			delete process.env.NANOCODER_PROVIDERS;
+		} else {
+			process.env.NANOCODER_PROVIDERS = previousProviders;
+		}
+		clearAppConfig();
+	}
 });
 
 // ============================================================================

--- a/source/acp/acp-agent.ts
+++ b/source/acp/acp-agent.ts
@@ -493,6 +493,7 @@ export class AcpAgent implements Agent {
 		const config = getAppConfig();
 		const providers = (config.providers ?? []).map(p => ({
 			id: p.name,
+			providerId: p.name,
 			required: false,
 			supported: ['openai' as const],
 		}));


### PR DESCRIPTION
## Summary

- add the SDK-required `providerId` to every ACP provider returned by `unstable_listProviders`
- preserve the existing provider `id` and authentication metadata
- add focused regression coverage and a patch changeset

## Root cause

PR #822 upgraded `@agentclientprotocol/sdk` from 0.25.0 to 1.3.0. In SDK 1.3, `ProviderInfo.providerId` is required, but NanoCoder's provider mapping still returned only `id`. As a result, current `main` fails type checking, the build, and the test workflow.

## Impact

This restores ACP provider discovery and unblocks checks for contributions rebased onto current `main`.

## Validation

- `pnpm exec ava source/acp/acp-agent.spec.ts` - 26 passed
- `pnpm run test:types`
- `pnpm run test:format`
- `pnpm run build`
- `pnpm run test:all` - 6,278 passed, 1 skipped
- Knip and dependency audit passed as part of the full gate
- `git diff --check`

Semgrep was not installed locally, so the repository script skipped that optional local scan.