### PR TITLE
feat(export): auto-generate descriptive filenames from first user message

### DIFF
--- a/.changeset/fiery-hats-pick.md
+++ b/.changeset/fiery-hats-pick.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Auto-generate descriptive filenames for /export instead of generic timestamps. Closes #934

--- a/source/commands/export.spec.tsx
+++ b/source/commands/export.spec.tsx
@@ -203,12 +203,17 @@ test('exportCommand renders Export component with correct filename', async t => 
 });
 
 test('exportCommand rejects path traversal in filename', async t => {
-	const result = await exportCommand.handler(
+	const result = (await exportCommand.handler(
 		['../../../etc/passwd'],
 		testMessages,
 		testMetadata,
-	);
+	)) as React.ReactElement;
 
 	t.is(mockWriteFileCalls.length, 0);
-	t.truthy(React.isValidElement(result));
+
+	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Invalid filename/);
+	t.false(output!.includes('Chat exported'));
 });

--- a/source/commands/export.spec.tsx
+++ b/source/commands/export.spec.tsx
@@ -245,3 +245,52 @@ test('exportCommand rejects path traversal in filename', async t => {
 	t.regex(output!, /Invalid filename/);
 	t.false(output!.includes('Chat exported'));
 });
+
+	test('exportCommand allows exporting into a subdirectory', async t => {
+	// isValidFilePath is segment-aware, so a subdirectory export must work while
+	// traversal is still blocked.
+	await exportCommand.handler(
+		['reports/chat.md'],
+		testMessages,
+		testMetadata,
+	);
+
+	t.is(mockWriteFileCalls.length, 1);
+	t.true(mockWriteFileCalls[0].path.endsWith('chat.md'));
+	t.true(
+		mockWriteFileCalls[0].path
+			.split(/[\\/]/)
+			.slice(-2)
+			.join('/') === 'reports/chat.md',
+	);
+});
+
+test('exportCommand rejects a filename with a null byte', async t => {
+	const result = (await exportCommand.handler(
+		['evil\u0000.md'],
+		testMessages,
+		testMetadata,
+	)) as React.ReactElement;
+
+	t.is(mockWriteFileCalls.length, 0);
+
+	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Invalid filename/);
+});
+
+test('exportCommand rejects a home-directory shorthand path', async t => {
+	const result = (await exportCommand.handler(
+		['~/notes.md'],
+		testMessages,
+		testMetadata,
+	)) as React.ReactElement;
+
+	t.is(mockWriteFileCalls.length, 0);
+
+	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Invalid filename/);
+});

--- a/source/commands/export.spec.tsx
+++ b/source/commands/export.spec.tsx
@@ -7,6 +7,11 @@ import React from 'react';
 import {render} from 'ink-testing-library';
 import {themes} from '../config/themes';
 import {ThemeContext} from '../hooks/useTheme';
+import {
+	resetSessionCwd,
+	setProjectRoot,
+	setSessionCwd,
+} from '../services/session-cwd';
 
 // Mock fs module
 const originalWriteFile = fs.writeFile;
@@ -18,10 +23,13 @@ test.beforeEach(() => {
 		mockWriteFileCalls.push({path: filepath, content});
 		return Promise.resolve(void 0);
 	};
+	// Isolate each test from session-cwd state set by others.
+	resetSessionCwd();
 });
 
 test.afterEach(() => {
 	fs.writeFile = originalWriteFile;
+	resetSessionCwd();
 });
 
 // Mock ThemeProvider for testing
@@ -332,4 +340,81 @@ test('exportCommand rejects an absolute path outside the project', async t => {
 	const output = lastFrame();
 	t.truthy(output);
 	t.regex(output!, /Invalid export path/);
+});
+
+test('exportCommand resolves a relative path against the session cwd (honours cd)', async t => {
+	// Pin the session cwd to a subdirectory, as a bash `cd` would, and confirm a
+	// bare relative export lands there -- not in the launch dir (process.cwd()).
+	const subdir = path.join(process.cwd(), 'tmp-session-cwd-test');
+	await fs.mkdir(subdir, {recursive: true});
+	setSessionCwd(subdir);
+
+	await exportCommand.handler(['chat.md'], testMessages, testMetadata);
+
+	t.is(mockWriteFileCalls.length, 1);
+	const expected = path.join(subdir, 'chat.md');
+	t.is(mockWriteFileCalls[0].path, expected);
+	await fs.rm(subdir, {recursive: true});
+});
+
+test('exportCommand contains writes to the project root even when the session cwd is deeper', async t => {
+	// A pinned project root is the non-shrinking containment boundary. With the
+	// session cwd inside a worktree, an absolute path inside the project root
+	// (but above the cwd) is still allowed, while one above the project root is
+	// rejected. Relative '..' is blocked outright by isValidFilePath.
+	const root = path.join(process.cwd(), 'tmp-prjroot-test');
+	const subdir = path.join(root, 'worktree');
+	await fs.mkdir(subdir, {recursive: true});
+	setProjectRoot(root);
+	setSessionCwd(subdir);
+
+	// Absolute path inside the project root but above the session cwd is allowed.
+	const insideRoot = path.join(root, 'chat.md');
+	await exportCommand.handler([insideRoot], testMessages, testMetadata);
+	t.is(mockWriteFileCalls.length, 1);
+	t.is(mockWriteFileCalls[0].path, insideRoot);
+
+	// Absolute path escaping above the project root is rejected.
+	const outside = path.join(root, '..', 'outside.md');
+	const escape = (await exportCommand.handler(
+		[outside],
+		testMessages,
+		testMetadata,
+	)) as React.ReactElement;
+	t.is(mockWriteFileCalls.length, 1);
+	const {lastFrame} = render(<MockThemeProvider>{escape}</MockThemeProvider>);
+	t.regex(lastFrame()!, /Invalid export path/);
+
+	await fs.rm(root, {recursive: true});
+});
+
+test('exportCommand reports a missing parent directory clearly', async t => {
+	fs.writeFile = originalWriteFile;
+
+	const result = (await exportCommand.handler(
+		['no-such-folder/chat.md'],
+		testMessages,
+		testMetadata,
+	)) as React.ReactElement;
+	fs.writeFile = originalWriteFile;
+
+	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
+	t.regex(lastFrame()!, /Failed to export chat/);
+	t.regex(lastFrame()!, /Parent directory does not exist/);
+});
+
+test('exportCommand renders a subdirectory export relative to the project root', async t => {
+	const result = (await exportCommand.handler(
+		['reports/chat.md'],
+		testMessages,
+		testMetadata,
+	)) as React.ReactElement;
+
+	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
+	const output = lastFrame()!;
+	// Full relative path is shown (with the platform separator), not a bare
+	// basename.
+	t.true(output.includes(`Chat exported to reports${path.sep}chat.md`));
+	t.false(output.includes(`Chat exported to chat${path.sep}`));
+	t.false(output.includes('Chat exported to chat.md'));
 });

--- a/source/commands/export.spec.tsx
+++ b/source/commands/export.spec.tsx
@@ -9,7 +9,6 @@ import {ThemeContext} from '../hooks/useTheme';
 
 // Mock fs module
 const originalWriteFile = fs.writeFile;
-const originalAccess = fs.access;
 let mockWriteFileCalls: Array<{path: string; content: string}> = [];
 
 test.beforeEach(() => {
@@ -18,14 +17,10 @@ test.beforeEach(() => {
 		mockWriteFileCalls.push({path: filepath, content});
 		return Promise.resolve(void 0);
 	};
-	fs.access = async () => {
-		throw new Error('ENOENT');
-	};
 });
 
 test.afterEach(() => {
 	fs.writeFile = originalWriteFile;
-	fs.access = originalAccess;
 });
 
 // Mock ThemeProvider for testing
@@ -72,12 +67,8 @@ test('exportCommand uses provided filename', async t => {
 });
 
 test('exportCommand keeps overwrite semantics for a user-provided filename', async t => {
-	// Simulate the target file already existing. A user-typed name must still
-	// write to that exact path (overwrite), not get auto-suffixed.
-	fs.access = async () => {
-		return void 0;
-	};
-
+	// A user-typed name must always write to that exact path (overwrite), never
+	// be auto-suffixed, no matter what already exists on disk.
 	await exportCommand.handler(['fixed-name.md'], testMessages, testMetadata);
 
 	t.is(mockWriteFileCalls.length, 1);
@@ -85,18 +76,33 @@ test('exportCommand keeps overwrite semantics for a user-provided filename', asy
 	t.false(mockWriteFileCalls[0].path.includes('fixed-name-2'));
 });
 
-test('exportCommand auto-suffixes a generated filename on collision', async t => {
-	const originalAccess = fs.access;
-	// Without this, uniqueFilename's check sees the file as not existing.
-	fs.access = async () => {
-		throw new Error('ENOENT');
-	};
-
+test('exportCommand writes a generated filename that is free', async t => {
 	await exportCommand.handler([], testMessages, testMetadata);
 
 	t.is(mockWriteFileCalls.length, 1);
-	t.false(mockWriteFileCalls[0].path.includes('/2'));
-	fs.access = originalAccess;
+	// No auto-suffix (matches -2, -3 etc.) when the target does not exist.
+	t.regex(mockWriteFileCalls[0].path, /hello-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('exportCommand surfaces a write failure instead of a false success', async t => {
+	const originalWriteFile = fs.writeFile;
+	fs.writeFile = async () => {
+		throw new Error('ENOSPC: no space left on device');
+	};
+
+	const result = (await exportCommand.handler(
+		['big.md'],
+		testMessages,
+		testMetadata,
+	)) as React.ReactElement;
+
+	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Failed to export chat/);
+	t.regex(output!, /ENOSPC/);
+	t.false(output!.includes('Chat exported'));
+	fs.writeFile = originalWriteFile;
 });
 
 test('exportCommand generates default filename from first user message', async t => {

--- a/source/commands/export.spec.tsx
+++ b/source/commands/export.spec.tsx
@@ -9,6 +9,7 @@ import {ThemeContext} from '../hooks/useTheme';
 
 // Mock fs module
 const originalWriteFile = fs.writeFile;
+const originalAccess = fs.access;
 let mockWriteFileCalls: Array<{path: string; content: string}> = [];
 
 test.beforeEach(() => {
@@ -17,10 +18,14 @@ test.beforeEach(() => {
 		mockWriteFileCalls.push({path: filepath, content});
 		return Promise.resolve(void 0);
 	};
+	fs.access = async () => {
+		throw new Error('ENOENT');
+	};
 });
 
 test.afterEach(() => {
 	fs.writeFile = originalWriteFile;
+	fs.access = originalAccess;
 });
 
 // Mock ThemeProvider for testing
@@ -66,8 +71,19 @@ test('exportCommand uses provided filename', async t => {
 	t.true(mockWriteFileCalls[0].path.includes('custom-export.md'));
 });
 
-test('exportCommand generates default filename when none provided', async t => {
+test('exportCommand generates default filename from first user message', async t => {
 	await exportCommand.handler([], testMessages, testMetadata);
+
+	t.is(mockWriteFileCalls.length, 1);
+	t.true(mockWriteFileCalls[0].path.includes('hello-'));
+	t.true(mockWriteFileCalls[0].path.endsWith('.md'));
+});
+
+test('exportCommand falls back to nanocoder-chat when no user messages', async t => {
+	const noUserMessages: Message[] = [
+		{role: 'assistant', content: 'Hi there', tool_calls: undefined},
+	];
+	await exportCommand.handler([], noUserMessages, testMetadata);
 
 	t.is(mockWriteFileCalls.length, 1);
 	t.true(mockWriteFileCalls[0].path.includes('nanocoder-chat-'));
@@ -184,4 +200,15 @@ test('exportCommand renders Export component with correct filename', async t => 
 		t.truthy(output);
 		t.regex(output!, /my-export\.md/);
 	}
+});
+
+test('exportCommand rejects path traversal in filename', async t => {
+	const result = await exportCommand.handler(
+		['../../../etc/passwd'],
+		testMessages,
+		testMetadata,
+	);
+
+	t.is(mockWriteFileCalls.length, 0);
+	t.truthy(React.isValidElement(result));
 });

--- a/source/commands/export.spec.tsx
+++ b/source/commands/export.spec.tsx
@@ -71,6 +71,34 @@ test('exportCommand uses provided filename', async t => {
 	t.true(mockWriteFileCalls[0].path.includes('custom-export.md'));
 });
 
+test('exportCommand keeps overwrite semantics for a user-provided filename', async t => {
+	// Simulate the target file already existing. A user-typed name must still
+	// write to that exact path (overwrite), not get auto-suffixed.
+	fs.access = async () => {
+		return void 0;
+	};
+
+	await exportCommand.handler(['fixed-name.md'], testMessages, testMetadata);
+
+	t.is(mockWriteFileCalls.length, 1);
+	t.true(mockWriteFileCalls[0].path.endsWith('fixed-name.md'));
+	t.false(mockWriteFileCalls[0].path.includes('fixed-name-2'));
+});
+
+test('exportCommand auto-suffixes a generated filename on collision', async t => {
+	const originalAccess = fs.access;
+	// Without this, uniqueFilename's check sees the file as not existing.
+	fs.access = async () => {
+		throw new Error('ENOENT');
+	};
+
+	await exportCommand.handler([], testMessages, testMetadata);
+
+	t.is(mockWriteFileCalls.length, 1);
+	t.false(mockWriteFileCalls[0].path.includes('/2'));
+	fs.access = originalAccess;
+});
+
 test('exportCommand generates default filename from first user message', async t => {
 	await exportCommand.handler([], testMessages, testMetadata);
 

--- a/source/commands/export.spec.tsx
+++ b/source/commands/export.spec.tsx
@@ -2,6 +2,7 @@ import test from 'ava';
 import type {Message} from '@/types/index';
 import {exportCommand} from './export';
 import {promises as fs} from 'fs';
+import path from 'path';
 import React from 'react';
 import {render} from 'ink-testing-library';
 import {themes} from '../config/themes';
@@ -248,7 +249,7 @@ test('exportCommand rejects path traversal in filename', async t => {
 	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /Invalid filename/);
+	t.regex(output!, /Invalid export path/);
 	t.false(output!.includes('Chat exported'));
 });
 
@@ -283,7 +284,7 @@ test('exportCommand rejects a filename with a null byte', async t => {
 	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /Invalid filename/);
+	t.regex(output!, /Invalid export path/);
 });
 
 test('exportCommand rejects a home-directory shorthand path', async t => {
@@ -298,5 +299,37 @@ test('exportCommand rejects a home-directory shorthand path', async t => {
 	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /Invalid filename/);
+	t.regex(output!, /Invalid export path/);
+});
+
+test('exportCommand rejects a path escaping the project directory', async t => {
+	const result = (await exportCommand.handler(
+		['../../outside.md'],
+		testMessages,
+		testMetadata,
+	)) as React.ReactElement;
+
+	t.is(mockWriteFileCalls.length, 0);
+
+	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Invalid export path/);
+	t.false(output!.includes('Chat exported'));
+});
+
+test('exportCommand rejects an absolute path outside the project', async t => {
+	const outside = path.resolve(process.cwd(), '..', 'outside.md');
+	const result = (await exportCommand.handler(
+		[outside],
+		testMessages,
+		testMetadata,
+	)) as React.ReactElement;
+
+	t.is(mockWriteFileCalls.length, 0);
+
+	const {lastFrame} = render(<MockThemeProvider>{result}</MockThemeProvider>);
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /Invalid export path/);
 });

--- a/source/commands/export.tsx
+++ b/source/commands/export.tsx
@@ -8,7 +8,7 @@ import {
 	generateExportFilename,
 	writeUniqueFile,
 } from '@/utils/generate-export-filename';
-import {isValidFilePath} from '@/utils/path-validation';
+import {resolveFilePath} from '@/utils/path-validation';
 
 const formatMessageContent = (message: Message) => {
 	let content = '';
@@ -73,14 +73,18 @@ export const exportCommand: Command = {
 		const userProvided = args.length > 0;
 		const requestedFilename = args[0] || generateExportFilename(messages);
 
-		if (!isValidFilePath(requestedFilename, process.cwd())) {
+		// resolveFilePath validates the path (traversal, null bytes, ~, absolute
+		// escapes), then enforces symlink-aware containment within the project so
+		// an in-project symlink cannot redirect the write outside it.
+		let filepath: string;
+		try {
+			filepath = resolveFilePath(requestedFilename, process.cwd());
+		} catch {
 			return React.createElement(ExportError, {
 				key: generateKey('export'),
-				message: 'Invalid filename: path traversal detected',
+				message: 'Invalid export path: outside the project directory',
 			});
 		}
-
-		const filepath = path.resolve(process.cwd(), requestedFilename); // nosemgrep
 
 		const frontmatter = `---
 session_date: ${new Date().toISOString()}

--- a/source/commands/export.tsx
+++ b/source/commands/export.tsx
@@ -4,6 +4,11 @@ import React from 'react';
 import {SuccessMessage} from '@/components/message-box';
 import {generateKey} from '@/session/key-generator';
 import {Command, Message} from '@/types/index';
+import {
+	generateExportFilename,
+	isUnsafeFilename,
+	uniqueFilename,
+} from '@/utils/generate-export-filename';
 
 const formatMessageContent = (message: Message) => {
 	let content = '';
@@ -54,10 +59,18 @@ export const exportCommand: Command = {
 		messages: Message[],
 		{provider, model, tokens},
 	) => {
-		const filename =
-			args[0] ||
-			`nanocoder-chat-${new Date().toISOString().replace(/:/g, '-')}.md`;
-		const filepath = path.resolve(process.cwd(), filename); // nosemgrep
+		const requestedFilename = args[0] || generateExportFilename(messages);
+
+		if (isUnsafeFilename(requestedFilename)) {
+			return React.createElement(Export, {
+				key: generateKey('export'),
+				filename: 'Error: invalid filename',
+			});
+		}
+
+		const filepath = path.resolve(process.cwd(), requestedFilename); // nosemgrep
+		const safeFilepath = await uniqueFilename(filepath);
+		const filename = path.basename(safeFilepath);
 
 		const frontmatter = `---
 session_date: ${new Date().toISOString()}
@@ -72,7 +85,7 @@ total_tokens: ${tokens}
 
 		const markdownContent = messages.map(formatMessageContent).join('');
 
-		await fs.writeFile(filepath, frontmatter + markdownContent);
+		await fs.writeFile(safeFilepath, frontmatter + markdownContent);
 
 		return React.createElement(Export, {
 			key: generateKey('export'),

--- a/source/commands/export.tsx
+++ b/source/commands/export.tsx
@@ -1,14 +1,14 @@
 import fs from 'fs/promises';
 import path from 'path';
 import React from 'react';
-import {SuccessMessage} from '@/components/message-box';
+import {ErrorMessage, SuccessMessage} from '@/components/message-box';
 import {generateKey} from '@/session/key-generator';
 import {Command, Message} from '@/types/index';
 import {
 	generateExportFilename,
-	isUnsafeFilename,
 	uniqueFilename,
 } from '@/utils/generate-export-filename';
+import {isValidFilePath} from '@/utils/path-validation';
 
 const formatMessageContent = (message: Message) => {
 	let content = '';
@@ -51,6 +51,17 @@ function Export({filename}: {filename: string}) {
 	);
 }
 
+function ExportError({message}: {message: string}) {
+	return (
+		<ErrorMessage
+			hideBox={true}
+			marginTop={1}
+			marginBottom={1}
+			message={message}
+		></ErrorMessage>
+	);
+}
+
 export const exportCommand: Command = {
 	name: 'export',
 	description: 'Export the chat history to a markdown file',
@@ -61,10 +72,10 @@ export const exportCommand: Command = {
 	) => {
 		const requestedFilename = args[0] || generateExportFilename(messages);
 
-		if (isUnsafeFilename(requestedFilename)) {
-			return React.createElement(Export, {
+		if (!isValidFilePath(requestedFilename, process.cwd())) {
+			return React.createElement(ExportError, {
 				key: generateKey('export'),
-				filename: 'Error: invalid filename',
+				message: 'Invalid filename: path traversal detected',
 			});
 		}
 

--- a/source/commands/export.tsx
+++ b/source/commands/export.tsx
@@ -70,6 +70,7 @@ export const exportCommand: Command = {
 		messages: Message[],
 		{provider, model, tokens},
 	) => {
+		const userProvided = args.length > 0;
 		const requestedFilename = args[0] || generateExportFilename(messages);
 
 		if (!isValidFilePath(requestedFilename, process.cwd())) {
@@ -80,7 +81,11 @@ export const exportCommand: Command = {
 		}
 
 		const filepath = path.resolve(process.cwd(), requestedFilename); // nosemgrep
-		const safeFilepath = await uniqueFilename(filepath);
+		// A name the user typed keeps overwrite semantics (least surprise). Only
+		// generated names get auto-suffixed so repeated exports never clobber.
+		const safeFilepath = userProvided
+			? filepath
+			: await uniqueFilename(filepath);
 		const filename = path.basename(safeFilepath);
 
 		const frontmatter = `---

--- a/source/commands/export.tsx
+++ b/source/commands/export.tsx
@@ -2,8 +2,10 @@ import fs from 'fs/promises';
 import path from 'path';
 import React from 'react';
 import {ErrorMessage, SuccessMessage} from '@/components/message-box';
+import {getProjectRoot, getSafeSessionCwd} from '@/services/session-cwd';
 import {generateKey} from '@/session/key-generator';
 import {Command, Message} from '@/types/index';
+import {formatError} from '@/utils/error-formatter';
 import {
 	generateExportFilename,
 	writeUniqueFile,
@@ -73,12 +75,16 @@ export const exportCommand: Command = {
 		const userProvided = args.length > 0;
 		const requestedFilename = args[0] || generateExportFilename(messages);
 
-		// resolveFilePath validates the path (traversal, null bytes, ~, absolute
-		// escapes), then enforces symlink-aware containment within the project so
-		// an in-project symlink cannot redirect the write outside it.
+		// Resolve against the session cwd (which honours bash `cd`) and enforce
+		// containment within the project root (which does not shrink as `cd`
+		// descends) -- the same convention as read_file / write_file / string_replace.
 		let filepath: string;
 		try {
-			filepath = resolveFilePath(requestedFilename, process.cwd());
+			filepath = resolveFilePath(
+				requestedFilename,
+				getSafeSessionCwd(),
+				getProjectRoot(),
+			);
 		} catch {
 			return React.createElement(ExportError, {
 				key: generateKey('export'),
@@ -109,18 +115,31 @@ total_tokens: ${tokens}
 				? await fs.writeFile(filepath, markdownContent).then(() => filepath)
 				: await writeUniqueFile(filepath, markdownContent);
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
+			// writeUniqueFile already translates a missing parent dir for
+			// generated names; mirror it for user-typed names that write directly.
+			const message =
+				error &&
+				typeof error === 'object' &&
+				'code' in error &&
+				error.code === 'ENOENT'
+					? `Parent directory does not exist: ${path.dirname(filepath)}`
+					: formatError(error);
 			return React.createElement(ExportError, {
 				key: generateKey('export'),
 				message: `Failed to export chat: ${message}`,
 			});
 		}
 
-		const filename = path.basename(writtenFilepath);
+		// Show the exported file relative to the project root so subdirectory
+		// exports (e.g. reports/chat.md) are recognisable rather than a bare basename.
+		const root = getProjectRoot();
+		const displayPath = writtenFilepath.startsWith(root + path.sep)
+			? writtenFilepath.slice(root.length + 1)
+			: writtenFilepath;
 
 		return React.createElement(Export, {
 			key: generateKey('export'),
-			filename,
+			filename: displayPath,
 		});
 	},
 };

--- a/source/commands/export.tsx
+++ b/source/commands/export.tsx
@@ -6,7 +6,7 @@ import {generateKey} from '@/session/key-generator';
 import {Command, Message} from '@/types/index';
 import {
 	generateExportFilename,
-	uniqueFilename,
+	writeUniqueFile,
 } from '@/utils/generate-export-filename';
 import {isValidFilePath} from '@/utils/path-validation';
 
@@ -81,12 +81,6 @@ export const exportCommand: Command = {
 		}
 
 		const filepath = path.resolve(process.cwd(), requestedFilename); // nosemgrep
-		// A name the user typed keeps overwrite semantics (least surprise). Only
-		// generated names get auto-suffixed so repeated exports never clobber.
-		const safeFilepath = userProvided
-			? filepath
-			: await uniqueFilename(filepath);
-		const filename = path.basename(safeFilepath);
 
 		const frontmatter = `---
 session_date: ${new Date().toISOString()}
@@ -99,9 +93,26 @@ total_tokens: ${tokens}
 
 `;
 
-		const markdownContent = messages.map(formatMessageContent).join('');
+		const markdownContent =
+			frontmatter + messages.map(formatMessageContent).join('');
 
-		await fs.writeFile(safeFilepath, frontmatter + markdownContent);
+		// A name the user typed keeps overwrite semantics (least surprise). Only
+		// generated names get auto-suffixed so repeated exports never clobber --
+		// and the write is atomic ('wx') so concurrent exports can't race.
+		let writtenFilepath: string;
+		try {
+			writtenFilepath = userProvided
+				? await fs.writeFile(filepath, markdownContent).then(() => filepath)
+				: await writeUniqueFile(filepath, markdownContent);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return React.createElement(ExportError, {
+				key: generateKey('export'),
+				message: `Failed to export chat: ${message}`,
+			});
+		}
+
+		const filename = path.basename(writtenFilepath);
 
 		return React.createElement(Export, {
 			key: generateKey('export'),

--- a/source/utils/generate-export-filename.spec.ts
+++ b/source/utils/generate-export-filename.spec.ts
@@ -1,10 +1,6 @@
 import test from 'ava';
 import type {Message} from '@/types/core';
-import {
-	generateExportFilename,
-	isUnsafeFilename,
-	uniqueFilename,
-} from './generate-export-filename';
+import {generateExportFilename, uniqueFilename} from './generate-export-filename';
 import {promises as fs} from 'fs';
 import path from 'path';
 import os from 'os';
@@ -74,23 +70,27 @@ test('skips empty first line and uses second', t => {
 test('truncates long slug at word boundary', t => {
 	const messages = [user('a'.repeat(100))];
 	const filename = generateExportFilename(messages);
-	const slug = filename.split('-20')[0]!;
+	const slug = filename.replace(/-\d{4}-\d{2}-\d{2}\.md$/, '');
 	t.true(slug.length <= 40);
 	t.false(slug.endsWith('-'));
 });
 
-test('isUnsafeFilename rejects path traversal', t => {
-	t.true(isUnsafeFilename('../etc/passwd'));
-	t.true(isUnsafeFilename('foo/../../bar.md'));
-	t.true(isUnsafeFilename('/etc/passwd'));
-	t.true(isUnsafeFilename('..'));
-	t.true(isUnsafeFilename('.'));
+test('preserves CJK characters in slug', t => {
+	const messages = [user('修复登录问题')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^修复登录问题-\d{4}-\d{2}-\d{2}\.md$/);
 });
 
-test('isUnsafeFilename accepts safe filenames', t => {
-	t.false(isUnsafeFilename('export.md'));
-	t.false(isUnsafeFilename('my-file.md'));
-	t.false(isUnsafeFilename('fix-login-bug-2026-08-25.md'));
+test('preserves Cyrillic characters in slug', t => {
+	const messages = [user('исправить ошибку входа')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^исправить-ошибку-входа-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('strips emoji while keeping adjacent words', t => {
+	const messages = [user('fix the 🐛 bug')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^fix-the-bug-\d{4}-\d{2}-\d{2}\.md$/);
 });
 
 test('uniqueFilename returns original when file does not exist', async t => {
@@ -118,5 +118,28 @@ test('uniqueFilename increments counter for multiple collisions', async t => {
 	await fs.writeFile(path.join(tmpDir, 'test-3.md'), 'existing');
 	const result = await uniqueFilename(filepath);
 	t.is(result, path.join(tmpDir, 'test-4.md'));
+	await fs.rm(tmpDir, {recursive: true});
+});
+
+test('uniqueFilename never returns the original path after exhausting counters', async t => {
+	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
+	const filepath = path.join(tmpDir, 'test.md');
+	await fs.writeFile(filepath, 'existing');
+	await fs.writeFile(path.join(tmpDir, 'test-2.md'), 'existing');
+	await fs.writeFile(path.join(tmpDir, 'test-3.md'), 'existing');
+	await fs.writeFile(path.join(tmpDir, 'test-4.md'), 'existing');
+	await fs.writeFile(path.join(tmpDir, 'test-5.md'), 'existing');
+	await fs.writeFile(path.join(tmpDir, 'test-6.md'), 'existing');
+
+	const result = await uniqueFilename(filepath);
+
+	t.not(result, filepath);
+	t.not(result, path.join(tmpDir, 'test-2.md'));
+	t.not(result, path.join(tmpDir, 'test-3.md'));
+	t.not(result, path.join(tmpDir, 'test-4.md'));
+	t.not(result, path.join(tmpDir, 'test-5.md'));
+	t.not(result, path.join(tmpDir, 'test-6.md'));
+	t.true(result.startsWith(path.join(tmpDir, 'test-new-')));
+	t.true(result.endsWith('.md'));
 	await fs.rm(tmpDir, {recursive: true});
 });

--- a/source/utils/generate-export-filename.spec.ts
+++ b/source/utils/generate-export-filename.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import type {Message} from '@/types/core';
-import {generateExportFilename, uniqueFilename} from './generate-export-filename';
+import {generateExportFilename, writeUniqueFile} from './generate-export-filename';
 import {promises as fs} from 'fs';
 import path from 'path';
 import os from 'os';
@@ -93,53 +93,70 @@ test('strips emoji while keeping adjacent words', t => {
 	t.regex(filename, /^fix-the-bug-\d{4}-\d{2}-\d{2}\.md$/);
 });
 
-test('uniqueFilename returns original when file does not exist', async t => {
+test('writeUniqueFile writes to the given path when it is free', async t => {
 	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
 	const filepath = path.join(tmpDir, 'test.md');
-	const result = await uniqueFilename(filepath);
+	const result = await writeUniqueFile(filepath, 'content');
 	t.is(result, filepath);
+	t.is(await fs.readFile(filepath, 'utf-8'), 'content');
 	await fs.rm(tmpDir, {recursive: true});
 });
 
-test('uniqueFilename appends counter when file exists', async t => {
+test('writeUniqueFile appends a counter when the path is taken', async t => {
 	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
 	const filepath = path.join(tmpDir, 'test.md');
 	await fs.writeFile(filepath, 'existing');
-	const result = await uniqueFilename(filepath);
+	const result = await writeUniqueFile(filepath, 'content');
 	t.is(result, path.join(tmpDir, 'test-2.md'));
+	t.is(await fs.readFile(path.join(tmpDir, 'test-2.md'), 'utf-8'), 'content');
 	await fs.rm(tmpDir, {recursive: true});
 });
 
-test('uniqueFilename increments counter for multiple collisions', async t => {
+test('writeUniqueFile never overwrites an existing file', async t => {
 	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
 	const filepath = path.join(tmpDir, 'test.md');
-	await fs.writeFile(filepath, 'existing');
-	await fs.writeFile(path.join(tmpDir, 'test-2.md'), 'existing');
-	await fs.writeFile(path.join(tmpDir, 'test-3.md'), 'existing');
-	const result = await uniqueFilename(filepath);
-	t.is(result, path.join(tmpDir, 'test-4.md'));
-	await fs.rm(tmpDir, {recursive: true});
-});
+	const originals = [
+		'test.md',
+		'test-2.md',
+		'test-3.md',
+		'test-4.md',
+		'test-5.md',
+		'test-6.md',
+	];
+	for (const name of originals) {
+		await fs.writeFile(path.join(tmpDir, name), 'existing');
+	}
 
-test('uniqueFilename never returns the original path after exhausting counters', async t => {
-	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
-	const filepath = path.join(tmpDir, 'test.md');
-	await fs.writeFile(filepath, 'existing');
-	await fs.writeFile(path.join(tmpDir, 'test-2.md'), 'existing');
-	await fs.writeFile(path.join(tmpDir, 'test-3.md'), 'existing');
-	await fs.writeFile(path.join(tmpDir, 'test-4.md'), 'existing');
-	await fs.writeFile(path.join(tmpDir, 'test-5.md'), 'existing');
-	await fs.writeFile(path.join(tmpDir, 'test-6.md'), 'existing');
+	const result = await writeUniqueFile(filepath, 'content');
 
-	const result = await uniqueFilename(filepath);
-
+	// Every pre-existing file keeps its content — none may be clobbered.
+	for (const name of originals) {
+		t.is(await fs.readFile(path.join(tmpDir, name), 'utf-8'), 'existing');
+	}
+	// The writer must have landed in a fresh, distinct file (timestamp suffix).
 	t.not(result, filepath);
-	t.not(result, path.join(tmpDir, 'test-2.md'));
-	t.not(result, path.join(tmpDir, 'test-3.md'));
-	t.not(result, path.join(tmpDir, 'test-4.md'));
-	t.not(result, path.join(tmpDir, 'test-5.md'));
-	t.not(result, path.join(tmpDir, 'test-6.md'));
 	t.true(result.startsWith(path.join(tmpDir, 'test-new-')));
 	t.true(result.endsWith('.md'));
+	t.is(await fs.readFile(result, 'utf-8'), 'content');
+	await fs.rm(tmpDir, {recursive: true});
+});
+
+test('writeUniqueFile is atomic: the original is never clobbered by a race', async t => {
+	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
+	const filepath = path.join(tmpDir, 'test.md');
+	await fs.writeFile(filepath, 'original');
+
+	// Simulate TWO concurrent exclusive-flag writers for the same target. Only
+	// one may win the base name; the other must fall to a suffix, and the
+	// original file's contents must be preserved.
+	const [a, b] = await Promise.all([
+		writeUniqueFile(filepath, 'first'),
+		writeUniqueFile(filepath, 'second'),
+	]);
+
+	t.not(a, filepath);
+	t.not(b, filepath);
+	t.not(a, b);
+	t.is(await fs.readFile(filepath, 'utf-8'), 'original');
 	await fs.rm(tmpDir, {recursive: true});
 });

--- a/source/utils/generate-export-filename.spec.ts
+++ b/source/utils/generate-export-filename.spec.ts
@@ -93,6 +93,17 @@ test('strips emoji while keeping adjacent words', t => {
 	t.regex(filename, /^fix-the-bug-\d{4}-\d{2}-\d{2}\.md$/);
 });
 
+test('truncates a long multi-byte slug to stay within the byte budget', t => {
+	// 40 CJK chars would exceed 96 UTF-8 bytes, so the slug must be trimmed at a
+	// word boundary while the whole filename stays well under 255 bytes.
+	const messages = [user('修'.repeat(40))];
+	const filename = generateExportFilename(messages);
+	const slug = filename.replace(/-\d{4}-\d{2}-\d{2}\.md$/, '');
+	t.true(Buffer.byteLength(slug, 'utf-8') <= 96);
+	t.true(Buffer.byteLength(filename, 'utf-8') < 255);
+	t.false(slug.endsWith('-'));
+});
+
 test('writeUniqueFile writes to the given path when it is free', async t => {
 	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
 	const filepath = path.join(tmpDir, 'test.md');

--- a/source/utils/generate-export-filename.spec.ts
+++ b/source/utils/generate-export-filename.spec.ts
@@ -93,15 +93,26 @@ test('strips emoji while keeping adjacent words', t => {
 	t.regex(filename, /^fix-the-bug-\d{4}-\d{2}-\d{2}\.md$/);
 });
 
-test('truncates a long multi-byte slug to stay within the byte budget', t => {
-	// 40 CJK chars would exceed 96 UTF-8 bytes, so the slug must be trimmed at a
-	// word boundary while the whole filename stays well under 255 bytes.
-	const messages = [user('修'.repeat(40))];
+test('truncates a long CJK slug at the 40-character limit', t => {
+	const messages = [user('修'.repeat(100))];
 	const filename = generateExportFilename(messages);
 	const slug = filename.replace(/-\d{4}-\d{2}-\d{2}\.md$/, '');
-	t.true(Buffer.byteLength(slug, 'utf-8') <= 96);
-	t.true(Buffer.byteLength(filename, 'utf-8') < 255);
+	// 40 CJK characters still keep the whole filename well under 255 bytes, so
+	// no byte budget is needed -- the char limit alone suffices.
+	t.is(slug.length, 40);
 	t.false(slug.endsWith('-'));
+	t.true(Buffer.byteLength(filename, 'utf-8') < 255);
+});
+
+test('truncates a long hyphenated slug at the last whole word', t => {
+	const messages = [user('fix-the-login-logout-registration-authentication')];
+	const filename = generateExportFilename(messages);
+	const slug = filename.replace(/-\d{4}-\d{2}-\d{2}\.md$/, '');
+	t.true(slug.length <= 40);
+	// Must not split a word: trimming stops at a word boundary, so it must not
+	// end mid-word with a break inside a hyphenated token.
+	t.true(/^fix(?:-[a-z]+)*$/.test(slug));
+	t.true(slug.length >= 20);
 });
 
 test('writeUniqueFile writes to the given path when it is free', async t => {
@@ -169,5 +180,16 @@ test('writeUniqueFile is atomic: the original is never clobbered by a race', asy
 	t.not(b, filepath);
 	t.not(a, b);
 	t.is(await fs.readFile(filepath, 'utf-8'), 'original');
+	await fs.rm(tmpDir, {recursive: true});
+});
+
+test('writeUniqueFile reports a missing parent directory clearly', async t => {
+	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
+	const filepath = path.join(tmpDir, 'does-not-exist', 'chat.md');
+
+	await t.throwsAsync(
+		() => writeUniqueFile(filepath, 'content'),
+		{message: /Parent directory does not exist/},
+	);
 	await fs.rm(tmpDir, {recursive: true});
 });

--- a/source/utils/generate-export-filename.spec.ts
+++ b/source/utils/generate-export-filename.spec.ts
@@ -1,0 +1,122 @@
+import test from 'ava';
+import type {Message} from '@/types/core';
+import {
+	generateExportFilename,
+	isUnsafeFilename,
+	uniqueFilename,
+} from './generate-export-filename';
+import {promises as fs} from 'fs';
+import path from 'path';
+import os from 'os';
+
+const user = (content: string): Message => ({role: 'user', content});
+const assistant = (content: string): Message => ({role: 'assistant', content});
+
+test('generates slug from first user message', t => {
+	const messages = [user('fix the login bug')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^fix-the-login-bug-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('truncates to 4 words', t => {
+	const messages = [user('add dark mode toggle to the navbar')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^add-dark-mode-toggle-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('handles single word message', t => {
+	const messages = [user('hello')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^hello-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('strips special characters', t => {
+	const messages = [user('fix: the auth login')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^fix-the-auth-login-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('trims leading and trailing whitespace', t => {
+	const messages = [user('  setup react router  ')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^setup-react-router-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('handles newlines in first line', t => {
+	const messages = [user('fix the bug\nin the auth module')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^fix-the-bug-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('falls back when no user messages', t => {
+	const messages = [assistant('hello')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^nanocoder-chat-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('falls back on empty messages array', t => {
+	const filename = generateExportFilename([]);
+	t.regex(filename, /^nanocoder-chat-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('falls back on empty content', t => {
+	const messages = [user('')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^nanocoder-chat-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('skips empty first line and uses second', t => {
+	const messages = [user('\nfix the login bug')];
+	const filename = generateExportFilename(messages);
+	t.regex(filename, /^fix-the-login-bug-\d{4}-\d{2}-\d{2}\.md$/);
+});
+
+test('truncates long slug at word boundary', t => {
+	const messages = [user('a'.repeat(100))];
+	const filename = generateExportFilename(messages);
+	const slug = filename.split('-20')[0]!;
+	t.true(slug.length <= 40);
+	t.false(slug.endsWith('-'));
+});
+
+test('isUnsafeFilename rejects path traversal', t => {
+	t.true(isUnsafeFilename('../etc/passwd'));
+	t.true(isUnsafeFilename('foo/../../bar.md'));
+	t.true(isUnsafeFilename('/etc/passwd'));
+	t.true(isUnsafeFilename('..'));
+	t.true(isUnsafeFilename('.'));
+});
+
+test('isUnsafeFilename accepts safe filenames', t => {
+	t.false(isUnsafeFilename('export.md'));
+	t.false(isUnsafeFilename('my-file.md'));
+	t.false(isUnsafeFilename('fix-login-bug-2026-08-25.md'));
+});
+
+test('uniqueFilename returns original when file does not exist', async t => {
+	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
+	const filepath = path.join(tmpDir, 'test.md');
+	const result = await uniqueFilename(filepath);
+	t.is(result, filepath);
+	await fs.rm(tmpDir, {recursive: true});
+});
+
+test('uniqueFilename appends counter when file exists', async t => {
+	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
+	const filepath = path.join(tmpDir, 'test.md');
+	await fs.writeFile(filepath, 'existing');
+	const result = await uniqueFilename(filepath);
+	t.is(result, path.join(tmpDir, 'test-2.md'));
+	await fs.rm(tmpDir, {recursive: true});
+});
+
+test('uniqueFilename increments counter for multiple collisions', async t => {
+	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'export-test-'));
+	const filepath = path.join(tmpDir, 'test.md');
+	await fs.writeFile(filepath, 'existing');
+	await fs.writeFile(path.join(tmpDir, 'test-2.md'), 'existing');
+	await fs.writeFile(path.join(tmpDir, 'test-3.md'), 'existing');
+	const result = await uniqueFilename(filepath);
+	t.is(result, path.join(tmpDir, 'test-4.md'));
+	await fs.rm(tmpDir, {recursive: true});
+});

--- a/source/utils/generate-export-filename.ts
+++ b/source/utils/generate-export-filename.ts
@@ -1,0 +1,96 @@
+import fs from 'fs/promises';
+import path from 'path';
+import type {Message} from '@/types/core';
+
+const MAX_WORDS = 4;
+const MAX_SLUG_LENGTH = 40;
+
+function sanitizeSlug(input: string): string {
+	return input
+		.toLowerCase()
+		.replace(/[^\w\s-]/g, '')
+		.replace(/\s+/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '');
+}
+
+function truncateAtWordBoundary(slug: string, maxLength: number): string {
+	if (slug.length <= maxLength) {
+		return slug;
+	}
+
+	const truncated = slug.substring(0, maxLength);
+	const lastHyphen = truncated.lastIndexOf('-');
+	return lastHyphen > 0 ? truncated.substring(0, lastHyphen) : truncated;
+}
+
+function generateSlugFromMessages(messages: Message[]): string {
+	const firstUserMessage = messages.find(m => m.role === 'user');
+	if (!firstUserMessage?.content) {
+		return '';
+	}
+
+	const lines = firstUserMessage.content.split('\n');
+	let firstLine = '';
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (trimmed) {
+			firstLine = trimmed;
+			break;
+		}
+	}
+
+	if (!firstLine) {
+		return '';
+	}
+
+	const words = firstLine.split(/\s+/).filter(Boolean);
+	const truncated = words.slice(0, MAX_WORDS).join(' ');
+	return truncateAtWordBoundary(sanitizeSlug(truncated), MAX_SLUG_LENGTH);
+}
+
+function isUnsafeFilename(filename: string): boolean {
+	const basename = path.basename(filename);
+	return (
+		basename !== filename ||
+		basename === '..' ||
+		basename === '.' ||
+		basename.includes('\0')
+	);
+}
+
+async function uniqueFilename(filepath: string): Promise<string> {
+	try {
+		await fs.access(filepath);
+	} catch {
+		return filepath;
+	}
+
+	const dir = path.dirname(filepath);
+	const ext = path.extname(filepath);
+	const base = path.basename(filepath, ext);
+
+	for (let i = 2; i < 1000; i++) {
+		const candidate = path.join(dir, `${base}-${i}${ext}`);
+		try {
+			await fs.access(candidate);
+		} catch {
+			return candidate;
+		}
+	}
+
+	return filepath;
+}
+
+export {isUnsafeFilename, uniqueFilename};
+
+export function generateExportFilename(messages: Message[]): string {
+	const slug = generateSlugFromMessages(messages);
+	const date = new Date().toISOString().split('T')[0];
+
+	if (!slug) {
+		return `nanocoder-chat-${date}.md`;
+	}
+
+	return `${slug}-${date}.md`;
+}

--- a/source/utils/generate-export-filename.ts
+++ b/source/utils/generate-export-filename.ts
@@ -4,6 +4,10 @@ import type {Message} from '@/types/core';
 
 const MAX_WORDS = 4;
 const MAX_SLUG_LENGTH = 40;
+// Keep the whole filename comfortably under the 255-byte filesystem limit even
+// for multi-byte (CJK) slugs. 40 chars x 3 bytes + "-" + "new-" + 13-digit
+// timestamp + ".md" stays far below it.
+const MAX_SLUG_BYTES = 96;
 const MAX_COLLISION_ATTEMPTS = 5;
 
 function sanitizeSlug(input: string): string {
@@ -15,14 +19,41 @@ function sanitizeSlug(input: string): string {
 		.replace(/^-|-$/g, '');
 }
 
-function truncateAtWordBoundary(slug: string, maxLength: number): string {
-	if (slug.length <= maxLength) {
+function truncateAtWordBoundary(slug: string, maxChars: number): string {
+	if (
+		slug.length <= maxChars &&
+		Buffer.byteLength(slug, 'utf-8') <= MAX_SLUG_BYTES
+	) {
 		return slug;
 	}
 
-	const truncated = slug.substring(0, maxLength);
-	const lastHyphen = truncated.lastIndexOf('-');
-	return lastHyphen > 0 ? truncated.substring(0, lastHyphen) : truncated;
+	// Prefer the byte limit (the real constraint); fall back to the char limit
+	// when it is stricter. The character slice must not split the slug mid-word,
+	// and cutting UTF-8 at an arbitrary byte can split a code point, so operate
+	// on character boundaries and then verify the result fits.
+	const truncated = slug.substring(0, maxChars);
+	let candidate =
+		Buffer.byteLength(slug, 'utf-8') > MAX_SLUG_BYTES ? slug : truncated;
+
+	// Trim toward the last word boundary until it fits the byte budget.
+	while (Buffer.byteLength(candidate, 'utf-8') > MAX_SLUG_BYTES) {
+		const hyphen = candidate.lastIndexOf('-');
+		if (hyphen <= 0) {
+			candidate = candidate.slice(0, Math.max(0, candidate.length - 1));
+			if (candidate.length === 0) break;
+			continue;
+		}
+		candidate = candidate.slice(0, hyphen);
+	}
+
+	// Then apply the character bound at a word boundary if still too long.
+	if (candidate.length > maxChars) {
+		const bound = candidate.substring(0, maxChars);
+		const lastHyphen = bound.lastIndexOf('-');
+		candidate = lastHyphen > 0 ? bound.slice(0, lastHyphen) : bound;
+	}
+
+	return candidate;
 }
 
 function generateSlugFromMessages(messages: Message[]): string {

--- a/source/utils/generate-export-filename.ts
+++ b/source/utils/generate-export-filename.ts
@@ -92,7 +92,10 @@ export async function writeUniqueFile(
 
 	for (let i = 1; i < MAX_COLLISION_ATTEMPTS + 1; i++) {
 		const suffix = i === 1 ? '' : `-${i}`;
-		const candidate = path.join(dir, `${base}${suffix}${ext}`);
+		// nosemgrep: `dir`/`base`/`ext` come from a path already validated and
+		// containment-checked by resolveFilePath in the handler, so this join
+		// cannot escape `dir`.
+		const candidate = path.join(dir, `${base}${suffix}${ext}`); // nosemgrep
 		const written = await tryWrite(candidate);
 		if (written) return written;
 	}
@@ -100,7 +103,8 @@ export async function writeUniqueFile(
 	// Bounded attempts all collided, drop a timestamp and try once more. If the
 	// astronomically-unlikely timestamp collision happens, surface the error
 	// rather than clobber anything.
-	const timestamped = path.join(dir, `${base}-new-${Date.now()}${ext}`);
+	// nosemgrep: same reasoning as the collision loop above.
+	const timestamped = path.join(dir, `${base}-new-${Date.now()}${ext}`); // nosemgrep
 	return tryWrite(timestamped).then(result => {
 		if (!result) {
 			throw new Error('Unable to allocate a unique export filename');

--- a/source/utils/generate-export-filename.ts
+++ b/source/utils/generate-export-filename.ts
@@ -4,10 +4,6 @@ import type {Message} from '@/types/core';
 
 const MAX_WORDS = 4;
 const MAX_SLUG_LENGTH = 40;
-// Keep the whole filename comfortably under the 255-byte filesystem limit even
-// for multi-byte (CJK) slugs. 40 chars x 3 bytes + "-" + "new-" + 13-digit
-// timestamp + ".md" stays far below it.
-const MAX_SLUG_BYTES = 96;
 const MAX_COLLISION_ATTEMPTS = 5;
 
 function sanitizeSlug(input: string): string {
@@ -19,41 +15,14 @@ function sanitizeSlug(input: string): string {
 		.replace(/^-|-$/g, '');
 }
 
-function truncateAtWordBoundary(slug: string, maxChars: number): string {
-	if (
-		slug.length <= maxChars &&
-		Buffer.byteLength(slug, 'utf-8') <= MAX_SLUG_BYTES
-	) {
+function truncateAtWordBoundary(slug: string, maxLength: number): string {
+	if (slug.length <= maxLength) {
 		return slug;
 	}
 
-	// Prefer the byte limit (the real constraint); fall back to the char limit
-	// when it is stricter. The character slice must not split the slug mid-word,
-	// and cutting UTF-8 at an arbitrary byte can split a code point, so operate
-	// on character boundaries and then verify the result fits.
-	const truncated = slug.substring(0, maxChars);
-	let candidate =
-		Buffer.byteLength(slug, 'utf-8') > MAX_SLUG_BYTES ? slug : truncated;
-
-	// Trim toward the last word boundary until it fits the byte budget.
-	while (Buffer.byteLength(candidate, 'utf-8') > MAX_SLUG_BYTES) {
-		const hyphen = candidate.lastIndexOf('-');
-		if (hyphen <= 0) {
-			candidate = candidate.slice(0, Math.max(0, candidate.length - 1));
-			if (candidate.length === 0) break;
-			continue;
-		}
-		candidate = candidate.slice(0, hyphen);
-	}
-
-	// Then apply the character bound at a word boundary if still too long.
-	if (candidate.length > maxChars) {
-		const bound = candidate.substring(0, maxChars);
-		const lastHyphen = bound.lastIndexOf('-');
-		candidate = lastHyphen > 0 ? bound.slice(0, lastHyphen) : bound;
-	}
-
-	return candidate;
+	const truncated = slug.substring(0, maxLength);
+	const lastHyphen = truncated.lastIndexOf('-');
+	return lastHyphen > 0 ? truncated.substring(0, lastHyphen) : truncated;
 }
 
 function generateSlugFromMessages(messages: Message[]): string {
@@ -109,7 +78,13 @@ export async function writeUniqueFile(
 			return candidate;
 		} catch (error) {
 			if (error && typeof error === 'object' && 'code' in error) {
+				// Collision: try the next candidate.
 				if (error.code === 'EEXIST') return null;
+				// Missing parent directory: report it plainly so the user knows
+				// the export failed because a directory doesn't exist.
+				if (error.code === 'ENOENT') {
+					throw new Error(`Parent directory does not exist: ${dir}`);
+				}
 			}
 			throw error;
 		}

--- a/source/utils/generate-export-filename.ts
+++ b/source/utils/generate-export-filename.ts
@@ -50,30 +50,57 @@ function generateSlugFromMessages(messages: Message[]): string {
 	return truncateAtWordBoundary(sanitizeSlug(truncated), MAX_SLUG_LENGTH);
 }
 
-export async function uniqueFilename(filepath: string): Promise<string> {
-	try {
-		await fs.access(filepath);
-	} catch {
-		return filepath;
-	}
-
+/**
+ * Deterministically finds a free filename for a generated export and writes it
+ * atomically.
+ *
+ * The write uses the exclusive flag 'wx' so the free-check and the create are
+ * a single atomic step: two concurrent exports for the same slug can never
+ * both succeed on the same path (no TOCTOU race, no clobbering). On EEXIST we
+ * try the next collision suffix; once the bounded attempts are exhausted we
+ * fall back to a timestamp suffix. This function never falls through to
+ * overwriting an existing file.
+ *
+ * Unlike /export with an explicit filename (which keeps overwrite semantics),
+ * generated names must never destroy a previous export.
+ */
+export async function writeUniqueFile(
+	filepath: string,
+	content: string,
+): Promise<string> {
 	const dir = path.dirname(filepath);
 	const ext = path.extname(filepath);
 	const base = path.basename(filepath, ext);
 
-	for (let i = 2; i < MAX_COLLISION_ATTEMPTS + 2; i++) {
-		const candidate = path.join(dir, `${base}-${i}${ext}`);
+	const tryWrite = async (candidate: string): Promise<string | null> => {
 		try {
-			await fs.access(candidate);
-		} catch {
+			await fs.writeFile(candidate, content, {flag: 'wx'});
 			return candidate;
+		} catch (error) {
+			if (error && typeof error === 'object' && 'code' in error) {
+				if (error.code === 'EEXIST') return null;
+			}
+			throw error;
 		}
+	};
+
+	for (let i = 1; i < MAX_COLLISION_ATTEMPTS + 1; i++) {
+		const suffix = i === 1 ? '' : `-${i}`;
+		const candidate = path.join(dir, `${base}${suffix}${ext}`);
+		const written = await tryWrite(candidate);
+		if (written) return written;
 	}
 
-	// Bounded attempts failed, fall back to a timestamp suffix. This must
-	// never return the original path: fs.writeFile would clobber the existing
-	// file, violating the "never overwrites" guarantee.
-	return path.join(dir, `${base}-new-${Date.now()}${ext}`);
+	// Bounded attempts all collided, drop a timestamp and try once more. If the
+	// astronomically-unlikely timestamp collision happens, surface the error
+	// rather than clobber anything.
+	const timestamped = path.join(dir, `${base}-new-${Date.now()}${ext}`);
+	return tryWrite(timestamped).then(result => {
+		if (!result) {
+			throw new Error('Unable to allocate a unique export filename');
+		}
+		return result;
+	});
 }
 
 export function generateExportFilename(messages: Message[]): string {

--- a/source/utils/generate-export-filename.ts
+++ b/source/utils/generate-export-filename.ts
@@ -92,10 +92,11 @@ export async function writeUniqueFile(
 
 	for (let i = 1; i < MAX_COLLISION_ATTEMPTS + 1; i++) {
 		const suffix = i === 1 ? '' : `-${i}`;
-		// nosemgrep: `dir`/`base`/`ext` come from a path already validated and
-		// containment-checked by resolveFilePath in the handler, so this join
-		// cannot escape `dir`.
-		const candidate = path.join(dir, `${base}${suffix}${ext}`); // nosemgrep
+		// `filepath` was already validated and containment-checked by
+		// resolveFilePath in the handler, so `dir`/`base`/`ext` cannot contain a
+		// separator or `..` and this join can never leave `dir`.
+		// nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+		const candidate = path.join(dir, `${base}${suffix}${ext}`);
 		const written = await tryWrite(candidate);
 		if (written) return written;
 	}
@@ -103,8 +104,8 @@ export async function writeUniqueFile(
 	// Bounded attempts all collided, drop a timestamp and try once more. If the
 	// astronomically-unlikely timestamp collision happens, surface the error
 	// rather than clobber anything.
-	// nosemgrep: same reasoning as the collision loop above.
-	const timestamped = path.join(dir, `${base}-new-${Date.now()}${ext}`); // nosemgrep
+	// nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+	const timestamped = path.join(dir, `${base}-new-${Date.now()}${ext}`);
 	return tryWrite(timestamped).then(result => {
 		if (!result) {
 			throw new Error('Unable to allocate a unique export filename');

--- a/source/utils/generate-export-filename.ts
+++ b/source/utils/generate-export-filename.ts
@@ -4,11 +4,12 @@ import type {Message} from '@/types/core';
 
 const MAX_WORDS = 4;
 const MAX_SLUG_LENGTH = 40;
+const MAX_COLLISION_ATTEMPTS = 5;
 
 function sanitizeSlug(input: string): string {
 	return input
 		.toLowerCase()
-		.replace(/[^\w\s-]/g, '')
+		.replace(/[^\p{L}\p{N}\s-]/gu, '')
 		.replace(/\s+/g, '-')
 		.replace(/-+/g, '-')
 		.replace(/^-|-$/g, '');
@@ -60,7 +61,7 @@ export async function uniqueFilename(filepath: string): Promise<string> {
 	const ext = path.extname(filepath);
 	const base = path.basename(filepath, ext);
 
-	for (let i = 2; i < 1000; i++) {
+	for (let i = 2; i < MAX_COLLISION_ATTEMPTS + 2; i++) {
 		const candidate = path.join(dir, `${base}-${i}${ext}`);
 		try {
 			await fs.access(candidate);
@@ -69,7 +70,10 @@ export async function uniqueFilename(filepath: string): Promise<string> {
 		}
 	}
 
-	return filepath;
+	// Bounded attempts failed, fall back to a timestamp suffix. This must
+	// never return the original path: fs.writeFile would clobber the existing
+	// file, violating the "never overwrites" guarantee.
+	return path.join(dir, `${base}-new-${Date.now()}${ext}`);
 }
 
 export function generateExportFilename(messages: Message[]): string {

--- a/source/utils/generate-export-filename.ts
+++ b/source/utils/generate-export-filename.ts
@@ -49,17 +49,7 @@ function generateSlugFromMessages(messages: Message[]): string {
 	return truncateAtWordBoundary(sanitizeSlug(truncated), MAX_SLUG_LENGTH);
 }
 
-function isUnsafeFilename(filename: string): boolean {
-	const basename = path.basename(filename);
-	return (
-		basename !== filename ||
-		basename === '..' ||
-		basename === '.' ||
-		basename.includes('\0')
-	);
-}
-
-async function uniqueFilename(filepath: string): Promise<string> {
+export async function uniqueFilename(filepath: string): Promise<string> {
 	try {
 		await fs.access(filepath);
 	} catch {
@@ -81,8 +71,6 @@ async function uniqueFilename(filepath: string): Promise<string> {
 
 	return filepath;
 }
-
-export {isUnsafeFilename, uniqueFilename};
 
 export function generateExportFilename(messages: Message[]): string {
 	const slug = generateSlugFromMessages(messages);


### PR DESCRIPTION
## Description

Auto-generate descriptive filenames for `/export` instead of generic timestamps. Exports now use the first 4 words of the user's first message as a slug, making files instantly recognizable in the filesystem.

Closes #934

## Before

/export
Chat exported to nanocoder-chat-2026-08-25T09-54-14.353Z.md

## After

/export
Chat exported to fix-my-button-2026-08-25.md

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Changes

- Add `generateExportFilename()` utility — extracts first 4 words from user's first message, sanitizes to slug, appends date
- Add `uniqueFilename()` — handles collisions by appending `-2`, `-3` etc. (never overwrites)
- Add `isUnsafeFilename()` — blocks path traversal attacks (`../`, `/`, null bytes)
- Add `truncateAtWordBoundary()` — long slugs break at word boundaries, never mid-word
- Update `source/commands/export.tsx` to use shared utilities
- Add 32 tests across 2 spec files covering success, edge cases, and security

## Examples

| User's first message | Generated filename |
|---|---|
| `fix the login bug` | `fix-the-login-bug-2026-08-25.md` |
| `add dark mode toggle to the navbar` | `add-dark-mode-toggle-2026-08-25.md` |
| `hello` | `hello-2026-08-25.md` |
| (no messages) | `nanocoder-chat-2026-08-25.md` |

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

pnpm run test:types          — passes
pnpm run test:lint           — passes
pnpm run test:ava source/utils/generate-export-filename.spec.ts  — 16/16 pass
pnpm run test:ava source/commands/export.spec.tsx                — 16/16 pass

### Manual Testing

- [x] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))