### PR TITLE
test(vscode): run the acp-client and acp-process-manager specs in CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Run TypeScript type checking
         run: pnpm test:types
 
+      # The root tsconfig only includes source/**, so the extension's own
+      # sources and specs are checked by their own project or not at all.
+      - name: Run TypeScript type checking (VS Code extension)
+        run: pnpm test:types:vscode
+
   test-format:
     name: Format Checks
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"test:ava:coverage": "c8 ava",
 		"test:format": "biome check --no-errors-on-unmatched .",
 		"test:types": "tsc --noEmit",
+		"test:types:vscode": "tsc --noEmit -p plugins/vscode/tsconfig.json",
 		"test:lint": "biome lint .",
 		"test:lint:fix": "biome check --write --unsafe .",
 		"test:knip": "knip",
@@ -143,8 +144,6 @@
 			"plugins/**/*.spec.ts",
 			"plugins/**/*.spec.tsx",
 			"!plugins/**/node_modules/**",
-			"!plugins/vscode/src/acp-client.spec.ts",
-			"!plugins/vscode/src/acp-process-manager.spec.ts",
 			"!source/**/*-helpers.ts",
 			"!source/**/test-helpers.ts"
 		],

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,6 +15,7 @@ echo ""
 
 echo "🔍 Checking TypeScript types..."
 pnpm test:types
+pnpm test:types:vscode
 echo ""
 echo "✅ Type check passed"
 echo ""


### PR DESCRIPTION
## Description

Six VS Code extension tests have never run in CI, including the two #869 just merged.

#842 added `plugins/**/*.spec.ts` to `ava.files`, but blocklisted two files by name:

```
"!plugins/vscode/src/acp-client.spec.ts",
"!plugins/vscode/src/acp-process-manager.spec.ts",
```

Its reasoning at the time: they *"transitively require('vscode'), which does not resolve outside the extension host."* That blocker no longer exists. The root tsconfig maps the bare `vscode` specifier to `plugins/vscode/test-stubs/vscode.ts` and tsx honours those paths - which is what the stub's own docstring says it is for. The exclusions outlived their reason.

Removing them brings back 6 tests, all passing **inside the full serial suite**, not just standalone:

- `acp-client` - 5 tests, including `reconnecting clears permissions left by the dead process` from #869
- `acp-process-manager` - 1 test

### Also: typecheck the extension

The root tsconfig only includes `source/**`, and `plugins/vscode` builds through esbuild, which strips types without checking them. So nothing in CI has ever typechecked the extension's own sources or specs - a type error in `plugins/vscode/src` ships silently.

`tsc -p plugins/vscode/tsconfig.json` is clean on main today, so this is a no-op that keeps it that way. Added as `test:types:vscode`, wired into the Type Checks job and `scripts/test.sh`.

## Type of Change

- [x] Bug fix (CI coverage gap)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Not applicable - test/CI infrastructure only, nothing user-facing to release.

## Testing

- [x] Full `ava` suite run locally with the exclusions removed; the 6 restored tests pass
- [x] `tsc --noEmit -p plugins/vscode/tsconfig.json` exits 0
- [x] `biome check` clean on the changed files