### PR TITLE
fix: trim whitespace after the ! bash command prefix

### DIFF
--- a/.changeset/fix-bash-command-leading-whitespace.md
+++ b/.changeset/fix-bash-command-leading-whitespace.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed bash commands entered with `!` keeping the whitespace that followed the prefix, so `! git status` now runs `git status` instead of ` git status`.

--- a/source/command-parser.spec.ts
+++ b/source/command-parser.spec.ts
@@ -22,7 +22,15 @@ test('parseInput - handles bash command with spaces', t => {
 
 	t.false(result.isCommand);
 	t.true(result.isBashCommand);
-	t.is(result.bashCommand, '   echo "hello world"');
+	t.is(result.bashCommand, 'echo "hello world"');
+});
+
+test('parseInput - trims whitespace after ! prefix', t => {
+	const result = parseInput('! git status');
+
+	t.false(result.isCommand);
+	t.true(result.isBashCommand);
+	t.is(result.bashCommand, 'git status');
 });
 
 test('parseInput - returns non-command for text without prefix', t => {

--- a/source/command-parser.ts
+++ b/source/command-parser.ts
@@ -5,7 +5,7 @@ export function parseInput(input: string): ParsedCommand {
 
 	// Check for bash command (prefixed with !)
 	if (trimmed.startsWith('!')) {
-		const bashCommand = trimmed.slice(1);
+		const bashCommand = trimmed.slice(1).trim();
 		return {
 			isCommand: false, // Not a regular command
 			isBashCommand: true,


### PR DESCRIPTION
Closes #722

## Problem

`parseInput` trims the overall input, but not the remainder after slicing off the `!`
prefix. Any whitespace between `!` and the command survives into the parsed string: 
'! git status'  ->  bashCommand: ' git status'

## Change

`trimmed.slice(1)` becomes `trimmed.slice(1).trim()` in `source/command-parser.ts`.
That's the whole fix.

## Tests

The existing `parseInput - handles bash command with spaces` case was asserting the old
behavior (`'   echo "hello world"'`), so its expectation is updated to the trimmed value.
Added one case in the same format for the `! git status` form from the issue.

`pnpm run test:ava source/command-parser.spec.ts` — 15 passed.
`pnpm run test:format` and `pnpm run test:types` — clean.
