### PR TITLE
feat(repo-map): local symbol index and /repomap command

### DIFF
--- a/.changeset/repo-map-command.md
+++ b/.changeset/repo-map-command.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added `/repomap`, a local codebase map. Nanocoder indexes the symbols defined in each source file, links files that reference each other's symbols into a directed graph, and ranks that graph with PageRank - so the map leads with the files the rest of the codebase leans on most. Everything runs on your machine with no LLM round-trip, covering TypeScript/JavaScript, Python, Go, Rust, Java/Kotlin/C#/Swift, Ruby, PHP, and C/C++. The map is budgeted to 1024 tokens by default; `/repomap --tokens <n>` widens it. Thanks to @akramcodez. Refs #890.

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -34,6 +34,7 @@ Type `/` in the chat input to see available commands. All commands start with `/
 | `/update` | Update Nanocoder to the latest version |
 | `/usage` | Get current model context usage visually |
 | `/lsp` | List connected LSP servers |
+| `/repomap` | Show a PageRank-ordered map of the codebase - the most-referenced files and the symbols they define. Use `/repomap --tokens <n>` to widen the map beyond its default 1024-token budget |
 | `/schedule` | Read-only view of cron subscriptions declared by skills (see [Skills → Event subscriptions](skills.md#event-subscriptions)) |
 | `/skills` | List and inspect loaded skills; scaffold new bundle skills with AI assistance (see [Skills](skills.md)) |
 | `/resume` | Resume a previous chat session (aliases: `/sessions`, `/history`). Also available at launch via the `--resume`/`--continue` CLI flags. See [Session Management](session-management.md) |

--- a/source/commands/lazy-registry.ts
+++ b/source/commands/lazy-registry.ts
@@ -217,6 +217,12 @@ export const lazyCommands: LazyCommand[] = [
 		load: () => import('@/commands/skills').then(m => m.skillsCommand),
 	},
 	{
+		name: 'repomap',
+		description:
+			'Show a ranked map of the codebase (files and their key symbols). Use --tokens <n> to widen it.',
+		load: () => import('@/commands/repomap').then(m => m.repomapCommand),
+	},
+	{
 		name: 'privacy',
 		description:
 			'Inspect what the prompt scrubber will remove from your prompts',

--- a/source/commands/repomap.spec.tsx
+++ b/source/commands/repomap.spec.tsx
@@ -1,3 +1,6 @@
+import {mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import test from 'ava';
 import React from 'react';
 
@@ -103,14 +106,37 @@ test('RepoMapView renders an empty state when nothing is indexable', t => {
 });
 
 test('repomapCommand handler renders a map for the current directory', async t => {
-	const result = await repomapCommand.handler([], [], metadata);
-	t.true(React.isValidElement(result));
+	const root = join(
+		tmpdir(),
+		`nanocoder-repomap-command-${process.pid}-${Date.now()}`,
+	);
+	mkdirSync(root, {recursive: true});
+	writeFileSync(
+		join(root, 'core.ts'),
+		'export function sharedHelper() {\n\treturn 1;\n}\n',
+	);
+	writeFileSync(
+		join(root, 'user.ts'),
+		'import {sharedHelper} from "./core";\nsharedHelper();\n',
+	);
 
-	const {lastFrame, unmount} = renderWithTheme(result as React.ReactElement);
-	const output = lastFrame() ?? '';
-	unmount();
-	t.true(output.includes('/repomap'));
-	t.true(output.includes('files'));
+	const previousCwd = process.cwd();
+	process.chdir(root);
+
+	try {
+		const result = await repomapCommand.handler([], [], metadata);
+		t.true(React.isValidElement(result));
+
+		const {lastFrame, unmount} = renderWithTheme(result as React.ReactElement);
+		const output = lastFrame() ?? '';
+		unmount();
+		t.true(output.includes('/repomap'));
+		t.true(output.includes('files'));
+		t.true(output.includes('core.ts'));
+	} finally {
+		process.chdir(previousCwd);
+		rmSync(root, {recursive: true, force: true});
+	}
 });
 
 test('repomapCommand handler renders usage for a bad argument', async t => {

--- a/source/commands/repomap.spec.tsx
+++ b/source/commands/repomap.spec.tsx
@@ -1,0 +1,85 @@
+import test from 'ava';
+import React from 'react';
+
+import {parseRepoMapArgs, repomapCommand, RepoMapView} from './repomap';
+import {DEFAULT_REPO_MAP_TOKENS} from '@/repo-map/index';
+
+console.log('\nrepomap.spec.tsx');
+
+const metadata = {
+	provider: 'test',
+	model: 'test',
+	tokens: 0,
+	getMessageTokens: () => 0,
+};
+
+test('repomapCommand exposes matching name and description', t => {
+	t.is(repomapCommand.name, 'repomap');
+	t.true(repomapCommand.description.includes('--tokens'));
+});
+
+test('parseRepoMapArgs defaults to the standard budget', t => {
+	t.deepEqual(parseRepoMapArgs([]), {maxTokens: DEFAULT_REPO_MAP_TOKENS});
+});
+
+test('parseRepoMapArgs accepts separated and inline token values', t => {
+	t.deepEqual(parseRepoMapArgs(['--tokens', '2048']), {maxTokens: 2048});
+	t.deepEqual(parseRepoMapArgs(['--tokens=2048']), {maxTokens: 2048});
+});
+
+test('parseRepoMapArgs floors fractional values and clamps the maximum', t => {
+	t.is(parseRepoMapArgs(['--tokens', '512.9']).maxTokens, 512);
+	t.is(parseRepoMapArgs(['--tokens', '999999']).maxTokens, 32_000);
+});
+
+test('parseRepoMapArgs rejects values below the minimum', t => {
+	const result = parseRepoMapArgs(['--tokens', '10']);
+	t.truthy(result.error);
+	t.is(result.maxTokens, DEFAULT_REPO_MAP_TOKENS);
+});
+
+test('parseRepoMapArgs rejects missing and non-numeric values', t => {
+	t.truthy(parseRepoMapArgs(['--tokens']).error);
+	t.truthy(parseRepoMapArgs(['--tokens', 'lots']).error);
+	t.truthy(parseRepoMapArgs(['--tokens=']).error);
+});
+
+test('parseRepoMapArgs rejects unknown arguments', t => {
+	t.is(parseRepoMapArgs(['--depth', '3']).error, 'Unknown argument: --depth');
+	t.is(
+		parseRepoMapArgs(['--tokensmax', '3']).error,
+		'Unknown argument: --tokensmax',
+	);
+});
+
+test('repomapCommand handler returns an element for the current directory', async t => {
+	const result = await repomapCommand.handler([], [], metadata);
+	t.true(React.isValidElement(result));
+});
+
+test('repomapCommand handler returns an error element for bad arguments', async t => {
+	const result = await repomapCommand.handler(['--nope'], [], metadata);
+	t.true(React.isValidElement(result));
+});
+
+test('RepoMapView renders both the populated and empty states', t => {
+	t.true(
+		React.isValidElement(
+			React.createElement(RepoMapView, {
+				map: {
+					files: [{path: 'a.ts', rank: 0.5, symbols: ['alpha']}],
+					scannedFiles: 1,
+					totalSymbols: 1,
+					truncated: false,
+				},
+			}),
+		),
+	);
+	t.true(
+		React.isValidElement(
+			React.createElement(RepoMapView, {
+				map: {files: [], scannedFiles: 0, totalSymbols: 0, truncated: false},
+			}),
+		),
+	);
+});

--- a/source/commands/repomap.spec.tsx
+++ b/source/commands/repomap.spec.tsx
@@ -1,8 +1,9 @@
 import test from 'ava';
 import React from 'react';
 
-import {parseRepoMapArgs, repomapCommand, RepoMapView} from './repomap';
-import {DEFAULT_REPO_MAP_TOKENS} from '@/repo-map/index';
+import {DEFAULT_REPO_MAP_TOKENS, type RepoMap} from '@/repo-map/index';
+import {renderWithTheme} from '@/test-utils/render-with-theme';
+import {parseRepoMapArgs, RepoMapView, repomapCommand} from './repomap';
 
 console.log('\nrepomap.spec.tsx');
 
@@ -12,6 +13,13 @@ const metadata = {
 	tokens: 0,
 	getMessageTokens: () => 0,
 };
+
+function frameOf(map: RepoMap): string {
+	const {lastFrame, unmount} = renderWithTheme(<RepoMapView map={map} />);
+	const output = lastFrame() ?? '';
+	unmount();
+	return output;
+}
 
 test('repomapCommand exposes matching name and description', t => {
 	t.is(repomapCommand.name, 'repomap');
@@ -52,34 +60,64 @@ test('parseRepoMapArgs rejects unknown arguments', t => {
 	);
 });
 
-test('repomapCommand handler returns an element for the current directory', async t => {
+test('RepoMapView renders the ranked files, their symbols and the summary', t => {
+	const output = frameOf({
+		files: [
+			{path: 'source/core.ts', rank: 0.4, symbols: ['alpha', 'beta']},
+			{path: 'source/leaf.ts', rank: 0.1, symbols: ['gamma']},
+		],
+		scannedFiles: 12,
+		totalSymbols: 30,
+		truncated: false,
+	});
+
+	t.true(output.includes('source/core.ts'));
+	t.true(output.includes('alpha, beta'));
+	t.true(output.includes('source/leaf.ts'));
+	t.true(output.includes('gamma'));
+	t.true(output.includes('Top 2 of 12 files'));
+	t.true(output.includes('30 symbols'));
+	t.false(output.includes('truncated'));
+});
+
+test('RepoMapView flags a truncated map', t => {
+	const output = frameOf({
+		files: [{path: 'a.ts', rank: 1, symbols: ['only']}],
+		scannedFiles: 900,
+		totalSymbols: 900,
+		truncated: true,
+	});
+
+	t.true(output.includes('truncated'));
+});
+
+test('RepoMapView renders an empty state when nothing is indexable', t => {
+	const output = frameOf({
+		files: [],
+		scannedFiles: 0,
+		totalSymbols: 0,
+		truncated: false,
+	});
+
+	t.true(output.includes('No indexable source files found'));
+});
+
+test('repomapCommand handler renders a map for the current directory', async t => {
 	const result = await repomapCommand.handler([], [], metadata);
 	t.true(React.isValidElement(result));
+
+	const {lastFrame, unmount} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() ?? '';
+	unmount();
+	t.true(output.includes('/repomap'));
+	t.true(output.includes('files'));
 });
 
-test('repomapCommand handler returns an error element for bad arguments', async t => {
+test('repomapCommand handler renders usage for a bad argument', async t => {
 	const result = await repomapCommand.handler(['--nope'], [], metadata);
-	t.true(React.isValidElement(result));
-});
-
-test('RepoMapView renders both the populated and empty states', t => {
-	t.true(
-		React.isValidElement(
-			React.createElement(RepoMapView, {
-				map: {
-					files: [{path: 'a.ts', rank: 0.5, symbols: ['alpha']}],
-					scannedFiles: 1,
-					totalSymbols: 1,
-					truncated: false,
-				},
-			}),
-		),
-	);
-	t.true(
-		React.isValidElement(
-			React.createElement(RepoMapView, {
-				map: {files: [], scannedFiles: 0, totalSymbols: 0, truncated: false},
-			}),
-		),
-	);
+	const {lastFrame, unmount} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() ?? '';
+	unmount();
+	t.true(output.includes('Unknown argument: --nope'));
+	t.true(output.includes('Usage: /repomap [--tokens <n>]'));
 });

--- a/source/commands/repomap.tsx
+++ b/source/commands/repomap.tsx
@@ -1,0 +1,110 @@
+import {Box, Text} from 'ink';
+import React from 'react';
+import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
+import {useTerminalWidth} from '@/hooks/useTerminalWidth';
+import {useTheme} from '@/hooks/useTheme';
+import {
+	buildRepoMap,
+	DEFAULT_REPO_MAP_TOKENS,
+	type RepoMap,
+} from '@/repo-map/index';
+import {generateKey} from '@/session/key-generator';
+import type {Command} from '@/types/index';
+import {errorMsg} from '@/utils/message-factory';
+
+const MIN_TOKENS = 64;
+const MAX_TOKENS = 32_000;
+
+export function parseRepoMapArgs(args: string[]): {
+	maxTokens: number;
+	error?: string;
+} {
+	let maxTokens = DEFAULT_REPO_MAP_TOKENS;
+
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (arg !== '--tokens' && !arg.startsWith('--tokens=')) {
+			return {maxTokens, error: `Unknown argument: ${arg}`};
+		}
+		const inline = arg === '--tokens' ? undefined : arg.slice(9);
+		const raw = inline ?? args[++index];
+		const parsed = Number(raw);
+		if (!raw || !Number.isFinite(parsed) || parsed < MIN_TOKENS) {
+			return {
+				maxTokens,
+				error: `--tokens expects a number of at least ${MIN_TOKENS}`,
+			};
+		}
+		maxTokens = Math.min(Math.floor(parsed), MAX_TOKENS);
+	}
+
+	return {maxTokens};
+}
+
+export function RepoMapView({map}: {map: RepoMap}) {
+	const boxWidth = useTerminalWidth();
+	const {colors} = useTheme();
+
+	return (
+		<TitledBoxWithPreferences
+			title="/repomap"
+			width={boxWidth}
+			borderColor={colors.primary}
+			paddingX={2}
+			paddingY={1}
+			flexDirection="column"
+			marginBottom={1}
+		>
+			{map.files.length === 0 ? (
+				<Text color={colors.secondary}>
+					No indexable source files found in this directory.
+				</Text>
+			) : (
+				<>
+					<Box marginBottom={1}>
+						<Text color={colors.primary}>
+							Top {map.files.length} of {map.scannedFiles} files ·{' '}
+							{map.totalSymbols} symbols
+							{map.truncated ? ' · truncated' : ''}
+						</Text>
+					</Box>
+					{map.files.map(file => (
+						<Box key={file.path} flexDirection="column" marginBottom={1}>
+							<Text color={colors.text} bold>
+								{file.path}
+							</Text>
+							<Text color={colors.secondary}>{file.symbols.join(', ')}</Text>
+						</Box>
+					))}
+				</>
+			)}
+		</TitledBoxWithPreferences>
+	);
+}
+
+export const repomapCommand: Command = {
+	name: 'repomap',
+	description:
+		'Show a ranked map of the codebase (files and their key symbols). Use --tokens <n> to widen it.',
+	handler: async (args, _messages, _metadata) => {
+		const {maxTokens, error} = parseRepoMapArgs(args);
+		if (error) {
+			return errorMsg(`${error}\n\nUsage: /repomap [--tokens <n>]`, 'repomap');
+		}
+
+		try {
+			const map = await buildRepoMap(process.cwd(), {maxTokens});
+			return React.createElement(RepoMapView, {
+				key: generateKey('repomap'),
+				map,
+			});
+		} catch (buildError) {
+			return errorMsg(
+				`Failed to build repo map: ${
+					buildError instanceof Error ? buildError.message : String(buildError)
+				}`,
+				'repomap',
+			);
+		}
+	},
+};

--- a/source/repo-map/index.spec.ts
+++ b/source/repo-map/index.spec.ts
@@ -1,0 +1,435 @@
+import {mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+
+import {buildRepoMap, DEFAULT_REPO_MAP_TOKENS} from './index';
+
+console.log('\nrepo-map/index.spec.ts');
+
+let counter = 0;
+
+function createRepo(files: Record<string, string>): string {
+	counter += 1;
+	const root = join(
+		tmpdir(),
+		`nanocoder-repomap-${process.pid}-${Date.now()}-${counter}`,
+	);
+	mkdirSync(root, {recursive: true});
+	for (const [relative, content] of Object.entries(files)) {
+		const absolute = join(root, relative);
+		mkdirSync(join(absolute, '..'), {recursive: true});
+		writeFileSync(absolute, content);
+	}
+	return root;
+}
+
+function cleanup(root: string): void {
+	rmSync(root, {recursive: true, force: true});
+}
+
+test.serial('ranks the most-referenced file first', async t => {
+	const root = createRepo({
+		'core.ts': 'export function sharedHelper() {\n\treturn 1;\n}\n',
+		'a.ts': 'import {sharedHelper} from "./core";\nsharedHelper();\n',
+		'b.ts': 'import {sharedHelper} from "./core";\nsharedHelper();\n',
+		'c.ts': 'import {sharedHelper} from "./core";\nsharedHelper();\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		t.is(map.files[0].path, 'core.ts');
+		t.true(map.files[0].symbols.includes('sharedHelper'));
+		t.true(map.files[0].rank > 0);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('orders a file symbols by cross-file reference weight', async t => {
+	const root = createRepo({
+		'lib.ts':
+			'export function rarelyUsed() {}\nexport function heavilyUsed() {}\n',
+		'user.ts':
+			'import {heavilyUsed} from "./lib";\nheavilyUsed();\nheavilyUsed();\nheavilyUsed();\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		const lib = map.files.find(file => file.path === 'lib.ts');
+		t.truthy(lib);
+		t.is(lib?.symbols[0], 'heavilyUsed');
+		t.true(lib?.symbols.includes('rarelyUsed'));
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('splits weight when a symbol is defined in several files', async t => {
+	const root = createRepo({
+		'one.ts': 'export function ambiguous() {}\n',
+		'two.ts': 'export function ambiguous() {}\n',
+		'only.ts': 'export function unique() {}\n',
+		'user.ts':
+			'import {ambiguous} from "./one";\nimport {unique} from "./only";\nambiguous();\nunique();\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		const one = map.files.find(file => file.path === 'one.ts');
+		const two = map.files.find(file => file.path === 'two.ts');
+		const only = map.files.find(file => file.path === 'only.ts');
+		t.truthy(one);
+		t.truthy(only);
+		t.is(one?.rank, two?.rank);
+		t.true((only?.rank ?? 0) > (one?.rank ?? 0));
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('ignores self-references when ranking', async t => {
+	const root = createRepo({
+		'lonely.ts':
+			'export function loop() {\n\tloop();\n\tloop();\n\tloop();\n}\n',
+		'other.ts': 'export const other = 1;\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		const lonely = map.files.find(file => file.path === 'lonely.ts');
+		const other = map.files.find(file => file.path === 'other.ts');
+		t.is(lonely?.rank, other?.rank);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('returns an empty map for a repo with no source files', async t => {
+	const root = createRepo({'README.md': '# hello\n', 'data.json': '{}\n'});
+
+	try {
+		const map = await buildRepoMap(root);
+		t.deepEqual(map.files, []);
+		t.is(map.scannedFiles, 0);
+		t.is(map.totalSymbols, 0);
+		t.false(map.truncated);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('skips files that define no symbols', async t => {
+	const root = createRepo({
+		'empty.ts': '\n\n',
+		'real.ts': 'export function realThing() {}\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		t.is(map.scannedFiles, 2);
+		t.deepEqual(
+			map.files.map(file => file.path),
+			['real.ts'],
+		);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('respects .gitignore and default ignore directories', async t => {
+	const root = createRepo({
+		'.gitignore': 'secret/\n',
+		'secret/hidden.ts': 'export function hiddenSymbol() {}\n',
+		'node_modules/dep/index.ts': 'export function depSymbol() {}\n',
+		'kept.ts': 'export function keptSymbol() {}\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		t.is(map.scannedFiles, 1);
+		t.deepEqual(
+			map.files.map(file => file.path),
+			['kept.ts'],
+		);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('skips unsupported extensions and files above the byte cap', async t => {
+	const root = createRepo({
+		'big.ts': `export function bigSymbol() {}\n${'// '.repeat(200)}\n`,
+		'small.ts': 'export function smallSymbol() {}\n',
+		'notes.txt': 'function notCode() {}\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root, {maxFileBytes: 120});
+		t.is(map.scannedFiles, 1);
+		t.is(map.files[0].path, 'small.ts');
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('stops scanning at maxFiles and reports truncation', async t => {
+	const root = createRepo({
+		'a.ts': 'export function aSymbol() {}\n',
+		'b.ts': 'export function bSymbol() {}\n',
+		'c.ts': 'export function cSymbol() {}\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root, {maxFiles: 2});
+		t.is(map.scannedFiles, 2);
+		t.true(map.truncated);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('truncates when the token budget is exhausted', async t => {
+	const root = createRepo({
+		'one.ts': 'export function oneSymbolHere() {}\n',
+		'two.ts': 'export function twoSymbolHere() {}\n',
+		'three.ts': 'export function threeSymbolHere() {}\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root, {maxTokens: 10});
+		t.is(map.scannedFiles, 3);
+		t.true(map.files.length < 3);
+		t.true(map.truncated);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('caps the symbols listed per file', async t => {
+	const definitions = Array.from(
+		{length: 20},
+		(_, index) => `export function symbolNumber${index}() {}`,
+	).join('\n');
+	const root = createRepo({'many.ts': `${definitions}\n`});
+
+	try {
+		const map = await buildRepoMap(root, {maxSymbolsPerFile: 3});
+		t.is(map.files[0].symbols.length, 3);
+		t.is(map.totalSymbols, 20);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('ignores definitions and references inside comments and strings', async t => {
+	const root = createRepo({
+		'real.ts': 'export function realOnly() {}\n',
+		'noise.ts':
+			'// export function commentedOut() {}\n/* export function blockedOut() {} */\nexport const text = "export function stringOut() {}";\nexport const ref = "realOnly realOnly realOnly";\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		const noise = map.files.find(file => file.path === 'noise.ts');
+		t.truthy(noise);
+		t.false(noise?.symbols.includes('commentedOut'));
+		t.false(noise?.symbols.includes('blockedOut'));
+		t.false(noise?.symbols.includes('stringOut'));
+		t.is(map.files.find(file => file.path === 'real.ts')?.rank, noise?.rank);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('indexes files written with CRLF line endings', async t => {
+	const root = createRepo({
+		'crlf.ts': 'export function crlfSymbol() {}\r\nexport const crlfConst = 1;\r\n',
+		'plain.c': 'int crlf_start(void)\r\n{\r\n\treturn 0;\r\n}\r\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		const symbolsFor = (path: string) =>
+			map.files.find(file => file.path === path)?.symbols ?? [];
+		t.true(symbolsFor('crlf.ts').includes('crlfSymbol'));
+		t.true(symbolsFor('crlf.ts').includes('crlfConst'));
+		t.true(symbolsFor('plain.c').includes('crlf_start'));
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('indexes only exported javascript symbols', async t => {
+	const root = createRepo({
+		'mod.ts':
+			'export function exportedFn() {}\nfunction privateFn() {}\nconst privateConst = 1;\nexport const exportedConst = 2;\nexport interface ExportedShape {}\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		const symbols = map.files[0].symbols;
+		t.true(symbols.includes('exportedFn'));
+		t.true(symbols.includes('exportedConst'));
+		t.true(symbols.includes('ExportedShape'));
+		t.false(symbols.includes('privateFn'));
+		t.false(symbols.includes('privateConst'));
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('links files only through names they actually import', async t => {
+	const root = createRepo({
+		'target.ts': 'export function collide() {}\n',
+		'importer.ts': 'import {collide} from "./target";\ncollide();\n',
+		'shadow.ts': 'function collide() {}\ncollide();\ncollide();\ncollide();\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		const target = map.files.find(file => file.path === 'target.ts');
+		const importer = map.files.find(file => file.path === 'importer.ts');
+		t.truthy(target);
+		t.is(importer, undefined);
+		t.true((target?.rank ?? 0) > 1 / 3);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('does not treat property access as a reference', async t => {
+	const root = createRepo({
+		'api.ts': 'export function fetchData() {}\n',
+		'noise.ts':
+			'import {fetchData} from "./api";\nconst client = {};\nclient.fetchData();\nclient.fetchData();\n',
+		'plain.ts': 'export const plain = 1;\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		const api = map.files.find(file => file.path === 'api.ts');
+		const plain = map.files.find(file => file.path === 'plain.ts');
+		t.truthy(api);
+		t.true((api?.rank ?? 0) > (plain?.rank ?? 0));
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('resolves python imports through from-import bindings', async t => {
+	const root = createRepo({
+		'helpers.py': 'def build_widget():\n\treturn 1\n',
+		'app.py': 'from helpers import build_widget\n\nbuild_widget()\n',
+		'idle.py': 'def unused_widget():\n\treturn 2\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		const helpers = map.files.find(file => file.path === 'helpers.py');
+		const idle = map.files.find(file => file.path === 'idle.py');
+		t.true((helpers?.rank ?? 0) > (idle?.rank ?? 0));
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('keeps python hash comments out of the index', async t => {
+	const root = createRepo({
+		'mod.py': '# def commentedDef():\nclass RealClass:\n\tdef real_method(self):\n\t\treturn 1\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		t.true(map.files[0].symbols.includes('RealClass'));
+		t.true(map.files[0].symbols.includes('real_method'));
+		t.false(map.files[0].symbols.includes('commentedDef'));
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('extracts definitions across supported languages', async t => {
+	const root = createRepo({
+		'svc.go': 'package main\n\nfunc RunServer() {}\n\ntype Options struct{}\n',
+		'lib.rs': 'pub fn run_task() {}\n\npub struct TaskOptions {}\n',
+		'App.java': 'public class AppRunner {\n\tpublic void execute() {}\n}\n',
+		'model.rb': 'class RecordModel\n\tdef persist\n\tend\nend\n',
+		'page.php': '<?php\nfunction render_page() {}\nclass PageBuilder {}\n',
+		'core.c': '#include <stdio.h>\n\nstruct CoreState;\n\nint core_start(int argc)\n{\n\treturn argc;\n}\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root, {maxTokens: 4096});
+		const symbolsFor = (path: string) =>
+			map.files.find(file => file.path === path)?.symbols ?? [];
+
+		t.true(symbolsFor('svc.go').includes('RunServer'));
+		t.true(symbolsFor('svc.go').includes('Options'));
+		t.true(symbolsFor('lib.rs').includes('run_task'));
+		t.true(symbolsFor('lib.rs').includes('TaskOptions'));
+		t.true(symbolsFor('App.java').includes('AppRunner'));
+		t.true(symbolsFor('model.rb').includes('RecordModel'));
+		t.true(symbolsFor('model.rb').includes('persist'));
+		t.true(symbolsFor('page.php').includes('render_page'));
+		t.true(symbolsFor('page.php').includes('PageBuilder'));
+		t.true(symbolsFor('core.c').includes('core_start'));
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('converges on a reference cycle and keeps ranks normalised', async t => {
+	const root = createRepo({
+		'alpha.ts':
+			'import {betaFn} from "./beta";\nexport function alphaFn() {\n\tbetaFn();\n}\n',
+		'beta.ts':
+			'import {gammaFn} from "./gamma";\nexport function betaFn() {\n\tgammaFn();\n}\n',
+		'gamma.ts':
+			'import {alphaFn} from "./alpha";\nexport function gammaFn() {\n\talphaFn();\n}\n',
+	});
+
+	try {
+		const map = await buildRepoMap(root);
+		t.is(map.files.length, 3);
+		const total = map.files.reduce((sum, file) => sum + file.rank, 0);
+		t.true(Math.abs(total - 1) < 1e-3);
+		for (const file of map.files) {
+			t.true(Number.isFinite(file.rank));
+			t.true(file.rank > 0);
+		}
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('produces a stable ordering across runs', async t => {
+	const root = createRepo({
+		'a.ts': 'export function sameA() {}\n',
+		'b.ts': 'export function sameB() {}\n',
+		'c.ts': 'export function sameC() {}\n',
+	});
+
+	try {
+		const first = await buildRepoMap(root);
+		const second = await buildRepoMap(root);
+		t.deepEqual(
+			first.files.map(file => file.path),
+			second.files.map(file => file.path),
+		);
+		t.deepEqual(
+			first.files.map(file => file.path),
+			['a.ts', 'b.ts', 'c.ts'],
+		);
+	} finally {
+		cleanup(root);
+	}
+});
+
+test.serial('rejects when the directory does not exist', async t => {
+	await t.throwsAsync(buildRepoMap(join(tmpdir(), 'nanocoder-repomap-missing')));
+});
+
+test.serial('exposes a 1024 token default budget', t => {
+	t.is(DEFAULT_REPO_MAP_TOKENS, 1024);
+});

--- a/source/repo-map/index.ts
+++ b/source/repo-map/index.ts
@@ -374,9 +374,6 @@ function pageRank(
 		}
 		for (const [from, targets] of edges) {
 			const total = outWeight[from];
-			if (total === 0) {
-				continue;
-			}
 			for (const [to, weight] of targets) {
 				next[to] += (ranks[from] * weight) / total;
 			}

--- a/source/repo-map/index.ts
+++ b/source/repo-map/index.ts
@@ -1,0 +1,488 @@
+import {readFile} from 'node:fs/promises';
+import {extname} from 'node:path';
+import {walkProjectEntries} from '@/utils/file-search';
+
+export interface RepoMapFile {
+	path: string;
+	rank: number;
+	symbols: string[];
+}
+
+export interface RepoMap {
+	files: RepoMapFile[];
+	scannedFiles: number;
+	totalSymbols: number;
+	truncated: boolean;
+}
+
+export interface RepoMapOptions {
+	maxTokens?: number;
+	maxFiles?: number;
+	maxFileBytes?: number;
+	maxSymbolsPerFile?: number;
+}
+
+export const DEFAULT_REPO_MAP_TOKENS = 1024;
+const DEFAULT_MAX_FILES = 2000;
+const DEFAULT_MAX_FILE_BYTES = 256 * 1024;
+const DEFAULT_MAX_SYMBOLS_PER_FILE = 12;
+const DAMPING = 0.85;
+const MAX_ITERATIONS = 24;
+const CONVERGENCE = 1e-6;
+const CHARS_PER_TOKEN = 4;
+
+const DEFINITION_PATTERNS: Record<string, RegExp[]> = {
+	js: [
+		/^export[ \t]+(?:default[ \t]+)?(?:declare[ \t]+)?(?:abstract[ \t]+)?(?:async[ \t]+)?(?:function\*?|class)[ \t]+([A-Za-z_$][\w$]*)/gm,
+		/^export[ \t]+(?:declare[ \t]+)?(?:const|let|var)[ \t]+([A-Za-z_$][\w$]*)[ \t]*[=:]/gm,
+		/^export[ \t]+(?:declare[ \t]+)?(?:interface|type|enum|namespace)[ \t]+([A-Za-z_$][\w$]*)[ \t]*[<={]/gm,
+		/^(?:module\.)?exports\.([A-Za-z_$][\w$]*)[ \t]*=/gm,
+		/^[ \t]+(?:(?:public|private|protected|static|async|readonly|get|set|\*)[ \t]+)*([A-Za-z_$][\w$]*)[ \t]*\([^)\n]*\)[ \t]*[:{]/gm,
+	],
+	py: [
+		/^[ \t]*(?:async[ \t]+)?def[ \t]+([A-Za-z_]\w*)/gm,
+		/^[ \t]*class[ \t]+([A-Za-z_]\w*)/gm,
+	],
+	go: [/\bfunc\s+(?:\([^)]*\)\s*)?([A-Za-z_]\w*)/g, /\btype\s+([A-Za-z_]\w*)/g],
+	rs: [/\b(?:fn|struct|enum|trait|union|mod)\s+([A-Za-z_]\w*)/g],
+	java: [
+		/\b(?:class|interface|enum|record)\s+([A-Za-z_]\w*)/g,
+		/^[ \t]*(?:(?:public|private|protected|static|final|abstract|synchronized|override|open|fun)[ \t]+)+[\w<>,.[\] ]*?([A-Za-z_]\w*)[ \t]*\(/gm,
+	],
+	rb: [/^[ \t]*(?:def|class|module)[ \t]+(?:self\.)?([A-Za-z_]\w*)/gm],
+	php: [/\b(?:function|class|interface|trait|enum)\s+([A-Za-z_]\w*)/g],
+	c: [
+		/\b(?:struct|union|enum|class)\s+([A-Za-z_]\w*)/g,
+		/^[A-Za-z_][\w \t*&:]*?\b([A-Za-z_]\w*)[ \t]*\([^;)]*\)[ \t]*\{?[ \t]*$/gm,
+	],
+};
+
+const EXTENSION_LANGUAGES: Record<string, string> = {
+	'.js': 'js',
+	'.jsx': 'js',
+	'.mjs': 'js',
+	'.cjs': 'js',
+	'.ts': 'js',
+	'.tsx': 'js',
+	'.mts': 'js',
+	'.cts': 'js',
+	'.py': 'py',
+	'.pyi': 'py',
+	'.go': 'go',
+	'.rs': 'rs',
+	'.java': 'java',
+	'.kt': 'java',
+	'.cs': 'java',
+	'.scala': 'java',
+	'.swift': 'java',
+	'.rb': 'rb',
+	'.php': 'php',
+	'.c': 'c',
+	'.h': 'c',
+	'.cc': 'c',
+	'.cpp': 'c',
+	'.cxx': 'c',
+	'.hpp': 'c',
+};
+
+const IMPORT_PATTERNS: Record<string, RegExp[]> = {
+	js: [
+		/^[ \t]*(?:import|export)[ \t]+(?:type[ \t]+)?([\w${},*\s]*?)[ \t]from[ \t]/gm,
+		/^[ \t]*(?:const|let|var)[ \t]+([\w${},:\s]*?)=[ \t]*(?:await[ \t]+)?require[ \t]*\(/gm,
+	],
+	py: [/^[ \t]*(?:from[ \t]+[\w.]+[ \t]+)?import[ \t]+([^\n]*)/gm],
+	rs: [/\buse\b([^;]*);/g],
+	php: [/\buse\b([^;]*);/g],
+};
+
+const HASH_COMMENT_LANGUAGES = new Set(['py', 'rb']);
+
+const KEYWORDS = new Set([
+	'abstract',
+	'and',
+	'any',
+	'as',
+	'assert',
+	'async',
+	'await',
+	'bool',
+	'boolean',
+	'break',
+	'byte',
+	'case',
+	'catch',
+	'char',
+	'class',
+	'const',
+	'constructor',
+	'continue',
+	'debugger',
+	'def',
+	'default',
+	'del',
+	'delete',
+	'do',
+	'double',
+	'elif',
+	'else',
+	'end',
+	'enum',
+	'except',
+	'export',
+	'extends',
+	'extern',
+	'false',
+	'final',
+	'finally',
+	'float',
+	'fn',
+	'for',
+	'from',
+	'fun',
+	'func',
+	'function',
+	'global',
+	'go',
+	'if',
+	'impl',
+	'implements',
+	'import',
+	'in',
+	'infer',
+	'init',
+	'instanceof',
+	'int',
+	'interface',
+	'is',
+	'keyof',
+	'lambda',
+	'let',
+	'long',
+	'match',
+	'mod',
+	'module',
+	'mut',
+	'namespace',
+	'new',
+	'nil',
+	'none',
+	'not',
+	'null',
+	'number',
+	'object',
+	'open',
+	'or',
+	'override',
+	'package',
+	'pass',
+	'private',
+	'protected',
+	'pub',
+	'public',
+	'raise',
+	'range',
+	'readonly',
+	'record',
+	'ref',
+	'require',
+	'return',
+	'satisfies',
+	'self',
+	'short',
+	'sizeof',
+	'static',
+	'string',
+	'struct',
+	'super',
+	'switch',
+	'symbol',
+	'synchronized',
+	'this',
+	'throw',
+	'trait',
+	'true',
+	'try',
+	'type',
+	'typedef',
+	'typeof',
+	'undefined',
+	'union',
+	'unknown',
+	'unsafe',
+	'use',
+	'using',
+	'var',
+	'void',
+	'when',
+	'where',
+	'while',
+	'with',
+	'yield',
+]);
+
+const IDENTIFIER = /(?<![.\w$])[A-Za-z_$][\w$]*/g;
+const BASE_NOISE =
+	/\/\*[\s\S]*?\*\/|\/\/[^\n]*|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*'|`(?:[^`\\]|\\.)*`/g;
+const HASH_NOISE =
+	/#[^\n]*|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*'|"""[\s\S]*?"""/g;
+
+function stripNoise(source: string, language: string): string {
+	const pattern = HASH_COMMENT_LANGUAGES.has(language)
+		? HASH_NOISE
+		: BASE_NOISE;
+	pattern.lastIndex = 0;
+	return source.replace(/\r\n?/g, '\n').replace(pattern, ' ');
+}
+
+function languageFor(filePath: string): string | undefined {
+	return EXTENSION_LANGUAGES[extname(filePath).toLowerCase()];
+}
+
+function extractDefinitions(source: string, language: string): Set<string> {
+	const names = new Set<string>();
+	for (const pattern of DEFINITION_PATTERNS[language] ?? []) {
+		pattern.lastIndex = 0;
+		let match = pattern.exec(source);
+		while (match !== null) {
+			const name = match[1];
+			if (name && name.length > 1 && !KEYWORDS.has(name)) {
+				names.add(name);
+			}
+			match = pattern.exec(source);
+		}
+	}
+	return names;
+}
+
+function collectIdentifiers(source: string, into: Map<string, number>): void {
+	IDENTIFIER.lastIndex = 0;
+	let match = IDENTIFIER.exec(source);
+	while (match !== null) {
+		const name = match[0];
+		if (name.length > 1 && !KEYWORDS.has(name)) {
+			into.set(name, (into.get(name) ?? 0) + 1);
+		}
+		match = IDENTIFIER.exec(source);
+	}
+}
+
+function countReferences(
+	source: string,
+	language: string,
+): Map<string, number> {
+	const counts = new Map<string, number>();
+	collectIdentifiers(source, counts);
+
+	const importPatterns = IMPORT_PATTERNS[language];
+	if (!importPatterns) {
+		return counts;
+	}
+
+	const imported = new Map<string, number>();
+	for (const pattern of importPatterns) {
+		pattern.lastIndex = 0;
+		let match = pattern.exec(source);
+		while (match !== null) {
+			collectIdentifiers(match[1] ?? '', imported);
+			match = pattern.exec(source);
+		}
+	}
+	for (const name of counts.keys()) {
+		if (!imported.has(name)) {
+			counts.delete(name);
+		}
+	}
+	return counts;
+}
+
+interface ScannedFile {
+	path: string;
+	definitions: Set<string>;
+	references: Map<string, number>;
+}
+
+async function scanFiles(
+	cwd: string,
+	maxFiles: number,
+	maxFileBytes: number,
+): Promise<{files: ScannedFile[]; truncated: boolean}> {
+	const files: ScannedFile[] = [];
+	let truncated = false;
+
+	await walkProjectEntries(cwd, undefined, async entry => {
+		if (entry.isDirectory) {
+			return false;
+		}
+		const language = languageFor(entry.relativePath);
+		if (!language) {
+			return false;
+		}
+
+		let source: string;
+		try {
+			source = await readFile(entry.absolutePath, 'utf-8');
+		} catch {
+			return false;
+		}
+		if (source.length > maxFileBytes) {
+			return false;
+		}
+
+		const stripped = stripNoise(source, language);
+		files.push({
+			path: entry.relativePath.replace(/\\/g, '/'),
+			definitions: extractDefinitions(stripped, language),
+			references: countReferences(stripped, language),
+		});
+
+		if (files.length >= maxFiles) {
+			truncated = true;
+			return true;
+		}
+		return false;
+	});
+
+	return {files, truncated};
+}
+
+function pageRank(
+	nodeCount: number,
+	edges: Map<number, Map<number, number>>,
+): number[] {
+	if (nodeCount === 0) {
+		return [];
+	}
+
+	const base = 1 / nodeCount;
+	const outWeight = new Array<number>(nodeCount).fill(0);
+	for (const [from, targets] of edges) {
+		let total = 0;
+		for (const weight of targets.values()) {
+			total += weight;
+		}
+		outWeight[from] = total;
+	}
+
+	let ranks = new Array<number>(nodeCount).fill(base);
+	for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+		const next = new Array<number>(nodeCount).fill(0);
+		let dangling = 0;
+		for (let node = 0; node < nodeCount; node++) {
+			if (outWeight[node] === 0) {
+				dangling += ranks[node];
+			}
+		}
+		for (const [from, targets] of edges) {
+			const total = outWeight[from];
+			if (total === 0) {
+				continue;
+			}
+			for (const [to, weight] of targets) {
+				next[to] += (ranks[from] * weight) / total;
+			}
+		}
+
+		let delta = 0;
+		for (let node = 0; node < nodeCount; node++) {
+			const value =
+				(1 - DAMPING) * base + DAMPING * (next[node] + dangling * base);
+			delta += Math.abs(value - ranks[node]);
+			next[node] = value;
+		}
+		ranks = next;
+		if (delta < CONVERGENCE) {
+			break;
+		}
+	}
+	return ranks;
+}
+
+function estimateTokens(text: string): number {
+	return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+export async function buildRepoMap(
+	cwd: string,
+	options: RepoMapOptions = {},
+): Promise<RepoMap> {
+	const maxTokens = options.maxTokens ?? DEFAULT_REPO_MAP_TOKENS;
+	const maxSymbolsPerFile =
+		options.maxSymbolsPerFile ?? DEFAULT_MAX_SYMBOLS_PER_FILE;
+	const {files, truncated} = await scanFiles(
+		cwd,
+		options.maxFiles ?? DEFAULT_MAX_FILES,
+		options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES,
+	);
+
+	const definers = new Map<string, number[]>();
+	files.forEach((file, index) => {
+		for (const name of file.definitions) {
+			const existing = definers.get(name);
+			if (existing) {
+				existing.push(index);
+			} else {
+				definers.set(name, [index]);
+			}
+		}
+	});
+
+	const edges = new Map<number, Map<number, number>>();
+	const symbolWeights = files.map(() => new Map<string, number>());
+	files.forEach((file, from) => {
+		for (const [name, count] of file.references) {
+			const targets = definers.get(name);
+			if (!targets || file.definitions.has(name)) {
+				continue;
+			}
+			const share = Math.sqrt(count) / targets.length;
+			let row = edges.get(from);
+			if (!row) {
+				row = new Map<number, number>();
+				edges.set(from, row);
+			}
+			for (const to of targets) {
+				row.set(to, (row.get(to) ?? 0) + share);
+				symbolWeights[to].set(name, (symbolWeights[to].get(name) ?? 0) + share);
+			}
+		}
+	});
+
+	const ranks = pageRank(files.length, edges);
+	const ordered = files
+		.map((file, index) => ({file, index, rank: ranks[index] ?? 0}))
+		.sort((a, b) =>
+			b.rank === a.rank
+				? a.file.path.localeCompare(b.file.path)
+				: b.rank - a.rank,
+		);
+
+	const selected: RepoMapFile[] = [];
+	let usedTokens = 0;
+	let budgetTruncated = false;
+	for (const {file, index, rank} of ordered) {
+		if (file.definitions.size === 0) {
+			continue;
+		}
+		const weights = symbolWeights[index];
+		const symbols = [...file.definitions]
+			.sort((a, b) => {
+				const diff = (weights.get(b) ?? 0) - (weights.get(a) ?? 0);
+				return diff === 0 ? a.localeCompare(b) : diff;
+			})
+			.slice(0, maxSymbolsPerFile);
+		const cost = estimateTokens(`${file.path}\n${symbols.join(' ')}\n`);
+		if (usedTokens + cost > maxTokens) {
+			budgetTruncated = true;
+			break;
+		}
+		usedTokens += cost;
+		selected.push({path: file.path, rank, symbols});
+	}
+
+	return {
+		files: selected,
+		scannedFiles: files.length,
+		totalSymbols: files.reduce((sum, file) => sum + file.definitions.size, 0),
+		truncated: truncated || budgetTruncated,
+	};
+}


### PR DESCRIPTION
## Description

Adds `source/repo-map/`, a dependency-free codebase index, and the `/repomap` slash command that renders it.

The scanner walks the project through the existing `walkProjectEntries` helper, so `.gitignore` and the default ignore directories apply for free. Per file it extracts the symbols that file defines and the identifiers it references, links a referencing file to every file defining a referenced name, and ranks the resulting directed graph with an in-house PageRank.

Three rules keep the graph honest without a real parser: only exported symbols count as definitions (a non-exported symbol cannot be referenced across files anyway), property accesses are not references, and for languages with named imports a reference only creates an edge when the file actually imports that name. Comments and string literals are stripped before either pass.

Covers TypeScript/JavaScript, Python, Go, Rust, Java/Kotlin/C#/Swift, Ruby, PHP and C/C++. Output is budgeted to 1024 tokens by default; `/repomap --tokens <n>` widens it. Scanning nanocoder itself takes ~850ms for 842 files.

This is the first of the three steps agreed on the issue: module plus command only. Prompt injection, the `repo_map` tool and an optional tree-sitter extractor stay out of scope here.

Refs #890

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update one row added to `docs/features/commands.md`

## Changeset

- [x] Added a changeset (`.changeset/repo-map-command.md`, `minor`)

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files **35 tests**, all passing (23 in `source/repo-map/index.spec.ts`, 12 in `source/commands/repomap.spec.tsx`)
- [ ] All existing tests pass (`pnpm test:all` completes successfully) **cannot be checked; see note below**
- [x] Tests cover both success and error scenarios

<details>
<summary>What the 35 tests cover</summary>

Ranking order, symbol ordering by cross-file weight, even weight split across multiple definers, self-reference exclusion, empty repos, symbol-less files, `.gitignore` + default-ignore dirs, per-file byte cap, file-count cap, token-budget truncation, per-file symbol cap, comment/string stripping, export-only indexing, import-scoped references, property-access exclusion, CRLF sources, per-language extraction across all nine language groups, cycle convergence with normalised ranks, deterministic ordering across runs, missing directory, the full `--tokens` argument surface (inline, separated, fractional, clamped, below-minimum, missing, non-numeric, unknown flag), and real Ink renders of the populated / truncated / empty views plus the error path.

</details>

**On `pnpm test:all`:** it does not complete on `main` today, and this PR neither causes nor fixes that. It stops at `test:types`, because the pinned TypeScript 7.0.2 rejects the repo's own `tsconfig.json` (`TS5102: Option 'baseUrl' has been removed`). `test:ava` separately refuses to start under the pinned AVA 8 (`The extensions option must be an array`  `package.json` still has the object form). Both reproduce on a clean `upstream/main` tree with none of my files present, and `git diff upstream/main` confirms this branch touches neither config.

Stage-by-stage, on this branch:

| Stage | Result |
|---|---|
| `test:format` | ✅ pass |
| `test:types` | ❌ pre-existing `tsconfig.json` `baseUrl` vs TypeScript 7 |
| `test:types:vscode` | ❌ pre-existing `TS6059 rootDir` in `plugins/vscode/` under TS 7 |
| `test:lint` | ✅ pass (2 pre-existing warnings in `chat-panel-harness.ts`) |
| `test:ava` | ❌ pre-existing config rejection; with only `ava.extensions` shimmed to an array, the suite runs my 35 pass, and the 19 failing files are **byte-identical** to a clean-`main` baseline (Windows path/shell specs: `getTasksPath` expecting `.nanocoder/tasks.json`, bash-executor, clipboard, CLI discovery) |
| `test:knip` | ✅ pass |
| `test:audit` | ✅ pass |
| `test:security` | ⏭️ skipped semgrep not installed locally |

I ran the failing-file comparison twice (AVA 7 and AVA 8) against a stashed clean tree; the set was identical every time.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it assigned on #890
- [x] Code follows project style guidelines biome clean, tabs/single quotes, `@/*` aliases
- [x] Self-review completed
- [x] Documentation updated (if needed) `docs/features/commands.md`
- [x] No breaking changes (or clearly documented) purely additive: one new module, one new command file, one registry entry
- [ ] Appropriate logging added using structured logging **none added, deliberately.** The command is synchronous request/response with no background work or failure modes worth tracing; errors surface directly in the returned `errorMsg` element. Happy to add `logger` calls to the scan if you'd rather have visibility into per-run file counts and timings.