### PR TITLE
fix(build): restore the build and type checks under TypeScript 7

### DIFF
--- a/plugins/vscode/tsconfig.json
+++ b/plugins/vscode/tsconfig.json
@@ -7,6 +7,11 @@
 		],
 		"sourceMap": true,
 		"outDir": "dist",
+		// `include` reaches into source/ below, and TypeScript 7 infers a
+		// rootDir of plugins/vscode and rejects those files. The extension is
+		// bundled by esbuild (see build:ext) and tsc only type-checks this
+		// project, so widening rootDir to the repo root costs nothing.
+		"rootDir": "../..",
 		"strict": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,

--- a/source/wizards/steps/location-step.spec.tsx
+++ b/source/wizards/steps/location-step.spec.tsx
@@ -4,6 +4,7 @@ import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
 import {renderWithTheme as render} from '@/test-utils/render-with-theme';
 import React from 'react';
+import stripAnsi from 'strip-ansi';
 import {LocationStep} from './location-step.js';
 
 // Mirrors base-config-wizard.tsx's real LocationStep box.
@@ -70,7 +71,9 @@ test('LocationStep shows the resolved project path next to the option', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	const lines = output!.split('\n');
+	// The path is rendered dimmed, so the frame carries ANSI escapes whenever
+	// colour is on - which it is under CI. Compare against the plain text.
+	const lines = stripAnsi(output!).split('\n');
 	const stemIndex = lines.findIndex(line =>
 		line.includes('Current project directory'),
 	);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,15 +16,16 @@
 		"declarationMap": true,
 		"sourceMap": true,
 		"types": ["node"],
-		"baseUrl": ".",
+		// TypeScript 7 removed `baseUrl` and rejects non-relative `paths`
+		// targets, so these resolve relative to this file instead.
 		"paths": {
-			"@/*": ["source/*"],
+			"@/*": ["./source/*"],
 			// The real `vscode` module only exists inside the extension host, so
 			// AVA (which loads specs through tsx, and tsx honours these paths)
 			// resolves it to a stub. Test-only: the extension is bundled from
 			// plugins/vscode/tsconfig.json with `--external:vscode`, and nothing
 			// under source/ imports it.
-			"vscode": ["plugins/vscode/test-stubs/vscode.ts"]
+			"vscode": ["./plugins/vscode/test-stubs/vscode.ts"]
 		}
 	},
 	"include": ["source/**/*"],


### PR DESCRIPTION
Closes the red build on `main`.

## Description

#913 bumped `typescript` 5.9.3 -> 7.0.2 and was merged with **Type Checks**, **Unit Tests** and **Verify Build** all failing on its own PR, so `main` has been red since. There were three breakages, two of them from that bump and one older.

- **`tsconfig.json`** TypeScript 7 removed `baseUrl` (TS5102) and rejects non-relative `paths` targets (TS5090). Dropped `baseUrl` and made both targets relative to the config file, which resolves to the same places. `tsc-alias` still rewrites every `@/` specifier, so `dist/` is unchanged.
- **`plugins/vscode/tsconfig.json`** `include` deliberately reaches into `source/`, and TypeScript 7 infers a `rootDir` of `plugins/vscode` and rejects those files with TS6059. Widened `rootDir` to the repo root. The extension is bundled by esbuild (`build:ext`), so `tsc` only ever type-checks this project and the wider `rootDir` has no effect on output. This one was hidden behind the first: `test:types` fails before `test:types:vscode` gets to run.
- **`source/wizards/steps/location-step.spec.tsx`** a separate breakage, from #855. The assertion compares a rendered line against the raw resolved path, but the path is rendered dimmed, so the frame carries ANSI escapes that `.trim()` leaves in place. It passed locally (colour off) and failed in CI (`FORCE_COLOR=1`). Now strips ANSI first, matching the existing convention in `write-file.spec.tsx` and `app-container.spec.tsx`.

Reproduce the third one on any checkout with `FORCE_COLOR=1 npx ava source/wizards/steps/location-step.spec.tsx`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Run against the real 7.0.2 install (`pnpm install --frozen-lockfile`), under `FORCE_COLOR=1 CI=true`:

- `pnpm test:types` pass
- `pnpm test:types:vscode` pass
- `pnpm test:format` pass
- `pnpm test:lint` pass
- `pnpm test:knip` pass
- `pnpm build` pass, `dist/` carries no unresolved `@/` specifiers
- full AVA suite 6565 passed, 0 failed

## Notes

No changeset: `dist/` output is unchanged, `typescript` is a devDependency, and the third change is test-only.

The open `dependabot/npm_and_yarn/tsc-alias-1.9.1` PR is red for exactly this `tsconfig` reason and should go green on rebase once this lands. The `ava-8.0.1` PR fails for an unrelated reason and is untouched here.