### PR TITLE
fix: normalize Copilot reasoning stream IDs

### DIFF
--- a/.changeset/fix-copilot-reasoning-streams.md
+++ b/.changeset/fix-copilot-reasoning-streams.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed GitHub Copilot reasoning streams that rotate response item identifiers by correlating events through their stable output index.

--- a/source/ai-sdk-client/providers/provider-factory.spec.ts
+++ b/source/ai-sdk-client/providers/provider-factory.spec.ts
@@ -4,7 +4,154 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type {AIProviderConfig} from '@/types/index';
 import {Agent, MockAgent} from 'undici';
-import {createProvider, createUndiciFetch} from './provider-factory.js';
+import {
+	createProvider,
+	createUndiciFetch,
+	normalizeCopilotSseResponse,
+} from './provider-factory.js';
+
+test('normalizeCopilotSseResponse correlates rotated item ids by output index', async t => {
+	const events = [
+		{
+			type: 'response.output_item.added',
+			output_index: 0,
+			item: {id: 'reasoning-canonical', type: 'reasoning'},
+		},
+		{
+			type: 'response.reasoning_summary_part.added',
+			output_index: 0,
+			item_id: 'reasoning-rotated',
+			summary_index: 0,
+		},
+		{
+			type: 'response.output_item.done',
+			output_index: 0,
+			item: {id: 'reasoning-done-rotated', type: 'reasoning'},
+		},
+		{
+			type: 'response.output_item.added',
+			output_index: 1,
+			item: {id: 'message-canonical', type: 'message'},
+		},
+		{
+			type: 'response.output_text.delta',
+			output_index: 1,
+			item_id: 'message-rotated',
+			delta: 'ok',
+		},
+		{
+			type: 'response.output_item.done',
+			output_index: 1,
+			item: {id: 'message-done-rotated', type: 'message'},
+		},
+		{
+			type: 'response.output_text.delta',
+			output_index: 1,
+			item_id: 'after-done-untracked',
+			delta: 'ignored',
+		},
+		{
+			type: 'response.output_item.added',
+			output_index: 1,
+			item: {id: 'message-reused-index', type: 'message'},
+		},
+		{
+			type: 'response.output_text.delta',
+			output_index: 1,
+			item_id: 'message-reused-rotated',
+			delta: 'again',
+		},
+	];
+	const sse = events.map(event => `data: ${JSON.stringify(event)}\n\n`).join('');
+	const splitAt = sse.indexOf('reasoning-rotated') + 9;
+	const encoder = new TextEncoder();
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(encoder.encode(sse.slice(0, splitAt)));
+			controller.enqueue(encoder.encode(sse.slice(splitAt)));
+			controller.close();
+		},
+	});
+	const response = new Response(body, {
+		headers: {'content-type': 'text/event-stream'},
+	});
+
+	const normalized = await normalizeCopilotSseResponse(response).text();
+	const normalizedEvents = normalized
+		.split('\n\n')
+		.filter(Boolean)
+		.map(block => JSON.parse(block.replace(/^data:\s*/, '')) as {
+			item_id?: string;
+			item?: {id: string};
+		});
+
+	t.is(normalizedEvents[1]?.item_id, 'reasoning-canonical');
+	t.is(normalizedEvents[2]?.item?.id, 'reasoning-canonical');
+	t.is(normalizedEvents[4]?.item_id, 'message-canonical');
+	t.is(normalizedEvents[5]?.item?.id, 'message-canonical');
+	t.is(normalizedEvents[6]?.item_id, 'after-done-untracked');
+	t.is(normalizedEvents[8]?.item_id, 'message-reused-index');
+});
+
+test('normalizeCopilotSseResponse supports CR-only event framing', async t => {
+	const added = {
+		type: 'response.output_item.added',
+		output_index: 0,
+		item: {id: 'canonical', type: 'reasoning'},
+	};
+	const delta = {
+		type: 'response.reasoning_summary_text.delta',
+		output_index: 0,
+		item_id: 'rotated',
+		summary_index: 0,
+		delta: 'thinking',
+	};
+	const body = `data: ${JSON.stringify(added)}\r\rdata: ${JSON.stringify(delta)}\r\r`;
+	const response = new Response(body, {
+		headers: {'content-type': 'text/event-stream'},
+	});
+
+	const normalized = await normalizeCopilotSseResponse(response).text();
+	t.true(normalized.includes('"item_id":"canonical"'));
+});
+
+test('normalizeCopilotSseResponse matches event-stream media types case-insensitively', async t => {
+	const added = {
+		type: 'response.output_item.added',
+		output_index: 0,
+		item: {id: 'canonical', type: 'message'},
+	};
+	const delta = {
+		type: 'response.output_text.delta',
+		output_index: 0,
+		item_id: 'rotated',
+		delta: 'ok',
+	};
+	const body = `data: ${JSON.stringify(added)}\n\ndata: ${JSON.stringify(delta)}\n\n`;
+	const response = new Response(body, {
+		headers: {'content-type': 'Text/Event-Stream; Charset=UTF-8'},
+	});
+
+	const normalized = await normalizeCopilotSseResponse(response).text();
+	t.true(normalized.includes('"item_id":"canonical"'));
+});
+
+test('normalizeCopilotSseResponse preserves non-SSE responses', async t => {
+	const response = new Response('{"ok":true}', {
+		headers: {'content-type': 'application/json'},
+	});
+
+	t.is(normalizeCopilotSseResponse(response), response);
+});
+
+test('normalizeCopilotSseResponse preserves control and malformed events', async t => {
+	const body = ': keepalive\n\ndata: not-json\n\ndata: [DONE]\n\n';
+	const response = new Response(body, {
+		headers: {'content-type': 'text/event-stream'},
+	});
+
+	t.is(await normalizeCopilotSseResponse(response).text(), body);
+});
 
 test('createProvider creates provider with basic config', async t => {
 	const config: AIProviderConfig = {

--- a/source/ai-sdk-client/providers/provider-factory.ts
+++ b/source/ai-sdk-client/providers/provider-factory.ts
@@ -47,6 +47,115 @@ export type TaggedProvider =
 	| {kind: 'anthropic'; provider: AnthropicProvider}
 	| {kind: 'google'; provider: GoogleGenerativeAIProvider};
 
+type CopilotSseEvent = {
+	type?: string;
+	output_index?: number;
+	item_id?: string;
+	item?: {id?: string; [key: string]: unknown};
+	[key: string]: unknown;
+};
+
+/**
+ * GitHub Copilot can rotate the opaque item id between Responses API events
+ * while keeping output_index stable. AI SDK 6's OpenAI provider keys active
+ * reasoning and text state by item id, so normalize later events back to the
+ * id announced by response.output_item.added.
+ */
+export function normalizeCopilotSseResponse(response: Response): Response {
+	const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+	if (!response.body || !contentType.includes('text/event-stream')) {
+		return response;
+	}
+
+	const decoder = new TextDecoder();
+	const encoder = new TextEncoder();
+	const itemIdsByOutputIndex = new Map<number, string>();
+	let buffer = '';
+
+	const normalizeBlock = (block: string): string => {
+		const lines = block.split(/\r\n|\r|\n/);
+		const dataLineIndex = lines.findIndex(line => line.startsWith('data:'));
+		if (dataLineIndex === -1) {
+			return block;
+		}
+
+		const data = lines
+			.filter(line => line.startsWith('data:'))
+			.map(line => line.slice(5).trimStart())
+			.join('\n');
+		if (data === '[DONE]') {
+			return block;
+		}
+
+		try {
+			const event = JSON.parse(data) as CopilotSseEvent;
+			const outputIndex = event.output_index;
+			if (typeof outputIndex !== 'number') {
+				return block;
+			}
+
+			if (
+				event.type === 'response.output_item.added' &&
+				typeof event.item?.id === 'string'
+			) {
+				itemIdsByOutputIndex.set(outputIndex, event.item.id);
+			} else {
+				const canonicalId = itemIdsByOutputIndex.get(outputIndex);
+				if (canonicalId) {
+					if (typeof event.item_id === 'string') {
+						event.item_id = canonicalId;
+					}
+					if (
+						event.type === 'response.output_item.done' &&
+						typeof event.item?.id === 'string'
+					) {
+						event.item.id = canonicalId;
+					}
+				}
+
+				if (event.type === 'response.output_item.done') {
+					itemIdsByOutputIndex.delete(outputIndex);
+				}
+			}
+
+			const normalizedLines = lines.filter(
+				(line, index) => index === dataLineIndex || !line.startsWith('data:'),
+			);
+			normalizedLines[dataLineIndex] = `data: ${JSON.stringify(event)}`;
+			return normalizedLines.join('\n');
+		} catch {
+			return block;
+		}
+	};
+
+	const transform = new TransformStream<Uint8Array, Uint8Array>({
+		transform(chunk, controller) {
+			buffer += decoder.decode(chunk, {stream: true});
+			let delimiter = /(?:\r\n|\r|\n){2}/.exec(buffer);
+			while (delimiter?.index !== undefined) {
+				const block = buffer.slice(0, delimiter.index);
+				buffer = buffer.slice(delimiter.index + delimiter[0].length);
+				controller.enqueue(
+					encoder.encode(`${normalizeBlock(block)}${delimiter[0]}`),
+				);
+				delimiter = /(?:\r\n|\r|\n){2}/.exec(buffer);
+			}
+		},
+		flush(controller) {
+			buffer += decoder.decode();
+			if (buffer) {
+				controller.enqueue(encoder.encode(normalizeBlock(buffer)));
+			}
+		},
+	});
+
+	return new Response(response.body.pipeThrough(transform), {
+		status: response.status,
+		statusText: response.statusText,
+		headers: response.headers,
+	});
+}
+
 /**
  * Wraps undici's fetch so requests flow through the shared Agent. The Agent
  * carries TLS connect options (e.g. caCertPath), so any SDK provider given
@@ -206,13 +315,15 @@ export async function createProvider(
 				headers[k] = v;
 			});
 
-			return undiciFetch(input as string | URL, {
+			const response = await undiciFetch(input as string | URL, {
 				method: init?.method,
 				body: init?.body as UndiciRequestInit['body'],
 				signal: init?.signal,
 				headers,
 				dispatcher: undiciAgent,
-			}) as Promise<Response>;
+			});
+
+			return normalizeCopilotSseResponse(response as unknown as Response);
 		};
 
 		const {createOpenAI} = await import('@ai-sdk/openai');


### PR DESCRIPTION
## Summary

- normalize GitHub Copilot Responses API event IDs by the stable `output_index` before AI SDK 6 parses the stream
- cover reasoning summaries, text deltas, completed items, state cleanup, and reused output indexes
- preserve non-SSE, control, malformed, and `[DONE]` events
- support LF, CRLF, and CR-only SSE framing plus case-insensitive media types
- add a patch changeset

Closes #719

## Root cause

GitHub Copilot can rotate the opaque `item_id` across events for one logical output while keeping `output_index` stable. `@ai-sdk/openai` 3.x keys active reasoning state by item ID, so the rotated ID triggers the reported `summaryParts` dereference.

NanoCoder already carries a pnpm patch, but published npm/Homebrew installations do not receive or apply it: the package publishes `dist` and selected assets, not `patches/` or `pnpm-workspace.yaml`. That explains why the reporter reproduces the crash in releases containing the repository commit.

The upstream SDK fixed the same live Copilot sequence in vercel/ai#18548 by correlating events through `output_index`, but that correction is on the provider's next major line. This PR applies the narrow compatibility normalization only to NanoCoder's Copilot fetch path without a broad AI SDK migration.

## Validation

- focused provider suite: 25 passed
- regression mutation confirmed the correlation test fails when ID rewriting is removed
- `pnpm run test:format`
- `pnpm run test:lint`
- `git diff --check`
- independent review found no remaining findings
- with prerequisite #830 applied, build and TypeScript checks pass
- the full suite reached 6,279 passing tests before one live Context7 network test timed out; that exact external test passed on immediate isolated rerun

Current branch CI will inherit the ACP SDK failure already on `main` until #830 merges.