### PR TITLE
Display compound bash commands on separate lines in execute_bash output

### DIFF
--- a/.changeset/shell-command-display.md
+++ b/.changeset/shell-command-display.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Display compound bash commands on separate lines in execute_bash output

--- a/source/components/bash-progress.spec.tsx
+++ b/source/components/bash-progress.spec.tsx
@@ -53,6 +53,40 @@ test('BashProgress displays the command', t => {
 	t.regex(output!, /npm run build/);
 });
 
+test('BashProgress splits compound commands onto separate lines', t => {
+	const command = 'dolt version; echo "==="; ls -la /usr/local/bin/dolt';
+	const {lastFrame} = renderWithTheme(
+		<BashProgress
+			executionId="test-id"
+			command={command}
+			completedState={createCompletedState({command})}
+		/>,
+	);
+
+	const output = lastFrame();
+	t.truthy(output);
+	const lines = output!.split('\n').map(line => line.trim());
+	t.true(lines.includes('dolt version;'));
+	t.true(lines.includes('echo "===";'));
+	t.true(lines.includes('ls -la /usr/local/bin/dolt'));
+});
+
+test('BashProgress keeps a quoted semicolon on one line', t => {
+	const command = 'echo "hello; world"';
+	const {lastFrame} = renderWithTheme(
+		<BashProgress
+			executionId="test-id"
+			command={command}
+			completedState={createCompletedState({command})}
+		/>,
+	);
+
+	const output = lastFrame();
+	t.truthy(output);
+	const lines = output!.split('\n').map(line => line.trim());
+	t.true(lines.includes('echo "hello; world"'));
+});
+
 test('BashProgress displays execute_bash tool name', t => {
 	const {lastFrame} = renderWithTheme(
 		<BashProgress

--- a/source/components/bash-progress.spec.tsx
+++ b/source/components/bash-progress.spec.tsx
@@ -65,10 +65,17 @@ test('BashProgress splits compound commands onto separate lines', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	const lines = output!.split('\n').map(line => line.trim());
-	t.true(lines.includes('dolt version;'));
-	t.true(lines.includes('echo "===";'));
-	t.true(lines.includes('ls -la /usr/local/bin/dolt'));
+	const lines = output!.split('\n');
+	t.true(lines.some(line => line.includes('dolt version;')));
+	t.true(lines.some(line => line.includes('echo "===";')));
+	t.true(lines.some(line => line.includes('ls -la /usr/local/bin/dolt')));
+	// The whole point: no single rendered line carries two segments
+	t.false(
+		lines.some(
+			line => line.includes('dolt version;') && line.includes('ls -la'),
+		),
+		'Compound segments must not share a line',
+	);
 });
 
 test('BashProgress keeps a quoted semicolon on one line', t => {
@@ -83,8 +90,8 @@ test('BashProgress keeps a quoted semicolon on one line', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	const lines = output!.split('\n').map(line => line.trim());
-	t.true(lines.includes('echo "hello; world"'));
+	const lines = output!.split('\n');
+	t.true(lines.some(line => line.includes('echo "hello; world"')));
 });
 
 test('BashProgress displays execute_bash tool name', t => {

--- a/source/components/bash-progress.tsx
+++ b/source/components/bash-progress.tsx
@@ -5,6 +5,7 @@ import ToolMessage from '@/components/tool-message';
 import {BASH_OUTPUT_DISPLAY_LINES, TRUNCATION_OUTPUT_LIMIT} from '@/constants';
 import {useTheme} from '@/hooks/useTheme';
 import {type BashExecutionState, bashExecutor} from '@/services/bash-executor';
+import {splitCommandForDisplay} from '@/utils/shell-command-display';
 import {calculateTokens} from '@/utils/token-calculator';
 
 interface BashProgressProps {
@@ -115,9 +116,11 @@ export default function BashProgress({
 
 			<Box flexDirection="column">
 				<Text color={colors.secondary}>Command:</Text>
-				<Text wrap="wrap" color={colors.primary}>
-					{command}
-				</Text>
+				{splitCommandForDisplay(command).map((segment, i) => (
+					<Text key={i} wrap="wrap" color={colors.primary}>
+						{segment}
+					</Text>
+				))}
 			</Box>
 			{state.isComplete && (
 				<Box>

--- a/source/tools/execute-bash.spec.tsx
+++ b/source/tools/execute-bash.spec.tsx
@@ -93,10 +93,17 @@ test('ExecuteBashFormatter splits compound commands onto separate lines', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	const lines = output!.split('\n').map(line => line.trim());
-	t.true(lines.includes('dolt version;'));
-	t.true(lines.includes('echo "===";'));
-	t.true(lines.includes('ls -la /usr/local/bin/dolt'));
+	const lines = output!.split('\n');
+	t.true(lines.some(line => line.includes('dolt version;')));
+	t.true(lines.some(line => line.includes('echo "===";')));
+	t.true(lines.some(line => line.includes('ls -la /usr/local/bin/dolt')));
+	// The whole point: no single rendered line carries two segments
+	t.false(
+		lines.some(
+			line => line.includes('dolt version;') && line.includes('ls -la'),
+		),
+		'Compound segments must not share a line',
+	);
 });
 
 test('ExecuteBashFormatter keeps a quoted semicolon on one line', t => {
@@ -111,8 +118,8 @@ test('ExecuteBashFormatter keeps a quoted semicolon on one line', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	const lines = output!.split('\n').map(line => line.trim());
-	t.true(lines.includes('echo "hello; world"'));
+	const lines = output!.split('\n');
+	t.true(lines.some(line => line.includes('echo "hello; world"')));
 });
 
 test('ExecuteBashFormatter handles complex commands', t => {

--- a/source/tools/execute-bash.spec.tsx
+++ b/source/tools/execute-bash.spec.tsx
@@ -80,6 +80,41 @@ test('ExecuteBashFormatter renders without result', t => {
 	t.regex(output!, /ls/);
 });
 
+test('ExecuteBashFormatter splits compound commands onto separate lines', t => {
+	const formatter = executeBashTool.formatter;
+	if (!formatter) {
+		t.fail('Formatter is not defined');
+		return;
+	}
+
+	const command = 'dolt version; echo "==="; ls -la /usr/local/bin/dolt';
+	const element = formatter({command});
+	const {lastFrame} = render(<TestThemeProvider>{element}</TestThemeProvider>);
+
+	const output = lastFrame();
+	t.truthy(output);
+	const lines = output!.split('\n').map(line => line.trim());
+	t.true(lines.includes('dolt version;'));
+	t.true(lines.includes('echo "===";'));
+	t.true(lines.includes('ls -la /usr/local/bin/dolt'));
+});
+
+test('ExecuteBashFormatter keeps a quoted semicolon on one line', t => {
+	const formatter = executeBashTool.formatter;
+	if (!formatter) {
+		t.fail('Formatter is not defined');
+		return;
+	}
+
+	const element = formatter({command: 'echo "hello; world"'});
+	const {lastFrame} = render(<TestThemeProvider>{element}</TestThemeProvider>);
+
+	const output = lastFrame();
+	t.truthy(output);
+	const lines = output!.split('\n').map(line => line.trim());
+	t.true(lines.includes('echo "hello; world"'));
+});
+
 test('ExecuteBashFormatter handles complex commands', t => {
 	const formatter = executeBashTool.formatter;
 	if (!formatter) {

--- a/source/tools/execute-bash.tsx
+++ b/source/tools/execute-bash.tsx
@@ -9,6 +9,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {type BashExecutionState, bashExecutor} from '@/services/bash-executor';
 import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
+import {splitCommandForDisplay} from '@/utils/shell-command-display';
 import {truncateToolResult} from '@/utils/truncate-tool-result';
 
 /**
@@ -103,9 +104,11 @@ function ExecuteBashFormatterComponent({
 			<Text color={colors.tool}>⚒ execute_bash</Text>
 			<Box flexDirection="column">
 				<Text color={colors.secondary}>Command:</Text>
-				<Text wrap="wrap" color={colors.primary}>
-					{command}
-				</Text>
+				{splitCommandForDisplay(command).map((segment, i) => (
+					<Text key={i} wrap="wrap" color={colors.primary}>
+						{segment}
+					</Text>
+				))}
 			</Box>
 		</Box>
 	);

--- a/source/utils/shell-command-display.spec.ts
+++ b/source/utils/shell-command-display.spec.ts
@@ -1,0 +1,157 @@
+import test from 'ava';
+import {splitCommandForDisplay} from './shell-command-display';
+
+console.log('\nshell-command-display.spec.ts');
+
+// ============================================================================
+// Splitting on top-level `;`
+// ============================================================================
+
+test('splits top-level ;-separated commands onto separate lines', t => {
+	t.deepEqual(
+		splitCommandForDisplay(
+			'dolt version; echo "==="; ls -la /usr/local/bin/dolt',
+		),
+		['dolt version;', 'echo "===";', 'ls -la /usr/local/bin/dolt'],
+	);
+});
+
+test('splits a simple compound command', t => {
+	t.deepEqual(splitCommandForDisplay('a; b; c'), ['a;', 'b;', 'c']);
+});
+
+test('keeps a trailing ; on its own segment', t => {
+	t.deepEqual(splitCommandForDisplay('ls;'), ['ls;']);
+});
+
+test('trims whitespace around each segment', t => {
+	t.deepEqual(splitCommandForDisplay('  a  ;  b  '), ['a;', 'b']);
+});
+
+// ============================================================================
+// Quoted / escaped ; must be left alone
+// ============================================================================
+
+test('does not split a quoted semicolon', t => {
+	t.deepEqual(splitCommandForDisplay('echo "hello; world"'), [
+		'echo "hello; world"',
+	]);
+});
+
+test('does not split a semicolon inside single quotes', t => {
+	t.deepEqual(splitCommandForDisplay("awk '{print $1; print $2}' file"), [
+		"awk '{print $1; print $2}' file",
+	]);
+});
+
+test('does not split an escaped semicolon', t => {
+	t.deepEqual(
+		splitCommandForDisplay('find . -name "*.tmp" -exec rm {} \\;'),
+		['find . -name "*.tmp" -exec rm {} \\;'],
+	);
+});
+
+test('does not split a semicolon in a quoted commit message', t => {
+	t.deepEqual(splitCommandForDisplay('git commit -m "fix; refactor"'), [
+		'git commit -m "fix; refactor"',
+	]);
+});
+
+// ============================================================================
+// Regions where `;` is not a statement separator (kept on one segment)
+// ============================================================================
+
+test('keeps a semicolon inside command substitution', t => {
+	t.deepEqual(splitCommandForDisplay('echo $(a; b); ls'), ['echo $(a; b);', 'ls']);
+});
+
+test('keeps a semicolon inside a subshell', t => {
+	t.deepEqual(splitCommandForDisplay('(a; b); c'), ['(a; b);', 'c']);
+});
+
+test('keeps a semicolon inside a brace group', t => {
+	t.deepEqual(splitCommandForDisplay('{ a; b; }; c'), ['{ a; b; };', 'c']);
+});
+
+test('keeps a semicolon inside backticks', t => {
+	t.deepEqual(splitCommandForDisplay('echo `a; b`; ls'), ['echo `a; b`;', 'ls']);
+});
+
+test('keeps a semicolon inside parameter expansion', t => {
+	t.deepEqual(splitCommandForDisplay('echo ${VAR:-a;b}; ls'), [
+		'echo ${VAR:-a;b};',
+		'ls',
+	]);
+});
+
+test('splits around command substitution in a realistic command', t => {
+	const command =
+		'cd /x && ls -la y 2>&1; echo "---"; NPM_BIN=$(dirname "$(which n)"); find z';
+	t.deepEqual(splitCommandForDisplay(command), [
+		'cd /x && ls -la y 2>&1;',
+		'echo "---";',
+		'NPM_BIN=$(dirname "$(which n)");',
+		'find z',
+	]);
+});
+
+test('keeps a semicolon inside nested substitution', t => {
+	t.deepEqual(splitCommandForDisplay('x=$(a; $(b; c)); y'), [
+		'x=$(a; $(b; c));',
+		'y',
+	]);
+});
+
+test('honors an escaped quote inside double quotes', t => {
+	t.deepEqual(splitCommandForDisplay('echo "say \\"hi\\"; again"; ls'), [
+		'echo "say \\"hi\\"; again";',
+		'ls',
+	]);
+});
+
+test('does not treat region chars inside quotes as regions', t => {
+	t.deepEqual(splitCommandForDisplay('echo "{a; b} (c; d)"; ls'), [
+		'echo "{a; b} (c; d)";',
+		'ls',
+	]);
+});
+
+test('does not split on && or || (only ; is a separator)', t => {
+	t.deepEqual(splitCommandForDisplay('cd x && make; ls'), ['cd x && make;', 'ls']);
+	t.deepEqual(splitCommandForDisplay('a || b; c'), ['a || b;', 'c']);
+});
+
+test('leaves an empty command unchanged', t => {
+	t.deepEqual(splitCommandForDisplay(''), ['']);
+	t.deepEqual(splitCommandForDisplay('   '), ['   ']);
+});
+
+// ============================================================================
+// Constructs where `;` is not a statement separator → bail, unchanged
+// ============================================================================
+
+test('leaves a for loop unchanged', t => {
+	t.deepEqual(splitCommandForDisplay('for f in *.ts; do echo $f; done'), [
+		'for f in *.ts; do echo $f; done',
+	]);
+});
+
+test('leaves a heredoc unchanged', t => {
+	const command = 'cat <<EOF\nhello; world\nEOF';
+	t.deepEqual(splitCommandForDisplay(command), [command]);
+});
+
+test('leaves unbalanced brackets unchanged', t => {
+	t.deepEqual(splitCommandForDisplay('echo (a; b'), ['echo (a; b']);
+});
+
+test('leaves an unterminated quote unchanged', t => {
+	t.deepEqual(splitCommandForDisplay('echo "unterminated; ls'), [
+		'echo "unterminated; ls',
+	]);
+});
+
+test('leaves a plain single command unchanged', t => {
+	t.deepEqual(splitCommandForDisplay('ls -la'), ['ls -la']);
+});
+

--- a/source/utils/shell-command-display.ts
+++ b/source/utils/shell-command-display.ts
@@ -1,0 +1,52 @@
+// Display-only: split a command on top-level ; for readability (execution untouched).
+export function splitCommandForDisplay(command: string): string[] {
+	if (command.trim().length === 0) return [command];
+	if (/<<|\b(?:for|while|until|if|case|select)\b/.test(command)) {
+		return [command];
+	}
+
+	const segments: string[] = [];
+	let current = '';
+	let quote: '"' | "'" | null = null;
+	let backtick = false;
+	let depth = 0;
+
+	for (let i = 0; i < command.length; i++) {
+		const ch = command[i];
+		if (ch === '\\' && quote !== "'") {
+			current += ch + (command[++i] ?? '');
+		} else if (quote) {
+			current += ch;
+			if (ch === quote) quote = null;
+		} else if (backtick) {
+			current += ch;
+			if (ch === '`') backtick = false;
+		} else if (ch === '"' || ch === "'") {
+			quote = ch;
+			current += ch;
+		} else if (ch === '`') {
+			backtick = true;
+			current += ch;
+		} else if (ch === '(' || ch === '{') {
+			depth++;
+			current += ch;
+		} else if ((ch === ')' || ch === '}') && depth > 0) {
+			depth--;
+			current += ch;
+		} else if (ch === ';' && depth === 0) {
+			segments.push(current);
+			current = '';
+		} else {
+			current += ch;
+		}
+	}
+
+	if (quote || backtick || depth > 0) return [command];
+	segments.push(current);
+
+	return segments
+		.map((segment, i) =>
+			i < segments.length - 1 ? `${segment.trim()};` : segment.trim(),
+		)
+		.filter(line => line.length > 0);
+}


### PR DESCRIPTION
## Description
Display compound bash commands on separate lines in execute_bash output

Resolves https://github.com/Nano-Collective/nanocoder/issues/1262

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
