### PR TITLE
Fix Expand Tool Results label inverted and compactToolDisplay preference never read at startup

### DIFF
--- a/.changeset/fix-compactToolDisplay-preferences.md
+++ b/.changeset/fix-compactToolDisplay-preferences.md
@@ -1,0 +1,6 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix Expand Tool Results label inverted and compactToolDisplay preference never read at startup
+  

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -829,7 +829,9 @@ export function SettingsDisplayPanel({
 				value: 'reasoningExpanded' as ToggleKey,
 			},
 			{
-				label: `Expand Tool Results by default: ${isOn(currentCompactToolDisplay)}`,
+				// compactToolDisplay=true means results are COMPACT, so
+				// expansion is on exactly when the preference is false.
+				label: `Expand Tool Results by default: ${isOn(!currentCompactToolDisplay)}`,
 				value: 'compactToolDisplay' as ToggleKey,
 			},
 		];

--- a/source/hooks/useAppState.tsx
+++ b/source/hooks/useAppState.tsx
@@ -149,8 +149,10 @@ export function useAppState(
 	const reasoningExpandedRef = useRef(false);
 	reasoningExpandedRef.current = reasoningExpanded;
 
-	// Compact tool display state
-	const [compactToolDisplay, setCompactToolDisplay] = useState<boolean>(true);
+	// Set to preference on launch, but can be toggled freely during runtime
+	const [compactToolDisplay, setCompactToolDisplay] = useState<boolean>(
+		preferences.compactToolDisplay ?? true,
+	);
 	// Ref keeps current value accessible to long-running async loops
 	const compactToolDisplayRef = useRef(true);
 	compactToolDisplayRef.current = compactToolDisplay;


### PR DESCRIPTION

## Description

Fix Expand Tool Results label inverted and compactToolDisplay preference never read at startup

Closes https://github.com/Nano-Collective/nanocoder/issues/942
* https://github.com/Nano-Collective/nanocoder/issues/942

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
