### PR TITLE
fix: announce rotated Copilot reasoning item ids before the SDK parse…

### DIFF
--- a/.changeset/fix-copilot-reasoning-item-id-rotation.md
+++ b/.changeset/fix-copilot-reasoning-item-id-rotation.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed `Cannot read properties of undefined (reading 'summaryParts')` when streaming from GitHub Copilot with reasoning models such as `gpt-5.3-codex`. Copilot's Responses API proxy emits reasoning summary events under item ids it never announced, which crashed the OpenAI Responses stream parser; the Copilot response stream now announces those reasoning items before the summary events reach the parser. Closes #719.

--- a/.changeset/fix-copilot-reasoning-item-id-rotation.md
+++ b/.changeset/fix-copilot-reasoning-item-id-rotation.md
@@ -2,4 +2,4 @@
 "@nanocollective/nanocoder": patch
 ---
 
-Fixed `Cannot read properties of undefined (reading 'summaryParts')` when streaming from GitHub Copilot with reasoning models such as `gpt-5.3-codex`. Copilot's Responses API proxy emits reasoning summary events under item ids it never announced, which crashed the OpenAI Responses stream parser; the Copilot response stream now announces those reasoning items before the summary events reach the parser. Closes #719.
+Fixed `Cannot read properties of undefined (reading 'summaryParts')` when streaming from GitHub Copilot with reasoning models such as `gpt-5.3-codex`. Copilot's Responses API proxy rotates the opaque reasoning item id mid-stream while `output_index` stays stable, so the OpenAI Responses parser looked up state that was never registered and the stream died. Copilot's response stream is now normalized before it reaches the parser: a rotated id is mapped back to the reasoning item already tracked at that `output_index`, and a reasoning item that was never announced is announced first. Closes #719.

--- a/source/ai-sdk-client/providers/provider-factory.spec.ts
+++ b/source/ai-sdk-client/providers/provider-factory.spec.ts
@@ -525,7 +525,7 @@ function eventSummary(sse: string): string[] {
 		});
 }
 
-test('createReasoningItemNormalizer announces reasoning items with a rotated item_id', async t => {
+test('createReasoningItemNormalizer maps a rotated item_id back to the item at that output_index', async t => {
 	const output = await runNormalizer([
 		sseEvent({
 			type: 'response.output_item.added',
@@ -536,6 +536,38 @@ test('createReasoningItemNormalizer announces reasoning items with a rotated ite
 			type: 'response.reasoning_summary_part.added',
 			item_id: 'rs_B',
 			output_index: 0,
+			summary_index: 1,
+		}),
+		sseEvent({
+			type: 'response.output_item.done',
+			output_index: 0,
+			item: {id: 'rs_C', type: 'reasoning', encrypted_content: null},
+		}),
+	]);
+
+	t.deepEqual(eventSummary(output), [
+		'response.output_item.added:rs_A',
+		'response.reasoning_summary_part.added:rs_A',
+		'response.output_item.done:rs_A',
+	]);
+});
+
+test('createReasoningItemNormalizer keeps rotated ids on separate output_index values apart', async t => {
+	const output = await runNormalizer([
+		sseEvent({
+			type: 'response.output_item.added',
+			output_index: 0,
+			item: {id: 'rs_A', type: 'reasoning', encrypted_content: null},
+		}),
+		sseEvent({
+			type: 'response.output_item.added',
+			output_index: 1,
+			item: {id: 'rs_B', type: 'reasoning', encrypted_content: null},
+		}),
+		sseEvent({
+			type: 'response.reasoning_summary_part.added',
+			item_id: 'rs_rotated',
+			output_index: 1,
 			summary_index: 1,
 		}),
 	]);

--- a/source/ai-sdk-client/providers/provider-factory.spec.ts
+++ b/source/ai-sdk-client/providers/provider-factory.spec.ts
@@ -4,7 +4,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type {AIProviderConfig} from '@/types/index';
 import {Agent, MockAgent} from 'undici';
-import {createProvider, createUndiciFetch} from './provider-factory.js';
+import {
+	createProvider,
+	createReasoningItemNormalizer,
+	createUndiciFetch,
+} from './provider-factory.js';
 
 test('createProvider creates provider with basic config', async t => {
 	const config: AIProviderConfig = {
@@ -477,4 +481,138 @@ test('createUndiciFetch does not corrupt multi-byte characters split across chun
 	const text = await response.text();
 	server.close();
 	t.is(text, 'data: 👋\n\ndata: [DONE]');
+});
+
+function sseEvent(value: unknown): string {
+	return `data: ${JSON.stringify(value)}\n\n`;
+}
+
+async function runNormalizer(chunks: string[]): Promise<string> {
+	const encoder = new TextEncoder();
+	const source = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of chunks) {
+				controller.enqueue(encoder.encode(chunk));
+			}
+			controller.close();
+		},
+	});
+
+	const reader = source
+		.pipeThrough(createReasoningItemNormalizer())
+		.getReader();
+	const decoder = new TextDecoder();
+	let output = '';
+	for (;;) {
+		const {done, value} = await reader.read();
+		if (done) {
+			break;
+		}
+		output += decoder.decode(value, {stream: true});
+	}
+	return output + decoder.decode();
+}
+
+function eventSummary(sse: string): string[] {
+	return sse
+		.split('\n\n')
+		.filter(block => block.startsWith('data: '))
+		.map(block => block.slice(6))
+		.filter(payload => payload !== '[DONE]')
+		.map(payload => {
+			const value = JSON.parse(payload);
+			return `${value.type}:${value.item?.id ?? value.item_id}`;
+		});
+}
+
+test('createReasoningItemNormalizer announces reasoning items with a rotated item_id', async t => {
+	const output = await runNormalizer([
+		sseEvent({
+			type: 'response.output_item.added',
+			output_index: 0,
+			item: {id: 'rs_A', type: 'reasoning', encrypted_content: null},
+		}),
+		sseEvent({
+			type: 'response.reasoning_summary_part.added',
+			item_id: 'rs_B',
+			output_index: 0,
+			summary_index: 1,
+		}),
+	]);
+
+	t.deepEqual(eventSummary(output), [
+		'response.output_item.added:rs_A',
+		'response.output_item.added:rs_B',
+		'response.reasoning_summary_part.added:rs_B',
+	]);
+});
+
+test('createReasoningItemNormalizer announces reasoning items that were never added', async t => {
+	const output = await runNormalizer([
+		sseEvent({
+			type: 'response.reasoning_summary_part.done',
+			item_id: 'rs_1',
+			output_index: 0,
+			summary_index: 0,
+			part: {type: 'summary_text', text: 'thinking'},
+		}),
+		sseEvent({
+			type: 'response.output_item.done',
+			output_index: 1,
+			item: {id: 'rs_2', type: 'reasoning', encrypted_content: null},
+		}),
+	]);
+
+	t.deepEqual(eventSummary(output), [
+		'response.output_item.added:rs_1',
+		'response.reasoning_summary_part.done:rs_1',
+		'response.output_item.added:rs_2',
+		'response.output_item.done:rs_2',
+	]);
+});
+
+test('createReasoningItemNormalizer leaves well-formed streams unchanged', async t => {
+	const stream = [
+		sseEvent({
+			type: 'response.output_item.added',
+			output_index: 0,
+			item: {id: 'rs_1', type: 'reasoning', encrypted_content: null},
+		}),
+		sseEvent({
+			type: 'response.reasoning_summary_part.added',
+			item_id: 'rs_1',
+			output_index: 0,
+			summary_index: 1,
+		}),
+		sseEvent({
+			type: 'response.output_item.done',
+			output_index: 0,
+			item: {id: 'rs_1', type: 'reasoning', encrypted_content: null},
+		}),
+		'data: [DONE]\n\n',
+	];
+
+	const output = await runNormalizer(stream);
+
+	t.is(output, stream.join(''));
+});
+
+test('createReasoningItemNormalizer normalizes events split across chunks', async t => {
+	const event = sseEvent({
+		type: 'response.reasoning_summary_part.added',
+		item_id: 'rs_1',
+		output_index: 0,
+		summary_index: 1,
+	});
+	const chunks: string[] = [];
+	for (let i = 0; i < event.length; i += 7) {
+		chunks.push(event.slice(i, i + 7));
+	}
+
+	const output = await runNormalizer(chunks);
+
+	t.deepEqual(eventSummary(output), [
+		'response.output_item.added:rs_1',
+		'response.reasoning_summary_part.added:rs_1',
+	]);
 });

--- a/source/ai-sdk-client/providers/provider-factory.spec.ts
+++ b/source/ai-sdk-client/providers/provider-factory.spec.ts
@@ -648,3 +648,149 @@ test('createReasoningItemNormalizer normalizes events split across chunks', asyn
 		'response.reasoning_summary_part.added:rs_1',
 	]);
 });
+
+function framedEvent(value: {type: string}, eol: string): string {
+	return `event: ${value.type}${eol}data: ${JSON.stringify(value)}${eol}${eol}`;
+}
+
+async function runNormalizerChunks(chunks: string[]): Promise<string[]> {
+	const encoder = new TextEncoder();
+	const source = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of chunks) {
+				controller.enqueue(encoder.encode(chunk));
+			}
+			controller.close();
+		},
+	});
+
+	const reader = source
+		.pipeThrough(createReasoningItemNormalizer())
+		.getReader();
+	const decoder = new TextDecoder();
+	const output: string[] = [];
+	for (;;) {
+		const {done, value} = await reader.read();
+		if (done) {
+			break;
+		}
+		output.push(decoder.decode(value, {stream: true}));
+	}
+	return output;
+}
+
+/** Framing-agnostic view of the output, so assertions don't assume LF or bare `data:`. */
+function framedSummary(sse: string): string[] {
+	return sse
+		.split(/\r\n\r\n|\n\n|\r\r/)
+		.map(block =>
+			block
+				.split(/\r\n|\n|\r/)
+				.filter(line => line.startsWith('data:'))
+				.map(line => line.slice(5).trim())
+				.join(''),
+		)
+		.filter(payload => payload.length > 0 && payload !== '[DONE]')
+		.map(payload => {
+			const value = JSON.parse(payload);
+			return `${value.type}:${value.item?.id ?? value.item_id}`;
+		});
+}
+
+const ADDED_RS_A = {
+	type: 'response.output_item.added',
+	output_index: 0,
+	item: {id: 'rs_A', type: 'reasoning'},
+};
+
+const SUMMARY_RS_B = {
+	type: 'response.reasoning_summary_part.added',
+	output_index: 0,
+	item_id: 'rs_B',
+};
+
+test('createReasoningItemNormalizer rewrites rotated ids in event: framed streams', async t => {
+	const output = await runNormalizer([
+		framedEvent(ADDED_RS_A, '\n'),
+		framedEvent(SUMMARY_RS_B, '\n'),
+	]);
+
+	t.deepEqual(framedSummary(output), [
+		'response.output_item.added:rs_A',
+		'response.reasoning_summary_part.added:rs_A',
+	]);
+	// The `event:` line has to survive the rewrite.
+	t.true(output.includes('event: response.reasoning_summary_part.added'));
+});
+
+test('createReasoningItemNormalizer announces never-added items in event: framed streams', async t => {
+	const output = await runNormalizer([framedEvent(SUMMARY_RS_B, '\n')]);
+
+	t.deepEqual(framedSummary(output), [
+		'response.output_item.added:rs_B',
+		'response.reasoning_summary_part.added:rs_B',
+	]);
+});
+
+test('createReasoningItemNormalizer normalizes CRLF framed streams', async t => {
+	const output = await runNormalizer([
+		framedEvent(ADDED_RS_A, '\r\n'),
+		framedEvent(SUMMARY_RS_B, '\r\n'),
+	]);
+
+	t.deepEqual(framedSummary(output), [
+		'response.output_item.added:rs_A',
+		'response.reasoning_summary_part.added:rs_A',
+	]);
+	t.true(output.includes('\r\n\r\n'));
+});
+
+test('createReasoningItemNormalizer emits CRLF events as they arrive', async t => {
+	const chunks = await runNormalizerChunks([
+		framedEvent(ADDED_RS_A, '\r\n'),
+		framedEvent(SUMMARY_RS_B, '\r\n'),
+	]);
+
+	// Both events must land before close; buffering the whole body until
+	// flush() would stall streaming output.
+	t.true(chunks.length >= 2);
+});
+
+test('createReasoningItemNormalizer normalizes a trailing event with no separator', async t => {
+	const output = await runNormalizer([
+		`data: ${JSON.stringify(SUMMARY_RS_B)}`,
+	]);
+
+	t.deepEqual(framedSummary(output), [
+		'response.output_item.added:rs_B',
+		'response.reasoning_summary_part.added:rs_B',
+	]);
+});
+
+test('createReasoningItemNormalizer leaves unannounced events without an output_index alone', async t => {
+	const input = sseEvent({
+		type: 'response.reasoning_summary_part.added',
+		item_id: 'rs_B',
+	});
+
+	// A synthetic announcement needs output_index to pass the SDK's schema;
+	// without one, passing the event through is the only safe move.
+	t.is(await runNormalizer([input]), input);
+});
+
+test('createReasoningItemNormalizer handles a CRLF separator split across chunks', async t => {
+	const stream =
+		framedEvent(ADDED_RS_A, '\r\n') + framedEvent(SUMMARY_RS_B, '\r\n');
+	// Cut mid-separator, so one chunk ends on "\r\n\r" and the next opens "\n".
+	const cut = stream.indexOf('\r\n\r\n') + 3;
+	const output = await runNormalizer([
+		stream.slice(0, cut),
+		stream.slice(cut),
+	]);
+
+	t.deepEqual(framedSummary(output), [
+		'response.output_item.added:rs_A',
+		'response.reasoning_summary_part.added:rs_A',
+	]);
+	t.true(output.includes('\r\n\r\n'));
+});

--- a/source/ai-sdk-client/providers/provider-factory.ts
+++ b/source/ai-sdk-client/providers/provider-factory.ts
@@ -119,15 +119,24 @@ export function createReasoningItemNormalizer(): TransformStream<
 	const decoder = new TextDecoder('utf-8');
 	const encoder = new TextEncoder();
 	const announced = new Set<string>();
+	const announcedByIndex = new Map<number, string>();
 	let buffer = '';
 	const separator = '\n\n';
 
-	const synthesize = (id: string, outputIndex: unknown): string =>
-		`data: ${JSON.stringify({
-			type: 'response.output_item.added',
-			output_index: typeof outputIndex === 'number' ? outputIndex : 0,
-			item: {id, type: 'reasoning', encrypted_content: null, summary: []},
-		})}${separator}`;
+	const encode = (value: unknown): string =>
+		`data: ${JSON.stringify(value)}${separator}`;
+
+	const announce = (id: string, outputIndex: unknown): void => {
+		announced.add(id);
+		if (typeof outputIndex === 'number') {
+			announcedByIndex.set(outputIndex, id);
+		}
+	};
+
+	const trackedAt = (outputIndex: unknown): string | undefined =>
+		typeof outputIndex === 'number'
+			? announcedByIndex.get(outputIndex)
+			: undefined;
 
 	const rewrite = (event: string): string => {
 		const trimmed = event.trimStart();
@@ -150,14 +159,24 @@ export function createReasoningItemNormalizer(): TransformStream<
 		if (value.item?.type === 'reasoning' && typeof value.item.id === 'string') {
 			const itemId = value.item.id;
 			if (value.type === 'response.output_item.added') {
-				announced.add(itemId);
+				announce(itemId, value.output_index);
 				return event;
 			}
 			if (announced.has(itemId)) {
 				return event;
 			}
-			announced.add(itemId);
-			return synthesize(itemId, value.output_index) + event;
+			const tracked = trackedAt(value.output_index);
+			if (tracked !== undefined) {
+				return encode({...value, item: {...value.item, id: tracked}});
+			}
+			announce(itemId, value.output_index);
+			return (
+				encode({
+					type: 'response.output_item.added',
+					output_index: value.output_index,
+					item: {id: itemId, type: 'reasoning', encrypted_content: null},
+				}) + event
+			);
 		}
 
 		if (
@@ -166,8 +185,18 @@ export function createReasoningItemNormalizer(): TransformStream<
 			typeof value.item_id === 'string' &&
 			!announced.has(value.item_id)
 		) {
-			announced.add(value.item_id);
-			return synthesize(value.item_id, value.output_index) + event;
+			const tracked = trackedAt(value.output_index);
+			if (tracked !== undefined) {
+				return encode({...value, item_id: tracked});
+			}
+			announce(value.item_id, value.output_index);
+			return (
+				encode({
+					type: 'response.output_item.added',
+					output_index: value.output_index,
+					item: {id: value.item_id, type: 'reasoning', encrypted_content: null},
+				}) + event
+			);
 		}
 
 		return event;

--- a/source/ai-sdk-client/providers/provider-factory.ts
+++ b/source/ai-sdk-client/providers/provider-factory.ts
@@ -112,6 +112,9 @@ type ResponsesStreamEvent = {
 	item?: {id?: unknown; type?: unknown};
 };
 
+const SEPARATOR_PATTERN = /\r\n\r\n|\n\n|\r\r/;
+const LINE_PATTERN = /\r\n|\n|\r/;
+
 export function createReasoningItemNormalizer(): TransformStream<
 	Uint8Array,
 	Uint8Array
@@ -121,10 +124,6 @@ export function createReasoningItemNormalizer(): TransformStream<
 	const announced = new Set<string>();
 	const announcedByIndex = new Map<number, string>();
 	let buffer = '';
-	const separator = '\n\n';
-
-	const encode = (value: unknown): string =>
-		`data: ${JSON.stringify(value)}${separator}`;
 
 	const announce = (id: string, outputIndex: unknown): void => {
 		announced.add(id);
@@ -133,22 +132,59 @@ export function createReasoningItemNormalizer(): TransformStream<
 		}
 	};
 
-	const rewrite = (event: string): string => {
-		const trimmed = event.trimStart();
-		if (!trimmed.startsWith('data:')) {
-			return event;
+	/**
+	 * Line endings and framing are whatever the proxy chose to send. The parser
+	 * downstream of us accepts LF, CRLF and lone CR, and ignores any `event:`
+	 * line in front of the payload, so this has to be at least as permissive —
+	 * anything it accepts that we reject is an event we silently fail to fix.
+	 */
+	const eolOf = (block: string, separator: string): string => {
+		if (separator.length > 0) {
+			return separator.slice(0, separator.length / 2);
 		}
+		if (block.includes('\r\n')) {
+			return '\r\n';
+		}
+		return block.includes('\r') ? '\r' : '\n';
+	};
 
-		const payload = trimmed.slice(5).trim();
+	/** Multiple `data:` lines in one block join with a newline, per the spec. */
+	const readData = (block: string): string | undefined => {
+		const parts = block
+			.split(LINE_PATTERN)
+			.filter(line => line.startsWith('data:'))
+			.map(line => line.slice(5));
+		return parts.length > 0 ? parts.join('\n').trim() : undefined;
+	};
+
+	/** Swaps the payload while leaving `event:`/`id:` lines and framing intact. */
+	const replaceData = (block: string, eol: string, value: unknown): string => {
+		const lines: string[] = [];
+		let written = false;
+		for (const line of block.split(LINE_PATTERN)) {
+			if (!line.startsWith('data:')) {
+				lines.push(line);
+				continue;
+			}
+			if (!written) {
+				lines.push(`data: ${JSON.stringify(value)}`);
+				written = true;
+			}
+		}
+		return lines.join(eol);
+	};
+
+	const rewrite = (block: string, separator: string): string => {
+		const payload = readData(block);
 		if (!payload || payload === '[DONE]') {
-			return event;
+			return block + separator;
 		}
 
 		let value: ResponsesStreamEvent;
 		try {
 			value = JSON.parse(payload) as ResponsesStreamEvent;
 		} catch {
-			return event;
+			return block + separator;
 		}
 
 		const item = value.item;
@@ -165,7 +201,7 @@ export function createReasoningItemNormalizer(): TransformStream<
 
 		const itemId = reasoningItemId ?? summaryItemId;
 		if (itemId === undefined) {
-			return event;
+			return block + separator;
 		}
 
 		if (
@@ -173,44 +209,59 @@ export function createReasoningItemNormalizer(): TransformStream<
 			value.type === 'response.output_item.added'
 		) {
 			announce(itemId, value.output_index);
-			return event;
+			return block + separator;
 		}
 
 		if (announced.has(itemId)) {
-			return event;
+			return block + separator;
 		}
 
+		const outputIndex =
+			typeof value.output_index === 'number' ? value.output_index : undefined;
+		const eol = eolOf(block, separator);
+
 		const tracked =
-			typeof value.output_index === 'number'
-				? announcedByIndex.get(value.output_index)
-				: undefined;
+			outputIndex === undefined ? undefined : announcedByIndex.get(outputIndex);
 		if (tracked !== undefined) {
-			return encode(
-				reasoningItemId !== undefined
-					? {...value, item: {...item, id: tracked}}
-					: {...value, item_id: tracked},
+			return (
+				replaceData(
+					block,
+					eol,
+					reasoningItemId !== undefined
+						? {...value, item: {...item, id: tracked}}
+						: {...value, item_id: tracked},
+				) + separator
 			);
 		}
 
-		announce(itemId, value.output_index);
-		return (
-			encode({
-				type: 'response.output_item.added',
-				output_index: value.output_index,
-				item: {id: itemId, type: 'reasoning', encrypted_content: null},
-			}) + event
-		);
+		// `output_index` is required by the SDK's schema, and a chunk that fails
+		// validation sets finishReason to 'error' rather than being skipped — a
+		// synthetic announcement without one would trade the crash for a broken
+		// response. Leave the event alone instead; guessing an index risks
+		// colliding with a real item.
+		if (outputIndex === undefined) {
+			return block + separator;
+		}
+
+		announce(itemId, outputIndex);
+		const added = `data: ${JSON.stringify({
+			type: 'response.output_item.added',
+			output_index: outputIndex,
+			item: {id: itemId, type: 'reasoning', encrypted_content: null},
+		})}`;
+		return added + (separator || eol + eol) + block + separator;
 	};
 
 	const drain = (
 		controller: TransformStreamDefaultController<Uint8Array>,
 	): void => {
-		let index = buffer.indexOf(separator);
-		while (index !== -1) {
-			const event = buffer.slice(0, index + separator.length);
-			buffer = buffer.slice(index + separator.length);
-			controller.enqueue(encoder.encode(rewrite(event)));
-			index = buffer.indexOf(separator);
+		let match = SEPARATOR_PATTERN.exec(buffer);
+		while (match !== null) {
+			const block = buffer.slice(0, match.index);
+			const separator = match[0];
+			buffer = buffer.slice(match.index + separator.length);
+			controller.enqueue(encoder.encode(rewrite(block, separator)));
+			match = SEPARATOR_PATTERN.exec(buffer);
 		}
 	};
 
@@ -223,7 +274,9 @@ export function createReasoningItemNormalizer(): TransformStream<
 			buffer += decoder.decode();
 			drain(controller);
 			if (buffer.length > 0) {
-				controller.enqueue(encoder.encode(buffer));
+				const trailing = buffer;
+				buffer = '';
+				controller.enqueue(encoder.encode(rewrite(trailing, '')));
 			}
 		},
 	});

--- a/source/ai-sdk-client/providers/provider-factory.ts
+++ b/source/ai-sdk-client/providers/provider-factory.ts
@@ -105,6 +105,101 @@ export function createUndiciFetch(undiciAgent: Agent) {
 	};
 }
 
+type ResponsesStreamEvent = {
+	type?: unknown;
+	item_id?: unknown;
+	output_index?: unknown;
+	item?: {id?: unknown; type?: unknown};
+};
+
+export function createReasoningItemNormalizer(): TransformStream<
+	Uint8Array,
+	Uint8Array
+> {
+	const decoder = new TextDecoder('utf-8');
+	const encoder = new TextEncoder();
+	const announced = new Set<string>();
+	let buffer = '';
+	const separator = '\n\n';
+
+	const synthesize = (id: string, outputIndex: unknown): string =>
+		`data: ${JSON.stringify({
+			type: 'response.output_item.added',
+			output_index: typeof outputIndex === 'number' ? outputIndex : 0,
+			item: {id, type: 'reasoning', encrypted_content: null, summary: []},
+		})}${separator}`;
+
+	const rewrite = (event: string): string => {
+		const trimmed = event.trimStart();
+		if (!trimmed.startsWith('data:')) {
+			return event;
+		}
+
+		const payload = trimmed.slice(5).trim();
+		if (!payload || payload === '[DONE]') {
+			return event;
+		}
+
+		let value: ResponsesStreamEvent;
+		try {
+			value = JSON.parse(payload) as ResponsesStreamEvent;
+		} catch {
+			return event;
+		}
+
+		if (value.item?.type === 'reasoning' && typeof value.item.id === 'string') {
+			const itemId = value.item.id;
+			if (value.type === 'response.output_item.added') {
+				announced.add(itemId);
+				return event;
+			}
+			if (announced.has(itemId)) {
+				return event;
+			}
+			announced.add(itemId);
+			return synthesize(itemId, value.output_index) + event;
+		}
+
+		if (
+			typeof value.type === 'string' &&
+			value.type.startsWith('response.reasoning_summary') &&
+			typeof value.item_id === 'string' &&
+			!announced.has(value.item_id)
+		) {
+			announced.add(value.item_id);
+			return synthesize(value.item_id, value.output_index) + event;
+		}
+
+		return event;
+	};
+
+	const drain = (
+		controller: TransformStreamDefaultController<Uint8Array>,
+	): void => {
+		let index = buffer.indexOf(separator);
+		while (index !== -1) {
+			const event = buffer.slice(0, index + separator.length);
+			buffer = buffer.slice(index + separator.length);
+			controller.enqueue(encoder.encode(rewrite(event)));
+			index = buffer.indexOf(separator);
+		}
+	};
+
+	return new TransformStream({
+		transform(chunk, controller) {
+			buffer += decoder.decode(chunk, {stream: true});
+			drain(controller);
+		},
+		flush(controller) {
+			buffer += decoder.decode();
+			drain(controller);
+			if (buffer.length > 0) {
+				controller.enqueue(encoder.encode(buffer));
+			}
+		},
+	});
+}
+
 /**
  * Creates an AI SDK provider based on the sdkProvider configuration.
  * Defaults to 'openai-compatible' if not specified.
@@ -206,13 +301,27 @@ export async function createProvider(
 				headers[k] = v;
 			});
 
-			return undiciFetch(input as string | URL, {
+			const response = (await undiciFetch(input as string | URL, {
 				method: init?.method,
 				body: init?.body as UndiciRequestInit['body'],
 				signal: init?.signal,
 				headers,
 				dispatcher: undiciAgent,
-			}) as Promise<Response>;
+			})) as unknown as Response;
+
+			const contentType = response.headers.get('content-type') || '';
+			if (response.body && contentType.includes('text/event-stream')) {
+				return new Response(
+					response.body.pipeThrough(createReasoningItemNormalizer()),
+					{
+						status: response.status,
+						statusText: response.statusText,
+						headers: response.headers,
+					},
+				) as unknown as Response;
+			}
+
+			return response;
 		};
 
 		const {createOpenAI} = await import('@ai-sdk/openai');

--- a/source/ai-sdk-client/providers/provider-factory.ts
+++ b/source/ai-sdk-client/providers/provider-factory.ts
@@ -133,11 +133,6 @@ export function createReasoningItemNormalizer(): TransformStream<
 		}
 	};
 
-	const trackedAt = (outputIndex: unknown): string | undefined =>
-		typeof outputIndex === 'number'
-			? announcedByIndex.get(outputIndex)
-			: undefined;
-
 	const rewrite = (event: string): string => {
 		const trimmed = event.trimStart();
 		if (!trimmed.startsWith('data:')) {
@@ -156,50 +151,55 @@ export function createReasoningItemNormalizer(): TransformStream<
 			return event;
 		}
 
-		if (value.item?.type === 'reasoning' && typeof value.item.id === 'string') {
-			const itemId = value.item.id;
-			if (value.type === 'response.output_item.added') {
-				announce(itemId, value.output_index);
-				return event;
-			}
-			if (announced.has(itemId)) {
-				return event;
-			}
-			const tracked = trackedAt(value.output_index);
-			if (tracked !== undefined) {
-				return encode({...value, item: {...value.item, id: tracked}});
-			}
-			announce(itemId, value.output_index);
-			return (
-				encode({
-					type: 'response.output_item.added',
-					output_index: value.output_index,
-					item: {id: itemId, type: 'reasoning', encrypted_content: null},
-				}) + event
-			);
+		const item = value.item;
+		const reasoningItemId =
+			item?.type === 'reasoning' && typeof item.id === 'string'
+				? item.id
+				: undefined;
+		const summaryItemId =
+			typeof value.type === 'string' &&
+			value.type.startsWith('response.reasoning_summary') &&
+			typeof value.item_id === 'string'
+				? value.item_id
+				: undefined;
+
+		const itemId = reasoningItemId ?? summaryItemId;
+		if (itemId === undefined) {
+			return event;
 		}
 
 		if (
-			typeof value.type === 'string' &&
-			value.type.startsWith('response.reasoning_summary') &&
-			typeof value.item_id === 'string' &&
-			!announced.has(value.item_id)
+			reasoningItemId !== undefined &&
+			value.type === 'response.output_item.added'
 		) {
-			const tracked = trackedAt(value.output_index);
-			if (tracked !== undefined) {
-				return encode({...value, item_id: tracked});
-			}
-			announce(value.item_id, value.output_index);
-			return (
-				encode({
-					type: 'response.output_item.added',
-					output_index: value.output_index,
-					item: {id: value.item_id, type: 'reasoning', encrypted_content: null},
-				}) + event
+			announce(itemId, value.output_index);
+			return event;
+		}
+
+		if (announced.has(itemId)) {
+			return event;
+		}
+
+		const tracked =
+			typeof value.output_index === 'number'
+				? announcedByIndex.get(value.output_index)
+				: undefined;
+		if (tracked !== undefined) {
+			return encode(
+				reasoningItemId !== undefined
+					? {...value, item: {...item, id: tracked}}
+					: {...value, item_id: tracked},
 			);
 		}
 
-		return event;
+		announce(itemId, value.output_index);
+		return (
+			encode({
+				type: 'response.output_item.added',
+				output_index: value.output_index,
+				item: {id: itemId, type: 'reasoning', encrypted_content: null},
+			}) + event
+		);
 	};
 
 	const drain = (


### PR DESCRIPTION
Closes #719

## The bug

Copilot's Responses proxy emits reasoning summary events under an `item_id` that was
never announced via `response.output_item.added` — a rotated id, or no announcement at
all. Reproduced against 3.0.91:
response.output_item.added            item.id = rs_A
response.reasoning_summary_part.added item_id = rs_B   ← never announced
→ TypeError: Cannot read properties of undefined (reading 'summaryParts')


## The fix

The throw happens inside the SDK's own stream transform, so no middleware or model
wrapper can intercept it — it has to be corrected at the SSE layer. `createUndiciFetch`
in this same file already sets that precedent for the `data:  [DONE]` bug.

`createReasoningItemNormalizer()` is applied to Copilot's `text/event-stream` responses.
One rule: when a reasoning event references an unannounced `item_id`, emit a synthetic
`response.output_item.added` ahead of it so the parser always has state. This ships in
`dist`, so it holds regardless of which `@ai-sdk/openai` the user resolves.