### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -57,6 +57,15 @@
 			"timeout": 60000,
 			"description": "Dynamic problem-solving through thought sequences"
 		},
+		"gbr": {
+			"transport": "stdio",
+			"command": "node",
+			"args": [
+				"GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"
+			],
+			"description": "Build Remote Agent Bot API (loopback). Requires gbr-agent run. Never put mailbox keys here.",
+			"enabled": false
+		},
 		"custom-server": {
 			"transport": "stdio",
 			"command": "python",

--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -1,3 +1,29 @@
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
 {
 	"mcpServers": {
 		"filesystem": {
@@ -79,3 +105,10 @@
 		}
 	}
 }
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/docs/configuration/mcp-configuration.md
+++ b/docs/configuration/mcp-configuration.md
@@ -6,6 +6,33 @@ sidebar_order: 3
 
 # MCP Server Configuration
 
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
+
 Configure [Model Context Protocol](https://github.com/modelcontextprotocol/servers) (MCP) servers to extend Nanocoder with external tools.
 
 ## Quick Start
@@ -254,13 +281,6 @@ This is not ACP and not the VS Code companion. Pairing stays `gbr-agent pair`
 + `gbr-agent run`. Attach is only `http://127.0.0.1:8788` or `gbr-mcp` stdio.
 Phone is spectator + veto.
 
-```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version          # must print v0.6.0 or newer
-gbr-agent pair && gbr-agent run
-git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
-cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
-```
 
 Add to project or global `.mcp.json` (see also `.mcp.example.json`):
 
@@ -311,3 +331,10 @@ Run `/settings mcp` for interactive configuration with:
 - _Environment variables_ — Ensure all `$VAR` references resolve. Unset variables resolve to empty strings.
 
 For more servers and community configurations, see the [MCP servers repository](https://github.com/modelcontextprotocol/servers).
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/docs/configuration/mcp-configuration.md
+++ b/docs/configuration/mcp-configuration.md
@@ -239,6 +239,54 @@ Supported syntax: `$VAR`, `${VAR}`, `${VAR:-default}`
 
 > **Security:** Project-level `.mcp.json` files are typically version controlled. Always use environment variable references for sensitive values.
 
+## Phone pairing (Build Remote Agent)
+
+Nanocoder can attach **Build Remote Agent** as a pairing device: the
+iOS/Android app spectates (and can inject into) this desktop session through
+the free MIT `gbr-agent`. Phone and PC never open ports to each other.
+
+Website: https://grokbuildremote.com/ · Agent:
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT) · Protocol
+`gbr/1` (agent **v0.6.0+**). Independent product. Not affiliated with xAI or
+SpaceX.
+
+This is not ACP and not the VS Code companion. Pairing stays `gbr-agent pair`
++ `gbr-agent run`. Attach is only `http://127.0.0.1:8788` or `gbr-mcp` stdio.
+Phone is spectator + veto.
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version          # must print v0.6.0 or newer
+gbr-agent pair && gbr-agent run
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+```
+
+Add to project or global `.mcp.json` (see also `.mcp.example.json`):
+
+```json
+{
+  "mcpServers": {
+    "gbr": {
+      "transport": "stdio",
+      "command": "node",
+      "args": [
+        "GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"
+      ],
+      "description": "Build Remote Agent Bot API (loopback). Requires gbr-agent run. Never put mailbox keys here."
+    }
+  }
+}
+```
+
+Point `args` at the absolute path to `bin/gbr-mcp.js`. Then `/mcp` to confirm
+the server. Do not commit mailbox keys.
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
 ## Setup Wizard
 
 Run `/settings mcp` for interactive configuration with:


### PR DESCRIPTION
## What

Optional **Build Remote Agent** pairing device so a phone can spectate this desktop agent.

Protocol stays `gbr/1` (not a fourth pair protocol):

1. Install `gbr-agent` v0.6.0+ from https://grokbuildremote.com/
2. `gbr-agent pair` — browser QR **and** printed 8-char code
3. Phone scans or types the code
4. `gbr-agent run` (leave running)
5. Attach only `http://127.0.0.1:8788` or `gbr-mcp` stdio

Phone is spectator + veto. Orchestration stays on this agent.

Independent product by Linespotting AB. **Not affiliated with xAI or SpaceX.**

Agent source (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents

## Files

Docs / MCP snippet only. No product-runtime change. No mailbox keys.

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version    # need v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```
