### PR TITLE
feat: surface usage tips on startup and via /tip

### DIFF
--- a/.changeset/kind-tips-wave.md
+++ b/.changeset/kind-tips-wave.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added discoverable usage tips to the welcome screen and a `/tip` command for showing another tip on demand.

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -33,6 +33,7 @@ Type `/` in the chat input to see available commands. All commands start with `/
 | `/doctor` | Show environment health report for bug reports |
 | `/update` | Update Nanocoder to the latest version |
 | `/usage` | Get current model context usage visually |
+| `/tip` | Show a random usage tip, shortcut, or slash command |
 | `/lsp` | List connected LSP servers |
 | `/schedule` | Read-only view of cron subscriptions declared by skills (see [Skills → Event subscriptions](skills.md#event-subscriptions)) |
 | `/skills` | List and inspect loaded skills; scaffold new bundle skills with AI assistance (see [Skills](skills.md)) |

--- a/source/commands/lazy-registry.ts
+++ b/source/commands/lazy-registry.ts
@@ -148,6 +148,11 @@ export const lazyCommands: LazyCommand[] = [
 		load: () => import('@/commands/usage').then(m => m.usageCommand),
 	},
 	{
+		name: 'tip',
+		description: 'Show a random Nanocoder usage tip',
+		load: () => import('@/commands/tip').then(m => m.tipCommand),
+	},
+	{
 		name: 'checkpoint',
 		description:
 			'Manage conversation checkpoints - save and restore session snapshots',

--- a/source/commands/tip.spec.tsx
+++ b/source/commands/tip.spec.tsx
@@ -1,0 +1,23 @@
+import test from 'ava';
+import React from 'react';
+import {TIPS} from '@/constants';
+import {tipCommand} from './tip';
+
+test('tipCommand has the expected metadata', t => {
+	t.is(tipCommand.name, 'tip');
+	t.is(tipCommand.description, 'Show a random Nanocoder usage tip');
+});
+
+test('tipCommand returns a tip from the shared catalogue', async t => {
+	const result = await tipCommand.handler([], [], {
+		provider: 'test',
+		model: 'test',
+		tokens: 0,
+		getMessageTokens: () => 0,
+	});
+
+	t.true(React.isValidElement(result));
+	const message = (result as React.ReactElement<{message: string}>).props.message;
+	t.true(message.startsWith('Tip: '));
+	t.true(TIPS.some(tip => message === `Tip: ${tip}`));
+});

--- a/source/commands/tip.tsx
+++ b/source/commands/tip.tsx
@@ -1,0 +1,9 @@
+import type {Command} from '@/types/index';
+import {infoMsg} from '@/utils/message-factory';
+import {getRandomTip} from '@/utils/tips';
+
+export const tipCommand: Command = {
+	name: 'tip',
+	description: 'Show a random Nanocoder usage tip',
+	handler: async () => infoMsg(`Tip: ${getRandomTip()}`, 'tip'),
+};

--- a/source/components/welcome-message.spec.tsx
+++ b/source/components/welcome-message.spec.tsx
@@ -3,6 +3,7 @@ import path from 'path';
 import {fileURLToPath} from 'url';
 import test from 'ava';
 import React from 'react';
+import {TIPS} from '@/constants';
 import {renderWithTheme} from '../test-utils/render-with-theme.js';
 import WelcomeMessage from './welcome-message';
 
@@ -61,6 +62,17 @@ test('WelcomeMessage shows quick tips in narrow layout', t => {
 	t.regex(output!, /\/help for commands/);
 	t.regex(output!, /Ctrl\+C to quit/);
 
+	process.stdout.columns = originalColumns;
+});
+
+test('WelcomeMessage shows a tip of the day in narrow layout', t => {
+	const originalColumns = process.stdout.columns;
+	process.stdout.columns = 50;
+
+	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
+	const output = lastFrame() ?? '';
+
+	t.true(TIPS.some(tip => output.includes(`Tip: ${tip}`)));
 	process.stdout.columns = originalColumns;
 });
 
@@ -137,6 +149,17 @@ test('WelcomeMessage shows help command for normal terminal', t => {
 	t.truthy(output);
 	t.regex(output!, /\/help for help/);
 
+	process.stdout.columns = originalColumns;
+});
+
+test('WelcomeMessage shows a tip of the day in full layout', t => {
+	const originalColumns = process.stdout.columns;
+	process.stdout.columns = 120;
+
+	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
+	const output = lastFrame() ?? '';
+
+	t.true(TIPS.some(tip => output.includes(`Tip: ${tip}`)));
 	process.stdout.columns = originalColumns;
 });
 

--- a/source/components/welcome-message.tsx
+++ b/source/components/welcome-message.tsx
@@ -3,13 +3,14 @@ import {Box, Text} from 'ink';
 import BigText from 'ink-big-text';
 import Gradient from 'ink-gradient';
 import path from 'path';
-import {memo} from 'react';
+import {memo, useState} from 'react';
 import {fileURLToPath} from 'url';
 import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {getNanocoderShape} from '@/config/preferences';
 import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
 import type {NanocoderShape} from '@/types/ui';
+import {getRandomTip} from '@/utils/tips';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -24,6 +25,7 @@ const DEFAULT_SHAPE: NanocoderShape = 'tiny';
 export default memo(function WelcomeMessage() {
 	const {boxWidth, isNarrow, isNormal} = useResponsiveTerminal();
 	const {colors} = useTheme();
+	const [tip] = useState(getRandomTip);
 
 	// Get the user's preferred nanocoder shape or use default
 	const nanocoderShape = getNanocoderShape() ?? DEFAULT_SHAPE;
@@ -97,6 +99,11 @@ export default memo(function WelcomeMessage() {
 					</TitledBoxWithPreferences>
 				</>
 			)}
+			<Box paddingX={isNarrow ? 1 : 2} marginBottom={1}>
+				<Text color={colors.secondary} dimColor>
+					Tip: {tip}
+				</Text>
+			</Box>
 		</>
 	);
 });

--- a/source/constants.ts
+++ b/source/constants.ts
@@ -79,6 +79,23 @@ export const TABLE_COLUMN_MIN_WIDTH = 10;
 export const WIZARD_ROW_CHROME_CHARS = 10;
 export const MIN_PATH_BUDGET_CHARS = 10;
 
+// Short, discoverable hints shown on the welcome screen and by `/tip`.
+// Keep these aligned with the documented command and keyboard behaviour.
+export const TIPS = [
+	'Press Ctrl+J to add a new line without sending your prompt.',
+	'Press Shift+Tab to cycle between development modes.',
+	'Press Ctrl+O to toggle compact tool output.',
+	'Press Ctrl+R to toggle expanded reasoning traces.',
+	'Use @ followed by a file path to add that file to context.',
+	'Use /explorer to browse project files and add them to context.',
+	'Run /checkpoint create before a risky refactor so you can restore it later.',
+	'Run /compact --preview to inspect a context compression before applying it.',
+	'Run /copy to copy the last assistant response to your clipboard.',
+	'Run /usage to see how much of the current model context is in use.',
+	'Run /model to switch providers or models without restarting your session.',
+	'Paste an image with Ctrl+V when your selected model supports vision.',
+] as const;
+
 // === TOKEN THRESHOLDS (percentages - useChatHandler) ===
 export const TOKEN_THRESHOLD_WARNING_PERCENT = 80;
 export const TOKEN_THRESHOLD_CRITICAL_PERCENT = 95;

--- a/source/utils/tips.spec.ts
+++ b/source/utils/tips.spec.ts
@@ -1,0 +1,17 @@
+import test from 'ava';
+import {TIPS} from '@/constants';
+import {getRandomTip} from './tips';
+
+test('getRandomTip selects the first tip at the lower boundary', t => {
+	t.is(getRandomTip(() => 0), TIPS[0]);
+});
+
+test('getRandomTip selects the last tip at the upper boundary', t => {
+	t.is(getRandomTip(() => 0.999_999), TIPS.at(-1));
+});
+
+test('getRandomTip always returns a tip from the catalogue', t => {
+	for (const random of [0, 0.1, 0.25, 0.5, 0.75, 0.999_999]) {
+		t.true(TIPS.includes(getRandomTip(() => random)));
+	}
+});

--- a/source/utils/tips.ts
+++ b/source/utils/tips.ts
@@ -1,0 +1,6 @@
+import {TIPS} from '@/constants';
+
+/** Return one tip using an injectable random source for deterministic tests. */
+export function getRandomTip(random: () => number = Math.random): string {
+	return TIPS[Math.floor(random() * TIPS.length)] ?? TIPS[0];
+}


### PR DESCRIPTION
## Description

Adds a small discovery loop for useful Nanocoder features: every new interactive welcome screen shows one stable, randomly selected tip, and `/tip` returns another on demand.

The implementation keeps startup light by registering `/tip` through the existing lazy command registry. Both entry points share one catalogue and one selector, with an injectable random source for deterministic boundary tests.

Closes #929.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Changeset

- [x] Added a changeset describing the user-facing change

## Testing

### Automated Tests

- [x] New feature includes passing `.spec.ts/tsx` tests
- [ ] Full `pnpm test:all` (CI requested; local Windows run was split because AVA startup exceeded its default harness timeout)
- [x] Selector boundaries, shared-catalogue output, and narrow/full welcome layouts are covered

Local verification:
- 24 feature/component assertions passed
- 50 CLI harness/integration assertions passed after production build
- `pnpm test:types`
- `pnpm test:types:vscode`
- `pnpm test:format`
- `pnpm test:lint`
- `KNIP_DISABLE_RAW_TRANSFER=1 pnpm test:knip` (normal parser for an 8 GB host)
- `pnpm test:audit`
- `pnpm build` under Git Bash
- repository pre-commit supply-chain and lint-staged gates

### Manual Testing

- [ ] Tested with Ollama (not applicable; no provider calls)
- [ ] Tested with OpenRouter (not applicable; no provider calls)
- [ ] Tested with OpenAI-compatible API (not applicable; no provider calls)
- [ ] Tested MCP integration (not applicable)

## Checklist

- [x] Assigned to the issue (requested in #929; contributor self-assignment is permission-restricted)
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No breaking changes
- [x] Structured logging not applicable; this adds no stateful or background operation