### PR TITLE
ci: credit every contributor in the release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,28 @@ jobs:
             echo "CHANGELOG=No changelog available for this version." >> $GITHUB_OUTPUT
           fi
 
+      - name: Build Contributors Section
+        id: contributors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          # Credits every PR author in the range, not just the ones a changeset
+          # happened to thank by hand. Never fails the release: the script exits 0
+          # and prints nothing if the list can't be built.
+          CONTRIBUTORS=$(node scripts/generate-contributors.js \
+            --tag "v${{ needs.check-version.outputs.package-version }}" \
+            --previous-tag "v${{ needs.check-version.outputs.npm-version }}" \
+            --target "${{ github.sha }}")
+          if [ -n "$CONTRIBUTORS" ]; then
+            echo "✅ Contributors section built"
+          else
+            echo "ℹ️ No contributors section for this release"
+          fi
+          echo "CONTRIBUTORS<<EOF" >> $GITHUB_OUTPUT
+          echo "$CONTRIBUTORS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Publish to NPM
         run: npm publish --access public
         env:
@@ -140,6 +162,8 @@ jobs:
             ## What's Changed
 
             ${{ steps.changelog.outputs.CHANGELOG }}
+
+            ${{ steps.contributors.outputs.CONTRIBUTORS }}
 
             ### Installation
             ```bash

--- a/scripts/generate-contributors.js
+++ b/scripts/generate-contributors.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * Build the "Contributors" section for a GitHub release body.
+ *
+ * The release notes themselves come from CHANGELOG.md (see extract-changelog.js),
+ * which only credits people when whoever wrote the changeset remembered to type
+ * "Thanks to @someone". This script credits everyone instead, by asking GitHub's
+ * own release-notes generator who authored the pull requests in the tag range.
+ *
+ * Usage:
+ *   node scripts/generate-contributors.js --tag v1.31.0 [--previous-tag v1.30.0] [--target <sha>]
+ *
+ * Requires GITHUB_TOKEN and GITHUB_REPOSITORY in the environment.
+ *
+ * Prints the markdown section to stdout, or nothing at all if the contributor
+ * list could not be determined. Always exits 0 - a release must not fail
+ * because the credits could not be built.
+ */
+
+const API = 'https://api.github.com';
+
+/** Accounts that author PRs but are not people. */
+const BOT_LOGINS = new Set([
+	'changeset-bot',
+	'dependabot',
+	'dependabot-preview',
+	'github-actions',
+	'renovate',
+]);
+
+function isBot(login) {
+	return login.endsWith('[bot]') || BOT_LOGINS.has(login.toLowerCase());
+}
+
+function parseArgs(argv) {
+	const args = {};
+	for (let i = 0; i < argv.length; i += 2) {
+		const key = argv[i]?.replace(/^--/, '');
+		if (key) args[key] = argv[i + 1];
+	}
+	return args;
+}
+
+async function api(path, token, init = {}) {
+	const response = await fetch(`${API}${path}`, {
+		...init,
+		headers: {
+			accept: 'application/vnd.github+json',
+			authorization: `Bearer ${token}`,
+			'x-github-api-version': '2022-11-28',
+			...(init.body ? {'content-type': 'application/json'} : {}),
+		},
+	});
+	if (!response.ok) {
+		throw new Error(
+			`${init.method ?? 'GET'} ${path} failed: ${response.status} ${response.statusText}`,
+		);
+	}
+	return response.json();
+}
+
+async function tagExists(repo, tag, token) {
+	try {
+		await api(`/repos/${repo}/git/ref/tags/${encodeURIComponent(tag)}`, token);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Pull the PR authors and first-time contributors out of GitHub's generated
+ * release notes. The generator emits lines shaped like:
+ *   * Some change by @octocat in https://github.com/owner/repo/pull/1
+ *   * @octocat made their first contribution in https://github.com/owner/repo/pull/1
+ */
+function parseContributors(notes) {
+	const authors = new Set();
+	const firstTimers = new Set();
+
+	for (const [, login] of notes.matchAll(/ by @([A-Za-z0-9-]+) in https/g)) {
+		if (!isBot(login)) authors.add(login);
+	}
+	for (const [, login] of notes.matchAll(
+		/@([A-Za-z0-9-]+) made their first contribution/g,
+	)) {
+		if (!isBot(login)) {
+			authors.add(login);
+			firstTimers.add(login);
+		}
+	}
+
+	const byName = (a, b) => a.toLowerCase().localeCompare(b.toLowerCase());
+	return {
+		authors: [...authors].sort(byName),
+		firstTimers: [...firstTimers].sort(byName),
+	};
+}
+
+/** "a", "a and b", "a, b and c" */
+function joinMentions(logins) {
+	const mentions = logins.map(login => `@${login}`);
+	if (mentions.length <= 1) return mentions.join('');
+	return `${mentions.slice(0, -1).join(', ')} and ${mentions.at(-1)}`;
+}
+
+function formatSection({authors, firstTimers}) {
+	if (authors.length === 0) return '';
+
+	const lines = [
+		'### Contributors',
+		'',
+		`This release shipped thanks to ${joinMentions(authors)}.`,
+	];
+	if (firstTimers.length > 0) {
+		lines.push(
+			'',
+			`First-time contributors: ${joinMentions(firstTimers)}. Welcome, and thank you!`,
+		);
+	}
+	return lines.join('\n');
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const token = process.env.GITHUB_TOKEN;
+	const repo = process.env.GITHUB_REPOSITORY;
+
+	if (!args.tag) throw new Error('--tag is required');
+	if (!token) throw new Error('GITHUB_TOKEN is not set');
+	if (!repo) throw new Error('GITHUB_REPOSITORY is not set');
+
+	const body = {tag_name: args.tag};
+	// Required when --tag does not exist yet, which is the case during a release:
+	// the tag is created by the step that publishes the release.
+	if (args.target) body.target_commitish = args.target;
+	// Left unset if the previous tag is missing (first release, or a version
+	// published to NPM without a matching tag) so GitHub picks the range itself.
+	if (
+		args['previous-tag'] &&
+		(await tagExists(repo, args['previous-tag'], token))
+	) {
+		body.previous_tag_name = args['previous-tag'];
+	}
+
+	const notes = await api(`/repos/${repo}/releases/generate-notes`, token, {
+		method: 'POST',
+		body: JSON.stringify(body),
+	});
+
+	const section = formatSection(parseContributors(notes.body ?? ''));
+	if (section) console.log(section);
+	else console.error('No contributors found for this range; skipping section.');
+}
+
+main().catch(error => {
+	console.error(`Could not build contributors section: ${error.message}`);
+	process.exit(0);
+});


### PR DESCRIPTION
## Problem

The GitHub release body is `CHANGELOG.md` piped through `scripts/extract-changelog.js`. Changesets only credit a person when whoever wrote the changeset remembered to type "Thanks to @someone", so crediting is ad hoc.

v1.30.0 named four people. Twenty-one had merged PRs in the range.

## Fix

Adds `scripts/generate-contributors.js`, which asks GitHub's own `releases/generate-notes` API who authored the PRs between the previously published NPM version and the one being released, filters bots, and prints a `### Contributors` section. The release workflow inserts it above `### Installation`.

- Attribution is **PR-author** based rather than commit-author based, so squash merges credit the contributor rather than the merger.
- Bots are filtered by `[bot]` suffix plus a small denylist (dependabot, github-actions, renovate, changeset-bot).
- The tag being released does not exist yet at that point in the workflow, so the script passes `target_commitish` (the triggering SHA). `previous_tag_name` is dropped if that tag is missing, letting GitHub pick the range itself.
- The script **always exits 0** and prints nothing on failure. A release can never break because the credits could not be built.

Names are listed alphabetically rather than by PR count, so the section does not rank people.

## Verification

Run against the real v1.29.0...v1.30.0 range, the script reproduces byte-for-byte the section now live on [the v1.30.0 release](https://github.com/Nano-Collective/nanocoder/releases/tag/v1.30.0), which was backfilled by hand:

> ### Contributors
>
> This release shipped thanks to @AaryanCdry, @addyCooks, @akramcodez, ... and @will-lamerton.
>
> First-time contributors: @AaryanCdry, @addyCooks, ... and @serhiizghama. Welcome, and thank you!

Also verified:

- The unreleased-tag path (`--tag v1.31.0 --target main`) resolves the range correctly.
- A bogus `--previous-tag` falls back rather than erroring.
- A missing `GITHUB_TOKEN` exits 0 with empty stdout.
- `test:format`, `test:lint` and `test:knip` are clean. The workflow YAML parses and the new step is ordered between Extract Changelog and Publish to NPM.

No changeset: this is CI-only and does not change the shipped package.
