### PR TITLE
fix(test): strip ANSI before comparing the rendered location-step path

### DIFF
--- a/source/wizards/steps/location-step.spec.tsx
+++ b/source/wizards/steps/location-step.spec.tsx
@@ -1,5 +1,6 @@
 import {resolve} from 'node:path';
 import test from 'ava';
+import stripAnsi from 'strip-ansi';
 import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
 import {renderWithTheme as render} from '@/test-utils/render-with-theme';
@@ -75,7 +76,7 @@ test('LocationStep shows the resolved project path next to the option', t => {
 		line.includes('Current project directory'),
 	);
 	t.true(stemIndex !== -1, 'expected to find the project directory stem');
-	t.is(lines[stemIndex + 1]?.trim(), resolve('/test/project'));
+	t.is(stripAnsi(lines[stemIndex + 1] ?? '').trim(), resolve('/test/project'));
 });
 
 test('LocationStep does not clip the leaf directory inside the real wizard box', t => {


### PR DESCRIPTION
## Description

Rebased onto `main`. #923 landed the `tsconfig.json`, `package.json` and `plugins/vscode/src/package.json` fixes this PR originally carried, so those commits are gone they replayed as no-ops. The `plugins/vscode/tsconfig.json` conflict was resolved in favour of `main`'s `rootDir: "../.."`; `noEmit: true` fixed the same TS6059 error, but there's no reason to re-open a settled decision.

**One change survives**, and it is still needed on `main` today.

### `source/wizards/steps/location-step.spec.tsx`

The test compares a rendered Ink line against a plain path. CI sets `FORCE_COLOR=1`, so the line carries ANSI escapes that `trim()` can't remove — and the reporter prints both sides identically, because the codes are invisible:

```
Difference (- actual, + expected):
- '/test/project'
+ '/test/project'
```

Stripping ANSI first matches what five other view specs in this repo already do. `strip-ansi` is already a devDependency.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset — not applicable: test-only, no user-facing behaviour change. Per CONTRIBUTING, internal chores need no changeset.

## Testing

### Automated Tests

- [ ] New features include passing tests — n/a, test-only
- [x] All existing tests pass
- [ ] Tests cover both success and error scenarios — n/a

Verified on the rebased branch:

| Check | Result |
| --- | --- |
| `FORCE_COLOR=1 ava source/wizards/steps/location-step.spec.tsx` | 17/17 pass |
| same file at `main`'s revision, `FORCE_COLOR=1` | fails `LocationStep shows the resolved project path next to the option` — confirms the fix is still needed |
| `tsc --noEmit` | clean |
| `tsc --noEmit -p plugins/vscode/tsconfig.json` | clean |
| `biome check` | spec files are excluded by `biome.json`, nothing to format |

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it — n/a, no issue
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes — test-only
- [ ] Appropriate logging added
