### PR TITLE
fix(test): strip ANSI codes before asserting on select-input frames

### DIFF
--- a/source/components/ui/styled-select-input.spec.tsx
+++ b/source/components/ui/styled-select-input.spec.tsx
@@ -3,6 +3,7 @@ import {Text} from 'ink';
 import {readdirSync, readFileSync, statSync} from 'node:fs';
 import {join} from 'node:path';
 import React from 'react';
+import stripAnsi from 'strip-ansi';
 import {StyledSelectInput} from '@/components/ui/styled-select-input';
 import {renderWithTheme} from '@/test-utils/render-with-theme';
 
@@ -16,7 +17,7 @@ test('StyledSelectInput marks the highlighted row with the "> " indicator', t =>
 		<StyledSelectInput items={items} onSelect={() => {}} />,
 	);
 
-	const lines = (lastFrame() ?? '').split('\n');
+	const lines = stripAnsi(lastFrame() ?? '').split('\n');
 	t.regex(lines[0] ?? '', /^>\s+First option/);
 	t.regex(lines[1] ?? '', /^\s+Second option/);
 	unmount();
@@ -27,7 +28,7 @@ test('StyledSelectInput forwards initialIndex to the highlighted row', t => {
 		<StyledSelectInput items={items} initialIndex={1} onSelect={() => {}} />,
 	);
 
-	const lines = (lastFrame() ?? '').split('\n');
+	const lines = stripAnsi(lastFrame() ?? '').split('\n');
 	t.regex(lines[1] ?? '', /^>\s+Second option/);
 	unmount();
 });
@@ -41,7 +42,7 @@ test('StyledSelectInput keeps the themed indicator for a custom itemComponent', 
 		/>,
 	);
 
-	const lines = (lastFrame() ?? '').split('\n');
+	const lines = stripAnsi(lastFrame() ?? '').split('\n');
 	t.regex(lines[0] ?? '', /^>\s+FIRST OPTION/);
 	unmount();
 });


### PR DESCRIPTION
## Description

`StyledSelectInput`'s frame assertions anchor on `/^>/` against the raw ink
frame. The themed indicator renders the `>` inside a colour escape sequence, so
with colour enabled the line actually starts with `\u001b[34m` and the `^` anchor
never matches:

    actual   '\u001b[34m>\u001b[39m First option'
    regex    /^>\s+First option/          → no match, ^ hits ESC

`.github/workflows/pr-checks.yml` sets `FORCE_COLOR: '1'`, so all three frame
tests fail in CI while passing locally, where ink emits no colour because stdout
is not a TTY.

This is not specific to any one branch — it reproduces on a clean `main` checkout
with no changes, so it fails **every** pull request. The spec was introduced in
5ae1e1d3 and has been red in CI since it landed; the colouring on the indicator
predates it.

Worth noting for reviewers: GitHub's log viewer strips ANSI when rendering, so
the failure output shows a value that looks like it should match. That is what
makes this one confusing to diagnose from the log alone.

The fix strips the frame before splitting, matching the existing convention in
`source/components/subagent-view.spec.tsx`. `strip-ansi` is already a
devDependency, so no new dependency is introduced.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Test-only change with no user-facing behaviour, so no changeset per the note above.

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

No new tests: this repairs existing assertions rather than adding behaviour. The
four tests in the file were run in both environments to confirm the fix is not
just inverting the problem:

| environment                      | result     |
| -------------------------------- | ---------- |
| `CI=true FORCE_COLOR=1` (CI's env) | 4/4 pass |
| default, colour off (local)        | 4/4 pass |

Before the change, the same three tests fail under `FORCE_COLOR=1` and pass
without it verified on a clean `main` checkout.

I have not run the full `pnpm test:all` locally, so that box is left unchecked.
The failing CI job's own summary reported "3 tests failed", all from this file,
so no other spec needs the same treatment.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Not applicable this touches a test file only. No provider, model, or MCP code
path is involved.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

Style: Biome excludes `**/*.spec.tsx`, so this follows the surrounding file and
the `stripAnsi` usage already established in `subagent-view.spec.tsx`.

Docs: none needed for a test fix.

Logging: not applicable no runtime code changed.
