### PR TITLE
fix: improve project branch startup summary

### DIFF
--- a/source/app/components/app-container.spec.tsx
+++ b/source/app/components/app-container.spec.tsx
@@ -8,6 +8,7 @@ import {renderWithTheme} from '../../test-utils/render-with-theme';
 import {
 	createStaticComponents,
 	formatBootSummaryGitLabel,
+	formatBootSummaryProjectLabel,
 } from './app-container';
 import type {AppContainerProps} from './app-container';
 
@@ -129,8 +130,48 @@ test('createStaticComponents omits mode label when interactive', t => {
 });
 
 // ============================================================================
-// Boot Summary — Git Branch Display
+// Boot Summary — Project and Git Branch Display
 // ============================================================================
+
+test('formatBootSummaryProjectLabel renders workspace without git status', t => {
+	t.is(formatBootSummaryProjectLabel('/work/example', null), '/work/example');
+});
+
+test('formatBootSummaryProjectLabel appends feature branch', t => {
+	t.is(
+		formatBootSummaryProjectLabel('/work/example', {
+			branch: 'fix/read-file-empty',
+			isDefault: false,
+			detached: false,
+		}),
+		'/work/example · fix/read-file-empty',
+	);
+});
+
+test('formatBootSummaryProjectLabel marks the default branch', t => {
+	t.is(
+		formatBootSummaryProjectLabel('/work/example', {
+			branch: 'main',
+			isDefault: true,
+			detached: false,
+		}),
+		'/work/example · main (default)',
+	);
+});
+
+test('formatBootSummaryProjectLabel marks detached HEAD', t => {
+	t.is(
+		formatBootSummaryProjectLabel('/work/example', {
+			branch: 'abc1234',
+			isDefault: false,
+			detached: true,
+		}),
+		'/work/example · abc1234 (detached)',
+	);
+});
+
+// Keep legacy formatter coverage because /status and external callers share
+// the branch marker semantics.
 
 test('formatBootSummaryGitLabel renders feature branch with ⎇ prefix', t => {
 	t.is(
@@ -180,7 +221,7 @@ test.serial(
 		const {lastFrame, unmount} = renderWithTheme(<>{components}</>);
 		const output = lastFrame();
 		t.truthy(output);
-		t.regex(output!, /⎇\s+\S+/);
+		t.regex(output!, /[^\n]+\s+·\s+\S+/);
 		unmount();
 	},
 );
@@ -202,6 +243,7 @@ test.serial(
 			const {lastFrame, unmount} = renderWithTheme(<>{components}</>);
 			const output = lastFrame();
 			t.truthy(output);
+			t.regex(output!, new RegExp(stripAnsi(process.cwd()).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
 			t.notRegex(output!, /⎇/);
 			unmount();
 		} finally {
@@ -226,7 +268,7 @@ test.serial(
 			const {lastFrame, unmount} = renderWithTheme(<>{components}</>);
 			const output = lastFrame();
 			t.truthy(output);
-			t.regex(output!, /⎇/);
+			t.regex(output!, /\S+\s+·\s+\S+/);
 			unmount();
 		} finally {
 			process.stdout.columns = originalColumns;
@@ -252,7 +294,7 @@ test.serial(
 			// Branch label sits on a line by itself, separated from the
 			// provider/model line by a newline. Strip ANSI so color codes
 			// (present when CI forces color) don't break the adjacency match.
-			t.regex(stripAnsi(output!), /test-model[^\n]*\n⎇\s+\S+/);
+			t.regex(stripAnsi(output!), /test-model[^\n]*\n\S+.*\s+·\s+\S+/);
 			unmount();
 		} finally {
 			process.stdout.columns = originalColumns;

--- a/source/app/components/app-container.tsx
+++ b/source/app/components/app-container.tsx
@@ -21,6 +21,24 @@ export function formatBootSummaryGitLabel(status: GitStatusSummary): string {
 	return marker ? `⎇ ${branch} (${marker})` : `⎇ ${branch}`;
 }
 
+/**
+ * Format the project/workspace segment shown in the startup summary.
+ *
+ * Keep this compact and user-oriented: show the directory Nanocoder is
+ * operating in, then append the active branch when one is available.
+ */
+export function formatBootSummaryProjectLabel(
+	workingDirectory: string,
+	status: GitStatusSummary | null,
+): string {
+	const workspace = homeRelative(workingDirectory);
+	if (!status) return workspace;
+
+	const {branch, marker} = formatGitStatusSummary(status);
+	const branchLabel = marker ? `${branch} (${marker})` : branch;
+	return `${workspace} · ${branchLabel}`;
+}
+
 export interface AppContainerProps {
 	shouldShowWelcome: boolean;
 	currentProvider: string;
@@ -54,14 +72,16 @@ function BootSummary({
 }): React.ReactElement {
 	const {colors} = useTheme();
 	const {isNarrow} = useResponsiveTerminal();
-	const configPath = getClosestConfigFile('agents.config.json');
-	const shortConfig = homeRelative(configPath);
+	// Trigger config discovery as before, but avoid surfacing that unrelated
+	// file path as the primary startup context. Users need to see the workspace
+	// Nanocoder will operate in.
+	getClosestConfigFile('agents.config.json');
 	const modeLabel = mode ? DEVELOPMENT_MODE_LABELS[mode] : undefined;
 	const gitStatus = getGitStatusSummarySync();
-	const gitLabel = gitStatus ? formatBootSummaryGitLabel(gitStatus) : undefined;
+	const projectLabel = formatBootSummaryProjectLabel(process.cwd(), gitStatus);
 
 	// Narrow terminals: provider + model + mode on the first line, with the
-	// branch (when present) underneath so the line doesn't overflow.
+	// workspace/branch underneath so the line doesn't overflow.
 	if (isNarrow) {
 		if (!provider || !model) return <></>;
 		return (
@@ -79,7 +99,7 @@ function BootSummary({
 						</>
 					)}
 				</Text>
-				{gitLabel && <Text color={colors.primary}>{gitLabel}</Text>}
+				<Text color={colors.primary}>{projectLabel}</Text>
 			</Box>
 		);
 	}
@@ -100,24 +120,10 @@ function BootSummary({
 						</>
 					)}
 					<Text color={colors.secondary}> · </Text>
-					<Text color={colors.secondary}>{shortConfig}</Text>
-					{gitLabel && (
-						<>
-							<Text color={colors.secondary}> · </Text>
-							<Text color={colors.primary}>{gitLabel}</Text>
-						</>
-					)}
+					<Text color={colors.primary}>{projectLabel}</Text>
 				</>
 			) : (
-				<>
-					<Text color={colors.secondary}>{shortConfig}</Text>
-					{gitLabel && (
-						<>
-							<Text color={colors.secondary}> · </Text>
-							<Text color={colors.primary}>{gitLabel}</Text>
-						</>
-					)}
-				</>
+				<Text color={colors.primary}>{projectLabel}</Text>
 			)}
 		</Text>
 	);


### PR DESCRIPTION
## Summary
- Show the current workspace directory in the startup summary instead of the config file path.
- Append the active Git branch in a compact `workspace · branch` format.
- Keep graceful behavior outside Git repositories by showing only the workspace path.

Fixes #950

## Test Plan
- pnpm exec ava source/app/components/app-container.spec.tsx
- pnpm run test:types
- pnpm exec biome check --no-errors-on-unmatched source/app/components/app-container.tsx source/app/components/app-container.spec.tsx
- pnpm run build