### PR TITLE
fix: only emit --json usage block when tokens are actually reported

### DIFF
--- a/.changeset/fix-json-usage-block-reporting.md
+++ b/.changeset/fix-json-usage-block-reporting.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed the `usage` block in the `--plain --json` run report being emitted as all zeros for providers that report no token telemetry, and reading as zero total spend for providers that report input/output counts without a total. The block is now omitted entirely unless at least one token count is actually reported, and `totalTokens` falls back to input+output when the provider omits it, so downstream harnesses can distinguish "no telemetry available" from a genuine zero.

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -120,7 +120,8 @@ The emitted object looks like:
 
 ```json
 {
-  "outcome": "success",
+  "kind": "success",
+  "exitCode": 0,
   "finalText": "...",
   "reasoning": "...",
   "toolCalls": [
@@ -131,14 +132,23 @@ The emitted object looks like:
       "error": null
     }
   ],
-  "modifiedFiles": ["src/api.ts"]
+  "filesChanged": ["src/api.ts"],
+  "usage": {
+    "inputTokens": 4520,
+    "outputTokens": 850,
+    "totalTokens": 5370
+  }
 }
 ```
 
-- `outcome` — `"success"`, `"tool-approval-required"`, or `"error"`, matching the underlying conversation result
+- `kind` — `"success"`, `"tool-approval-required"`, or `"error"`, matching the underlying conversation result
+- `exitCode` — `0` for success, `1` for error, `2` for tool-approval-required; mirrors the process exit code
 - `finalText` — the model's final response text
 - `reasoning` — accumulated reasoning/thinking content, or `null` if the model didn't emit any
 - `toolCalls` — every tool call made during the run, each with its arguments and either a `result` or an `error` (never both)
-- `modifiedFiles` — deduplicated list of file paths touched by file-mutating tools (`write_to_file`, `create_file`, `string_replace`, `edit_file`)
+- `filesChanged` — deduplicated list of file paths touched by file-mutating tools (`write_to_file`, `create_file`, `string_replace`, `edit_file`)
+- `usage` — provider-reported token counts summed across every turn of the run. Omitted entirely when the provider reports no token telemetry (common with local models), so an absent block means "unknown", never "zero". When a provider reports input and output counts but no total, `totalTokens` is derived as their sum.
 
-On error (e.g. an untrusted workspace directory, or the turn limit being hit without a final answer), `outcome` is `"error"` and the object still includes whatever `toolCalls` were captured before the failure, so partial progress isn't silently dropped.
+Two more fields appear conditionally: `message` (the error text, when `kind` is `"error"`) and `toolNames` (the tools awaiting approval, when `kind` is `"tool-approval-required"`).
+
+On error (e.g. an untrusted workspace directory, or the turn limit being hit without a final answer), `kind` is `"error"` and the object still includes whatever `toolCalls` were captured before the failure, so partial progress isn't silently dropped.

--- a/source/plain/conversation.spec.ts
+++ b/source/plain/conversation.spec.ts
@@ -872,3 +872,121 @@ test.serial(
 		t.is(outcome.usage, undefined);
 	},
 );
+
+test.serial(
+	"omits usage property when the provider reports an empty usage object",
+	async (t) => {
+		// The real client always returns a `usage` object; providers with no
+		// telemetry leave every field undefined. That must stay indistinguishable
+		// from no usage at all, not surface as an all-zero block.
+		const client = makeFakeClient({
+			responses: [
+				{
+					choices: [
+						{
+							message: {
+								role: "assistant",
+								content: "no usage here",
+							},
+						},
+					],
+					usage: {},
+				},
+			],
+		});
+		const toolManager = makeFakeToolManager();
+
+		const outcome = await runPlainConversation({
+			client,
+			toolManager,
+			systemMessage: SYSTEM,
+			initialMessages: [USER],
+			developmentMode: "auto-accept",
+			nonInteractiveAlwaysAllow: [],
+			abortSignal: new AbortController().signal,
+		});
+
+		t.is(outcome.kind, "success");
+		t.is(outcome.usage, undefined);
+	},
+);
+
+test.serial(
+	"derives totalTokens from input+output when the provider omits it",
+	async (t) => {
+		const client = makeFakeClient({
+			responses: [
+				{
+					choices: [
+						{
+							message: {
+								role: "assistant",
+								content: "all done",
+							},
+						},
+					],
+					usage: { inputTokens: 100, outputTokens: 20 },
+				},
+			],
+		});
+		const toolManager = makeFakeToolManager();
+
+		const outcome = await runPlainConversation({
+			client,
+			toolManager,
+			systemMessage: SYSTEM,
+			initialMessages: [USER],
+			developmentMode: "auto-accept",
+			nonInteractiveAlwaysAllow: [],
+			abortSignal: new AbortController().signal,
+		});
+
+		t.is(outcome.kind, "success");
+		t.deepEqual(outcome.usage, {
+			inputTokens: 100,
+			outputTokens: 20,
+			totalTokens: 120,
+		});
+	},
+);
+
+test.serial(
+	"counts a partially reported turn without zeroing the other fields",
+	async (t) => {
+		// Only outputTokens reported: the turn still counts, and the derived total
+		// falls back to input+output rather than reading as zero spend.
+		const client = makeFakeClient({
+			responses: [
+				{
+					choices: [
+						{
+							message: {
+								role: "assistant",
+								content: "all done",
+							},
+						},
+					],
+					usage: { outputTokens: 42 },
+				},
+			],
+		});
+		const toolManager = makeFakeToolManager();
+
+		const outcome = await runPlainConversation({
+			client,
+			toolManager,
+			systemMessage: SYSTEM,
+			initialMessages: [USER],
+			developmentMode: "auto-accept",
+			nonInteractiveAlwaysAllow: [],
+			abortSignal: new AbortController().signal,
+		});
+
+		t.is(outcome.kind, "success");
+		t.deepEqual(outcome.usage, {
+			inputTokens: 0,
+			outputTokens: 42,
+			totalTokens: 42,
+		});
+	},
+);

--- a/source/plain/conversation.ts
+++ b/source/plain/conversation.ts
@@ -197,11 +197,29 @@ export async function runPlainConversation(
 			modeOverrides,
 		);
 
-		if (result?.usage) {
+		// The client always returns a `usage` object, but every field inside it is
+		// optional — providers that report nothing leave all three undefined, and
+		// OpenAI-compatible local servers commonly report input/output without a
+		// total. Only count a turn as reporting usage when at least one field is a
+		// real number, so the block stays absent (rather than an all-zero block
+		// indistinguishable from a genuine zero) for providers with no telemetry.
+		const turnUsage = result?.usage;
+		const inputTokens =
+			typeof turnUsage?.inputTokens === 'number' ? turnUsage.inputTokens : null;
+		const outputTokens =
+			typeof turnUsage?.outputTokens === 'number'
+				? turnUsage.outputTokens
+				: null;
+		const totalTokens =
+			typeof turnUsage?.totalTokens === 'number' ? turnUsage.totalTokens : null;
+
+		if (inputTokens !== null || outputTokens !== null || totalTokens !== null) {
 			hasReportedUsage = true;
-			accumulatedInputTokens += result.usage.inputTokens ?? 0;
-			accumulatedOutputTokens += result.usage.outputTokens ?? 0;
-			accumulatedTotalTokens += result.usage.totalTokens ?? 0;
+			accumulatedInputTokens += inputTokens ?? 0;
+			accumulatedOutputTokens += outputTokens ?? 0;
+			// Fall back to input+output so a missing total never reads as zero spend.
+			accumulatedTotalTokens +=
+				totalTokens ?? (inputTokens ?? 0) + (outputTokens ?? 0);
 		}
 
 		if (!isJson && (reasoningPrinted || contentStarted)) {


### PR DESCRIPTION
## Description

Follow-up to #821, which added the `usage` block to the `--plain --json` run report.

The client always returns a `usage` object (`source/ai-sdk-client/chat/chat-handler.ts:477`), but every field inside it is typed `number | undefined` by the AI SDK. The accumulator treated the object's mere presence as "provider reported usage" and coalesced each field to `0` independently, which produced two wrong outputs:

- Providers with no token telemetry emitted `{"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}` rather than omitting the block, so a consumer cannot tell "unknown" from a genuine zero. The graceful-degradation behaviour #821 intended never actually triggered on the real client path.
- Providers that report input/output but no total (common with OpenAI-compatible local servers) emitted a correct input/output pair alongside `"totalTokens": 0`, so a harness summing totals reads zero spend.

## What this PR does

- Counts a turn as reporting usage only when at least one of the three fields is genuinely a `number`.
- Derives `totalTokens` as input+output when the provider omits it.
- An absent `usage` block now means "unknown", never "zero".

## Docs

Refreshed the `#### Output Shape` section of `docs/features/commands.md`, which had drifted from the code before #821: it documented `outcome` and `modifiedFiles` while the code emits `kind` and `filesChanged`. Added the previously undocumented `exitCode`, plus the conditional `message` and `toolNames` fields, and documented the `usage` contract.

## Tests

Three tests added to `conversation.spec.ts`. Each was verified non-vacuous by reverting the production change and re-running — all three fail on the old code with exactly the expected deltas:

- an empty `usage: {}` object omits the block (this is the real client's shape, which the existing test never exercised — it omitted the `usage` key entirely, which the real client never does
-  with no total derives 
-  alone still counts the turn and totals 

33 pass across  + . Biome clean.

Note:  reports one error in  (/). That is pre-existing on  and unrelated to this change.

## Type of Change

- [x] Bug fix
EOF
)