### PR TITLE
fix: move mid-file extname import to top of file-cache.ts

### DIFF
--- a/source/utils/file-cache.spec.ts
+++ b/source/utils/file-cache.spec.ts
@@ -346,3 +346,33 @@ test('getCachedFileContent - throws descriptive error for corrupt DOCX', async t
 		await cleanupTempDir(tempDir);
 	}
 });
+
+test('getCachedFileContent - reads extensionless file as utf-8 text', async t => {
+	const tempDir = await createTempDir();
+	try {
+		const filePath = join(tempDir, 'LICENSE');
+		await writeFile(filePath, 'plain text\nno extension', 'utf-8');
+
+		const result = await getCachedFileContent(filePath);
+
+		t.is(result.content, 'plain text\nno extension');
+		t.deepEqual(result.lines, ['plain text', 'no extension']);
+	} finally {
+		await cleanupTempDir(tempDir);
+	}
+});
+
+test('getCachedFileContent - document extension check is case-insensitive', async t => {
+	const tempDir = await createTempDir();
+	try {
+		const filePath = join(tempDir, 'test.PDF');
+		await writeFile(filePath, '%PDF-1.4\n%Fake PDF content');
+
+		await t.throwsAsync(
+			async () => getCachedFileContent(filePath),
+			{message: /Failed to extract text from document/}
+		);
+	} finally {
+		await cleanupTempDir(tempDir);
+	}
+});

--- a/source/utils/file-cache.ts
+++ b/source/utils/file-cache.ts
@@ -1,4 +1,5 @@
 import {readFile, stat} from 'node:fs/promises';
+import {extname} from 'node:path';
 import {CACHE_FILE_TTL_MS, MAX_FILE_READ_RETRIES} from '@/constants';
 
 /**
@@ -100,8 +101,6 @@ export async function getCachedFileContent(
 		pendingReads.delete(absPath);
 	}
 }
-
-import {extname} from 'node:path';
 
 /**
  * Read file from disk and cache it.


### PR DESCRIPTION
Closes #735

## Problem

`import {extname} from 'node:path'` sat on line 104 of `source/utils/file-cache.ts`,
between the end of `getCachedFileContent` and the `readAndCacheFile` definition, while
every other import in the file was at the top.

TypeScript hoists import declarations, so runtime behavior was never affected — but the
placement violates `import/first` style, and it confuses static analysis tools and
editors that expect imports grouped at the top.

## Change

Moved the single import up next to `import {readFile, stat} from 'node:fs/promises'`.
No logic change — the diff is a two-line move.

## Tests

Added two cases to the existing `source/utils/file-cache.spec.ts`, covering the
`extname` branch in `readAndCacheFile` that this import feeds:

- an extensionless file (`LICENSE`) reads as plain utf-8 text
- an uppercase `.PDF` extension still routes to document conversion, confirming the
  `.toLowerCase()` check stays case-insensitive

`pnpm run test:ava source/utils/file-cache.spec.ts` — 18 passed.
`pnpm run test:format` — clean.
