### PR TITLE
fix(test): make styled-select-input assertions color-agnostic

### DIFF
--- a/source/components/ui/styled-select-input.spec.tsx
+++ b/source/components/ui/styled-select-input.spec.tsx
@@ -3,6 +3,7 @@ import {Text} from 'ink';
 import {readdirSync, readFileSync, statSync} from 'node:fs';
 import {join} from 'node:path';
 import React from 'react';
+import stripAnsi from 'strip-ansi';
 import {StyledSelectInput} from '@/components/ui/styled-select-input';
 import {renderWithTheme} from '@/test-utils/render-with-theme';
 
@@ -16,7 +17,7 @@ test('StyledSelectInput marks the highlighted row with the "> " indicator', t =>
 		<StyledSelectInput items={items} onSelect={() => {}} />,
 	);
 
-	const lines = (lastFrame() ?? '').split('\n');
+	const lines = stripAnsi(lastFrame() ?? '').split('\n');
 	t.regex(lines[0] ?? '', /^>\s+First option/);
 	t.regex(lines[1] ?? '', /^\s+Second option/);
 	unmount();
@@ -27,7 +28,7 @@ test('StyledSelectInput forwards initialIndex to the highlighted row', t => {
 		<StyledSelectInput items={items} initialIndex={1} onSelect={() => {}} />,
 	);
 
-	const lines = (lastFrame() ?? '').split('\n');
+	const lines = stripAnsi(lastFrame() ?? '').split('\n');
 	t.regex(lines[1] ?? '', /^>\s+Second option/);
 	unmount();
 });
@@ -41,7 +42,7 @@ test('StyledSelectInput keeps the themed indicator for a custom itemComponent', 
 		/>,
 	);
 
-	const lines = (lastFrame() ?? '').split('\n');
+	const lines = stripAnsi(lastFrame() ?? '').split('\n');
 	t.regex(lines[0] ?? '', /^>\s+FIRST OPTION/);
 	unmount();
 });


### PR DESCRIPTION
## Description

Three `StyledSelectInput` tests fail in CI while passing locally.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging