### PR TITLE
fix(events): normalize path separators so file.changed globs match on Windows

### DIFF
--- a/.changeset/fix-windows-event-glob-separators.md
+++ b/.changeset/fix-windows-event-glob-separators.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed `file.changed` skill subscriptions silently never firing on Windows. Chokidar reports changed files using the platform separator, so a documented pattern like `docs/**` was asked to match `docs\guide.md` and never could — the daemon started, reported healthy, logged nothing, and did nothing. The same mismatch let a root-scoped pattern such as `*.md` match the nested `sub\a.md`, dispatching an unattended agent run against a file that was deliberately scoped out. Paths are now normalized to `/` at the watcher boundary, so the router, activity reports, and the payload handed to a triggered agent all read one path shape. Closes #964.

--- a/source/events/event-router.spec.ts
+++ b/source/events/event-router.spec.ts
@@ -165,3 +165,33 @@ test('matchGlob: basic patterns', t => {
 	t.true(matchGlob('file.txt', 'file.txt'));
 	t.false(matchGlob('file.txt', 'other.txt'));
 });
+
+// Chokidar reports the platform separator, so on Windows a `/`-authored
+// pattern is asked to match `docs\guide.md`. Both directions matter: a
+// segment pattern must still match, and `*` must not cross a backslash any
+// more than it crosses a slash.
+test('matchGlob: paths using Windows separators', t => {
+	const cases: Array<[pattern: string, path: string, expected: boolean]> = [
+		['docs/**', 'docs\\guide.md', true],
+		['docs/**', 'docs\\api\\ref.md', true],
+		['docs/*.md', 'docs\\guide.md', true],
+		['k8s/**/*.yaml', 'k8s\\deploy.yaml', true],
+		['k8s/**/*.yaml', 'k8s\\prod\\deploy.yaml', true],
+		['src/**/*.ts', 'src\\deep\\file.ts', true],
+		['**/*.md', 'docs\\intro.md', true],
+		['docs/**', 'src\\index.ts', false],
+		// `*` stops at a directory boundary, whichever separator draws it
+		['*.md', 'sub\\a.md', false],
+		['src/*.ts', 'src\\deep\\file.ts', false],
+		['?.md', 'sub\\a.md', false],
+	];
+	for (const [pattern, path, expected] of cases) {
+		t.is(matchGlob(pattern, path), expected, `${pattern} vs ${path}`);
+	}
+});
+
+test('matchGlob: patterns authored with Windows separators', t => {
+	t.true(matchGlob('docs\\**', 'docs/guide.md'));
+	t.true(matchGlob('docs\\**', 'docs\\guide.md'));
+	t.false(matchGlob('docs\\*.md', 'docs/deep/guide.md'));
+});

--- a/source/events/event-router.ts
+++ b/source/events/event-router.ts
@@ -98,14 +98,27 @@ export function matchesFilter(sub: Subscription, event: Event): boolean {
 	return false;
 }
 
+/**
+ * Rewrite Windows separators to `/` so patterns and paths meet on one shape.
+ *
+ * Subscription globs are always authored with `/`, but chokidar reports
+ * changes using the platform separator — on Windows `docs/**` would be asked
+ * to match `docs\guide.md` and never could. The matcher below also leans on
+ * `/` to stop `*` at a directory boundary, so an un-normalized path makes
+ * `*.md` match the nested `sub\a.md` as well.
+ */
+export function toPosixPath(path: string): string {
+	return path.split('\\').join('/');
+}
+
 // Minimal glob -> regex matcher: enough for `docs/<star><star>`,
 // `src/<star><star>/*.ts`, `<star><star>/*.md`, literal paths, and `?`
 // single-character wildcards. Step 9 brings chokidar (and its picomatch dep)
 // into the tree, at which point we can swap this for picomatch and delete
 // the helper. Until then this is sufficient to make the router unit-testable.
 export function matchGlob(pattern: string, path: string): boolean {
-	const regex = globToRegex(pattern);
-	return regex.test(path);
+	const regex = globToRegex(toPosixPath(pattern));
+	return regex.test(toPosixPath(path));
 }
 
 function globToRegex(pattern: string): RegExp {

--- a/source/events/sources/file-watcher.spec.ts
+++ b/source/events/sources/file-watcher.spec.ts
@@ -120,9 +120,12 @@ test.serial('paths emitted are relative to the watch root', async t => {
 		const match = events.find(
 			e => e.kind === 'file.changed' && e.payload.file.endsWith('leaf.ts'),
 		);
+		// Separators are normalized at this boundary, so the shape is `/` on
+		// every platform — the router, activity reports and the payload handed
+		// to a triggered agent all read the same path.
 		t.regex(
 			match?.kind === 'file.changed' ? match.payload.file : '',
-			/^src[\\/]inner[\\/]leaf\.ts$/,
+			/^src\/inner\/leaf\.ts$/,
 		);
 	} finally {
 		await source.stop();

--- a/source/events/sources/file-watcher.ts
+++ b/source/events/sources/file-watcher.ts
@@ -1,5 +1,5 @@
 import {type FSWatcher, watch} from 'chokidar';
-import type {EventRouter} from '@/events/event-router';
+import {type EventRouter, toPosixPath} from '@/events/event-router';
 import type {FileChangeEventKind} from '@/types/skills';
 
 export interface FileWatcherOptions {
@@ -68,7 +68,10 @@ export class FileWatcherSource {
 	private emit(file: string, eventKind: FileChangeEventKind): void {
 		void this.router.emit({
 			kind: 'file.changed',
-			payload: {file, eventKind},
+			// Normalized at the boundary, not just in the matcher, so the router,
+			// activity reports and the payload handed to a triggered agent all
+			// speak one path shape rather than the platform's.
+			payload: {file: toPosixPath(file), eventKind},
 			at: Date.now(),
 		});
 	}


### PR DESCRIPTION
## Description

chokidar reports changed files using the platform separator, so on Windows the router was asked to match a `/`-authored pattern like `docs/**` against `docs\guide.md` a comparison that can never succeed. Path-scoped `file.changed` subscriptions therefore never fired, and nothing reported a problem: the daemon started, reported healthy and logged nothing, because no code path treats a non-match as an error.

The same mismatch ran the other way too. `globToRegex` compiles `*` to `[^/]*`, which does not exclude a backslash, so a root-scoped pattern such as `*.md` matched the nested `sub\a.md` and dispatched an unattended agent run against a file that was deliberately scoped out.

Normalize in `FileWatcherSource.emit` rather than only in the matcher, so the router, activity reports and the payload handed to a triggered agent all read one path shape; `matchGlob` normalizes both pattern and path defensively. Once the path uses `/`, `[^/]` stops at a real separator and the over-match disappears along with the under-match.

The picomatch swap noted at `event-router.ts:100` is left as a follow-up it is not resolvable as a transitive dependency under pnpm's strict linking and would need adding as a direct one.

Closes #964.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))