### PR TITLE
fix: correct inline diff similarity helper name

### DIFF
--- a/.changeset/fix-lines-similar-name.md
+++ b/.changeset/fix-lines-similar-name.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+Fix the exported inline-diff similarity helper name from `areLinesSimlar` to `areLinesSimilar`. Thanks to @hafzism. Closes #968.

--- a/source/tools/file-ops/string-replace-preview.tsx
+++ b/source/tools/file-ops/string-replace-preview.tsx
@@ -10,7 +10,7 @@ import {truncateAnsi} from '@/utils/ansi-truncate';
 import {formatError} from '@/utils/error-formatter';
 import {getCachedFileContent} from '@/utils/file-cache';
 import {normalizeIndentation} from '@/utils/indentation-normalizer';
-import {areLinesSimlar, computeInlineDiff} from '@/utils/inline-diff';
+import {areLinesSimilar, computeInlineDiff} from '@/utils/inline-diff';
 import {getLanguageFromExtension} from '@/utils/programming-language-helper';
 
 interface StringReplaceArgs {
@@ -218,7 +218,7 @@ export async function formatStringReplacePreview(
 			} else if (
 				oldLine !== null &&
 				newLine !== null &&
-				areLinesSimlar(oldLine, newLine)
+				areLinesSimilar(oldLine, newLine)
 			) {
 				const truncatedOldLine = truncateLine(oldLine, availableWidth);
 				const truncatedNewLine = truncateLine(newLine, availableWidth);

--- a/source/utils/inline-diff.spec.ts
+++ b/source/utils/inline-diff.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {areLinesSimlar, computeInlineDiff} from './inline-diff.js';
+import {areLinesSimilar, computeInlineDiff} from './inline-diff.js';
 
 // ============================================================================
 // computeInlineDiff Tests
@@ -93,73 +93,73 @@ test('computeInlineDiff: preserves whitespace in diff', t => {
 });
 
 // ============================================================================
-// areLinesSimlar Tests
+// areLinesSimilar Tests
 // ============================================================================
 
-test('areLinesSimlar: identical lines are similar', t => {
-	t.true(areLinesSimlar('const x = 1;', 'const x = 1;'));
+test('areLinesSimilar: identical lines are similar', t => {
+	t.true(areLinesSimilar('const x = 1;', 'const x = 1;'));
 });
 
-test('areLinesSimlar: lines with minor changes are similar', t => {
-	t.true(areLinesSimlar('const x = 1;', 'const x = 2;'));
-	t.true(areLinesSimlar('function foo() {}', 'function bar() {}'));
-	t.true(areLinesSimlar('import React from "react";', 'import React from "react";'));
+test('areLinesSimilar: lines with minor changes are similar', t => {
+	t.true(areLinesSimilar('const x = 1;', 'const x = 2;'));
+	t.true(areLinesSimilar('function foo() {}', 'function bar() {}'));
+	t.true(areLinesSimilar('import React from "react";', 'import React from "react";'));
 });
 
-test('areLinesSimlar: lines with same structure are similar', t => {
-	t.true(areLinesSimlar(
+test('areLinesSimilar: lines with same structure are similar', t => {
+	t.true(areLinesSimilar(
 		'MIT License with Attribution',
 		'MIT License',
 	));
 });
 
-test('areLinesSimlar: completely different lines are not similar', t => {
-	t.false(areLinesSimlar(
+test('areLinesSimilar: completely different lines are not similar', t => {
+	t.false(areLinesSimilar(
 		'const x = 1;',
 		'import foo from "bar";',
 	));
-	t.false(areLinesSimlar(
+	t.false(areLinesSimilar(
 		'function test() {',
 		'// This is a comment',
 	));
 });
 
-test('areLinesSimlar: empty lines are similar to each other', t => {
-	t.true(areLinesSimlar('', ''));
-	t.true(areLinesSimlar('   ', '  '));
-	t.true(areLinesSimlar('\t', '  '));
+test('areLinesSimilar: empty lines are similar to each other', t => {
+	t.true(areLinesSimilar('', ''));
+	t.true(areLinesSimilar('   ', '  '));
+	t.true(areLinesSimilar('\t', '  '));
 });
 
-test('areLinesSimlar: empty vs non-empty are not similar', t => {
-	t.false(areLinesSimlar('', 'content'));
-	t.false(areLinesSimlar('content', ''));
-	t.false(areLinesSimlar('   ', 'content'));
+test('areLinesSimilar: empty vs non-empty are not similar', t => {
+	t.false(areLinesSimilar('', 'content'));
+	t.false(areLinesSimilar('content', ''));
+	t.false(areLinesSimilar('   ', 'content'));
 });
 
-test('areLinesSimlar: lines sharing 30%+ words are similar', t => {
+test('areLinesSimilar: lines sharing 30%+ words are similar', t => {
 	// 3 out of 5 words shared = 60%
-	t.true(areLinesSimlar(
+	t.true(areLinesSimilar(
 		'const foo = bar + baz;',
 		'const foo = qux + quux;',
 	));
 
 	// Only 1 out of 5 words shared = 20%
-	t.false(areLinesSimlar(
+	t.false(areLinesSimilar(
 		'const foo = bar + baz;',
 		'let qux = quux * corge;',
 	));
 });
 
-test('areLinesSimlar: handles special characters', t => {
-	t.true(areLinesSimlar(
+test('areLinesSimilar: handles special characters', t => {
+	t.true(areLinesSimilar(
 		'const regex = /test.*pattern/;',
 		'const regex = /new.*pattern/;',
 	));
 });
 
-test('areLinesSimlar: handles long lines', t => {
+test('areLinesSimilar: handles long lines', t => {
 	const longLine1 = 'const result = someFunction(arg1, arg2, arg3, arg4, arg5);';
 	const longLine2 = 'const result = someFunction(arg1, arg2, arg3, arg4, arg6);';
 
-	t.true(areLinesSimlar(longLine1, longLine2));
+	t.true(areLinesSimilar(longLine1, longLine2));
 });

--- a/source/utils/inline-diff.tsx
+++ b/source/utils/inline-diff.tsx
@@ -53,7 +53,7 @@ export function computeInlineDiff(
  * Check if two lines are similar enough to show as an inline diff.
  * Returns true if the lines share significant common content.
  */
-export function areLinesSimlar(oldLine: string, newLine: string): boolean {
+export function areLinesSimilar(oldLine: string, newLine: string): boolean {
 	// If either is empty, they're not similar for inline display
 	if (!oldLine.trim() && !newLine.trim()) return true; // Both empty/whitespace
 	if (!oldLine.trim() || !newLine.trim()) return false;


### PR DESCRIPTION
## Description

Renames the exported inline-diff helper from `areLinesSimlar` to `areLinesSimilar` and updates its internal consumer and regression tests.

Closes #968.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a patch changeset describing this fix for the changelog

## Testing

### Automated Tests

- [x] Updated the existing `.spec.ts` coverage for the corrected public name
- [x] Focused inline-diff tests pass (17 tests)
- [x] Type checks, formatting, lint, build, knip, dependency audit, and Semgrep pass

The full AVA run exposed only two environment-specific conditions: the CLI integration tests require the documented build first, and the security-disclaimer snapshot wraps the unusually long local workspace path. After building and rerunning the affected files from a short path, all 19 affected tests passed.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (not applicable)

## Checklist

- [x] Assigned to the issue after receiving maintainer approval
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (not needed)
- [x] No breaking changes
- [x] Appropriate structured logging added (not applicable to this rename)