### PR TITLE
feat: headless api mode

### DIFF
--- a/.changeset/eight-seas-matter.md
+++ b/.changeset/eight-seas-matter.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Introduce a "Headless API Mode" for the core engine that completely bypasses Ink.js terminal rendering when the --acp flag is provided

--- a/.changeset/eight-seas-matter.md
+++ b/.changeset/eight-seas-matter.md
@@ -1,5 +1,5 @@
 ---
-"@nanocollective/nanocoder": minor
+'@nanocollective/nanocoder': patch
 ---
 
-Introduce a "Headless API Mode" for the core engine that completely bypasses Ink.js terminal rendering when the --acp flag is provided
+Defer ink and @/app loading in the CLI entry point until the interactive TUI branch, so --acp, --plain and auth paths no longer pay the Ink/App module-graph cost at startup.

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -24,74 +24,64 @@
 		},
 		"interactive_module_count": {
 			"kind": "numeric",
-			"value": 595,
+			"value": 567,
 			"warnOnDecrease": false
 		},
 		"interactive_boot_ms_approx": {
 			"kind": "numeric",
-			"value": 1415,
-			"warnOnDecrease": false
-		},
-		"acp_module_count": {
-			"kind": "numeric",
-			"value": 429,
-			"warnOnDecrease": false
-		},
-		"acp_boot_ms_approx": {
-			"kind": "numeric",
-			"value": 604,
+			"value": 606,
 			"warnOnDecrease": false
 		},
 		"first_render_ms_approx": {
 			"kind": "numeric",
-			"value": 1127,
+			"value": 549,
 			"warnOnDecrease": false
 		},
 		"dist_size_bytes": {
 			"kind": "numeric",
-			"value": 4925828
+			"value": 4703103
 		},
 		"dist_file_count": {
 			"kind": "numeric",
-			"value": 1773,
+			"value": 1793,
 			"warnOnDecrease": false
 		}
 	},
 	"stability": {
 		"cli_flag_count": {
 			"kind": "numeric",
-			"value": 25,
+			"value": 15,
 			"warnOnDecrease": true
 		},
 		"tool_count": {
 			"kind": "numeric",
-			"value": 22,
+			"value": 21,
 			"warnOnDecrease": true
 		},
 		"command_count": {
 			"kind": "numeric",
-			"value": 38,
+			"value": 35,
 			"warnOnDecrease": true
 		},
 		"help_hash": {
 			"kind": "hash",
-			"value": "d327b65d079f"
+			"value": "606a3816f6c9"
 		}
 	},
 	"health": {
 		"test_file_count": {
 			"kind": "numeric",
-			"value": 342,
+			"value": 315,
 			"warnOnDecrease": true
 		},
 		"test_case_count": {
 			"kind": "numeric",
-			"value": 6403,
+			"value": 5867,
 			"warnOnDecrease": true
 		},
 		"audit_high_vulns": {
 			"kind": "numeric",
-			"value": 17
+			"value": 2
 		}
 	}
 }

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -24,64 +24,74 @@
 		},
 		"interactive_module_count": {
 			"kind": "numeric",
-			"value": 567,
+			"value": 595,
 			"warnOnDecrease": false
 		},
 		"interactive_boot_ms_approx": {
 			"kind": "numeric",
-			"value": 606,
+			"value": 2119,
+			"warnOnDecrease": false
+		},
+		"acp_module_count": {
+			"kind": "numeric",
+			"value": 429,
+			"warnOnDecrease": false
+		},
+		"acp_boot_ms_approx": {
+			"kind": "numeric",
+			"value": 906,
 			"warnOnDecrease": false
 		},
 		"first_render_ms_approx": {
 			"kind": "numeric",
-			"value": 549,
+			"value": 1409,
 			"warnOnDecrease": false
 		},
 		"dist_size_bytes": {
 			"kind": "numeric",
-			"value": 4703103
+			"value": 4925828
 		},
 		"dist_file_count": {
 			"kind": "numeric",
-			"value": 1793,
+			"value": 1773,
 			"warnOnDecrease": false
 		}
 	},
 	"stability": {
 		"cli_flag_count": {
 			"kind": "numeric",
-			"value": 15,
+			"value": 25,
 			"warnOnDecrease": true
 		},
 		"tool_count": {
 			"kind": "numeric",
-			"value": 21,
+			"value": 22,
 			"warnOnDecrease": true
 		},
 		"command_count": {
 			"kind": "numeric",
-			"value": 35,
+			"value": 38,
 			"warnOnDecrease": true
 		},
 		"help_hash": {
 			"kind": "hash",
-			"value": "606a3816f6c9"
+			"value": "d327b65d079f"
 		}
 	},
 	"health": {
 		"test_file_count": {
 			"kind": "numeric",
-			"value": 315,
+			"value": 340,
 			"warnOnDecrease": true
 		},
 		"test_case_count": {
 			"kind": "numeric",
-			"value": 5857,
+			"value": 6353,
 			"warnOnDecrease": true
 		},
 		"audit_high_vulns": {
 			"kind": "numeric",
-			"value": 2
+			"value": 17
 		}
 	}
 }

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -76,7 +76,7 @@
 		},
 		"test_case_count": {
 			"kind": "numeric",
-			"value": 5867,
+			"value": 5857,
 			"warnOnDecrease": true
 		},
 		"audit_high_vulns": {

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -29,7 +29,7 @@
 		},
 		"interactive_boot_ms_approx": {
 			"kind": "numeric",
-			"value": 2119,
+			"value": 1415,
 			"warnOnDecrease": false
 		},
 		"acp_module_count": {
@@ -39,12 +39,12 @@
 		},
 		"acp_boot_ms_approx": {
 			"kind": "numeric",
-			"value": 906,
+			"value": 604,
 			"warnOnDecrease": false
 		},
 		"first_render_ms_approx": {
 			"kind": "numeric",
-			"value": 1409,
+			"value": 1127,
 			"warnOnDecrease": false
 		},
 		"dist_size_bytes": {
@@ -81,12 +81,12 @@
 	"health": {
 		"test_file_count": {
 			"kind": "numeric",
-			"value": 340,
+			"value": 342,
 			"warnOnDecrease": true
 		},
 		"test_case_count": {
 			"kind": "numeric",
-			"value": 6353,
+			"value": 6403,
 			"warnOnDecrease": true
 		},
 		"audit_high_vulns": {

--- a/benchmarks/measure.ts
+++ b/benchmarks/measure.ts
@@ -122,34 +122,30 @@ function measureModuleCount(args: string[]): number {
 }
 
 /**
- * Boots the CLI in interactive mode under the counting loader, waits until
- * the module-resolution count has been stable for `stableMs`, then kills the
- * process and returns the final count.
+ * Boots the CLI under the counting loader, waits until the module-resolution
+ * count has been stable for `stableMs`, then kills the process and returns
+ * the final count plus approximate wall-clock boot time.
  *
- * This measures the full app graph (Ink, hooks, tool manager, command
- * registry, MCP loader, etc.) rather than just the `--help` fast path.
+ * This measures the full resolved graph for the given args (interactive TUI,
+ * ACP server, etc.) rather than just a oneshot `--help` fast path.
  * Polling-until-stable keeps the result deterministic regardless of machine
  * speed: we wait for steady state, not a fixed wall-clock window.
- */
-/**
- * Same polling-until-stable pattern as `measureInteractiveModuleCount`, but
- * returns both the module count AND the wall-clock time (in ms) from process
- * spawn to the moment the module count reached its final value.
  *
  * The wall-clock number is labelled **approximate** because it's
  * machine-dependent and subject to I/O / scheduler noise. It's not a
  * deterministic metric like module count — it's a sanity check that
  * optimizations translate into real boot-time savings on the local machine.
  */
-async function measureInteractiveStartup(
+async function measureStartupUntilStable(
 	args: string[] = [],
+	label = 'interactive',
 ): Promise<{moduleCount: number; bootMs: number}> {
 	const loaderPath = path.join(__dirname, 'count-loader.mjs');
 	const loaderUrl = new URL(`file://${loaderPath}`).href;
 	const countFile = path.join(
 		repoRoot,
 		'benchmarks',
-		`.module-count-interactive-${process.pid}-${Date.now()}`,
+		`.module-count-${label}-${process.pid}-${Date.now()}`,
 	);
 
 	const child = spawn(
@@ -356,7 +352,7 @@ async function runWithUrlCapture(
 					CI: '1',
 					// Keep the user's global MCP config out of the graph
 					// so the explain breakdown only reflects nanocoder's own
-					// boot cost. Matches `measureInteractiveStartup`.
+					// boot cost. Matches `measureStartupUntilStable`.
 					NODE_ENV: 'test',
 				},
 			},
@@ -709,13 +705,23 @@ export async function measure(): Promise<Measurements> {
 	// clock boot number; the module count is deterministic so we only keep
 	// the first one.
 	const interactiveRuns = [
-		await measureInteractiveStartup(),
-		await measureInteractiveStartup(),
-		await measureInteractiveStartup(),
+		await measureStartupUntilStable([], 'interactive'),
+		await measureStartupUntilStable([], 'interactive'),
+		await measureStartupUntilStable([], 'interactive'),
 	];
 	const interactiveModuleCount = interactiveRuns[0].moduleCount;
 	const bootSamples = interactiveRuns.map(r => r.bootMs).sort((a, b) => a - b);
 	const interactiveBootMsMedian = bootSamples[1];
+	// ACP server is long-lived (JSON-RPC over stdin/stdout). Poll until the
+	// module graph is stable, then terminate — same pattern as interactive.
+	const acpRuns = [
+		await measureStartupUntilStable(['--acp'], 'acp'),
+		await measureStartupUntilStable(['--acp'], 'acp'),
+		await measureStartupUntilStable(['--acp'], 'acp'),
+	];
+	const acpModuleCount = acpRuns[0].moduleCount;
+	const acpBootSamples = acpRuns.map(r => r.bootMs).sort((a, b) => a - b);
+	const acpBootMsMedian = acpBootSamples[1];
 	// Time from spawn to first stdout byte — what the user actually perceives.
 	const firstRenderMs = await measureTimeToFirstRender();
 	const distStats = measureDir(path.join(repoRoot, 'dist'));
@@ -808,6 +814,18 @@ export async function measure(): Promise<Measurements> {
 			interactive_boot_ms_approx: {
 				kind: 'numeric',
 				value: interactiveBootMsMedian,
+				warnOnDecrease: false,
+			},
+			// ACP server steady-state module graph (no Ink / App). Deterministic
+			// proxy for editor-integration startup cost.
+			acp_module_count: {
+				kind: 'numeric',
+				value: acpModuleCount,
+				warnOnDecrease: false,
+			},
+			acp_boot_ms_approx: {
+				kind: 'numeric',
+				value: acpBootMsMedian,
 				warnOnDecrease: false,
 			},
 			// Time from spawn to first stdout byte — what the user sees.

--- a/docs/features/acp.md
+++ b/docs/features/acp.md
@@ -1,29 +1,29 @@
 ---
 title: "ACP (Editor Integration)"
-description: "Run Nanocoder as an Agent Client Protocol server for editors like Zed"
+description: "Run Nanocoder as an Agent Client Protocol server for editors like Zed and the VS Code sidebar"
 sidebar_order: 9
 ---
 
 # ACP (Agent Client Protocol)
 
-Nanocoder can run as an [Agent Client Protocol](https://agentclientprotocol.com) (ACP) server, letting ACP-compatible editors drive it as a native coding agent. Instead of the Ink terminal UI, Nanocoder speaks JSON-RPC over stdin/stdout, and the editor renders the conversation, tool calls, diffs, and permission prompts in its own UI.
+Nanocoder can run as an [Agent Client Protocol](https://agentclientprotocol.com) (ACP) server, letting ACP-compatible clients drive it as a native coding agent. Instead of the Ink terminal UI, Nanocoder speaks JSON-RPC over stdin/stdout, and the client renders the conversation, tool calls, diffs, and permission prompts in its own UI.
 
 ```bash
 nanocoder --acp
 ```
 
-You normally don't run this command yourself — the editor spawns it for you (see [Setup in Zed](#setup-in-zed) below).
+You normally don't run this command yourself — the editor or extension spawns it for you (see [Setup in Zed](#setup-in-zed) and the [VS Code extension](vscode-extension.md)).
 
-## ACP vs. the VS Code extension
+## ACP vs. the VS Code companion
 
-Both connect Nanocoder to an editor, but they are different mechanisms — pick the one your editor supports:
+ACP is the transport for both the **VS Code sidebar chat** and other ACP clients (Zed, etc.). The older `--vscode` WebSocket path is a separate, opt-in **legacy terminal companion** for Ink TUI sessions — not how the sidebar works.
 
-| | Transport | Flag | Editors |
+| | Transport | Flag | Clients |
 | --- | --- | --- | --- |
-| **ACP** | JSON-RPC over stdin/stdout | `--acp` | Zed and other ACP clients |
-| **[VS Code extension](vscode-extension.md)** | WebSocket | `--vscode` | VS Code |
+| **ACP** | JSON-RPC over stdin/stdout | `--acp` | VS Code sidebar, Zed, and other ACP clients |
+| **Legacy companion** | WebSocket | `--vscode` | VS Code (opt-in terminal companion) |
 
-With ACP the **editor is the UI**: the agent runs headless and everything (streaming text, tool cards, diffs, approvals) is rendered by the editor. With the VS Code extension, the Nanocoder terminal UI stays in charge and the editor adds diff previews and editor context on top.
+With ACP the **client is the UI**: the agent runs headless and everything (streaming text, tool cards, diffs, approvals) is rendered by the editor or sidebar. The legacy `--vscode` companion keeps the Nanocoder terminal TUI in charge and adds diff previews and editor context on top — see [Legacy Companion Mode](vscode-extension.md#legacy-companion-mode).
 
 ## What works over ACP
 

--- a/source/app/utils/app-util.spec.ts
+++ b/source/app/utils/app-util.spec.ts
@@ -3,7 +3,6 @@ import React from 'react';
 import {
 	createClearMessagesHandler,
 	handleMessageSubmission,
-	parseContextLimit,
 	parseCustomCommandArgs,
 } from './app-util.js';
 import {lazyCommands} from '@/commands/lazy-registry';
@@ -215,51 +214,6 @@ test('commands create - preserves .md extension when present', t => {
 	const fileName = 'my-tool.md';
 	const safeName = fileName.endsWith('.md') ? fileName : `${fileName}.md`;
 	t.is(safeName, 'my-tool.md');
-});
-
-// Test parseContextLimit
-test('parseContextLimit - plain number', t => {
-	t.is(parseContextLimit('8192'), 8192);
-});
-
-test('parseContextLimit - k suffix lowercase', t => {
-	t.is(parseContextLimit('128k'), 128000);
-});
-
-test('parseContextLimit - K suffix uppercase', t => {
-	t.is(parseContextLimit('128K'), 128000);
-});
-
-test('parseContextLimit - fractional k value', t => {
-	t.is(parseContextLimit('4.5k'), 4500);
-});
-
-test('parseContextLimit - zero returns null', t => {
-	t.is(parseContextLimit('0'), null);
-});
-
-test('parseContextLimit - negative returns null', t => {
-	t.is(parseContextLimit('-5'), null);
-});
-
-test('parseContextLimit - non-numeric returns null', t => {
-	t.is(parseContextLimit('abc'), null);
-});
-
-test('parseContextLimit - just k returns null', t => {
-	t.is(parseContextLimit('k'), null);
-});
-
-test('parseContextLimit - whitespace is trimmed', t => {
-	t.is(parseContextLimit('  8192  '), 8192);
-});
-
-test('parseContextLimit - large value with k suffix', t => {
-	t.is(parseContextLimit('256k'), 256000);
-});
-
-test('parseContextLimit - decimal without k suffix', t => {
-	t.is(parseContextLimit('1024.5'), 1025);
 });
 
 // Test /ide command parsing

--- a/source/app/utils/app-util.ts
+++ b/source/app/utils/app-util.ts
@@ -27,7 +27,7 @@ import {handleRetryCommand} from './handlers/retry-handler';
 import {handleResumeCommand} from './handlers/session-handler';
 
 // Re-export for consumers that import parseContextLimit from here
-export {parseContextLimit} from './handlers/context-max-handler';
+export {parseContextLimit} from '@/utils/parse-context-limit';
 
 /**
  * "Special commands" need access to app-level state (setting modes, mutating

--- a/source/app/utils/app-util.ts
+++ b/source/app/utils/app-util.ts
@@ -26,9 +26,6 @@ import {
 import {handleRetryCommand} from './handlers/retry-handler';
 import {handleResumeCommand} from './handlers/session-handler';
 
-// Re-export for consumers that import parseContextLimit from here
-export {parseContextLimit} from '@/utils/parse-context-limit';
-
 /**
  * "Special commands" need access to app-level state (setting modes, mutating
  * messages, swapping live components) that the standard `Command.handler`

--- a/source/app/utils/handlers/context-max-handler.ts
+++ b/source/app/utils/handlers/context-max-handler.ts
@@ -11,9 +11,6 @@ import type {MessageSubmissionOptions} from '@/types/index';
 import {errorMsg, infoMsg, successMsg} from '@/utils/message-factory';
 import {parseContextLimit} from '@/utils/parse-context-limit';
 
-// Re-export so existing imports from this module keep working.
-export {parseContextLimit};
-
 /**
  * Handles /context-max command. Returns true if handled.
  */

--- a/source/app/utils/handlers/context-max-handler.ts
+++ b/source/app/utils/handlers/context-max-handler.ts
@@ -9,28 +9,10 @@ import {
 import {generateKey} from '@/session/key-generator';
 import type {MessageSubmissionOptions} from '@/types/index';
 import {errorMsg, infoMsg, successMsg} from '@/utils/message-factory';
+import {parseContextLimit} from '@/utils/parse-context-limit';
 
-/**
- * Parses a context limit value string, supporting k/K suffix.
- * e.g. "8192" -> 8192, "128k" -> 128000, "128K" -> 128000
- */
-export function parseContextLimit(value: string): number | null {
-	const trimmed = value.trim().toLowerCase();
-	let multiplier = 1;
-	let numStr = trimmed;
-
-	if (trimmed.endsWith('k')) {
-		multiplier = 1000;
-		numStr = trimmed.slice(0, -1);
-	}
-
-	const parsed = Number.parseFloat(numStr);
-	if (Number.isNaN(parsed) || parsed <= 0) {
-		return null;
-	}
-
-	return Math.round(parsed * multiplier);
-}
+// Re-export so existing imports from this module keep working.
+export {parseContextLimit};
 
 /**
  * Handles /context-max command. Returns true if handled.

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -121,18 +121,9 @@ function isValidOutputFormat(value: unknown): value is 'text' | 'json' {
 }
 
 async function main(): Promise<void> {
-	// Dynamic imports so the fast-path flag handlers above never pay for them.
-	const [
-		{render},
-		{default: App},
-		{parseContextLimit},
-		{setSessionContextLimit},
-	] = await Promise.all([
-		import('ink'),
-		import('@/app'),
-		import('@/app/utils/handlers/context-max-handler'),
-		import('@/models/index'),
-	]);
+	// Parse args and dispatch non-TUI branches BEFORE importing ink or @/app.
+	// Those packages pull ~thousand+ modules; --acp / --plain / auth must stay
+	// on the lightweight path. Ink + App load only in the final TUI branch.
 
 	const vscodeMode = args.includes('--vscode');
 
@@ -178,9 +169,13 @@ async function main(): Promise<void> {
 		}
 	}
 
-	// Extract --context-max if specified
+	// Extract --context-max if specified (framework-free parser — no React/Ink)
 	const contextMaxArgIndex = args.findIndex(arg => arg === '--context-max');
 	if (contextMaxArgIndex !== -1 && args[contextMaxArgIndex + 1]) {
+		const [{parseContextLimit}, {setSessionContextLimit}] = await Promise.all([
+			import('@/utils/parse-context-limit'),
+			import('@/models/index'),
+		]);
 		const limit = parseContextLimit(args[contextMaxArgIndex + 1]);
 		if (limit !== null) {
 			setSessionContextLimit(limit);
@@ -193,6 +188,7 @@ async function main(): Promise<void> {
 	}
 
 	// Extract --mode if specified. Accept `--mode value` and `--mode=value`.
+	// `@/app/types` is a tiny const module (no React/Ink) — safe before TUI.
 	const {VALID_MODES} = await import('@/app/types');
 	type CliMode = (typeof VALID_MODES)[number];
 	let cliMode: CliMode | undefined;
@@ -460,11 +456,16 @@ async function main(): Promise<void> {
 			outputFormat,
 		});
 	} else {
+		// Interactive TUI — load Ink + App only now.
+		const [{render}, {default: App}] = await Promise.all([
+			import('ink'),
+			import('@/app'),
+		]);
+
 		// Prevent Node's global performance entry buffer from growing without
 		// bound during long Ink sessions. See issue #521.
 		const {installPerfBufferGuard} = await import('@/utils/perf-buffer');
 		installPerfBufferGuard();
-
 		// Resolve --continue/--resume <id> into a Session BEFORE rendering, so
 		// the app can apply it on first mount (see App's initialSession prop).
 		// A bare --resume (no id) instead opens the picker at startup — no

--- a/source/utils/parse-context-limit.spec.ts
+++ b/source/utils/parse-context-limit.spec.ts
@@ -1,0 +1,46 @@
+import test from 'ava';
+import {parseContextLimit} from './parse-context-limit';
+
+test('parseContextLimit - plain number', t => {
+	t.is(parseContextLimit('8192'), 8192);
+});
+
+test('parseContextLimit - k suffix lowercase', t => {
+	t.is(parseContextLimit('128k'), 128000);
+});
+
+test('parseContextLimit - K suffix uppercase', t => {
+	t.is(parseContextLimit('128K'), 128000);
+});
+
+test('parseContextLimit - fractional k value', t => {
+	t.is(parseContextLimit('4.5k'), 4500);
+});
+
+test('parseContextLimit - zero returns null', t => {
+	t.is(parseContextLimit('0'), null);
+});
+
+test('parseContextLimit - negative returns null', t => {
+	t.is(parseContextLimit('-5'), null);
+});
+
+test('parseContextLimit - non-numeric returns null', t => {
+	t.is(parseContextLimit('abc'), null);
+});
+
+test('parseContextLimit - just k returns null', t => {
+	t.is(parseContextLimit('k'), null);
+});
+
+test('parseContextLimit - whitespace is trimmed', t => {
+	t.is(parseContextLimit('  8192  '), 8192);
+});
+
+test('parseContextLimit - large value with k suffix', t => {
+	t.is(parseContextLimit('256k'), 256000);
+});
+
+test('parseContextLimit - decimal without k suffix', t => {
+	t.is(parseContextLimit('1024.5'), 1025);
+});

--- a/source/utils/parse-context-limit.ts
+++ b/source/utils/parse-context-limit.ts
@@ -1,0 +1,24 @@
+/**
+ * Parses a context limit value string, supporting k/K suffix.
+ * e.g. "8192" -> 8192, "128k" -> 128000, "128K" -> 128000
+ *
+ * Framework-free so the CLI can apply `--context-max` without loading
+ * React/Ink (needed for the ACP / plain / auth fast paths).
+ */
+export function parseContextLimit(value: string): number | null {
+	const trimmed = value.trim().toLowerCase();
+	let multiplier = 1;
+	let numStr = trimmed;
+
+	if (trimmed.endsWith('k')) {
+		multiplier = 1000;
+		numStr = trimmed.slice(0, -1);
+	}
+
+	const parsed = Number.parseFloat(numStr);
+	if (Number.isNaN(parsed) || parsed <= 0) {
+		return null;
+	}
+
+	return Math.round(parsed * multiplier);
+}

--- a/source/vscode/chat-panel-harness.ts
+++ b/source/vscode/chat-panel-harness.ts
@@ -2,20 +2,26 @@
  * Boots `plugins/vscode/media/chat-panel.js` inside a VM against a stub DOM so
  * the panel's rendering can be driven and inspected from tests. Shared by the
  * chat-panel specs; extracted verbatim from chat-panel-thoughts.spec.ts.
+ *
+ * `mention-utils.js` must run first: the real webview loads it before
+ * `chat-panel.js`, which immediately reads `globalThis.NanocoderMentionUtils`.
  */
 import {readFileSync} from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import {createContext, runInContext} from 'node:vm';
 
-const PANEL_SOURCE = readFileSync(
+const mediaUrl = (filename: string) =>
 	fileURLToPath(
-		new URL('../../plugins/vscode/media/chat-panel.js', import.meta.url),
-	),
-	'utf8',
-);
+		new URL(`../../plugins/vscode/media/${filename}`, import.meta.url),
+	);
+
+const MENTION_UTILS_SOURCE = readFileSync(mediaUrl('mention-utils.js'), 'utf8');
+const PANEL_SOURCE = readFileSync(mediaUrl('chat-panel.js'), 'utf8');
 
 const SHELL_IDS = [
 	'add-image-btn',
+	'add-menu-btn',
+	'add-menu-dropdown',
 	'attach-btn',
 	'chat-input',
 	'chat-view',
@@ -29,6 +35,9 @@ const SHELL_IDS = [
 	'image-modal',
 	'image-preview-container',
 	'image-upload',
+	'menu-attach-file',
+	'menu-upload-image',
+	'mention-dropdown',
 	'messages-container',
 	'modal-image',
 	'mode-dropdown',
@@ -236,7 +245,9 @@ export function createPanel(options: {marked?: boolean} = {}) {
 		sandbox.marked = {parse: (value: string) => `<md>${value}</md>`};
 	}
 
+	sandbox.globalThis = sandbox;
 	createContext(sandbox);
+	runInContext(MENTION_UTILS_SOURCE, sandbox);
 	runInContext(PANEL_SOURCE, sandbox);
 
 	const container = findById(root, 'messages-container') as StubElement;


### PR DESCRIPTION
Refs https://github.com/Nano-Collective/nanocoder/issues/810

## Description

Defer ink and @/app loading in the CLI entry point until the interactive TUI branch, so --acp, --plain run and copilot login no longer pay the Ink/App module-graph cost at startup. Extract a framework-free `parseContextLimit()` for `--context-max`, add ACP startup metrics to the quality benchmark, refresh the baseline, and correct ACP vs legacy `--vscode` docs.

Related to https://github.com/Nano-Collective/nanocoder/issues/810 — first step toward Headless API Mode. `--acp` already runs the Ink-free ACP server; this PR removes the remaining CLI-level cost of resolving Ink/`App` before that branch is taken.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Focused coverage used for this change:
- `pnpm run test:ava source/cli.spec.ts source/app/utils/app-util.spec.ts source/app/utils/handlers/context-max-handler.spec.ts source/acp/acp-capabilities.spec.ts`
- `pnpm run test:types && pnpm run test:format && pnpm run test:lint`
- `pnpm run build && pnpm run test:benchmark` (confirms `acp_module_count` / `acp_boot_ms_approx`)

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Manual smoke checks:
- [x] `node dist/cli.js --json --acp run "hi"` rejects with `--json cannot be combined with --acp`
- [x] `node dist/cli.js --acp --provider … --model …` starts the ACP server (no Ink TUI)
- [x] ACP module-URL capture shows no `dist/app/App.js` / `dist/app/index.js`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))