### PR TITLE
Document tool output conventions for file content

### DIFF
--- a/.changeset/document-tool-output-conventions.md
+++ b/.changeset/document-tool-output-conventions.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+Document the tool output convention for file content and add a regression test.

--- a/docs/features/tool-output-conventions.md
+++ b/docs/features/tool-output-conventions.md
@@ -1,0 +1,21 @@
+# Tool output conventions
+
+File-content tools use two different model-facing representations.
+
+## read_file
+
+`read_file` returns raw file content without line numbers. This keeps the payload clean for content-based editing and makes it the canonical representation for exact text matching.
+
+## Edit tools
+
+Bounded edit-tool responses, such as `string_replace` and `diff_edit`, return partial file windows. Those responses should keep line numbers because the excerpt needs to be placed inside the larger file.
+
+When an edit tool returns file content:
+
+- Include a header such as `Updated file context (lines X-Y of N)`.
+- Use absolute file line numbers, not window-relative offsets.
+- Keep omission markers aligned with absolute line numbers.
+
+## UI display
+
+Line numbers rendered by the terminal or editor UI are presentation-only unless the tool intentionally returns a bounded, line-addressed excerpt.

--- a/source/tools/tool-output-conventions.spec.ts
+++ b/source/tools/tool-output-conventions.spec.ts
@@ -1,0 +1,44 @@
+import test from 'ava';
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const toolsDir = join(process.cwd(), 'source', 'tools');
+
+test('read_file returns raw content without line-number prefixes', (t) => {
+  const readFilePath = join(toolsDir, 'read-file.tsx');
+  if (!existsSync(readFilePath)) {
+    t.fail('source/tools/read-file.tsx should exist');
+    return;
+  }
+
+  const source = readFileSync(readFilePath, 'utf8');
+  t.false(
+    source.includes('%4d:'),
+    'read_file should not return model-facing content with line-number prefixes',
+  );
+});
+
+test('bounded edit tools keep absolute line-numbered context headers', (t) => {
+  const fileOpsDir = join(toolsDir, 'file-ops');
+  if (!existsSync(fileOpsDir)) {
+    t.fail('source/tools/file-ops should exist');
+    return;
+  }
+
+  const files = readdirSync(fileOpsDir).filter(
+    (file) =>
+      (file.endsWith('.tsx') || file.endsWith('.ts')) &&
+      !file.includes('.spec.'),
+  );
+
+  const hasContextHeader = files.some((file) => {
+    const source = readFileSync(join(fileOpsDir, file), 'utf8');
+    return source.includes('Updated file context (lines');
+  });
+
+  t.true(
+    hasContextHeader,
+    'bounded edit tools should include an absolute line-numbered context header',
+  );
+});


### PR DESCRIPTION
Records the convention from #765: `read_file` returns raw content without line numbers, while bounded edit-tool responses keep absolute line-numbered context headers. Also adds a lightweight source-level regression test so future tools don't drift from the split.

Addresses #765