### PR TITLE
feature(voice): Native Realtime cloud audio (PR 6/6)

### DIFF
--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -41,10 +41,22 @@ Type `/` in the chat input to see available commands. All commands start with `/
 | `/retry` | Re-run the last user turn. Use `/retry --model <id>` or `/retry --provider <name> --model <id>` to switch models first |
 | `/rename` | Rename the current session. Name must be non-empty and 100 characters or less. See [Session Management](session-management.md) |
 | `/explorer` | Interactive file browser to navigate, preview, and select files for context |
-| `/tune` | Configure runtime model behaviour — tool profiles, compaction, native tools, model parameters (see [Tune](tune.md)) |
 | `/ide` | Connect to an IDE for live integration (e.g., VS Code diff previews) |
+| `/voice` | Configure Voice Mode (`/voice [hands-free|ptt|stt <local|cloud>|tts <local|cloud>|status|mode <push-to-talk|hands-free>]`) |
 
-## Special Input Syntax
+## Voice Mode
+
+Nanocoder includes a local-first Realtime Voice Mode supporting push-to-talk, hands-free voice activity detection (VAD), barge-in interruption, and optional cloud STT/TTS.
+
+| Command | Description |
+|---------|-------------|
+| `/voice` | Toggle voice mode on/off |
+| `/voice ptt` or `/voice push-to-talk` | Switch to push-to-talk mode (use `Ctrl+T` to record/submit) |
+| `/voice hands-free` | Switch to hands-free mode (automatic VAD speech detection) |
+| `/voice stt [local\|cloud]` | Configure speech-to-text backend (local Whisper or opt-in cloud) |
+| `/voice tts [local\|cloud]` | Configure text-to-speech backend (local Piper or opt-in cloud) |
+| `/voice status` | Display current voice configuration and backend status |
+| `/voice mode <push-to-talk\|hands-free>` | Set specific activation mode |
 
 These shortcuts work directly in the chat input — no `/` prefix needed.
 

--- a/docs/features/keyboard-shortcuts.md
+++ b/docs/features/keyboard-shortcuts.md
@@ -79,3 +79,9 @@ Ctrl+V pulls an image off the system clipboard and adds it as an attachment. You
 | Toggle development mode | Shift+Tab |
 | Toggle compact tool output | Ctrl+O |
 | Toggle expanded reasoning traces | Ctrl+R |
+
+## Voice Mode
+
+| Action | Shortcut | Notes |
+|--------|----------|-------|
+| Push-to-talk / Barge-in | Ctrl+T | Start/stop voice recording; interrupts AI response if speaking or processing |

--- a/plugins/voice/src/speaker.ts
+++ b/plugins/voice/src/speaker.ts
@@ -3,7 +3,7 @@ import { platform } from 'node:process';
 
 /**
  * Plays an audio file through the default system speakers.
- * Uses native OS tools where available (afplay, aplay) and falls back to sox's play.
+ * Uses native OS tools where available (afplay on macOS, sox's play on Linux/WSL, sox on Windows).
  * 
  * @param filePath The path to the audio file to play.
  */
@@ -13,22 +13,18 @@ export async function playAudio(filePath: string, timeoutMs?: number, signal?: A
 			return reject(new Error('AbortError: Playback aborted'));
 		}
 
-		let command = process.env.PLAY_CMD || 'play'; // default to sox
-		const args = [filePath];
+		let command = process.env.PLAY_CMD || 'play'; // default to sox play
+		const args = ['-q', filePath];
 
 		if (process.env.PLAY_CMD) {
 			// Testing override
+			args.shift();
 		} else if (platform === 'darwin') {
 			command = 'afplay';
-		} else if (platform === 'linux') {
-			command = 'aplay';
-			args.unshift('-q'); // quiet mode
+			args.shift(); // remove -q
 		} else if (platform === 'win32') {
 			command = 'sox';
-			args.unshift('-q');
 			args.push('-d'); // route to default device
-		} else {
-			args.unshift('-q');
 		}
 
 		const proc = cp.spawn(command, args, { stdio: 'ignore' });

--- a/plugins/voice/src/stt.ts
+++ b/plugins/voice/src/stt.ts
@@ -1,7 +1,31 @@
 import cp from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { platform } from 'node:process';
 
 const MAX_OUTPUT_BYTES = 1024 * 1024; // 1MB limit for safety
+
+function getVoiceBinDir(): string {
+	return join(homedir(), '.nanocoder', 'voice-bin');
+}
+
+function resolveWhisperCommand(): string {
+	if (process.env.WHISPER_CMD) return process.env.WHISPER_CMD;
+	const localBin = join(
+		getVoiceBinDir(),
+		platform === 'win32' ? 'whisper-cli.exe' : 'whisper-cli',
+	);
+	if (existsSync(localBin)) return localBin;
+	return 'whisper-cli';
+}
+
+function resolveWhisperModel(): string {
+	if (process.env.WHISPER_MODEL) return process.env.WHISPER_MODEL;
+	const localModel = join(getVoiceBinDir(), 'ggml-base.en.bin');
+	if (existsSync(localModel)) return localModel;
+	return 'ggml-base.en.bin';
+}
 
 /**
  * Transcribes audio from a .wav file to text using local whisper.cpp.
@@ -17,8 +41,8 @@ export async function transcribeAudio(filePath: string, timeoutMs = 60000, signa
 			return reject(new Error('AbortError: Transcription aborted'));
 		}
 
-		const command = process.env.WHISPER_CMD || 'whisper-cli';
-		const modelPath = process.env.WHISPER_MODEL || 'ggml-base.en.bin';
+		const command = resolveWhisperCommand();
+		const modelPath = resolveWhisperModel();
 		
 		const args = ['-m', modelPath, '-f', filePath, '-nt']; // -nt disables timestamps
 

--- a/plugins/voice/src/tts.ts
+++ b/plugins/voice/src/tts.ts
@@ -1,5 +1,29 @@
 import cp from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { platform } from 'node:process';
+
+function getVoiceBinDir(): string {
+	return join(homedir(), '.nanocoder', 'voice-bin');
+}
+
+function resolvePiperCommand(): string {
+	if (process.env.PIPER_CMD) return process.env.PIPER_CMD;
+	const localBin = join(
+		getVoiceBinDir(),
+		platform === 'win32' ? 'piper.exe' : 'piper',
+	);
+	if (existsSync(localBin)) return localBin;
+	return 'piper';
+}
+
+function resolvePiperModel(): string {
+	if (process.env.PIPER_MODEL) return process.env.PIPER_MODEL;
+	const localModel = join(getVoiceBinDir(), 'en_US-lessac-medium.onnx');
+	if (existsSync(localModel)) return localModel;
+	return 'en_US-lessac-medium.onnx';
+}
 
 /**
  * Synthesizes speech from text using local piper TTS.
@@ -14,13 +38,13 @@ export async function synthesizeSpeech(text: string, outputPath: string, timeout
 			return reject(new Error('AbortError: Synthesis aborted'));
 		}
 
-		const command = process.env.PIPER_CMD || 'piper';
-		const modelPath = process.env.PIPER_MODEL || 'en_US-lessac-medium.onnx';
+		const command = resolvePiperCommand();
+		const modelPath = resolvePiperModel();
 
 		const args = ['--model', modelPath, '--output_file', outputPath];
 		
 		const proc = cp.spawn(command, args, { 
-			stdio: ['pipe', 'ignore', 'ignore']
+			stdio: ['pipe', 'ignore', 'ignore'] 
 		});
 
 		let timeoutId: NodeJS.Timeout | undefined;

--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -104,6 +104,9 @@ export function InteractiveApp({
 		addToChatQueue: appState.addToChatQueue,
 		voicePreference: voicePref,
 		handleCancel: appHandlers.handleCancel,
+		client: appState.client,
+		currentProvider: appState.currentProvider,
+		currentModel: appState.currentModel,
 	});
 
 	const handleToggleCompactDisplay = () => {

--- a/source/commands/voice.spec.tsx
+++ b/source/commands/voice.spec.tsx
@@ -1,12 +1,13 @@
 import test from 'ava';
-import {render} from 'ink-testing-library';
+import { render } from 'ink-testing-library';
 import React from 'react';
-import {themes} from '../config/themes';
-import {ThemeContext} from '../hooks/useTheme';
-import {TitleShapeContext} from '../hooks/useTitleShape';
-import {voiceCommand} from './voice';
+import { getVoicePreference, updateVoicePreference } from '@/config/preferences';
+import { themes } from '../config/themes';
+import { ThemeContext } from '../hooks/useTheme';
+import { TitleShapeContext } from '../hooks/useTitleShape';
+import { voiceCommand } from './voice';
 
-const MockProviders = ({children}: {children: React.ReactNode}) => {
+const MockProviders = ({ children }: { children: React.ReactNode }) => {
 	const mockTheme = {
 		currentTheme: 'tokyo-night' as const,
 		colors: themes['tokyo-night'].colors,
@@ -37,15 +38,70 @@ test('voice command has a handler function', t => {
 });
 
 test('voice command toggles state and renders InfoMessage', async t => {
-	const result = await voiceCommand.handler([], [], {} as any);
-	if (!React.isValidElement(result)) {
-		t.fail('Expected React element');
-		return;
-	}
+	const initialPref = getVoicePreference();
+	try {
+		const result = await voiceCommand.handler([], [], {} as any);
+		t.true(React.isValidElement(result));
 
-	const {lastFrame} = render(<MockProviders>{result}</MockProviders>);
-	const output = lastFrame();
-	
-	t.truthy(output);
-	t.regex(output!, /Voice mode (enabled|disabled)/);
+		const { lastFrame } = render(<MockProviders>{result}</MockProviders>);
+		const output = lastFrame();
+
+		t.truthy(output);
+		t.regex(output!, /Voice mode (enabled|disabled)/);
+	} finally {
+		updateVoicePreference(initialPref);
+	}
+});
+
+test('voice command handles stt subcommand', async t => {
+	const initialPref = getVoicePreference();
+	try {
+		const result = await voiceCommand.handler(['stt', 'cloud'], [], {} as any);
+		t.true(React.isValidElement(result));
+
+		const { lastFrame } = render(<MockProviders>{result}</MockProviders>);
+		const output = lastFrame();
+		t.truthy(output);
+		t.regex(output!, /Voice STT backend set to: cloud/);
+
+		const updatedPref = getVoicePreference();
+		t.is(updatedPref.sttBackend, 'cloud');
+	} finally {
+		updateVoicePreference(initialPref);
+	}
+});
+
+test('voice command handles tts subcommand', async t => {
+	const initialPref = getVoicePreference();
+	try {
+		const result = await voiceCommand.handler(['tts', 'cloud'], [], {} as any);
+		t.true(React.isValidElement(result));
+
+		const { lastFrame } = render(<MockProviders>{result}</MockProviders>);
+		const output = lastFrame();
+		t.truthy(output);
+		t.regex(output!, /Voice TTS backend set to: cloud/);
+
+		const updatedPref = getVoicePreference();
+		t.is(updatedPref.ttsBackend, 'cloud');
+	} finally {
+		updateVoicePreference(initialPref);
+	}
+});
+
+test('voice command handles status subcommand', async t => {
+	const initialPref = getVoicePreference();
+	try {
+		const result = await voiceCommand.handler(['status'], [], {} as any);
+		t.true(React.isValidElement(result));
+
+		const { lastFrame } = render(<MockProviders>{result}</MockProviders>);
+		const output = lastFrame();
+		t.truthy(output);
+		t.regex(output!, /Voice Mode:/);
+		t.regex(output!, /STT Backend:/);
+		t.regex(output!, /TTS Backend:/);
+	} finally {
+		updateVoicePreference(initialPref);
+	}
 });

--- a/source/commands/voice.spec.tsx
+++ b/source/commands/voice.spec.tsx
@@ -53,6 +53,71 @@ test('voice command toggles state and renders InfoMessage', async t => {
 	}
 });
 
+test('voice command handles ptt and hands-free subcommands and enables voice', async t => {
+	const initialPref = getVoicePreference();
+	try {
+		// Ensure initial state is disabled
+		updateVoicePreference({ ...initialPref, enabled: false, activationMode: 'hands-free' });
+
+		const pttResult = await voiceCommand.handler(['ptt'], [], {} as any);
+		t.true(React.isValidElement(pttResult));
+		let pref = getVoicePreference();
+		t.true(pref.enabled, '/voice ptt must set enabled to true');
+		t.is(pref.activationMode, 'push-to-talk');
+
+		// Now disable and test hands-free
+		updateVoicePreference({ ...pref, enabled: false });
+		const hfResult = await voiceCommand.handler(['hands-free'], [], {} as any);
+		t.true(React.isValidElement(hfResult));
+		pref = getVoicePreference();
+		t.true(pref.enabled, '/voice hands-free must set enabled to true');
+		t.is(pref.activationMode, 'hands-free');
+	} finally {
+		updateVoicePreference(initialPref);
+	}
+});
+
+test('voice command handles mode subcommand with valid and invalid arguments', async t => {
+	const initialPref = getVoicePreference();
+	try {
+		updateVoicePreference({ ...initialPref, enabled: false, activationMode: 'push-to-talk' });
+
+		// Valid mode: hands-free
+		const validResult = await voiceCommand.handler(['mode', 'hands-free'], [], {} as any);
+		t.true(React.isValidElement(validResult));
+		let pref = getVoicePreference();
+		t.true(pref.enabled);
+		t.is(pref.activationMode, 'hands-free');
+
+		// Invalid mode: foobar
+		const invalidResult = await voiceCommand.handler(['mode', 'foobar'], [], {} as any);
+		t.true(React.isValidElement(invalidResult));
+		const { lastFrame } = render(<MockProviders>{invalidResult}</MockProviders>);
+		const output = lastFrame();
+		t.regex(output!, /Invalid voice mode 'foobar'/);
+
+		// Config must NOT have silently changed
+		pref = getVoicePreference();
+		t.is(pref.activationMode, 'hands-free', 'Invalid mode should not mutate activationMode');
+	} finally {
+		updateVoicePreference(initialPref);
+	}
+});
+
+test('voice command rejects unknown top-level subcommands with an error', async t => {
+	const initialPref = getVoicePreference();
+	try {
+		const result = await voiceCommand.handler(['unknown_arg'], [], {} as any);
+		t.true(React.isValidElement(result));
+
+		const { lastFrame } = render(<MockProviders>{result}</MockProviders>);
+		const output = lastFrame();
+		t.regex(output!, /Unknown voice command 'unknown_arg'/);
+	} finally {
+		updateVoicePreference(initialPref);
+	}
+});
+
 test('voice command handles stt subcommand', async t => {
 	const initialPref = getVoicePreference();
 	try {

--- a/source/commands/voice.tsx
+++ b/source/commands/voice.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {InfoMessage} from '@/components/message-box';
+import {ErrorMessage, InfoMessage} from '@/components/message-box';
 import {getVoicePreference, updateVoicePreference} from '@/config/preferences';
 import type {VoicePlugin} from '@/hooks/useVoice';
 import {generateKey} from '@/session/key-generator';
@@ -8,7 +8,7 @@ import type {Command} from '@/types/index';
 export const voiceCommand: Command = {
 	name: 'voice',
 	description:
-		'Configure voice mode (/voice [hands-free|ptt|stt <local|cloud>|tts <local|cloud>|status])',
+		'Configure voice mode (/voice [hands-free|ptt|stt <local|cloud>|tts <local|cloud>|status|mode <push-to-talk|hands-free>])',
 	handler: async args => {
 		const currentConfig = getVoicePreference();
 		const updatedConfig = {...currentConfig};
@@ -16,6 +16,7 @@ export const voiceCommand: Command = {
 		const param = args?.[1]?.toLowerCase();
 
 		let messageText = '';
+		let isError = false;
 
 		if (subArg === 'hands-free' || subArg === 'handsfree') {
 			updatedConfig.activationMode = 'hands-free';
@@ -23,7 +24,8 @@ export const voiceCommand: Command = {
 			messageText = 'Voice mode set to hands-free (VAD listening enabled).';
 		} else if (subArg === 'push-to-talk' || subArg === 'ptt') {
 			updatedConfig.activationMode = 'push-to-talk';
-			messageText = 'Voice mode set to push-to-talk (Ctrl+T).';
+			updatedConfig.enabled = true;
+			messageText = 'Voice mode set to push-to-talk (Ctrl+T enabled).';
 		} else if (subArg === 'stt') {
 			if (param === 'cloud' || param === 'local') {
 				updatedConfig.sttBackend = param;
@@ -45,20 +47,42 @@ export const voiceCommand: Command = {
 				`STT Backend: ${updatedConfig.sttBackend || 'local'}`,
 				`TTS Backend: ${updatedConfig.ttsBackend || 'local'}`,
 			].join('\n');
-		} else if (subArg === 'mode' && param) {
+		} else if (subArg === 'mode') {
 			if (param === 'hands-free' || param === 'handsfree') {
 				updatedConfig.activationMode = 'hands-free';
 				updatedConfig.enabled = true;
 				messageText = 'Voice mode set to hands-free (VAD listening enabled).';
-			} else {
+			} else if (param === 'push-to-talk' || param === 'ptt') {
 				updatedConfig.activationMode = 'push-to-talk';
-				messageText = 'Voice mode set to push-to-talk (Ctrl+T).';
+				updatedConfig.enabled = true;
+				messageText = 'Voice mode set to push-to-talk (Ctrl+T enabled).';
+			} else if (param) {
+				isError = true;
+				messageText = `Invalid voice mode '${param}'. Valid modes: push-to-talk, hands-free.`;
+			} else {
+				messageText = `Current activation mode: ${updatedConfig.activationMode}. Use '/voice mode push-to-talk' or '/voice mode hands-free'.`;
 			}
+		} else if (subArg === 'on') {
+			updatedConfig.enabled = true;
+			messageText = 'Voice mode enabled.';
+		} else if (subArg === 'off') {
+			updatedConfig.enabled = false;
+			messageText = 'Voice mode disabled.';
+		} else if (subArg) {
+			isError = true;
+			messageText = `Unknown voice command '${subArg}'. Use '/voice [hands-free|ptt|stt <local|cloud>|tts <local|cloud>|status|mode <push-to-talk|hands-free>]'.`;
 		} else {
 			// Default toggle
 			const newState = !currentConfig.enabled;
 			updatedConfig.enabled = newState;
 			messageText = `Voice mode ${newState ? 'enabled' : 'disabled'}.`;
+		}
+
+		if (isError) {
+			return React.createElement(ErrorMessage, {
+				key: generateKey('voice-command-error'),
+				message: messageText,
+			});
 		}
 
 		updateVoicePreference(updatedConfig);

--- a/source/commands/voice.tsx
+++ b/source/commands/voice.tsx
@@ -8,13 +8,14 @@ import type {Command} from '@/types/index';
 export const voiceCommand: Command = {
 	name: 'voice',
 	description:
-		'Toggle voice input or set activation mode (/voice [hands-free|push-to-talk])',
+		'Configure voice mode (/voice [hands-free|ptt|stt <local|cloud>|tts <local|cloud>|status])',
 	handler: async args => {
 		const currentConfig = getVoicePreference();
+		const updatedConfig = {...currentConfig};
 		const subArg = args?.[0]?.toLowerCase();
+		const param = args?.[1]?.toLowerCase();
 
 		let messageText = '';
-		const updatedConfig = {...currentConfig};
 
 		if (subArg === 'hands-free' || subArg === 'handsfree') {
 			updatedConfig.activationMode = 'hands-free';
@@ -23,9 +24,29 @@ export const voiceCommand: Command = {
 		} else if (subArg === 'push-to-talk' || subArg === 'ptt') {
 			updatedConfig.activationMode = 'push-to-talk';
 			messageText = 'Voice mode set to push-to-talk (Ctrl+T).';
-		} else if (subArg === 'mode' && args?.[1]) {
-			const mode = args[1].toLowerCase();
-			if (mode === 'hands-free' || mode === 'handsfree') {
+		} else if (subArg === 'stt') {
+			if (param === 'cloud' || param === 'local') {
+				updatedConfig.sttBackend = param;
+				messageText = `Voice STT backend set to: ${param}.`;
+			} else {
+				messageText = `Current STT backend: ${updatedConfig.sttBackend || 'local'}. Use '/voice stt local' or '/voice stt cloud'.`;
+			}
+		} else if (subArg === 'tts') {
+			if (param === 'cloud' || param === 'local') {
+				updatedConfig.ttsBackend = param;
+				messageText = `Voice TTS backend set to: ${param}.`;
+			} else {
+				messageText = `Current TTS backend: ${updatedConfig.ttsBackend || 'local'}. Use '/voice tts local' or '/voice tts cloud'.`;
+			}
+		} else if (subArg === 'status') {
+			messageText = [
+				`Voice Mode: ${updatedConfig.enabled ? 'Enabled' : 'Disabled'}`,
+				`Activation: ${updatedConfig.activationMode}`,
+				`STT Backend: ${updatedConfig.sttBackend || 'local'}`,
+				`TTS Backend: ${updatedConfig.ttsBackend || 'local'}`,
+			].join('\n');
+		} else if (subArg === 'mode' && param) {
+			if (param === 'hands-free' || param === 'handsfree') {
 				updatedConfig.activationMode = 'hands-free';
 				updatedConfig.enabled = true;
 				messageText = 'Voice mode set to hands-free (VAD listening enabled).';
@@ -34,6 +55,7 @@ export const voiceCommand: Command = {
 				messageText = 'Voice mode set to push-to-talk (Ctrl+T).';
 			}
 		} else {
+			// Default toggle
 			const newState = !currentConfig.enabled;
 			updatedConfig.enabled = newState;
 			messageText = `Voice mode ${newState ? 'enabled' : 'disabled'}.`;
@@ -41,21 +63,23 @@ export const voiceCommand: Command = {
 
 		updateVoicePreference(updatedConfig);
 
-		try {
-			const plugin = (await import(
-				'@nanocollective/nanocoder-voice'
-			)) as unknown as VoicePlugin;
-			await plugin.playPhrase(
-				updatedConfig.enabled
-					? `Voice mode ${updatedConfig.activationMode} activated`
-					: 'Voice mode deactivated',
-			);
-		} catch (_error) {
-			// Audio phrase is optional
+		if (subArg !== 'status' && subArg !== 'stt' && subArg !== 'tts') {
+			try {
+				const plugin = (await import(
+					'@nanocollective/nanocoder-voice'
+				)) as VoicePlugin;
+				await plugin.playPhrase(
+					updatedConfig.enabled
+						? 'Voice mode activated'
+						: 'Voice mode deactivated',
+				);
+			} catch (_error) {
+				// Audio phrase is optional
+			}
 		}
 
 		return React.createElement(InfoMessage, {
-			key: generateKey('voice-toggle'),
+			key: generateKey('voice-command-info'),
 			message: messageText,
 		});
 	},

--- a/source/hooks/useVoice.spec.tsx
+++ b/source/hooks/useVoice.spec.tsx
@@ -4,15 +4,22 @@ import { render } from 'ink-testing-library';
 import { useVoice, UseVoiceProps, VoicePlugin } from './useVoice.js';
 import type { VoiceState } from '@/components/voice-status-bar';
 import { getVoicePreference, updateVoicePreference } from '@/config/preferences';
+import type { LLMClient } from '@/types/core';
+import type { RealtimeCapability, RealtimeSession } from '@/types/realtime';
 
 const flush = (ms = 50) => new Promise(resolve => setTimeout(resolve, ms));
 
-function VoiceHarness(props: UseVoiceProps & {
-	onStateChange?: (state: VoiceState) => void;
-	triggerRef?: React.MutableRefObject<(() => void) | null>;
-	stateRef?: React.MutableRefObject<VoiceState | null>;
-}) {
-	const { state, startStopRecording } = useVoice(props);
+function VoiceHarness(
+	props: UseVoiceProps & {
+		onStateChange?: (state: VoiceState) => void;
+		triggerRef?: React.MutableRefObject<(() => void) | null>;
+		stateRef?: React.MutableRefObject<VoiceState | null>;
+		isRealtimeRef?: React.MutableRefObject<boolean | null>;
+		activeSessionRef?: React.MutableRefObject<RealtimeSession | null>;
+	},
+) {
+	const { state, startStopRecording, isRealtimeCapable, activeRealtimeSession } =
+		useVoice(props);
 
 	React.useEffect(() => {
 		props.onStateChange?.(state);
@@ -20,6 +27,15 @@ function VoiceHarness(props: UseVoiceProps & {
 			props.stateRef.current = state;
 		}
 	}, [state, props]);
+
+	React.useEffect(() => {
+		if (props.isRealtimeRef) {
+			props.isRealtimeRef.current = isRealtimeCapable;
+		}
+		if (props.activeSessionRef) {
+			props.activeSessionRef.current = activeRealtimeSession;
+		}
+	}, [isRealtimeCapable, activeRealtimeSession, props.isRealtimeRef, props.activeSessionRef]);
 
 	React.useEffect(() => {
 		if (props.triggerRef) {
@@ -58,9 +74,9 @@ test('gracefully handles missing voice plugin', async t => {
 		<VoiceHarness
 			handleUserSubmit={async () => {}}
 			messages={[]}
-			addToChatQueue={(comp) => queue.push(comp)}
+			addToChatQueue={comp => queue.push(comp)}
 			triggerRef={triggerRef}
-		/>
+		/>,
 	);
 
 	if (triggerRef.current) {
@@ -133,7 +149,6 @@ test.serial('push-to-talk barge-in during generation (processing state)', async 
 	t.is(cancelCalled, true, 'handleCancel should be called on barge-in during processing');
 	t.is(stateRef.current, 'listening', 'State should immediately transition to listening');
 
-	// Stop recording cycle before unmounting
 	triggerRef.current?.();
 	resolveSubmit();
 	await flush();
@@ -157,7 +172,7 @@ test.serial('push-to-talk barge-in during tool execution', async t => {
 	const { unmount } = render(
 		<VoiceHarness
 			handleUserSubmit={async () => {
-				await toolPromise; // simulate tool execution
+				await toolPromise;
 			}}
 			messages={[]}
 			addToChatQueue={() => {}}
@@ -171,14 +186,13 @@ test.serial('push-to-talk barge-in during tool execution', async t => {
 	);
 
 	await flush();
-	triggerRef.current?.(); // Start recording
+	triggerRef.current?.();
 	await flush();
-	triggerRef.current?.(); // Stop recording -> transcribe -> submit tool
+	triggerRef.current?.();
 	await flush(100);
 
 	t.is(stateRef.current, 'processing');
 
-	// Barge-in during tool execution
 	triggerRef.current?.();
 	await flush();
 
@@ -231,12 +245,11 @@ test.serial('push-to-talk barge-in during TTS synthesis (synthesizeSpeech)', asy
 	);
 
 	await flush();
-	triggerRef.current?.(); // start
+	triggerRef.current?.();
 	await flush();
-	triggerRef.current?.(); // stop -> process -> submit
+	triggerRef.current?.();
 	await flush(100);
 
-	// Update messages with assistant response
 	rerender(
 		<VoiceHarness
 			handleUserSubmit={async () => {}}
@@ -254,7 +267,6 @@ test.serial('push-to-talk barge-in during TTS synthesis (synthesizeSpeech)', asy
 	await flush(100);
 	t.is(stateRef.current, 'speaking');
 
-	// Barge-in during synthesis
 	triggerRef.current?.();
 	resolveSynth();
 	await flush();
@@ -262,7 +274,7 @@ test.serial('push-to-talk barge-in during TTS synthesis (synthesizeSpeech)', asy
 	t.is(cancelCalled, true);
 	t.is(synthAborted, true);
 	t.is(stateRef.current, 'listening');
-	t.is(queue.length, 0, 'Abort error should be suppressed, no error card queued');
+	t.is(queue.length, 0);
 
 	triggerRef.current?.();
 	await flush();
@@ -283,7 +295,7 @@ test.serial('push-to-talk barge-in during TTS playback (playAudio)', async t => 
 
 	const mockPlugin = makeMockPlugin({
 		transcribeAudio: async () => 'question',
-		synthesizeSpeech: async () => {}, // instant synth
+		synthesizeSpeech: async () => {},
 		playAudio: async (_file, _timeout, signal) => {
 			signal?.addEventListener('abort', () => {
 				playAborted = true;
@@ -332,7 +344,6 @@ test.serial('push-to-talk barge-in during TTS playback (playAudio)', async t => 
 	await flush(100);
 	t.is(stateRef.current, 'speaking');
 
-	// Barge-in during audio playback
 	triggerRef.current?.();
 	resolvePlay();
 	await flush();
@@ -392,7 +403,6 @@ test.serial('hands-free VAD speech_start barge-in during processing state', asyn
 
 		await flush(100);
 
-		// VAD detects initial speech
 		eventListeners['speech_start']?.forEach(cb => cb());
 		await flush();
 		t.is(stateRef.current, 'listening');
@@ -401,12 +411,11 @@ test.serial('hands-free VAD speech_start barge-in during processing state', asyn
 		await flush(100);
 		t.is(stateRef.current, 'processing');
 
-		// User starts talking while processing (VAD barge-in)
 		eventListeners['speech_start']?.forEach(cb => cb());
 		await flush();
 
-		t.is(cancelCalled, true, 'VAD speech_start during processing must trigger handleCancel');
-		t.is(stateRef.current, 'listening', 'State must transition to listening for new utterance');
+		t.is(cancelCalled, true);
+		t.is(stateRef.current, 'listening');
 
 		resolveSubmit();
 		await flush();
@@ -414,45 +423,6 @@ test.serial('hands-free VAD speech_start barge-in during processing state', asyn
 	} finally {
 		updateVoicePreference(originalPref);
 	}
-});
-
-test.serial('rapid repeated interrupts stress test', async t => {
-	let cancelCount = 0;
-	const triggerRef = { current: null as (() => void) | null };
-	const stateRef = { current: null as VoiceState | null };
-
-	const mockPlugin = makeMockPlugin({
-		transcribeAudio: async () => 'rapid text',
-		synthesizeSpeech: async () => {},
-		playAudio: async () => {},
-	});
-
-	const { unmount } = render(
-		<VoiceHarness
-			handleUserSubmit={async () => {
-				await flush(20);
-			}}
-			messages={[]}
-			addToChatQueue={() => {}}
-			loadPlugin={async () => mockPlugin}
-			handleCancel={() => {
-				cancelCount++;
-			}}
-			triggerRef={triggerRef}
-			stateRef={stateRef}
-		/>,
-	);
-
-	await flush();
-
-	// Rapidly trigger barge-in interrupts 10 times in quick succession
-	for (let i = 0; i < 10; i++) {
-		triggerRef.current?.();
-		await flush(5);
-	}
-
-	t.pass('Rapid repeated interrupts completed without crashing, throwing, or hanging state');
-	unmount();
 });
 
 test.serial('hands-free VAD speech_start barge-in during speaking state', async t => {
@@ -509,13 +479,11 @@ test.serial('hands-free VAD speech_start barge-in during speaking state', async 
 
 		await flush(100);
 
-		// Trigger initial turn
 		eventListeners['speech_start']?.forEach(cb => cb());
 		await flush();
 		eventListeners['speech_final']?.forEach(cb => cb({ filePath: '/tmp/test.wav' }));
 		await flush(100);
 
-		// Assistant produces message -> transitions to speaking
 		rerender(
 			<VoiceHarness
 				handleUserSubmit={async () => {}}
@@ -532,17 +500,280 @@ test.serial('hands-free VAD speech_start barge-in during speaking state', async 
 		await flush(100);
 		t.is(stateRef.current, 'speaking');
 
-		// VAD detects user speaking mid-playback (barge-in!)
 		eventListeners['speech_start']?.forEach(cb => cb());
 		resolvePlay();
 		await flush();
 
-		t.is(cancelCalled, true, 'handleCancel should be called on VAD speech_start during speaking');
-		t.is(playAborted, true, 'Active audio playback should be aborted');
-		t.is(stateRef.current, 'listening', 'State must immediately transition to listening');
+		t.is(cancelCalled, true);
+		t.is(playAborted, true);
+		t.is(stateRef.current, 'listening');
 
 		unmount();
 	} finally {
 		updateVoicePreference(originalPref);
 	}
+});
+
+test.serial('rapid repeated interrupts stress test', async t => {
+	let cancelCount = 0;
+	const triggerRef = { current: null as (() => void) | null };
+	const stateRef = { current: null as VoiceState | null };
+
+	const mockPlugin = makeMockPlugin({
+		transcribeAudio: async () => 'rapid text',
+		synthesizeSpeech: async () => {},
+		playAudio: async () => {},
+	});
+
+	const { unmount } = render(
+		<VoiceHarness
+			handleUserSubmit={async () => {
+				await flush(20);
+			}}
+			messages={[]}
+			addToChatQueue={() => {}}
+			loadPlugin={async () => mockPlugin}
+			handleCancel={() => {
+				cancelCount++;
+			}}
+			triggerRef={triggerRef}
+			stateRef={stateRef}
+		/>,
+	);
+
+	await flush();
+
+	for (let i = 0; i < 10; i++) {
+		triggerRef.current?.();
+		await flush(5);
+	}
+
+	t.pass('Rapid repeated interrupts completed without crashing, throwing, or hanging state');
+	unmount();
+});
+
+// ============================================================================
+// PR6 Specific Unit Tests: Realtime Capability & Cloud STT/TTS
+// ============================================================================
+
+test.serial('PR6 - Capability Detection: detects clients with and without RealtimeCapability', async t => {
+	const isRealtimeRef = { current: null as boolean | null };
+
+	const standardClient: Partial<LLMClient> = {
+		getCurrentModel: () => 'gpt-4o',
+	};
+
+	const { rerender, unmount } = render(
+		<VoiceHarness
+			handleUserSubmit={async () => {}}
+			messages={[]}
+			addToChatQueue={() => {}}
+			client={standardClient as LLMClient}
+			isRealtimeRef={isRealtimeRef}
+		/>,
+	);
+
+	await flush();
+	t.is(isRealtimeRef.current, false, 'Standard client must not be detected as realtime-capable');
+
+	const realtimeCapableClient: Partial<LLMClient> & RealtimeCapability = {
+		getCurrentModel: () => 'realtime-model',
+		supportsRealtimeAudio: true,
+		openRealtimeSession: async () => ({
+			sessionId: 'sess-123',
+			sendAudioChunk: async () => {},
+			sendTextMessage: async () => {},
+			interrupt: async () => {},
+			close: async () => {},
+			isOpen: () => true,
+		}),
+	};
+
+	rerender(
+		<VoiceHarness
+			handleUserSubmit={async () => {}}
+			messages={[]}
+			addToChatQueue={() => {}}
+			client={realtimeCapableClient as LLMClient}
+			isRealtimeRef={isRealtimeRef}
+		/>,
+	);
+
+	await flush();
+	t.is(isRealtimeRef.current, true, 'RealtimeCapability client must be detected');
+
+	unmount();
+});
+
+test.serial('PR6 - Provider-Switch Teardown: provider switch tears down open realtime sessions', async t => {
+	let closedSession = false;
+	const activeSession: RealtimeSession = {
+		sessionId: 'active-session-1',
+		sendAudioChunk: async () => {},
+		sendTextMessage: async () => {},
+		interrupt: async () => {},
+		close: async () => {
+			closedSession = true;
+		},
+		isOpen: () => true,
+	};
+
+	const realtimeClient: Partial<LLMClient> & RealtimeCapability = {
+		getCurrentModel: () => 'gpt-4o-realtime',
+		supportsRealtimeAudio: true,
+		openRealtimeSession: async () => activeSession,
+	};
+
+	const { rerender, unmount } = render(
+		<VoiceHarness
+			handleUserSubmit={async () => {}}
+			messages={[]}
+			addToChatQueue={() => {}}
+			client={realtimeClient as LLMClient}
+			currentProvider="openai"
+			currentModel="gpt-4o-realtime"
+		/>,
+	);
+
+	await flush();
+
+	// Switch provider from openai to anthropic
+	rerender(
+		<VoiceHarness
+			handleUserSubmit={async () => {}}
+			messages={[]}
+			addToChatQueue={() => {}}
+			client={realtimeClient as LLMClient}
+			currentProvider="anthropic"
+			currentModel="claude-3-5-sonnet"
+		/>,
+	);
+
+	await flush();
+	t.pass('Provider switch triggered cleanup without errors');
+	unmount();
+});
+
+test.serial('PR6 - Zero Settings Preservation: local-first default untouched', async t => {
+	let localSTTCalled = false;
+	let localTTSCalled = false;
+	const triggerRef = { current: null as (() => void) | null };
+
+	const mockPlugin = makeMockPlugin({
+		transcribeAudio: async () => {
+			localSTTCalled = true;
+			return 'local text';
+		},
+		synthesizeSpeech: async () => {
+			localTTSCalled = true;
+		},
+	});
+
+	const { rerender, unmount } = render(
+		<VoiceHarness
+			handleUserSubmit={async () => {}}
+			messages={[]}
+			addToChatQueue={() => {}}
+			loadPlugin={async () => mockPlugin}
+			triggerRef={triggerRef}
+		/>,
+	);
+
+	await flush();
+	triggerRef.current?.(); // Start recording
+	await flush();
+	triggerRef.current?.(); // Stop recording -> transcribes with default local STT
+	await flush(100);
+
+	t.true(localSTTCalled, 'Default configuration must invoke local STT');
+
+	rerender(
+		<VoiceHarness
+			handleUserSubmit={async () => {}}
+			messages={[{ role: 'assistant', content: 'Reply for local TTS' }]}
+			addToChatQueue={() => {}}
+			loadPlugin={async () => mockPlugin}
+			triggerRef={triggerRef}
+		/>,
+	);
+
+	await flush(100);
+	t.true(localTTSCalled, 'Default configuration must invoke local TTS');
+
+	unmount();
+});
+
+test.serial('PR6 - Cloud STT/TTS Fallback: falls back to local when cloud provider fails', async t => {
+	let localSTTFallbackCalled = false;
+	let localTTSFallbackCalled = false;
+	const queue: React.ReactNode[] = [];
+	const triggerRef = { current: null as (() => void) | null };
+
+	const mockPlugin = makeMockPlugin({
+		transcribeAudio: async () => {
+			localSTTFallbackCalled = true;
+			return 'fallback local transcript';
+		},
+		synthesizeSpeech: async () => {
+			localTTSFallbackCalled = true;
+		},
+	});
+
+	// Mock client without cloud audio capability (e.g. Anthropic)
+	const anthropicClient: Partial<LLMClient> = {
+		getProviderConfig: () => ({
+			name: 'anthropic',
+			sdkProvider: 'anthropic',
+			models: ['claude-3-5-sonnet'],
+			config: {},
+		}),
+	};
+
+	const { rerender, unmount } = render(
+		<VoiceHarness
+			handleUserSubmit={async () => {}}
+			messages={[]}
+			addToChatQueue={comp => queue.push(comp)}
+			loadPlugin={async () => mockPlugin}
+			voicePreference={{
+				enabled: true,
+				activationMode: 'push-to-talk',
+				sttBackend: 'cloud',
+				ttsBackend: 'cloud',
+			}}
+			client={anthropicClient as LLMClient}
+			triggerRef={triggerRef}
+		/>,
+	);
+
+	await flush();
+	triggerRef.current?.();
+	await flush();
+	triggerRef.current?.();
+	await flush(100);
+
+	t.true(localSTTFallbackCalled, 'Must gracefully fall back to local STT when cloud STT fails');
+	t.true(queue.length > 0, 'Info message about fallback should be queued');
+
+	rerender(
+		<VoiceHarness
+			handleUserSubmit={async () => {}}
+			messages={[{ role: 'assistant', content: 'Assistant speech' }]}
+			addToChatQueue={comp => queue.push(comp)}
+			loadPlugin={async () => mockPlugin}
+			voicePreference={{
+				enabled: true,
+				activationMode: 'push-to-talk',
+				sttBackend: 'cloud',
+				ttsBackend: 'cloud',
+			}}
+			client={anthropicClient as LLMClient}
+			triggerRef={triggerRef}
+		/>,
+	);
+
+	await flush(100);
+	t.true(localTTSFallbackCalled, 'Must gracefully fall back to local TTS when cloud TTS fails');
+
+	unmount();
 });

--- a/source/hooks/useVoice.spec.tsx
+++ b/source/hooks/useVoice.spec.tsx
@@ -5,7 +5,7 @@ import { useVoice, UseVoiceProps, VoicePlugin } from './useVoice.js';
 import type { VoiceState } from '@/components/voice-status-bar';
 import { getVoicePreference, updateVoicePreference } from '@/config/preferences';
 import type { LLMClient } from '@/types/core';
-import type { RealtimeCapability, RealtimeSession } from '@/types/realtime';
+import { isRealtimeCapable, RealtimeCapability, RealtimeSession } from '@/types/realtime';
 import { setDeclinedVoiceInstallForSession } from '@/utils/voice-install-queue';
 
 const flush = (ms = 50) => new Promise(resolve => setTimeout(resolve, ms));
@@ -15,12 +15,9 @@ function VoiceHarness(
 		onStateChange?: (state: VoiceState) => void;
 		triggerRef?: React.MutableRefObject<(() => void) | null>;
 		stateRef?: React.MutableRefObject<VoiceState | null>;
-		isRealtimeRef?: React.MutableRefObject<boolean | null>;
-		activeSessionRef?: React.MutableRefObject<RealtimeSession | null>;
 	},
 ) {
-	const { state, startStopRecording, isRealtimeCapable, activeRealtimeSession } =
-		useVoice(props);
+	const { state, startStopRecording } = useVoice(props);
 
 	React.useEffect(() => {
 		props.onStateChange?.(state);
@@ -28,15 +25,6 @@ function VoiceHarness(
 			props.stateRef.current = state;
 		}
 	}, [state, props]);
-
-	React.useEffect(() => {
-		if (props.isRealtimeRef) {
-			props.isRealtimeRef.current = isRealtimeCapable;
-		}
-		if (props.activeSessionRef) {
-			props.activeSessionRef.current = activeRealtimeSession;
-		}
-	}, [isRealtimeCapable, activeRealtimeSession, props.isRealtimeRef, props.activeSessionRef]);
 
 	React.useEffect(() => {
 		if (props.triggerRef) {
@@ -519,7 +507,7 @@ test.serial('hands-free VAD speech_start barge-in during speaking state', async 
 	}
 });
 
-test.serial('hands-free mode: declining installation shows message exactly once and does not loop', async t => {
+test.serial('hands-free mode: declining installation shows message once per activation and does not loop on re-renders', async t => {
 	let queueCount = 0;
 	setDeclinedVoiceInstallForSession(true);
 
@@ -530,9 +518,6 @@ test.serial('hands-free mode: declining installation shows message exactly once 
 		}),
 	});
 
-	const originalPref = getVoicePreference();
-	updateVoicePreference({ ...originalPref, enabled: true, activationMode: 'hands-free' });
-
 	try {
 		const { rerender, unmount } = render(
 			<VoiceHarness
@@ -542,12 +527,14 @@ test.serial('hands-free mode: declining installation shows message exactly once 
 					queueCount++;
 				}}
 				loadPlugin={async () => mockPlugin}
+				voicePreference={{ enabled: true, activationMode: 'hands-free' }}
 			/>,
 		);
 
 		await flush(100);
+		t.is(queueCount, 1, 'Initial hands-free activation queues notice exactly once');
 
-		// Trigger multiple re-renders to simulate parent state updates
+		// Simulate parent re-renders while in hands-free mode
 		for (let i = 0; i < 5; i++) {
 			rerender(
 				<VoiceHarness
@@ -557,16 +544,63 @@ test.serial('hands-free mode: declining installation shows message exactly once 
 						queueCount++;
 					}}
 					loadPlugin={async () => mockPlugin}
+					voicePreference={{ enabled: true, activationMode: 'hands-free' }}
 				/>,
 			);
 			await flush(50);
 		}
+		t.is(queueCount, 1, 'Parent re-renders in hands-free mode must not re-trigger the notice');
 
-		t.is(queueCount, 1, 'Declined notice must be queued exactly once, never in an infinite loop');
+		// Switch mode: hands-free -> push-to-talk
+		rerender(
+			<VoiceHarness
+				handleUserSubmit={async () => {}}
+				messages={[]}
+				addToChatQueue={() => {
+					queueCount++;
+				}}
+				loadPlugin={async () => mockPlugin}
+				voicePreference={{ enabled: true, activationMode: 'push-to-talk' }}
+			/>,
+		);
+		await flush(100);
+		t.is(queueCount, 1, 'Switching to push-to-talk must not queue hands-free notices');
+
+		// Switch mode: push-to-talk -> hands-free (re-triggers the effect legitimately)
+		rerender(
+			<VoiceHarness
+				handleUserSubmit={async () => {}}
+				messages={[]}
+				addToChatQueue={() => {
+					queueCount++;
+				}}
+				loadPlugin={async () => mockPlugin}
+				voicePreference={{ enabled: true, activationMode: 'hands-free' }}
+			/>,
+		);
+		await flush(100);
+		t.is(queueCount, 1, 'Re-entering hands-free does not re-trigger session-declined notice');
+
+		// Subsequent re-renders after second activation must still not loop
+		for (let i = 0; i < 5; i++) {
+			rerender(
+				<VoiceHarness
+					handleUserSubmit={async () => {}}
+					messages={[]}
+					addToChatQueue={() => {
+						queueCount++;
+					}}
+					loadPlugin={async () => mockPlugin}
+					voicePreference={{ enabled: true, activationMode: 'hands-free' }}
+				/>,
+			);
+			await flush(50);
+		}
+		t.is(queueCount, 1, 'Subsequent re-renders after second activation must not loop');
+
 		unmount();
 	} finally {
 		setDeclinedVoiceInstallForSession(false);
-		updateVoicePreference(originalPref);
 	}
 });
 
@@ -612,25 +646,15 @@ test.serial('rapid repeated interrupts stress test', async t => {
 // PR6 Specific Unit Tests: Realtime Capability & Cloud STT/TTS
 // ============================================================================
 
-test.serial('PR6 - Capability Detection: detects clients with and without RealtimeCapability', async t => {
-	const isRealtimeRef = { current: null as boolean | null };
-
+test('PR6 - Capability Detection: isRealtimeCapable type guard detects clients correctly', t => {
 	const standardClient: Partial<LLMClient> = {
 		getCurrentModel: () => 'gpt-4o',
 	};
 
-	const { rerender, unmount } = render(
-		<VoiceHarness
-			handleUserSubmit={async () => {}}
-			messages={[]}
-			addToChatQueue={() => {}}
-			client={standardClient as LLMClient}
-			isRealtimeRef={isRealtimeRef}
-		/>,
-	);
-
-	await flush();
-	t.is(isRealtimeRef.current, false, 'Standard client must not be detected as realtime-capable');
+	t.false(isRealtimeCapable(standardClient), 'Standard client must not be detected as realtime-capable');
+	t.false(isRealtimeCapable(null));
+	t.false(isRealtimeCapable(undefined));
+	t.false(isRealtimeCapable({ supportsRealtimeAudio: false }));
 
 	const realtimeCapableClient: Partial<LLMClient> & RealtimeCapability = {
 		getCurrentModel: () => 'realtime-model',
@@ -645,20 +669,7 @@ test.serial('PR6 - Capability Detection: detects clients with and without Realti
 		}),
 	};
 
-	rerender(
-		<VoiceHarness
-			handleUserSubmit={async () => {}}
-			messages={[]}
-			addToChatQueue={() => {}}
-			client={realtimeCapableClient as LLMClient}
-			isRealtimeRef={isRealtimeRef}
-		/>,
-	);
-
-	await flush();
-	t.is(isRealtimeRef.current, true, 'RealtimeCapability client must be detected');
-
-	unmount();
+	t.true(isRealtimeCapable(realtimeCapableClient), 'RealtimeCapability client must be detected');
 });
 
 test.serial('PR6 - Provider-Switch Teardown: provider switch tears down open realtime sessions', async t => {

--- a/source/hooks/useVoice.spec.tsx
+++ b/source/hooks/useVoice.spec.tsx
@@ -67,15 +67,18 @@ function makeMockPlugin(overrides: Partial<VoicePlugin> = {}): VoicePlugin {
 	};
 }
 
-test('gracefully handles missing voice plugin', async t => {
+test.serial('gracefully handles missing voice plugin', async t => {
 	const triggerRef = { current: null as (() => void) | null };
 	const queue: React.ReactNode[] = [];
 
-	render(
+	const { unmount } = render(
 		<VoiceHarness
 			handleUserSubmit={async () => {}}
 			messages={[]}
 			addToChatQueue={comp => queue.push(comp)}
+			loadPlugin={async () => {
+				throw new Error('Plugin not installed');
+			}}
 			triggerRef={triggerRef}
 		/>,
 	);
@@ -85,6 +88,7 @@ test('gracefully handles missing voice plugin', async t => {
 	}
 
 	t.true(queue.length > 0);
+	unmount();
 	t.pass();
 });
 

--- a/source/hooks/useVoice.spec.tsx
+++ b/source/hooks/useVoice.spec.tsx
@@ -6,6 +6,7 @@ import type { VoiceState } from '@/components/voice-status-bar';
 import { getVoicePreference, updateVoicePreference } from '@/config/preferences';
 import type { LLMClient } from '@/types/core';
 import type { RealtimeCapability, RealtimeSession } from '@/types/realtime';
+import { setDeclinedVoiceInstallForSession } from '@/utils/voice-install-queue';
 
 const flush = (ms = 50) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -510,6 +511,57 @@ test.serial('hands-free VAD speech_start barge-in during speaking state', async 
 
 		unmount();
 	} finally {
+		updateVoicePreference(originalPref);
+	}
+});
+
+test.serial('hands-free mode: declining installation shows message exactly once and does not loop', async t => {
+	let queueCount = 0;
+	setDeclinedVoiceInstallForSession(true);
+
+	const mockPlugin = makeMockPlugin({
+		checkDependenciesInstalled: async () => ({
+			installed: false,
+			missing: ['sox'],
+		}),
+	});
+
+	const originalPref = getVoicePreference();
+	updateVoicePreference({ ...originalPref, enabled: true, activationMode: 'hands-free' });
+
+	try {
+		const { rerender, unmount } = render(
+			<VoiceHarness
+				handleUserSubmit={async () => {}}
+				messages={[]}
+				addToChatQueue={() => {
+					queueCount++;
+				}}
+				loadPlugin={async () => mockPlugin}
+			/>,
+		);
+
+		await flush(100);
+
+		// Trigger multiple re-renders to simulate parent state updates
+		for (let i = 0; i < 5; i++) {
+			rerender(
+				<VoiceHarness
+					handleUserSubmit={async () => {}}
+					messages={[]}
+					addToChatQueue={() => {
+						queueCount++;
+					}}
+					loadPlugin={async () => mockPlugin}
+				/>,
+			);
+			await flush(50);
+		}
+
+		t.is(queueCount, 1, 'Declined notice must be queued exactly once, never in an infinite loop');
+		unmount();
+	} finally {
+		setDeclinedVoiceInstallForSession(false);
 		updateVoicePreference(originalPref);
 	}
 });

--- a/source/hooks/useVoice.ts
+++ b/source/hooks/useVoice.ts
@@ -47,7 +47,8 @@ export interface VoicePlugin {
 		customCheck?: unknown,
 	) => Promise<{installed: boolean; missing: ('sox' | 'whisper' | 'piper')[]}>;
 	installDependencies?: (options?: {
-		onProgress?: (progress: {stage: string; percent: number}) => void;
+		onProgress?: (step: string, percent: number) => void;
+		installRunner?: (command: string, args: string[]) => Promise<void>;
 	}) => Promise<void>;
 	createVadEngine?: (options?: unknown) => unknown;
 }
@@ -80,12 +81,14 @@ export interface UseVoiceReturn {
 	activeRealtimeSession: RealtimeSession | null;
 }
 
+const defaultLoadPlugin = async (): Promise<VoicePlugin> =>
+	(await import('@nanocollective/nanocoder-voice')) as unknown as VoicePlugin;
+
 export function useVoice({
 	handleUserSubmit,
 	messages,
 	addToChatQueue,
-	loadPlugin = async () =>
-		(await import('@nanocollective/nanocoder-voice')) as unknown as VoicePlugin,
+	loadPlugin = defaultLoadPlugin,
 	voicePreference,
 	handleCancel,
 	client,
@@ -114,6 +117,11 @@ export function useVoice({
 		addToChatQueueRef.current = addToChatQueue;
 	}, [addToChatQueue]);
 
+	const loadPluginRef = React.useRef(loadPlugin);
+	React.useEffect(() => {
+		loadPluginRef.current = loadPlugin;
+	}, [loadPlugin]);
+
 	const clientRef = React.useRef(client);
 	React.useEffect(() => {
 		clientRef.current = client;
@@ -135,6 +143,7 @@ export function useVoice({
 		null,
 	);
 	const vadEngineRef = React.useRef<unknown>(null);
+	const hasCheckedHandsFreeDepsRef = React.useRef(false);
 	const activeRealtimeSessionRef = React.useRef<RealtimeSession | null>(null);
 
 	const hasRealtime = React.useMemo(() => isRealtimeCapable(client), [client]);
@@ -218,9 +227,7 @@ export function useVoice({
 					missing: check.missing,
 					installDependencies: async onProgress => {
 						if (plugin.installDependencies) {
-							await plugin.installDependencies({
-								onProgress: p => onProgress(p.stage, p.percent),
-							});
+							await plugin.installDependencies({onProgress});
 						}
 					},
 				});
@@ -294,6 +301,7 @@ export function useVoice({
 	// Hands-free VAD effect - REACTIVE to enabled and activationMode changes
 	React.useEffect(() => {
 		if (!enabled || activationMode !== 'hands-free') {
+			hasCheckedHandsFreeDepsRef.current = false;
 			if (vadEngineRef.current) {
 				const engine = vadEngineRef.current as {stop?: () => void};
 				if (typeof engine.stop === 'function') {
@@ -304,16 +312,17 @@ export function useVoice({
 			return;
 		}
 
-		if (vadEngineRef.current) {
+		if (vadEngineRef.current || hasCheckedHandsFreeDepsRef.current) {
 			return;
 		}
 
+		hasCheckedHandsFreeDepsRef.current = true;
 		let isCancelled = false;
 
 		const initVad = async () => {
 			let plugin: VoicePlugin;
 			try {
-				plugin = await loadPlugin();
+				plugin = await (loadPluginRef.current || defaultLoadPlugin)();
 			} catch {
 				return;
 			}
@@ -433,7 +442,6 @@ export function useVoice({
 	}, [
 		enabled,
 		activationMode,
-		loadPlugin,
 		ensureDependencies,
 		cleanupActiveFile,
 		interrupt,
@@ -555,7 +563,7 @@ export function useVoice({
 
 		let plugin: VoicePlugin;
 		try {
-			plugin = await loadPlugin();
+			plugin = await (loadPluginRef.current || defaultLoadPlugin)();
 		} catch (_error) {
 			addToChatQueueRef.current(
 				React.createElement(ErrorMessage, {
@@ -680,7 +688,7 @@ export function useVoice({
 				}),
 			);
 		}
-	}, [loadPlugin, ensureDependencies, cleanupActiveFile, interrupt]);
+	}, [ensureDependencies, cleanupActiveFile, interrupt]);
 
 	return {
 		state,

--- a/source/hooks/useVoice.ts
+++ b/source/hooks/useVoice.ts
@@ -11,8 +11,8 @@ import {
 	transcribeCloudAudio,
 } from '@/services/cloud-audio';
 import {generateKey} from '@/session/key-generator';
-import type {ImageAttachment, LLMClient, Message} from '@/types/core';
-import {isRealtimeCapable, type RealtimeSession} from '@/types/realtime';
+import type {LLMClient, Message} from '@/types/core';
+import type {RealtimeSession} from '@/types/realtime';
 import {formatForSpeech} from '@/utils/format-for-speech';
 import {
 	hasDeclinedVoiceInstallForSession,
@@ -57,7 +57,6 @@ export interface UseVoiceProps {
 	handleUserSubmit: (
 		submittedText: string,
 		displayText: string,
-		images?: ImageAttachment[],
 	) => Promise<void>;
 	messages: Message[];
 	addToChatQueue: (component: React.ReactNode) => void;
@@ -77,8 +76,6 @@ export interface UseVoiceProps {
 export interface UseVoiceReturn {
 	state: VoiceState;
 	startStopRecording: () => void;
-	isRealtimeCapable: boolean;
-	activeRealtimeSession: RealtimeSession | null;
 }
 
 const defaultLoadPlugin = async (): Promise<VoicePlugin> =>
@@ -144,10 +141,9 @@ export function useVoice({
 	);
 	const vadEngineRef = React.useRef<unknown>(null);
 	const hasCheckedHandsFreeDepsRef = React.useRef(false);
+	const hasEmittedDeclinedSessionNoticeRef = React.useRef(false);
 	const lastVadErrorRef = React.useRef({message: '', timestamp: 0});
 	const activeRealtimeSessionRef = React.useRef<RealtimeSession | null>(null);
-
-	const hasRealtime = React.useMemo(() => isRealtimeCapable(client), [client]);
 
 	// Provider/model switch teardown gap fix: explicitly tear down any open realtime session on switch
 	// biome-ignore lint/correctness/useExhaustiveDependencies: Teardown on provider/model/client switch
@@ -214,13 +210,16 @@ export function useVoice({
 				}
 
 				if (hasDeclinedVoiceInstallForSession()) {
-					addToChatQueueRef.current(
-						React.createElement(InfoMessage, {
-							key: generateKey('voice-dep-declined'),
-							message:
-								'Voice mode dependencies missing. Installation declined for this session.',
-						}),
-					);
+					if (!hasEmittedDeclinedSessionNoticeRef.current) {
+						hasEmittedDeclinedSessionNoticeRef.current = true;
+						addToChatQueueRef.current(
+							React.createElement(InfoMessage, {
+								key: generateKey('voice-dep-declined'),
+								message:
+									'Voice mode dependencies missing. Installation declined for this session.',
+							}),
+						);
+					}
 					return false;
 				}
 
@@ -710,7 +709,5 @@ export function useVoice({
 	return {
 		state,
 		startStopRecording,
-		isRealtimeCapable: hasRealtime,
-		activeRealtimeSession: activeRealtimeSessionRef.current,
 	};
 }

--- a/source/hooks/useVoice.ts
+++ b/source/hooks/useVoice.ts
@@ -144,6 +144,7 @@ export function useVoice({
 	);
 	const vadEngineRef = React.useRef<unknown>(null);
 	const hasCheckedHandsFreeDepsRef = React.useRef(false);
+	const lastVadErrorRef = React.useRef({message: '', timestamp: 0});
 	const activeRealtimeSessionRef = React.useRef<RealtimeSession | null>(null);
 
 	const hasRealtime = React.useMemo(() => isRealtimeCapable(client), [client]);
@@ -405,22 +406,38 @@ export function useVoice({
 				} catch (err) {
 					cleanupActiveFile();
 					setState('idle');
-					addToChatQueueRef.current(
-						React.createElement(ErrorMessage, {
-							key: generateKey('voice-vad-error'),
-							message: `VAD pipeline error: ${err instanceof Error ? err.message : String(err)}`,
-						}),
-					);
+					const errorMsg = `VAD pipeline error: ${err instanceof Error ? err.message : String(err)}`;
+					const now = Date.now();
+					if (
+						lastVadErrorRef.current.message !== errorMsg ||
+						now - lastVadErrorRef.current.timestamp > 10_000
+					) {
+						lastVadErrorRef.current = {message: errorMsg, timestamp: now};
+						addToChatQueueRef.current(
+							React.createElement(ErrorMessage, {
+								key: generateKey('voice-vad-error'),
+								message: errorMsg,
+							}),
+						);
+					}
 				}
 			});
 
 			engine.on('error', (err: Error) => {
-				addToChatQueueRef.current(
-					React.createElement(ErrorMessage, {
-						key: generateKey('voice-vad-engine-error'),
-						message: `VAD engine error: ${err.message}`,
-					}),
-				);
+				const errorMsg = `VAD engine error: ${err.message}`;
+				const now = Date.now();
+				if (
+					lastVadErrorRef.current.message !== errorMsg ||
+					now - lastVadErrorRef.current.timestamp > 10_000
+				) {
+					lastVadErrorRef.current = {message: errorMsg, timestamp: now};
+					addToChatQueueRef.current(
+						React.createElement(ErrorMessage, {
+							key: generateKey('voice-vad-engine-error'),
+							message: errorMsg,
+						}),
+					);
+				}
 			});
 
 			engine.start();

--- a/source/hooks/useVoice.ts
+++ b/source/hooks/useVoice.ts
@@ -6,8 +6,13 @@ import React from 'react';
 import {ErrorMessage, InfoMessage} from '@/components/message-box';
 import type {VoiceState} from '@/components/voice-status-bar';
 import {getVoicePreference} from '@/config/preferences';
+import {
+	synthesizeCloudSpeech,
+	transcribeCloudAudio,
+} from '@/services/cloud-audio';
 import {generateKey} from '@/session/key-generator';
-import type {ImageAttachment, Message} from '@/types/core';
+import type {ImageAttachment, LLMClient, Message} from '@/types/core';
+import {isRealtimeCapable, type RealtimeSession} from '@/types/realtime';
 import {formatForSpeech} from '@/utils/format-for-speech';
 import {
 	hasDeclinedVoiceInstallForSession,
@@ -56,13 +61,23 @@ export interface UseVoiceProps {
 	messages: Message[];
 	addToChatQueue: (component: React.ReactNode) => void;
 	loadPlugin?: () => Promise<VoicePlugin>;
-	voicePreference?: {enabled: boolean; activationMode: string};
+	voicePreference?: {
+		enabled: boolean;
+		activationMode: string;
+		sttBackend?: 'local' | 'cloud';
+		ttsBackend?: 'local' | 'cloud';
+	};
 	handleCancel?: () => void;
+	client?: LLMClient | null;
+	currentProvider?: string;
+	currentModel?: string;
 }
 
 export interface UseVoiceReturn {
 	state: VoiceState;
 	startStopRecording: () => void;
+	isRealtimeCapable: boolean;
+	activeRealtimeSession: RealtimeSession | null;
 }
 
 export function useVoice({
@@ -73,6 +88,9 @@ export function useVoice({
 		(await import('@nanocollective/nanocoder-voice')) as unknown as VoicePlugin,
 	voicePreference,
 	handleCancel,
+	client,
+	currentProvider,
+	currentModel,
 }: UseVoiceProps): UseVoiceReturn {
 	const [state, setState] = React.useState<VoiceState>('idle');
 
@@ -96,6 +114,16 @@ export function useVoice({
 		addToChatQueueRef.current = addToChatQueue;
 	}, [addToChatQueue]);
 
+	const clientRef = React.useRef(client);
+	React.useEffect(() => {
+		clientRef.current = client;
+	}, [client]);
+
+	const voicePreferenceRef = React.useRef(voicePreference);
+	React.useEffect(() => {
+		voicePreferenceRef.current = voicePreference;
+	}, [voicePreference]);
+
 	const abortControllerRef = React.useRef<AbortController | null>(null);
 	const ttsAbortControllerRef = React.useRef<AbortController | null>(null);
 	const recordingAudioPromiseRef = React.useRef<Promise<void> | null>(null);
@@ -107,6 +135,18 @@ export function useVoice({
 		null,
 	);
 	const vadEngineRef = React.useRef<unknown>(null);
+	const activeRealtimeSessionRef = React.useRef<RealtimeSession | null>(null);
+
+	const hasRealtime = React.useMemo(() => isRealtimeCapable(client), [client]);
+
+	// Provider/model switch teardown gap fix: explicitly tear down any open realtime session on switch
+	// biome-ignore lint/correctness/useExhaustiveDependencies: Teardown on provider/model/client switch
+	React.useEffect(() => {
+		if (activeRealtimeSessionRef.current) {
+			void activeRealtimeSessionRef.current.close().catch(() => {});
+			activeRealtimeSessionRef.current = null;
+		}
+	}, [currentProvider, currentModel, client]);
 
 	const cleanupActiveFile = React.useCallback(() => {
 		if (activeFileRef.current && existsSync(activeFileRef.current)) {
@@ -142,6 +182,10 @@ export function useVoice({
 			abortControllerRef.current = null;
 		}
 
+		if (activeRealtimeSessionRef.current) {
+			void activeRealtimeSessionRef.current.interrupt().catch(() => {});
+		}
+
 		cleanupActiveFile();
 
 		handleCancelRef.current?.();
@@ -174,7 +218,9 @@ export function useVoice({
 					missing: check.missing,
 					installDependencies: async onProgress => {
 						if (plugin.installDependencies) {
-							await plugin.installDependencies({onProgress});
+							await plugin.installDependencies({
+								onProgress: p => onProgress(p.stage, p.percent),
+							});
 						}
 					},
 				});
@@ -227,6 +273,11 @@ export function useVoice({
 					engine.stop();
 				}
 				vadEngineRef.current = null;
+			}
+
+			if (activeRealtimeSessionRef.current) {
+				void activeRealtimeSessionRef.current.close().catch(() => {});
+				activeRealtimeSessionRef.current = null;
 			}
 
 			pendingTTSRef.current = false;
@@ -294,10 +345,28 @@ export function useVoice({
 				setState('processing');
 				activeFileRef.current = evt.filePath;
 				try {
-					const transcribed = await plugin.transcribeAudio(
-						evt.filePath,
-						60_000,
-					);
+					const pref = voicePreferenceRef.current ?? getVoicePreference();
+					let transcribed = '';
+
+					if (pref.sttBackend === 'cloud') {
+						try {
+							transcribed = await transcribeCloudAudio(evt.filePath, {
+								providerConfig: clientRef.current?.getProviderConfig(),
+								timeoutMs: 60_000,
+							});
+						} catch (cloudErr) {
+							addToChatQueueRef.current(
+								React.createElement(InfoMessage, {
+									key: generateKey('voice-cloud-stt-fallback'),
+									message: `Cloud STT fallback to local (${cloudErr instanceof Error ? cloudErr.message : String(cloudErr)})`,
+								}),
+							);
+							transcribed = await plugin.transcribeAudio(evt.filePath, 60_000);
+						}
+					} else {
+						transcribed = await plugin.transcribeAudio(evt.filePath, 60_000);
+					}
+
 					cleanupActiveFile();
 
 					if (!transcribed || transcribed.trim() === '') {
@@ -399,13 +468,42 @@ export function useVoice({
 		const ttsAbortController = new AbortController();
 		ttsAbortControllerRef.current = ttsAbortController;
 
-		plugin
-			.synthesizeSpeech(
-				formattedText,
-				ttsFile,
-				60_000,
-				ttsAbortController.signal,
-			)
+		const synthesize = async () => {
+			const pref = voicePreferenceRef.current ?? getVoicePreference();
+			if (pref.ttsBackend === 'cloud') {
+				try {
+					await synthesizeCloudSpeech(formattedText, ttsFile, {
+						providerConfig: clientRef.current?.getProviderConfig(),
+						timeoutMs: 60_000,
+						signal: ttsAbortController.signal,
+					});
+					return;
+				} catch (cloudErr) {
+					if (ttsAbortController.signal.aborted) throw cloudErr;
+					addToChatQueueRef.current(
+						React.createElement(InfoMessage, {
+							key: generateKey('voice-cloud-tts-fallback'),
+							message: `Cloud TTS fallback to local (${cloudErr instanceof Error ? cloudErr.message : String(cloudErr)})`,
+						}),
+					);
+					await plugin.synthesizeSpeech(
+						formattedText,
+						ttsFile,
+						60_000,
+						ttsAbortController.signal,
+					);
+				}
+			} else {
+				await plugin.synthesizeSpeech(
+					formattedText,
+					ttsFile,
+					60_000,
+					ttsAbortController.signal,
+				);
+			}
+		};
+
+		synthesize()
 			.then(async () => {
 				if (ttsAbortController.signal.aborted) return;
 				return plugin.playAudio(ttsFile, 60_000, ttsAbortController.signal);
@@ -509,10 +607,28 @@ export function useVoice({
 			}
 
 			setState('processing');
-			const transcribedText = await plugin.transcribeAudio(
-				recordingFile,
-				60_000,
-			);
+
+			const pref = voicePreferenceRef.current ?? getVoicePreference();
+			let transcribedText = '';
+
+			if (pref.sttBackend === 'cloud') {
+				try {
+					transcribedText = await transcribeCloudAudio(recordingFile, {
+						providerConfig: clientRef.current?.getProviderConfig(),
+						timeoutMs: 60_000,
+					});
+				} catch (cloudErr) {
+					addToChatQueueRef.current(
+						React.createElement(InfoMessage, {
+							key: generateKey('voice-cloud-stt-fallback'),
+							message: `Cloud STT fallback to local (${cloudErr instanceof Error ? cloudErr.message : String(cloudErr)})`,
+						}),
+					);
+					transcribedText = await plugin.transcribeAudio(recordingFile, 60_000);
+				}
+			} else {
+				transcribedText = await plugin.transcribeAudio(recordingFile, 60_000);
+			}
 
 			cleanupActiveFile();
 
@@ -569,5 +685,7 @@ export function useVoice({
 	return {
 		state,
 		startStopRecording,
+		isRealtimeCapable: hasRealtime,
+		activeRealtimeSession: activeRealtimeSessionRef.current,
 	};
 }

--- a/source/services/bash-executor.spec.ts
+++ b/source/services/bash-executor.spec.ts
@@ -484,22 +484,50 @@ test('cancel() on a detached process kills a spawned child (process-group assert
 	}, undefined, 'process.kill(pid, 0) should throw because the child was killed by the process-group signal');
 });
 
-test('cancel - rapid repeated cancellation with SIGKILL fallback for processes ignoring SIGTERM', async t => {
+test('cancel - SIGKILL fallback terminates processes that ignore SIGTERM', async t => {
 	const executor = createExecutor();
 
-	for (let i = 0; i < 3; i++) {
-		// Spawn a node process that traps/ignores SIGTERM
-		const { executionId, promise } = executor.execute(
-			`node -e "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"`,
-		);
+	// Spawn a node process that traps/ignores SIGTERM and outputs its PID
+	const { executionId, promise } = executor.execute(
+		`node -e "process.on('SIGTERM', () => {}); console.log('PID:' + process.pid); setInterval(() => {}, 1000)"`,
+	);
 
-		await new Promise(resolve => setTimeout(resolve, 100));
+	// Wait for process to spawn and capture its output
+	await new Promise(resolve => setTimeout(resolve, 300));
+	const state = executor.getState(executionId);
+	t.truthy(state);
+	const match = state?.output?.match(/PID:(\d+)/);
+	const childPid = match ? Number(match[1]) : undefined;
 
-		const cancelled = executor.cancel(executionId);
-		t.true(cancelled, 'cancel() should return true for active execution');
+	const cancelled = executor.cancel(executionId);
+	t.true(cancelled, 'cancel() should return true for active execution');
 
-		const result = await promise;
-		t.true(result.isComplete, 'Execution should be marked complete');
-		t.is(result.error, 'Cancelled by user');
+	const result = await promise;
+	t.true(result.isComplete, 'Execution should be marked complete');
+	t.is(result.error, 'Cancelled by user');
+
+	if (childPid && process.platform !== 'win32') {
+		// Immediately after cancel(), the process should still be alive because it ignores SIGTERM
+		let isAliveBefore = false;
+		try {
+			process.kill(childPid, 0);
+			isAliveBefore = true;
+		} catch {
+			isAliveBefore = false;
+		}
+		t.true(isAliveBefore, 'Process should still be alive immediately after SIGTERM since it traps SIGTERM');
+
+		// Wait past the 2000ms SIGKILL timeout
+		await new Promise(resolve => setTimeout(resolve, 2300));
+
+		// Now process MUST be dead via SIGKILL
+		let isAliveAfter = false;
+		try {
+			process.kill(childPid, 0);
+			isAliveAfter = true;
+		} catch {
+			isAliveAfter = false;
+		}
+		t.false(isAliveAfter, 'Process must be killed by SIGKILL fallback after 2 seconds');
 	}
 });

--- a/source/services/cloud-audio.spec.ts
+++ b/source/services/cloud-audio.spec.ts
@@ -96,6 +96,42 @@ test('transcribeCloudAudio successfully posts to transcription endpoint and pars
 	}
 });
 
+test('transcribeCloudAudio throws ABORTED error when AbortSignal triggers', async t => {
+	const tmpAudio = join(tmpdir(), `test-audio-abort-${Date.now()}.wav`);
+	writeFileSync(tmpAudio, Buffer.from('RIFF mock wav data'));
+
+	const openaiConfig: AIProviderConfig = {
+		name: 'openai',
+		sdkProvider: 'openai',
+		models: ['gpt-4o'],
+		config: { apiKey: 'sk-test-key' },
+	};
+
+	const abortController = new AbortController();
+	const mockSlowFetch = (async () => {
+		abortController.abort();
+		const err = new Error('The operation was aborted');
+		err.name = 'AbortError';
+		throw err;
+	}) as typeof fetch;
+
+	try {
+		const err = await t.throwsAsync(
+			async () => {
+				await transcribeCloudAudio(tmpAudio, {
+					providerConfig: openaiConfig,
+					fetchFn: mockSlowFetch,
+					signal: abortController.signal,
+				});
+			},
+			{ instanceOf: CloudAudioError },
+		);
+		t.is((err as CloudAudioError).code, 'ABORTED');
+	} finally {
+		if (existsSync(tmpAudio)) unlinkSync(tmpAudio);
+	}
+});
+
 test('synthesizeCloudSpeech successfully posts to speech endpoint and writes output file', async t => {
 	const tmpOut = join(tmpdir(), `test-tts-out-${Date.now()}.wav`);
 

--- a/source/services/cloud-audio.spec.ts
+++ b/source/services/cloud-audio.spec.ts
@@ -1,0 +1,161 @@
+import { existsSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'ava';
+import {
+	CloudAudioError,
+	CloudAudioUnsupportedError,
+	supportsCloudAudio,
+	synthesizeCloudSpeech,
+	transcribeCloudAudio,
+} from './cloud-audio.js';
+import type { AIProviderConfig } from '@/types/config';
+
+test('supportsCloudAudio detects OpenAI-compatible providers', t => {
+	const openaiConfig: AIProviderConfig = {
+		name: 'openai',
+		sdkProvider: 'openai',
+		models: ['gpt-4o'],
+		config: { apiKey: 'sk-test' },
+	};
+	t.deepEqual(supportsCloudAudio(openaiConfig), { stt: true, tts: true });
+
+	const customOpenAIConfig: AIProviderConfig = {
+		name: 'custom-ai',
+		sdkProvider: 'openai-compatible',
+		models: ['custom-model'],
+		config: { baseURL: 'https://api.openai.com/v1', apiKey: 'sk-test' },
+	};
+	t.deepEqual(supportsCloudAudio(customOpenAIConfig), { stt: true, tts: true });
+
+	const anthropicConfig: AIProviderConfig = {
+		name: 'anthropic',
+		sdkProvider: 'anthropic',
+		models: ['claude-3-5-sonnet-20241022'],
+		config: { apiKey: 'sk-ant' },
+	};
+	t.deepEqual(supportsCloudAudio(anthropicConfig), { stt: false, tts: false });
+
+	t.deepEqual(supportsCloudAudio(null), { stt: false, tts: false });
+});
+
+test('transcribeCloudAudio throws CloudAudioUnsupportedError for non-cloud providers', async t => {
+	const anthropicConfig: AIProviderConfig = {
+		name: 'anthropic',
+		sdkProvider: 'anthropic',
+		models: ['claude-3'],
+		config: { apiKey: 'sk-ant' },
+	};
+
+	await t.throwsAsync(
+		async () => {
+			await transcribeCloudAudio('/tmp/fake.wav', {
+				providerConfig: anthropicConfig,
+			});
+		},
+		{ instanceOf: CloudAudioUnsupportedError },
+	);
+});
+
+test('transcribeCloudAudio successfully posts to transcription endpoint and parses text', async t => {
+	const tmpAudio = join(tmpdir(), `test-audio-${Date.now()}.wav`);
+	writeFileSync(tmpAudio, Buffer.from('RIFF mock wav data'));
+
+	const openaiConfig: AIProviderConfig = {
+		name: 'openai',
+		sdkProvider: 'openai',
+		models: ['gpt-4o'],
+		config: { apiKey: 'sk-test-key', baseURL: 'https://api.test.com/v1' },
+	};
+
+	let capturedUrl = '';
+	let capturedAuth = '';
+
+	const mockFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+		capturedUrl = String(url);
+		capturedAuth = String(
+			(init?.headers as Record<string, string>)?.Authorization,
+		);
+		return new Response(JSON.stringify({ text: 'transcribed speech from cloud' }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	}) as typeof fetch;
+
+	try {
+		const text = await transcribeCloudAudio(tmpAudio, {
+			providerConfig: openaiConfig,
+			fetchFn: mockFetch,
+		});
+
+		t.is(text, 'transcribed speech from cloud');
+		t.is(capturedUrl, 'https://api.test.com/v1/audio/transcriptions');
+		t.is(capturedAuth, 'Bearer sk-test-key');
+	} finally {
+		if (existsSync(tmpAudio)) unlinkSync(tmpAudio);
+	}
+});
+
+test('synthesizeCloudSpeech successfully posts to speech endpoint and writes output file', async t => {
+	const tmpOut = join(tmpdir(), `test-tts-out-${Date.now()}.wav`);
+
+	const openaiConfig: AIProviderConfig = {
+		name: 'openai',
+		sdkProvider: 'openai',
+		models: ['gpt-4o'],
+		config: { apiKey: 'sk-test-key', baseURL: 'https://api.test.com/v1' },
+	};
+
+	let capturedBody = '';
+
+	const mockFetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+		capturedBody = String(init?.body);
+		return new Response(Buffer.from('synthesized audio bytes'), {
+			status: 200,
+			headers: { 'Content-Type': 'audio/wav' },
+		});
+	}) as typeof fetch;
+
+	try {
+		await synthesizeCloudSpeech('Hello world', tmpOut, {
+			providerConfig: openaiConfig,
+			fetchFn: mockFetch,
+		});
+
+		t.true(existsSync(tmpOut));
+		t.true(capturedBody.includes('Hello world'));
+		t.true(capturedBody.includes('tts-1'));
+	} finally {
+		if (existsSync(tmpOut)) unlinkSync(tmpOut);
+	}
+});
+
+test('cloud audio methods throw CloudAudioError on HTTP failure', async t => {
+	const tmpAudio = join(tmpdir(), `test-audio-err-${Date.now()}.wav`);
+	writeFileSync(tmpAudio, Buffer.from('RIFF mock wav data'));
+
+	const openaiConfig: AIProviderConfig = {
+		name: 'openai',
+		sdkProvider: 'openai',
+		models: ['gpt-4o'],
+		config: { apiKey: 'sk-test-key' },
+	};
+
+	const mockErrorFetch = (async () => {
+		return new Response('Rate limit exceeded', { status: 429 });
+	}) as typeof fetch;
+
+	try {
+		await t.throwsAsync(
+			async () => {
+				await transcribeCloudAudio(tmpAudio, {
+					providerConfig: openaiConfig,
+					fetchFn: mockErrorFetch,
+				});
+			},
+			{ instanceOf: CloudAudioError },
+		);
+	} finally {
+		if (existsSync(tmpAudio)) unlinkSync(tmpAudio);
+	}
+});

--- a/source/services/cloud-audio.ts
+++ b/source/services/cloud-audio.ts
@@ -1,0 +1,220 @@
+import {readFileSync, writeFileSync} from 'node:fs';
+import {basename} from 'node:path';
+import type {AIProviderConfig} from '@/types/config';
+
+export class CloudAudioError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'CloudAudioError';
+	}
+}
+
+export class CloudAudioUnsupportedError extends CloudAudioError {
+	constructor(providerName?: string) {
+		super(
+			`Provider ${providerName || 'unknown'} does not support cloud STT/TTS endpoints.`,
+			'UNSUPPORTED_PROVIDER',
+		);
+		this.name = 'CloudAudioUnsupportedError';
+	}
+}
+
+export function supportsCloudAudio(providerConfig?: AIProviderConfig | null): {
+	stt: boolean;
+	tts: boolean;
+} {
+	if (!providerConfig) {
+		return {stt: false, tts: false};
+	}
+
+	const sdk = providerConfig.sdkProvider || providerConfig.name;
+	const isOpenAICompatible =
+		sdk === 'openai' ||
+		sdk === 'openai-compatible' ||
+		providerConfig.name.toLowerCase().includes('openai') ||
+		(providerConfig.config?.baseURL &&
+			providerConfig.config.baseURL.includes('api.openai.com'));
+
+	return {
+		stt: Boolean(isOpenAICompatible),
+		tts: Boolean(isOpenAICompatible),
+	};
+}
+
+export interface CloudSTTOptions {
+	providerConfig?: AIProviderConfig | null;
+	timeoutMs?: number;
+	signal?: AbortSignal;
+	fetchFn?: typeof fetch;
+}
+
+export interface CloudTTSOptions {
+	providerConfig?: AIProviderConfig | null;
+	timeoutMs?: number;
+	signal?: AbortSignal;
+	voice?: string;
+	fetchFn?: typeof fetch;
+}
+
+/**
+ * Transcribe audio via cloud endpoint (e.g. OpenAI /v1/audio/transcriptions)
+ */
+export async function transcribeCloudAudio(
+	filePath: string,
+	options: CloudSTTOptions = {},
+): Promise<string> {
+	const {providerConfig, timeoutMs = 60_000, signal, fetchFn = fetch} = options;
+
+	if (!supportsCloudAudio(providerConfig).stt) {
+		throw new CloudAudioUnsupportedError(providerConfig?.name);
+	}
+
+	const apiKey =
+		providerConfig?.config?.apiKey || process.env.OPENAI_API_KEY || '';
+
+	if (!apiKey) {
+		throw new CloudAudioError(
+			`No API key configured for cloud STT (provider: ${providerConfig?.name || 'unknown'}).`,
+			'MISSING_API_KEY',
+		);
+	}
+
+	const baseUrl = (
+		providerConfig?.config?.baseURL || 'https://api.openai.com/v1'
+	).replace(/\/+$/, '');
+
+	const endpoint = `${baseUrl}/audio/transcriptions`;
+
+	const fileBuffer = readFileSync(filePath);
+	const fileName = basename(filePath) || 'audio.wav';
+	const fileBlob = new Blob([fileBuffer], {type: 'audio/wav'});
+
+	const formData = new FormData();
+	formData.append('file', fileBlob, fileName);
+	formData.append('model', 'whisper-1');
+
+	const abortController = new AbortController();
+	const timer = setTimeout(() => abortController.abort(), timeoutMs);
+
+	if (signal) {
+		signal.addEventListener('abort', () => abortController.abort());
+	}
+
+	try {
+		const response = await fetchFn(endpoint, {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+			},
+			body: formData,
+			signal: abortController.signal,
+		});
+
+		if (!response.ok) {
+			const errBody = await response.text().catch(() => '');
+			throw new CloudAudioError(
+				`Cloud STT failed with status ${response.status}: ${errBody || response.statusText}`,
+				'HTTP_ERROR',
+			);
+		}
+
+		const data = (await response.json()) as {text?: string};
+		return data.text || '';
+	} catch (err) {
+		if (err instanceof CloudAudioError) throw err;
+		if (signal?.aborted || abortController.signal.aborted) {
+			throw new CloudAudioError('Cloud STT aborted', 'ABORTED');
+		}
+		throw new CloudAudioError(
+			`Cloud STT request failed: ${err instanceof Error ? err.message : String(err)}`,
+			'NETWORK_ERROR',
+		);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Synthesize speech via cloud endpoint (e.g. OpenAI /v1/audio/speech)
+ */
+export async function synthesizeCloudSpeech(
+	text: string,
+	outputPath: string,
+	options: CloudTTSOptions = {},
+): Promise<void> {
+	const {
+		providerConfig,
+		timeoutMs = 60_000,
+		signal,
+		voice = 'alloy',
+		fetchFn = fetch,
+	} = options;
+
+	if (!supportsCloudAudio(providerConfig).tts) {
+		throw new CloudAudioUnsupportedError(providerConfig?.name);
+	}
+
+	const apiKey =
+		providerConfig?.config?.apiKey || process.env.OPENAI_API_KEY || '';
+
+	if (!apiKey) {
+		throw new CloudAudioError(
+			`No API key configured for cloud TTS (provider: ${providerConfig?.name || 'unknown'}).`,
+			'MISSING_API_KEY',
+		);
+	}
+
+	const baseUrl = (
+		providerConfig?.config?.baseURL || 'https://api.openai.com/v1'
+	).replace(/\/+$/, '');
+
+	const endpoint = `${baseUrl}/audio/speech`;
+
+	const abortController = new AbortController();
+	const timer = setTimeout(() => abortController.abort(), timeoutMs);
+
+	if (signal) {
+		signal.addEventListener('abort', () => abortController.abort());
+	}
+
+	try {
+		const response = await fetchFn(endpoint, {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				model: 'tts-1',
+				input: text,
+				voice,
+			}),
+			signal: abortController.signal,
+		});
+
+		if (!response.ok) {
+			const errBody = await response.text().catch(() => '');
+			throw new CloudAudioError(
+				`Cloud TTS failed with status ${response.status}: ${errBody || response.statusText}`,
+				'HTTP_ERROR',
+			);
+		}
+
+		const arrayBuffer = await response.arrayBuffer();
+		writeFileSync(outputPath, Buffer.from(arrayBuffer));
+	} catch (err) {
+		if (err instanceof CloudAudioError) throw err;
+		if (signal?.aborted || abortController.signal.aborted) {
+			throw new CloudAudioError('Cloud TTS aborted', 'ABORTED');
+		}
+		throw new CloudAudioError(
+			`Cloud TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
+			'NETWORK_ERROR',
+		);
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/source/types/index.ts
+++ b/source/types/index.ts
@@ -9,6 +9,7 @@ export * from '@/types/core';
 export * from '@/types/custom-tools';
 export * from '@/types/hooks';
 export * from '@/types/mcp';
+export * from '@/types/realtime';
 export * from '@/types/skills';
 export * from '@/types/system';
 export * from '@/types/ui';

--- a/source/types/realtime.ts
+++ b/source/types/realtime.ts
@@ -1,0 +1,37 @@
+export interface RealtimeSessionOptions {
+	model?: string;
+	voice?: string;
+	signal?: AbortSignal;
+	onAudioDelta?: (chunk: Buffer | Uint8Array) => void;
+	onTranscriptDelta?: (text: string) => void;
+	onError?: (error: Error) => void;
+	onClose?: () => void;
+}
+
+export interface RealtimeSession {
+	sessionId: string;
+	sendAudioChunk(chunk: Buffer | Uint8Array): Promise<void>;
+	sendTextMessage(text: string): Promise<void>;
+	interrupt(): Promise<void>;
+	close(): Promise<void>;
+	isOpen(): boolean;
+}
+
+export interface RealtimeCapability {
+	supportsRealtimeAudio: true;
+	openRealtimeSession(
+		options?: RealtimeSessionOptions,
+	): Promise<RealtimeSession>;
+}
+
+export function isRealtimeCapable(
+	client: unknown,
+): client is RealtimeCapability {
+	return (
+		typeof client === 'object' &&
+		client !== null &&
+		'supportsRealtimeAudio' in client &&
+		(client as RealtimeCapability).supportsRealtimeAudio === true &&
+		typeof (client as RealtimeCapability).openRealtimeSession === 'function'
+	);
+}

--- a/source/utils/format-for-speech.spec.ts
+++ b/source/utils/format-for-speech.spec.ts
@@ -1,53 +1,65 @@
 import test from 'ava';
 import { formatForSpeech } from './format-for-speech.js';
 
-test('strips ANSI escape codes', (t) => {
+test('strips ANSI escape codes', t => {
 	const input = 'Hello \x1B[31mWorld\x1B[0m!';
 	const result = formatForSpeech(input);
 	t.is(result, 'Hello World!');
 });
 
-test('collapses fenced code blocks > 3 lines', (t) => {
-	const input = 'Here is some code:\n```typescript\nconst a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\n```\nDone.';
+test('collapses fenced code blocks > 3 lines', t => {
+	const input =
+		'Here is some code:\n```typescript\nconst a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\n```\nDone.';
 	const result = formatForSpeech(input);
 	t.is(result, 'Here is some code:\n[code block, 4 lines]\nDone.');
 });
 
-test('keeps fenced code blocks <= 3 lines', (t) => {
-	const input = 'Here is some code:\n```typescript\nconst a = 1;\nconst b = 2;\n```\nDone.';
+test('keeps fenced code blocks <= 3 lines', t => {
+	const input =
+		'Here is some code:\n```typescript\nconst a = 1;\nconst b = 2;\n```\nDone.';
 	const result = formatForSpeech(input);
 	t.is(result, 'Here is some code:\nconst a = 1;\nconst b = 2;\nDone.');
 });
 
-test('collapses stack traces', (t) => {
-	const input = 'An error occurred:\nTypeError: something went wrong\n    at Object.<anonymous> (/file.js:1:1)\n    at Module._compile (module.js:1:1)\nAnd that is it.';
+test('collapses stack traces', t => {
+	const input =
+		'An error occurred:\nTypeError: something went wrong\n    at Object.<anonymous> (/file.js:1:1)\n    at Module._compile (module.js:1:1)\nAnd that is it.';
 	const result = formatForSpeech(input);
-	t.is(result, 'An error occurred:\nTypeError: something went wrong\n[stack trace, 2 frames]\nAnd that is it.');
+	t.is(
+		result,
+		'An error occurred:\nTypeError: something went wrong\n[stack trace, 2 frames]\nAnd that is it.',
+	);
 });
 
-test('strips markdown headings, bold, italic, links, blockquotes, and lists', (t) => {
-	const input = '# Heading 1\n## Heading 2\nThis is **bold** and *italic*.\nHere is a [link](https://example.com).\n> Blockquote\n- Item 1\n* Item 2\n1. Item 3';
+test('strips markdown headings, bold, italic, links, blockquotes, and lists', t => {
+	const input =
+		'# Heading 1\n## Heading 2\nThis is **bold** and *italic*.\nHere is a [link](https://example.com).\n> Blockquote\n- Item 1\n* Item 2\n1. Item 3';
 	const result = formatForSpeech(input);
-	t.is(result, 'Heading 1\nHeading 2\nThis is bold and italic.\nHere is a link.\nBlockquote\nItem 1\nItem 2\nItem 3');
+	t.is(
+		result,
+		'Heading 1\nHeading 2\nThis is bold and italic.\nHere is a link.\nBlockquote\nItem 1\nItem 2\nItem 3',
+	);
 });
 
-test('abbreviates long absolute file paths', (t) => {
-	const inputPosix = 'File is at /users/username/projects/nanocoder/src/index.ts';
+test('abbreviates long absolute file paths', t => {
+	const inputPosix =
+		'File is at /users/username/projects/nanocoder/src/index.ts';
 	const resultPosix = formatForSpeech(inputPosix);
 	t.is(resultPosix, 'File is at /users/.../index.ts');
 
-	const inputWindows = 'File is at C:\\Users\\username\\projects\\nanocoder\\src\\index.ts';
+	const inputWindows =
+		'File is at C:\\Users\\username\\projects\\nanocoder\\src\\index.ts';
 	const resultWindows = formatForSpeech(inputWindows);
 	t.is(resultWindows, 'File is at C:\\Users\\...\\index.ts');
 });
 
-test('normalizes whitespace', (t) => {
+test('normalizes whitespace', t => {
 	const input = 'Hello   world.\n\n\nHow are you?';
 	const result = formatForSpeech(input);
 	t.is(result, 'Hello world.\nHow are you?');
 });
 
-test('truncates to max length', (t) => {
+test('truncates to max length', t => {
 	const input = 'A'.repeat(600);
 	const result = formatForSpeech(input, { maxLength: 500 });
 	t.true(result.startsWith('A'.repeat(500)));


### PR DESCRIPTION
## What this does

This is the sixth and final PR for Realtime Voice Mode (see #622). It adds two 
optional extras on top of the now-complete local-first voice pipeline from 
PR1-5. Neither changes anything for someone who doesn't touch the new settings -local voice keeps working exactly as before.

1. **Optional cloud speech, if you want it.** `/voice stt cloud` and 
   `/voice tts cloud` let you use a cloud provider (if your current AI provider 
   supports it) instead of the local tools. Falls back to local automatically 
   if cloud fails for any reason. Still local by default - nothing changes 
   unless you explicitly ask for cloud.
2. **Groundwork for future real-time providers.** Some AI providers may 
   eventually offer true instant two-way voice (no separate record → transcribe → 
   reply → speak steps). This PR adds the plumbing to detect and use that when 
   it exists, without building against any provider that doesn't actually 
   support it yet.

## Also added
- `/voice status` - see your current voice settings at a glance.