### PR TITLE
fix: preserve newer pending file reads

### DIFF
--- a/.changeset/quiet-rays-cache.md
+++ b/.changeset/quiet-rays-cache.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Prevent concurrent file-cache reads from clearing a newer pending read.

--- a/source/utils/file-cache.spec.ts
+++ b/source/utils/file-cache.spec.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import fs, {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {mock} from 'node:test';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {
@@ -282,6 +283,121 @@ test('getCachedFileContent - concurrent reads with mtime change get consistent r
 		t.is(result1, result2);
 		t.is(result2, result3);
 	} finally {
+		await cleanupTempDir(tempDir);
+	}
+});
+
+test('getCachedFileContent - does not clear a replacement pending read', async t => {
+	const tempDir = await createTempDir();
+	try {
+		const filePath = join(tempDir, 'pending-read-race.txt');
+		await writeFile(filePath, 'original', 'utf-8');
+		await getCachedFileContent(filePath);
+
+		let targetStatCalls = 0;
+		let targetReadCalls = 0;
+		let replacementRead: ReturnType<typeof getCachedFileContent> | undefined;
+
+		let releaseInitialStats!: () => void;
+		const initialStatsReleased = new Promise<void>(resolve => {
+			releaseInitialStats = resolve;
+		});
+		let resolveInitialStatsStarted!: () => void;
+		const initialStatsStarted = new Promise<void>(resolve => {
+			resolveInitialStatsStarted = resolve;
+		});
+
+		let releaseOriginalRead!: () => void;
+		const originalReadReleased = new Promise<void>(resolve => {
+			releaseOriginalRead = resolve;
+		});
+		let resolveOriginalReadStarted!: () => void;
+		const originalReadStarted = new Promise<void>(resolve => {
+			resolveOriginalReadStarted = resolve;
+		});
+
+		let releaseReplacementRead!: () => void;
+		const replacementReadReleased = new Promise<void>(resolve => {
+			releaseReplacementRead = resolve;
+		});
+		let resolveReplacementReadStarted!: () => void;
+		const replacementReadStarted = new Promise<void>(resolve => {
+			resolveReplacementReadStarted = resolve;
+		});
+
+		const syntheticStat = (mtimeMs: number) => ({mtimeMs});
+		const originalStat = fs.stat;
+		const originalReadFile = fs.readFile;
+
+		mock.method(fs, 'stat', async path => {
+			if (path !== filePath) {
+				return originalStat(path);
+			}
+
+			targetStatCalls += 1;
+			if (targetStatCalls <= 2) {
+				if (targetStatCalls === 2) {
+					resolveInitialStatsStarted();
+				}
+				await initialStatsReleased;
+				return syntheticStat(2);
+			}
+
+			if (targetStatCalls === 3) {
+				// Replace the original pending read before its owner resumes.
+				clearCache();
+				replacementRead = getCachedFileContent(filePath);
+				return syntheticStat(2);
+			}
+
+			return syntheticStat(3);
+		});
+
+		mock.method(fs, 'readFile', async path => {
+			if (path !== filePath) {
+				return originalReadFile(path);
+			}
+
+			targetReadCalls += 1;
+			if (targetReadCalls === 1) {
+				resolveOriginalReadStarted();
+				await originalReadReleased;
+				return Buffer.from('original read');
+			}
+			if (targetReadCalls === 2) {
+				resolveReplacementReadStarted();
+				await replacementReadReleased;
+				return Buffer.from('replacement read');
+			}
+
+			throw new Error('duplicate read after replacement pending read was cleared');
+		});
+
+		const firstRead = getCachedFileContent(filePath);
+		const secondRead = getCachedFileContent(filePath);
+		await initialStatsStarted;
+		releaseInitialStats();
+		await originalReadStarted;
+		releaseOriginalRead();
+		await replacementReadStarted;
+		await Promise.all([firstRead, secondRead]);
+
+		if (!replacementRead) {
+			t.fail('Expected a replacement pending read to be created');
+			return;
+		}
+
+		const deduplicatedRead = getCachedFileContent(filePath);
+		releaseReplacementRead();
+		const [replacementResult, deduplicatedResult] = await Promise.all([
+			replacementRead,
+			deduplicatedRead,
+		]);
+
+		t.is(deduplicatedResult, replacementResult);
+		t.is(targetReadCalls, 2);
+	} finally {
+		mock.restoreAll();
 		await cleanupTempDir(tempDir);
 	}
 });

--- a/source/utils/file-cache.ts
+++ b/source/utils/file-cache.ts
@@ -1,4 +1,4 @@
-import {readFile, stat} from 'node:fs/promises';
+import fs from 'node:fs/promises';
 import {extname} from 'node:path';
 import {CACHE_FILE_TTL_MS, MAX_FILE_READ_RETRIES} from '@/constants';
 
@@ -31,6 +31,15 @@ let accessCounter = 0;
 // Track pending reads to deduplicate concurrent requests for the same file
 const pendingReads = new Map<string, Promise<CachedFile>>();
 
+function cleanupPendingRead(
+	absPath: string,
+	pending: Promise<CachedFile>,
+): void {
+	if (pendingReads.get(absPath) === pending) {
+		pendingReads.delete(absPath);
+	}
+}
+
 /**
  * Get file content from cache or read from disk.
  * Automatically checks mtime to ensure freshness.
@@ -54,7 +63,7 @@ export async function getCachedFileContent(
 		} else {
 			// Check if file mtime has changed
 			try {
-				const fileStat = await stat(absPath);
+				const fileStat = await fs.stat(absPath);
 				const currentMtime = fileStat.mtimeMs;
 
 				if (currentMtime === data.mtime) {
@@ -67,16 +76,20 @@ export async function getCachedFileContent(
 
 				// Check for pending read before starting a new one (deduplication)
 				let pending = pendingReads.get(absPath);
+				let ownsPendingRead = false;
 				if (!pending) {
 					// Reuse the stat we just did to avoid double stat
 					pending = readAndCacheFile(absPath, now, fileStat.mtimeMs);
 					pendingReads.set(absPath, pending);
+					ownsPendingRead = true;
 				}
 
 				try {
 					return await pending;
 				} finally {
-					pendingReads.delete(absPath);
+					if (ownsPendingRead) {
+						cleanupPendingRead(absPath, pending);
+					}
 				}
 			} catch {
 				// File may have been deleted, invalidate cache
@@ -98,7 +111,7 @@ export async function getCachedFileContent(
 	try {
 		return await readPromise;
 	} finally {
-		pendingReads.delete(absPath);
+		cleanupPendingRead(absPath, readPromise);
 	}
 }
 
@@ -114,13 +127,13 @@ async function readAndCacheFile(
 	retryCount = 0,
 ): Promise<CachedFile> {
 	// Get mtime before reading (or use known mtime from caller)
-	const mtimeBefore = knownMtime ?? (await stat(absPath)).mtimeMs;
+	const mtimeBefore = knownMtime ?? (await fs.stat(absPath)).mtimeMs;
 
 	// Read as Buffer to support both text and binary formats
-	const buffer = await readFile(absPath);
+	const buffer = await fs.readFile(absPath);
 
 	// Verify mtime didn't change during read
-	const mtimeAfter = (await stat(absPath)).mtimeMs;
+	const mtimeAfter = (await fs.stat(absPath)).mtimeMs;
 	if (mtimeAfter !== mtimeBefore) {
 		if (retryCount >= MAX_FILE_READ_RETRIES) {
 			throw new Error(


### PR DESCRIPTION
## Summary

- Make pending-read cleanup owner-aware on the mtime invalidation path.
- Only remove a pending read when the map still points to the same Promise.
- Add a deterministic regression test that prevents an older read from clearing a replacement read.

Fixes #840

## Validation

- `pnpm run test:ava source/utils/file-cache.spec.ts` — 19 passed
- `pnpm test:format` — passed
- `pnpm test:types` — passed
- `pnpm test:lint` — passed
- `pnpm test:knip` — passed
- `pnpm audit --registry=https://registry.npmjs.org --audit-level=high --ignore-unfixable` — passed

The repository's `pnpm run test:all` wrapper cannot start on Windows because it invokes `./scripts/test.sh`. Running the equivalent commands individually reached existing full-suite failures/timeouts in `acp-content.spec.ts` and `ai-sdk-client` tests; the focused file-cache suite passes.