### PR TITLE
feat: add first-class OrcaRouter provider template

### DIFF
--- a/.changeset/add-orcarouter-provider.md
+++ b/.changeset/add-orcarouter-provider.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added first-class provider template for OrcaRouter to the setup wizard.

--- a/docs/configuration/providers/index.md
+++ b/docs/configuration/providers/index.md
@@ -39,6 +39,7 @@ Hosted services using the OpenAI-compatible API format.
 
 - [OpenRouter](openrouter.md) - Unified API for multiple AI providers
 - [Requesty](requesty.md) - OpenAI-compatible LLM router for multiple AI providers
+- [OrcaRouter](orcarouter.md) - OpenAI-compatible LLM router for multiple AI providers
 - [Together AI](together.md) - Fast inference for open-source models with OpenAI-compatible API
 - [OpenAI](openai.md) - GPT models via OpenAI's API
 - [Mistral AI](mistral.md) - Mistral models

--- a/docs/configuration/providers/orcarouter.md
+++ b/docs/configuration/providers/orcarouter.md
@@ -1,0 +1,34 @@
+---
+title: "OrcaRouter"
+description: "Configure OrcaRouter as a cloud AI provider for Nanocoder"
+sidebar_order: 19
+---
+
+# OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible LLM router that gives you a single endpoint and API key to access models from OpenAI, Anthropic, Google, Meta, and many other providers. Because it speaks the OpenAI Chat Completions API, it works as a drop-in coding provider for Nanocoder.
+
+## Configuration
+
+```json
+{
+	"name": "OrcaRouter",
+	"baseUrl": "https://api.orcarouter.ai/v1",
+	"apiKey": "${ORCAROUTER_API_KEY}",
+	"models": ["openai/gpt-5.5"]
+}
+```
+
+## Setup
+
+1. Create an account at [orcarouter.ai](https://www.orcarouter.ai)
+2. Generate an API key from the [console](https://www.orcarouter.ai/console)
+3. Browse available models in the [model list](https://www.orcarouter.ai/models)
+
+Model names follow the `provider/model-name` format, e.g. `openai/gpt-5.5` or `anthropic/claude-sonnet-5`.
+
+## Fetching Available Models
+
+The `/setup-providers` wizard can automatically fetch available models from your OrcaRouter account.
+
+See the [OrcaRouter docs](https://docs.orcarouter.ai) for the full model catalog and routing options.

--- a/source/ai-sdk-client/providers/orcarouter.ts
+++ b/source/ai-sdk-client/providers/orcarouter.ts
@@ -1,0 +1,16 @@
+/**
+ * Single source of truth for "is this an OrcaRouter provider?". Used by:
+ *   - provider-factory.ts to attach OrcaRouter attribution headers
+ *
+ * Matching by `name` (case-insensitive) keeps configuration simple — users
+ * just name the provider "orcarouter" / "OrcaRouter" / "ORCAROUTER" and
+ * everything OrcaRouter-specific lights up. Mirrors `isOpenRouterProvider`.
+ *
+ * OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible router, so it
+ * flows through the generic `openai-compatible` SDK path with a fixed base URL
+ * (https://api.orcarouter.ai/v1) and provider/model naming like OpenRouter
+ * (e.g. `openai/gpt-5.5`).
+ */
+export function isOrcaRouterProvider(providerName: string): boolean {
+	return providerName.toLowerCase() === 'orcarouter';
+}

--- a/source/ai-sdk-client/providers/provider-factory.spec.ts
+++ b/source/ai-sdk-client/providers/provider-factory.spec.ts
@@ -67,6 +67,24 @@ test('createProvider adds Requesty headers for requesty provider', async t => {
 	t.is(provider.kind, 'openai-compatible');
 });
 
+test('createProvider adds OrcaRouter headers for orcarouter provider', async t => {
+	const config: AIProviderConfig = {
+		name: 'OrcaRouter',
+		type: 'openai',
+		models: ['openai/gpt-5.5'],
+		config: {
+			baseURL: 'https://api.orcarouter.ai/v1',
+			apiKey: 'test-key',
+		},
+	};
+
+	const agent = new Agent();
+	const provider = await createProvider(config, agent);
+
+	t.truthy(provider);
+	t.is(provider.kind, 'openai-compatible');
+});
+
 test('createProvider handles provider with no API key', async t => {
 	const config: AIProviderConfig = {
 		name: 'TestProvider',

--- a/source/ai-sdk-client/providers/provider-factory.ts
+++ b/source/ai-sdk-client/providers/provider-factory.ts
@@ -30,6 +30,7 @@ import {
 import type {AIProviderConfig} from '@/types/index';
 import {getLogger} from '@/utils/logging';
 import {isOpenRouterProvider} from './openrouter.js';
+import {isOrcaRouterProvider} from './orcarouter.js';
 import {isRequestyProvider} from './requesty.js';
 
 /**
@@ -512,6 +513,13 @@ export async function createProvider(
 	// Requesty (https://requesty.ai) is an OpenAI-compatible router and uses
 	// the same app-attribution headers as OpenRouter.
 	if (isRequestyProvider(providerConfig.name)) {
+		headers['HTTP-Referer'] = 'https://github.com/Nano-Collective/nanocoder';
+		headers['X-Title'] = 'Nanocoder';
+	}
+
+	// OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible router and
+	// uses the same app-attribution headers as OpenRouter.
+	if (isOrcaRouterProvider(providerConfig.name)) {
 		headers['HTTP-Referer'] = 'https://github.com/Nano-Collective/nanocoder';
 		headers['X-Title'] = 'Nanocoder';
 	}

--- a/source/wizards/templates/provider-templates.spec.ts
+++ b/source/wizards/templates/provider-templates.spec.ts
@@ -530,6 +530,42 @@ test('requesty template: uses default provider name and model default', t => {
 	t.is(config.name, 'Requesty');
 });
 
+test('orcarouter template: sets baseUrl, default model, and parses models', t => {
+	const template = PROVIDER_TEMPLATES.find(t => t.id === 'orcarouter');
+	t.truthy(template);
+
+	const config = template!.buildConfig({
+		providerName: 'OrcaRouter',
+		apiKey: 'test-key',
+		model: 'openai/gpt-5.5, anthropic/claude-sonnet-5',
+	});
+
+	t.is(config.name, 'OrcaRouter');
+	t.is(config.baseUrl, 'https://api.orcarouter.ai/v1');
+	t.is(config.apiKey, 'test-key');
+	t.is(config.sdkProvider, undefined);
+	t.deepEqual(config.models, [
+		'openai/gpt-5.5',
+		'anthropic/claude-sonnet-5',
+	]);
+});
+
+test('orcarouter template: uses default provider name and model default', t => {
+	const template = PROVIDER_TEMPLATES.find(t => t.id === 'orcarouter');
+	t.truthy(template);
+
+	const modelField = template!.fields.find(f => f.name === 'model');
+	t.is(modelField?.default, 'openai/gpt-5.5');
+
+	const config = template!.buildConfig({
+		providerName: '',
+		apiKey: 'test-key',
+		model: 'openai/gpt-5.5',
+	});
+
+	t.is(config.name, 'OrcaRouter');
+});
+
 // ============================================================================
 // Tests for template ID vs sdkProvider collision prevention
 // Providers that use sdkProvider: 'anthropic' (like MiniMax, Kimi) must not

--- a/source/wizards/templates/provider-templates.ts
+++ b/source/wizards/templates/provider-templates.ts
@@ -420,6 +420,13 @@ export const PROVIDER_TEMPLATES: ProviderTemplate[] = [
 		apiKeyPrompt: 'API Key (from https://app.requesty.ai/api-keys)',
 		modelDefault: 'openai/gpt-4o-mini',
 	}),
+	apiKeyTemplate({
+		id: 'orcarouter',
+		name: 'OrcaRouter',
+		baseUrl: 'https://api.orcarouter.ai/v1',
+		apiKeyPrompt: 'API Key (from https://www.orcarouter.ai/console)',
+		modelDefault: 'openai/gpt-5.5',
+	}),
 	{
 		id: 'openai',
 		name: 'OpenAI',


### PR DESCRIPTION
## Description

Adds a first-class [OrcaRouter](https://www.orcarouter.ai) provider to the `/setup-providers` wizard and the provider factory, mirroring how the existing Requesty/OpenRouter providers are wired. OrcaRouter exposes 150+ namespaced models (`openai/*`, `anthropic/*`, `deepseek/*`, `z-ai/*`, …) behind a single OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`) and one API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

- Wizard: the new `OrcaRouter` template (base URL `https://api.orcarouter.ai/v1`, default model `openai/gpt-5.5`) sits next to `Requesty`/`OpenRouter` in `PROVIDER_TEMPLATES`.
- Provider factory: an `orcarouter`-named provider now gets the same `HTTP-Referer`/`X-Title` app-attribution headers as OpenRouter/Requesty, via a new `isOrcaRouterProvider` helper.
- Docs: a dedicated [OrcaRouter provider page](https://github.com/Nano-Collective/nanocoder/blob/main/docs/configuration/providers/orcarouter.md) plus a row in the Cloud Providers index.
- Tests: mirror the existing Requesty spec cases — wizard template config/build, and factory header wiring.
- Changeset: `minor` bump for the new provider template.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`.changeset/add-orcarouter-provider.md`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts` files (`provider-factory.spec.ts`, `provider-templates.spec.ts`)
- [x] All targeted tests pass (`ava` on both spec files)
- [x] `pnpm test:types`, `pnpm test:lint`, `pnpm test:format`, `pnpm test:knip` all pass locally

### Manual Testing

- [x] Live API test through Nanocoder's own code path (`AISDKClient.create` → `createProvider` → `@ai-sdk/openai-compatible`): a real `openai/gpt-5.5` request to `https://api.orcarouter.ai/v1` returned `ORCA_OK` (usage 4,393 in / 18 out tokens).
- [ ] Tested with Ollama
- [x] Tested with OpenAI-compatible API (OrcaRouter)

## Checklist

- [x] If this was for an open issue, I was assigned to it (n/a)
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (n/a — provider plumbing only)
