### PR TITLE
feat(vscode): add GUI settings panel to the extension

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -98,6 +98,13 @@ Or from the repo root: `pnpm run build:vscode` builds and packages to `assets/na
 - **History**: the clock icon - resume a previous session (the full thread replays) or delete it
 - Switching to another sidebar view and back keeps the transcript
 
+### Settings
+
+The gear icon in the view title bar opens a settings panel. It edits the default
+mode and auto-compact behaviour, lists the configured providers and MCP servers,
+and links to the raw config file for anything it does not cover. Saves are merged
+into `agents.config.json` under the `nanocoder` key.
+
 ### Slash Commands
 
 `/help` lists what's available. `/clear` resets the conversation. Custom commands from `.nanocoder/commands` run as in the CLI. Interactive CLI-only commands (`/init`, `/theme`, `/compact`, ...) explain that they need the terminal CLI. Messages starting with a file path are treated as text, not commands.
@@ -110,6 +117,7 @@ Access via Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 | -------------------------------------- | --------------------------------------------------------- |
 | `Nanocoder: New Chat`                  | Start a fresh conversation (also the `+` view title icon) |
 | `Nanocoder: View Session History`      | Toggle the session history list (also the clock icon)     |
+| `Nanocoder: Open Settings`             | Toggle the settings panel (also the gear icon)            |
 | `Nanocoder: Open Configuration`        | Open the active `agents.config.json`                      |
 | `Nanocoder: Connect to Nanocoder`      | Connect the legacy companion to a running terminal CLI    |
 | `Nanocoder: Disconnect from Nanocoder` | Disconnect the legacy companion                           |

--- a/plugins/vscode/media/chat-panel.html
+++ b/plugins/vscode/media/chat-panel.html
@@ -36,6 +36,49 @@
 			<div id="history-list" class="flex-1 overflow-y-auto py-1.5"></div>
 		</div>
 
+		<div id="settings-view" class="flex flex-col flex-1 overflow-hidden hidden">
+			<div class="pt-2.5 pb-1.5 px-4 border-b border-vscode-border shrink-0">
+				<span class="font-semibold text-[0.9em] uppercase tracking-[0.04em] opacity-70">Settings</span>
+			</div>
+			<div class="flex-1 overflow-y-auto p-4 flex flex-col gap-5">
+				<div id="settings-error" class="hidden text-[0.85em] text-[#f14c4c] border border-[#f14c4c] rounded p-2"></div>
+
+				<div class="flex flex-col gap-3">
+					<span class="font-semibold text-[0.8em] uppercase tracking-[0.04em] opacity-60">General</span>
+
+					<label class="flex flex-col gap-1">
+						<span class="text-[0.9em]">Default mode</span>
+						<select id="settings-default-mode" class="bg-vscode-dropdown-bg text-vscode-fg border border-vscode-input-border rounded px-2 py-1 text-[0.9em] outline-none focus:border-vscode-input-focus"></select>
+					</label>
+
+					<label class="flex items-center gap-2 cursor-pointer">
+						<input type="checkbox" id="settings-auto-compact" class="cursor-pointer">
+						<span class="text-[0.9em]">Auto-compact context</span>
+					</label>
+
+					<label class="flex flex-col gap-1">
+						<span class="text-[0.9em]">Auto-compact threshold (<span id="settings-threshold-value">60</span>%)</span>
+						<input type="range" id="settings-threshold" min="50" max="95" step="1" class="cursor-pointer">
+					</label>
+				</div>
+
+				<div class="flex flex-col gap-2">
+					<span class="font-semibold text-[0.8em] uppercase tracking-[0.04em] opacity-60">Providers</span>
+					<div id="settings-providers" class="flex flex-col gap-1 text-[0.85em] opacity-80"></div>
+				</div>
+
+				<div class="flex flex-col gap-2">
+					<span class="font-semibold text-[0.8em] uppercase tracking-[0.04em] opacity-60">MCP Servers</span>
+					<div id="settings-mcp" class="flex flex-col gap-1 text-[0.85em] opacity-80"></div>
+				</div>
+
+				<div class="flex items-center gap-2 pt-1">
+					<button id="settings-save" class="bg-vscode-button-bg text-vscode-button-fg border-none rounded px-3 py-1.5 text-[0.85em] cursor-pointer hover:bg-vscode-button-hover">Save</button>
+					<button id="settings-open-config" class="bg-transparent text-vscode-fg border border-vscode-input-border rounded px-3 py-1.5 text-[0.85em] cursor-pointer hover:bg-vscode-toolbarHover">Edit agents.config.json</button>
+				</div>
+			</div>
+		</div>
+
 		<div class="p-4 pt-2 bg-vscode-bg shrink-0">
 			<div id="composer-box" class="flex flex-col bg-vscode-input-bg border border-vscode-input-border rounded-2xl focus-within:border-vscode-input-focus transition-colors shadow-sm relative">
 				<div id="image-preview-container" class="flex flex-wrap gap-2 px-3 pt-3 empty:hidden"></div>

--- a/plugins/vscode/media/chat-panel.js
+++ b/plugins/vscode/media/chat-panel.js
@@ -121,6 +121,8 @@
 	function toggleHistoryView() {
 		isHistoryView = !isHistoryView;
 		if (isHistoryView) {
+			isSettingsView = false;
+			document.getElementById('settings-view').classList.add('hidden');
 			document.getElementById('chat-view').classList.add('hidden');
 			document.getElementById('history-view').classList.remove('hidden');
 			// Fetch sessions from extension host and render immediately
@@ -131,10 +133,25 @@
 		}
 	}
 
+	function toggleSettingsView() {
+		isSettingsView = !isSettingsView;
+		if (isSettingsView) {
+			isHistoryView = false;
+			document.getElementById('history-view').classList.add('hidden');
+			document.getElementById('chat-view').classList.add('hidden');
+			document.getElementById('settings-view').classList.remove('hidden');
+			vscode.postMessage({ type: 'loadSettings' });
+		} else {
+			showChatView();
+		}
+	}
+
 	function showChatView() {
 		isHistoryView = false;
+		isSettingsView = false;
 		document.getElementById('chat-view').classList.remove('hidden');
 		document.getElementById('history-view').classList.add('hidden');
+		document.getElementById('settings-view').classList.add('hidden');
 	}
 
 	const sendStopBtn = document.getElementById('send-stop-btn');
@@ -148,6 +165,7 @@
 	let renderTimeout = null;
 	let sessionsData = [];
 	let isHistoryView = false;
+	let isSettingsView = false;
 	let isProcessing = false;
 	let currentAggregator = null;
 	let currentThoughtBox = null;
@@ -1056,7 +1074,88 @@
 						: 'Could not copy to clipboard'
 				);
 				break;
+			case 'toggleSettings':
+				toggleSettingsView();
+				break;
+			case 'settingsLoaded':
+				renderSettings(message);
+				break;
+			case 'settingsSaved':
+				showToast(message.ok ? 'Settings saved' : `Could not save settings: ${message.error}`);
+				break;
 		}
+	});
+
+	const SETTINGS_MODES = ['normal', 'auto-accept', 'yolo', 'plan'];
+
+	function renderSettings(payload) {
+		const errorBox = document.getElementById('settings-error');
+		if (payload.error) {
+			errorBox.textContent = `Could not read ${payload.configPath}: ${payload.error}`;
+			errorBox.classList.remove('hidden');
+		} else {
+			errorBox.classList.add('hidden');
+		}
+
+		const general = payload.settings.general;
+
+		const modeSelect = document.getElementById('settings-default-mode');
+		modeSelect.innerHTML = '';
+		SETTINGS_MODES.forEach(mode => {
+			const option = document.createElement('option');
+			option.value = mode;
+			option.textContent = mode;
+			modeSelect.appendChild(option);
+		});
+		modeSelect.value = general.defaultMode;
+
+		document.getElementById('settings-auto-compact').checked = general.autoCompactEnabled;
+		document.getElementById('settings-threshold').value = general.autoCompactThreshold;
+		document.getElementById('settings-threshold-value').textContent = general.autoCompactThreshold;
+
+		renderSettingsList('settings-providers', payload.settings.providers.map(
+			provider => `${provider.name} — ${provider.models} model${provider.models === 1 ? '' : 's'}`
+		), 'No providers configured.');
+
+		renderSettingsList('settings-mcp', payload.settings.mcpServers.map(
+			server => server.name
+		), 'No MCP servers configured.');
+	}
+
+	function renderSettingsList(containerId, entries, emptyText) {
+		const container = document.getElementById(containerId);
+		container.innerHTML = '';
+		if (entries.length === 0) {
+			const empty = document.createElement('div');
+			empty.className = 'opacity-60';
+			empty.textContent = emptyText;
+			container.appendChild(empty);
+			return;
+		}
+		entries.forEach(entry => {
+			const row = document.createElement('div');
+			row.textContent = entry;
+			container.appendChild(row);
+		});
+	}
+
+	document.getElementById('settings-threshold').addEventListener('input', event => {
+		document.getElementById('settings-threshold-value').textContent = event.target.value;
+	});
+
+	document.getElementById('settings-save').addEventListener('click', () => {
+		vscode.postMessage({
+			type: 'saveSettings',
+			settings: {
+				defaultMode: document.getElementById('settings-default-mode').value,
+				autoCompactEnabled: document.getElementById('settings-auto-compact').checked,
+				autoCompactThreshold: Number(document.getElementById('settings-threshold').value)
+			}
+		});
+	});
+
+	document.getElementById('settings-open-config').addEventListener('click', () => {
+		vscode.postMessage({ type: 'openConfigFile' });
 	});
 
 

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -83,6 +83,12 @@
 				"icon": "$(add)"
 			},
 			{
+				"command": "nanocoder.openSettings",
+				"title": "Open Settings",
+				"category": "Nanocoder",
+				"icon": "$(gear)"
+			},
+			{
 				"command": "nanocoder.copyLastCodeBlock",
 				"title": "Copy Last Code Block",
 				"category": "Nanocoder"
@@ -107,6 +113,11 @@
 					"command": "nanocoder.toggleHistory",
 					"when": "view == nanocoder.chatView",
 					"group": "navigation@2"
+				},
+				{
+					"command": "nanocoder.openSettings",
+					"when": "view == nanocoder.chatView",
+					"group": "navigation@3"
 				}
 			]
 		},

--- a/plugins/vscode/src/chat-webview-provider.ts
+++ b/plugins/vscode/src/chat-webview-provider.ts
@@ -5,6 +5,13 @@ import { WebviewToExtensionMessage, ExtensionToWebviewMessage } from './webview-
 
 import { NanocoderAcpClient } from './acp-client';
 import { DiffManager } from './diff-manager';
+import {
+	applyGeneralSettings,
+	parseConfig,
+	readSettings,
+	serialiseConfig,
+	DEFAULT_GENERAL_SETTINGS
+} from './settings-config';
 
 export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 	public static readonly viewType = 'nanocoder.chatView';
@@ -79,6 +86,58 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 	public toggleHistory() {
 		if (this._view) {
 			this._view.webview.postMessage({ type: 'toggleHistory' });
+		}
+	}
+
+	public toggleSettings() {
+		if (this._view) {
+			this.postMessage({ type: 'toggleSettings' });
+		}
+	}
+
+	private _configPath(): string {
+		const config = vscode.workspace.getConfiguration('nanocoder');
+		const cwd = config.get<string>('cwd') || (vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd());
+		return path.join(cwd, 'agents.config.json');
+	}
+
+	private _readConfigFile(): { config: Record<string, unknown>; error?: string } {
+		const configPath = this._configPath();
+		if (!fs.existsSync(configPath)) {
+			return { config: {} };
+		}
+		try {
+			return { config: parseConfig(fs.readFileSync(configPath, 'utf8')) };
+		} catch (error) {
+			return { config: {}, error: String(error) };
+		}
+	}
+
+	private _sendSettings() {
+		const { config, error } = this._readConfigFile();
+		this.postMessage({
+			type: 'settingsLoaded',
+			settings: error
+				? { general: DEFAULT_GENERAL_SETTINGS, providers: [], mcpServers: [] }
+				: readSettings(config),
+			configPath: this._configPath(),
+			error
+		});
+	}
+
+	private _saveSettings(settings: unknown) {
+		const { config, error } = this._readConfigFile();
+		if (error) {
+			this.postMessage({ type: 'settingsSaved', ok: false, error });
+			return;
+		}
+		try {
+			fs.writeFileSync(this._configPath(), serialiseConfig(applyGeneralSettings(config, settings)), 'utf8');
+			this.postMessage({ type: 'settingsSaved', ok: true });
+			this._sendSettings();
+		} catch (writeError) {
+			this._outputChannel.appendLine(`Failed to save settings: ${writeError}`);
+			this.postMessage({ type: 'settingsSaved', ok: false, error: String(writeError) });
 		}
 	}
 
@@ -216,6 +275,16 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
 						break;
 					case 'copyToClipboard':
 						this._copyToClipboard(message.text);
+						break;
+					case 'loadSettings':
+						this._sendSettings();
+						break;
+					case 'saveSettings':
+						this._outputChannel.appendLine('[Webview] User saved settings.');
+						this._saveSettings(message.settings);
+						break;
+					case 'openConfigFile':
+						vscode.commands.executeCommand('nanocoder.openConfig');
 						break;
 				}
 			}

--- a/plugins/vscode/src/extension.ts
+++ b/plugins/vscode/src/extension.ts
@@ -86,6 +86,9 @@ export function activate(context: vscode.ExtensionContext) {
 			acpProcessManager = new AcpProcessManager(outputChannel, acpStateManager, acpClient);
 			acpProcessManager.start();
 		}),
+		vscode.commands.registerCommand('nanocoder.openSettings', () => {
+			chatProvider.toggleSettings();
+		}),
 		vscode.commands.registerCommand('nanocoder.openConfig', async () => {
 			const config = vscode.workspace.getConfiguration('nanocoder');
 			const cwdSetting = config.get<string>('cwd') || (vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd());

--- a/plugins/vscode/src/settings-config.spec.ts
+++ b/plugins/vscode/src/settings-config.spec.ts
@@ -1,0 +1,130 @@
+import test from 'ava';
+import {
+	applyGeneralSettings,
+	DEFAULT_GENERAL_SETTINGS,
+	parseConfig,
+	readSettings,
+	serialiseConfig,
+	THRESHOLD_MAX,
+	THRESHOLD_MIN
+} from './settings-config';
+
+test('settings-config - falls back to defaults on an empty config', (t) => {
+	const snapshot = readSettings({});
+
+	t.deepEqual(snapshot.general, DEFAULT_GENERAL_SETTINGS, 'Should use defaults');
+	t.deepEqual(snapshot.providers, [], 'Should report no providers');
+	t.deepEqual(snapshot.mcpServers, [], 'Should report no MCP servers');
+});
+
+test('settings-config - reads settings nested under the nanocoder key', (t) => {
+	const snapshot = readSettings({
+		nanocoder: {
+			defaultMode: 'yolo',
+			autoCompact: { enabled: false, threshold: 75 }
+		}
+	});
+
+	t.is(snapshot.general.defaultMode, 'yolo', 'Should read defaultMode');
+	t.false(snapshot.general.autoCompactEnabled, 'Should read autoCompact.enabled');
+	t.is(snapshot.general.autoCompactThreshold, 75, 'Should read autoCompact.threshold');
+});
+
+test('settings-config - rejects an unknown development mode', (t) => {
+	const snapshot = readSettings({nanocoder: {defaultMode: 'headless'}});
+
+	t.is(snapshot.general.defaultMode, 'normal', 'Should fall back to normal');
+});
+
+test('settings-config - clamps the auto-compact threshold', (t) => {
+	const low = readSettings({nanocoder: {autoCompact: {threshold: 5}}});
+	const high = readSettings({nanocoder: {autoCompact: {threshold: 500}}});
+
+	t.is(low.general.autoCompactThreshold, THRESHOLD_MIN, 'Should clamp upwards');
+	t.is(high.general.autoCompactThreshold, THRESHOLD_MAX, 'Should clamp downwards');
+});
+
+test('settings-config - summarises providers and MCP servers', (t) => {
+	const snapshot = readSettings({
+		providers: [
+			{name: 'Ollama', models: ['qwen3', 'llama3.1']},
+			{models: ['gpt-4o']}
+		],
+		mcpServers: [{name: 'filesystem'}]
+	});
+
+	t.deepEqual(
+		snapshot.providers,
+		[
+			{name: 'Ollama', models: 2},
+			{name: 'Unnamed', models: 1}
+		],
+		'Should count models per provider'
+	);
+	t.deepEqual(snapshot.mcpServers, [{name: 'filesystem'}], 'Should list MCP servers');
+});
+
+test('settings-config - preserves unrelated config when saving', (t) => {
+	const existing = {
+		providers: [{name: 'Ollama', models: ['qwen3']}],
+		mcpServers: [{name: 'filesystem'}],
+		nanocoder: {
+			sessions: {autoSave: true},
+			autoCompact: {strategy: 'llm', mode: 'conservative', notifyUser: true}
+		}
+	};
+
+	const updated = applyGeneralSettings(existing, {
+		defaultMode: 'plan',
+		autoCompactEnabled: false,
+		autoCompactThreshold: 80
+	}) as any;
+
+	t.deepEqual(updated.providers, existing.providers, 'Should not touch providers');
+	t.deepEqual(updated.mcpServers, existing.mcpServers, 'Should not touch MCP servers');
+	t.deepEqual(
+		updated.nanocoder.sessions,
+		{autoSave: true},
+		'Should not touch sibling nanocoder keys'
+	);
+	t.is(updated.nanocoder.autoCompact.strategy, 'llm', 'Should keep autoCompact.strategy');
+	t.is(updated.nanocoder.autoCompact.mode, 'conservative', 'Should keep autoCompact.mode');
+	t.true(updated.nanocoder.autoCompact.notifyUser, 'Should keep autoCompact.notifyUser');
+	t.is(updated.nanocoder.defaultMode, 'plan', 'Should write the new mode');
+	t.false(updated.nanocoder.autoCompact.enabled, 'Should write the new enabled flag');
+	t.is(updated.nanocoder.autoCompact.threshold, 80, 'Should write the new threshold');
+});
+
+test('settings-config - does not mutate the config it was given', (t) => {
+	const existing = {nanocoder: {defaultMode: 'normal'}};
+
+	applyGeneralSettings(existing, {defaultMode: 'yolo'});
+
+	t.is(existing.nanocoder.defaultMode, 'normal', 'Original config should be untouched');
+});
+
+test('settings-config - sanitises values coming from the webview', (t) => {
+	const updated = applyGeneralSettings(
+		{},
+		{defaultMode: 'rm -rf', autoCompactEnabled: 'yes', autoCompactThreshold: '999'}
+	) as any;
+
+	t.is(updated.nanocoder.defaultMode, 'normal', 'Should reject an invalid mode');
+	t.true(updated.nanocoder.autoCompact.enabled, 'Should coerce the enabled flag');
+	t.is(updated.nanocoder.autoCompact.threshold, THRESHOLD_MAX, 'Should clamp the threshold');
+});
+
+test('settings-config - parses config text', (t) => {
+	t.deepEqual(parseConfig(''), {}, 'Empty file should be an empty config');
+	t.deepEqual(parseConfig('{"a":1}'), {a: 1}, 'Should parse an object');
+	t.throws(() => parseConfig('[]'), undefined, 'Should reject a non-object root');
+	t.throws(() => parseConfig('{'), undefined, 'Should reject malformed JSON');
+});
+
+test('settings-config - serialises with tabs and a trailing newline', (t) => {
+	const text = serialiseConfig({nanocoder: {defaultMode: 'plan'}});
+
+	t.true(text.includes('\n\t"nanocoder"'), 'Should indent with tabs');
+	t.true(text.endsWith('\n'), 'Should end with a newline');
+	t.deepEqual(parseConfig(text), {nanocoder: {defaultMode: 'plan'}}, 'Should round-trip');
+});

--- a/plugins/vscode/src/settings-config.ts
+++ b/plugins/vscode/src/settings-config.ts
@@ -1,0 +1,134 @@
+export type SettingsMode = 'normal' | 'auto-accept' | 'yolo' | 'plan';
+
+export const SETTINGS_MODES: readonly SettingsMode[] = [
+	'normal',
+	'auto-accept',
+	'yolo',
+	'plan'
+];
+
+export const THRESHOLD_MIN = 50;
+export const THRESHOLD_MAX = 95;
+
+export interface GeneralSettings {
+	defaultMode: SettingsMode;
+	autoCompactEnabled: boolean;
+	autoCompactThreshold: number;
+}
+
+export interface SettingsSnapshot {
+	general: GeneralSettings;
+	providers: { name: string; models: number }[];
+	mcpServers: { name: string }[];
+}
+
+export const DEFAULT_GENERAL_SETTINGS: GeneralSettings = {
+	defaultMode: 'normal',
+	autoCompactEnabled: true,
+	autoCompactThreshold: 60
+};
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function child(parent: JsonObject, key: string): JsonObject {
+	const value = parent[key];
+	return isObject(value) ? value : {};
+}
+
+export function parseConfig(text: string): JsonObject {
+	const trimmed = text.trim();
+	if (!trimmed) {
+		return {};
+	}
+	const parsed = JSON.parse(trimmed);
+	if (!isObject(parsed)) {
+		throw new Error('agents.config.json must contain a JSON object.');
+	}
+	return parsed;
+}
+
+export function serialiseConfig(config: JsonObject): string {
+	return `${JSON.stringify(config, null, '\t')}\n`;
+}
+
+export function clampThreshold(value: unknown): number {
+	const numeric = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(numeric)) {
+		return DEFAULT_GENERAL_SETTINGS.autoCompactThreshold;
+	}
+	return Math.min(THRESHOLD_MAX, Math.max(THRESHOLD_MIN, Math.round(numeric)));
+}
+
+function toMode(value: unknown): SettingsMode {
+	if (typeof value === 'string') {
+		const normalised = value.toLowerCase().trim();
+		if ((SETTINGS_MODES as readonly string[]).includes(normalised)) {
+			return normalised as SettingsMode;
+		}
+	}
+	return DEFAULT_GENERAL_SETTINGS.defaultMode;
+}
+
+export function normaliseGeneralSettings(input: unknown): GeneralSettings {
+	const source = isObject(input) ? input : {};
+	return {
+		defaultMode: toMode(source.defaultMode),
+		autoCompactEnabled:
+			source.autoCompactEnabled === undefined
+				? DEFAULT_GENERAL_SETTINGS.autoCompactEnabled
+				: Boolean(source.autoCompactEnabled),
+		autoCompactThreshold:
+			source.autoCompactThreshold === undefined
+				? DEFAULT_GENERAL_SETTINGS.autoCompactThreshold
+				: clampThreshold(source.autoCompactThreshold)
+	};
+}
+
+export function readSettings(config: JsonObject): SettingsSnapshot {
+	const nanocoder = child(config, 'nanocoder');
+	const autoCompact = child(nanocoder, 'autoCompact');
+
+	const providers = Array.isArray(config.providers) ? config.providers : [];
+	const mcpServers = Array.isArray(config.mcpServers) ? config.mcpServers : [];
+
+	return {
+		general: normaliseGeneralSettings({
+			defaultMode: nanocoder.defaultMode,
+			autoCompactEnabled: autoCompact.enabled,
+			autoCompactThreshold: autoCompact.threshold
+		}),
+		providers: providers.filter(isObject).map(provider => ({
+			name: typeof provider.name === 'string' ? provider.name : 'Unnamed',
+			models: Array.isArray(provider.models) ? provider.models.length : 0
+		})),
+		mcpServers: mcpServers.filter(isObject).map(server => ({
+			name: typeof server.name === 'string' ? server.name : 'Unnamed'
+		}))
+	};
+}
+
+export function applyGeneralSettings(
+	config: JsonObject,
+	settings: unknown
+): JsonObject {
+	const general = normaliseGeneralSettings(settings);
+	const nanocoder = child(config, 'nanocoder');
+	const autoCompact = child(nanocoder, 'autoCompact');
+
+	return {
+		...config,
+		nanocoder: {
+			...nanocoder,
+			defaultMode: general.defaultMode,
+			autoCompact: {
+				...autoCompact,
+				enabled: general.autoCompactEnabled,
+				threshold: general.autoCompactThreshold
+			}
+		}
+	};
+}

--- a/plugins/vscode/src/webview-protocol.ts
+++ b/plugins/vscode/src/webview-protocol.ts
@@ -3,6 +3,8 @@
  * and the Sidebar Webview UI.
  */
 
+import type { GeneralSettings, SettingsSnapshot } from './settings-config';
+
 // ---------------------------------------------------------
 // Messages: Extension Host -> Webview
 // ---------------------------------------------------------
@@ -99,6 +101,23 @@ export interface ExtensionMessagePathInfoResolved {
 	kind: 'file' | 'folder';
 }
 
+export interface ExtensionMessageToggleSettings {
+	type: 'toggleSettings';
+}
+
+export interface ExtensionMessageSettingsLoaded {
+	type: 'settingsLoaded';
+	settings: SettingsSnapshot;
+	configPath: string;
+	error?: string;
+}
+
+export interface ExtensionMessageSettingsSaved {
+	type: 'settingsSaved';
+	ok: boolean;
+	error?: string;
+}
+
 export type ExtensionToWebviewMessage =
 	| ExtensionMessageAppendMessage
 	| ExtensionMessageAppendThought
@@ -114,7 +133,10 @@ export type ExtensionToWebviewMessage =
 	| ExtensionMessageSessionLoaded
 	| ExtensionMessagePathInfoResolved
 	| ExtensionMessageCopyLastCodeBlock
-	| ExtensionMessageCopyResult;
+	| ExtensionMessageCopyResult
+	| ExtensionMessageToggleSettings
+	| ExtensionMessageSettingsLoaded
+	| ExtensionMessageSettingsSaved;
 
 
 // ---------------------------------------------------------
@@ -212,6 +234,19 @@ export interface WebviewMessageCopyToClipboard {
 	text: string;
 }
 
+export interface WebviewMessageLoadSettings {
+	type: 'loadSettings';
+}
+
+export interface WebviewMessageSaveSettings {
+	type: 'saveSettings';
+	settings: GeneralSettings;
+}
+
+export interface WebviewMessageOpenConfigFile {
+	type: 'openConfigFile';
+}
+
 export type WebviewToExtensionMessage =
 	| WebviewMessageReady
 	| WebviewMessageSubmitMessage
@@ -230,4 +265,7 @@ export type WebviewToExtensionMessage =
 	| WebviewMessageRequestOpenDialog
 	| WebviewMessageOpenPath
 	| WebviewMessageShowError
-	| WebviewMessageCopyToClipboard;
+	| WebviewMessageCopyToClipboard
+	| WebviewMessageLoadSettings
+	| WebviewMessageSaveSettings
+	| WebviewMessageOpenConfigFile;


### PR DESCRIPTION
Closes #807

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

`nanocoder-vscode` is in the `ignore` list in `.changeset/config.json`, so
extension-only changes are not versioned by changesets.

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

10 tests in `plugins/vscode/src/settings-config.spec.ts`, matching the format of
the existing specs in that directory. Error paths covered: unknown development
mode, out-of-range threshold, malformed JSON, non-object config root, and
unsanitised values arriving from the webview.

Note that the root AVA config globs `source/**/*.spec.ts` only, so no
`plugins/vscode` spec is picked up by `pnpm test:all` this predates this PR.
I ran the new spec with a temporary AVA config (not committed): 10/10 pass.

Also verified:
- `tsc --noEmit` clean for `plugins/vscode`
- `esbuild` bundles the extension
- Tailwind picks up the new markup classes
- Real-file round trip on a temp `agents.config.json`: `providers`, `mcpServers`,
  `nanocoder.sessions`, and untouched `autoCompact` fields (`strategy`,
  `notifyUser`) all survive a save
- End-to-end against the engine: saved through the panel's write path, then the
  CLI's own `loadDefaultMode()` read the value back

### Manual Testing

- [x] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

This change does not touch the model request path it reads and writes
`agents.config.json` and renders a webview panel, so no provider was exercised.
The MCP list is read-only.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

Style: `plugins/**` is excluded from Biome, so this follows the local extension
conventions (tabs, single quotes, bracket spacing) already used in `plugins/vscode/src`.

Docs: `plugins/vscode/README.md` gains a Settings section and a
`Nanocoder: Open Settings` command-table row.

Logging: the structured pino logger is core-side. The extension host logs through
its `OutputChannel`, which is what every other handler in
`chat-webview-provider.ts` does; this adds one line on save plus error detail on
a failed write.
