### PR TITLE
feat(notifications): add an opt-in terminal bell

### DIFF
--- a/.changeset/notifications-terminal-bell.md
+++ b/.changeset/notifications-terminal-bell.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added a **terminal bell** option to notifications. Every notifier Nanocoder had was desktop-only — `terminal-notifier`, `osascript`, `notify-send`, the PowerShell balloon — so anyone driving Nanocoder over SSH, inside tmux, or from a remote container got nothing at all when a long run finished. `notifications.bell` now also writes a BEL character to stdout for whichever events you have enabled, which the terminal in front of you renders as a beep or a visual flash. Toggle it under `/settings` → Input → Notifications, next to Sound. BEL is non-printing, so it does not disturb the rendered frame, and it is skipped when stdout is not a TTY so piped output and daemon logs stay clean. Also corrected the notification docs, which described the preference as living under a `nanocoder.notifications` namespace — it is read from the top-level `notifications` key, so anything written at the documented path was silently ignored. Closes #931.

--- a/docs/configuration/preferences.md
+++ b/docs/configuration/preferences.md
@@ -105,15 +105,16 @@ The setting is read per message, so toggling it applies from the next response o
 
 ### Notification Configuration
 
-Desktop notification preferences are stored under the `nanocoder.notifications` namespace:
+Desktop notification preferences are stored under the top-level `notifications` key:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `nanocoder.notifications.enabled` | boolean | `false` | Enable desktop notifications |
-| `nanocoder.notifications.sound` | boolean | `false` | Play a sound with notifications |
-| `nanocoder.notifications.events.toolConfirmation` | boolean | `true` | Notify when a tool needs approval |
-| `nanocoder.notifications.events.questionPrompt` | boolean | `true` | Notify when the AI asks a question |
-| `nanocoder.notifications.events.generationComplete` | boolean | `true` | Notify when a response is ready |
+| `notifications.enabled` | boolean | `false` | Enable desktop notifications |
+| `notifications.sound` | boolean | `false` | Play a sound with notifications |
+| `notifications.bell` | boolean | `false` | Also ring the terminal bell (works over SSH / tmux) |
+| `notifications.events.toolConfirmation` | boolean | `true` | Notify when a tool needs approval |
+| `notifications.events.questionPrompt` | boolean | `true` | Notify when the AI asks a question |
+| `notifications.events.generationComplete` | boolean | `true` | Notify when a response is ready |
 
 You can change these via `/settings` → **Input** → **Notifications**. See [Desktop Notifications](../features/notifications.md) for full details including platform-specific setup.
 

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -16,7 +16,7 @@ Open `/settings` and select **Notifications** to enable them. Toggle which event
 - **Question Prompt** — the AI has asked you a question
 - **Generation Complete** — the AI has finished responding and is ready for your next message
 
-You can also enable notification **sound**.
+You can also enable notification **sound**, and a **Terminal Bell** that writes a BEL character to stdout. The bell is rendered by the terminal emulator itself, so it still reaches you over SSH or inside tmux, where the desktop notifiers cannot land.
 
 ## How It Works
 
@@ -45,24 +45,23 @@ Notifications use `notify-send`, which is included with most desktop environment
 
 ## Configuration
 
-Notification preferences are stored in `nanocoder-preferences.json` under the `nanocoder.notifications` namespace. You can configure them via `/settings` or by editing the file directly:
+Notification preferences are stored in `nanocoder-preferences.json` under the top-level `notifications` key. You can configure them via `/settings` or by editing the file directly:
 
 ```json
 {
-  "nanocoder": {
-    "notifications": {
-      "enabled": true,
-      "sound": true,
-      "events": {
-        "toolConfirmation": true,
-        "questionPrompt": true,
-        "generationComplete": false
-      },
-      "customMessages": {
-        "toolConfirmation": {
-          "title": "Action Required",
-          "message": "Nanocoder needs your approval"
-        }
+  "notifications": {
+    "enabled": true,
+    "sound": true,
+    "bell": true,
+    "events": {
+      "toolConfirmation": true,
+      "questionPrompt": true,
+      "generationComplete": false
+    },
+    "customMessages": {
+      "toolConfirmation": {
+        "title": "Action Required",
+        "message": "Nanocoder needs your approval"
       }
     }
   }
@@ -73,6 +72,7 @@ Notification preferences are stored in `nanocoder-preferences.json` under the `n
 |--------|------|---------|-------------|
 | `enabled` | boolean | `false` | Master toggle for all notifications |
 | `sound` | boolean | `false` | Play a sound with each notification |
+| `bell` | boolean | `false` | Also write a terminal bell (BEL) to stdout — skipped when stdout is not a TTY |
 | `events.toolConfirmation` | boolean | `true` | Notify when a tool needs approval |
 | `events.questionPrompt` | boolean | `true` | Notify when the AI asks a question |
 | `events.generationComplete` | boolean | `true` | Notify when a response is ready |

--- a/source/app/components/settings-selector.spec.tsx
+++ b/source/app/components/settings-selector.spec.tsx
@@ -14,8 +14,12 @@ resetPreferencesCache();
 
 const {renderWithTheme} = await import('../../test-utils/render-with-theme');
 const {SettingsSelector} = await import('./settings-tabs');
-const {SettingsDisplayPanel} = await import('./settings-selector');
-const {updateShowUsageFooter} = await import('@/config/preferences');
+const {SettingsDisplayPanel, SettingsNotificationsPanel} = await import(
+	'./settings-selector'
+);
+const {updateShowUsageFooter, updateNotificationsPreference} = await import(
+	'@/config/preferences'
+);
 
 test('SettingsSelector renders without crashing', t => {
 	const {unmount} = renderWithTheme(<SettingsSelector onCancel={() => {}} />);
@@ -95,5 +99,33 @@ test('SettingsDisplayPanel reflects a disabled Usage & Cost Footer preference', 
 		unmount();
 	} finally {
 		updateShowUsageFooter(true);
+	}
+});
+
+test('SettingsNotificationsPanel offers a Terminal Bell toggle, OFF by default', t => {
+	const {lastFrame, unmount} = renderWithTheme(
+		<SettingsNotificationsPanel onBack={() => {}} onCancel={() => {}} />,
+	);
+	const output = lastFrame();
+	t.truthy(output);
+	// No preference saved in the temp config dir, so the bell starts off.
+	t.true(output!.includes('Terminal Bell: OFF'));
+	unmount();
+});
+
+test('SettingsNotificationsPanel reflects an enabled bell preference', t => {
+	updateNotificationsPreference({enabled: true, bell: true});
+	try {
+		const {lastFrame, unmount} = renderWithTheme(
+			<SettingsNotificationsPanel onBack={() => {}} onCancel={() => {}} />,
+		);
+		const output = lastFrame();
+		t.truthy(output);
+		t.true(output!.includes('Terminal Bell: ON'));
+		// The bell is an extra channel beside sound, not a replacement for it.
+		t.true(output!.includes('Sound: OFF'));
+		unmount();
+	} finally {
+		updateNotificationsPreference({enabled: false, bell: false});
 	}
 });

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -705,6 +705,7 @@ export function SettingsNotificationsPanel({
 		saved ?? {
 			enabled: false,
 			sound: false,
+			bell: false,
 			events: {
 				toolConfirmation: true,
 				questionPrompt: true,
@@ -725,6 +726,7 @@ export function SettingsNotificationsPanel({
 	type ToggleKey =
 		| 'enabled'
 		| 'sound'
+		| 'bell'
 		| 'toolConfirmation'
 		| 'questionPrompt'
 		| 'generationComplete';
@@ -739,6 +741,10 @@ export function SettingsNotificationsPanel({
 			{
 				label: `  Sound: ${isOn(config.sound)}`,
 				value: 'sound' as ToggleKey,
+			},
+			{
+				label: `  Terminal Bell: ${isOn(config.bell)}`,
+				value: 'bell' as ToggleKey,
 			},
 			{
 				label: `  Tool Confirmation: ${isOn(config.events?.toolConfirmation)}`,
@@ -761,6 +767,8 @@ export function SettingsNotificationsPanel({
 			next.enabled = !next.enabled;
 		} else if (item.value === 'sound') {
 			next.sound = !next.sound;
+		} else if (item.value === 'bell') {
+			next.bell = !next.bell;
 		} else {
 			next.events = {...next.events, [item.value]: !next.events?.[item.value]};
 		}

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -114,6 +114,10 @@ export interface SystemPromptConfig {
 export interface NotificationsConfig {
 	enabled: boolean;
 	sound?: boolean;
+	// Emit a terminal bell (BEL) alongside the desktop notification. Unlike the
+	// native notifiers it reaches the terminal itself, so it still lands over SSH
+	// or inside tmux.
+	bell?: boolean;
 	timeout?: number;
 	events?: {
 		toolConfirmation?: boolean;

--- a/source/utils/notifications.spec.ts
+++ b/source/utils/notifications.spec.ts
@@ -107,6 +107,86 @@ test.serial('sendNotification handles undefined events gracefully', (t) => {
 	t.notThrows(() => sendNotification('toolConfirmation'));
 });
 
+// ============================================================================
+// Terminal Bell Tests
+// ============================================================================
+
+const BELL = '\x07';
+
+function capturingStdout(isTTY: boolean): {get: () => string; restore: () => void} {
+	const originalWrite = process.stdout.write.bind(process.stdout);
+	const originalIsTTY = process.stdout.isTTY;
+	let buffer = '';
+	process.stdout.isTTY = isTTY;
+	// biome-ignore lint/suspicious/noExplicitAny: matching Node's overloaded write signature
+	(process.stdout.write as any) = (chunk: any) => {
+		buffer += typeof chunk === 'string' ? chunk : chunk.toString();
+		return true;
+	};
+	return {
+		get: () => buffer,
+		restore: () => {
+			process.stdout.write = originalWrite;
+			process.stdout.isTTY = originalIsTTY;
+		},
+	};
+}
+
+function bellFor(config: NotificationsConfig, isTTY = true): string {
+	setNotificationsConfig(config);
+	const stdout = capturingStdout(isTTY);
+	try {
+		sendNotification('generationComplete');
+	} finally {
+		stdout.restore();
+	}
+	return stdout.get();
+}
+
+test.serial('sendNotification rings the terminal bell when bell is enabled', (t) => {
+	const written = bellFor({
+		enabled: true,
+		bell: true,
+		events: {generationComplete: true},
+	});
+	t.true(written.includes(BELL));
+});
+
+test.serial('sendNotification does not ring the bell when bell is off', (t) => {
+	const written = bellFor({
+		enabled: true,
+		events: {generationComplete: true},
+	});
+	t.false(written.includes(BELL));
+});
+
+test.serial('sendNotification does not ring the bell for a disabled event', (t) => {
+	const written = bellFor({
+		enabled: true,
+		bell: true,
+		events: {generationComplete: false},
+	});
+	t.false(written.includes(BELL));
+});
+
+test.serial('sendNotification does not ring the bell when notifications are disabled', (t) => {
+	const written = bellFor({
+		enabled: false,
+		bell: true,
+		events: {generationComplete: true},
+	});
+	t.false(written.includes(BELL));
+});
+
+test.serial('sendNotification does not ring the bell when stdout is not a TTY', (t) => {
+	// Piped output (CI, redirected logs) must not collect stray control chars
+	const written = bellFor(
+		{enabled: true, bell: true, events: {generationComplete: true}},
+		false,
+	);
+	t.false(written.includes(BELL));
+});
+
 // Reset config after all tests
 test.after.always(() => {
 	setNotificationsConfig({enabled: false});

--- a/source/utils/notifications.ts
+++ b/source/utils/notifications.ts
@@ -151,6 +151,21 @@ $notify.Dispose()
 	execFile('powershell', ['-NoProfile', '-Command', script], () => {});
 }
 
+// A terminal bell is delivered by the terminal emulator itself, so it still
+// lands over SSH or inside tmux where the desktop notifier daemons are not
+// reachable. BEL is non-printing, so writing it mid-render leaves Ink frames
+// intact.
+function ringTerminalBell(): void {
+	if (!process.stdout.isTTY) {
+		return;
+	}
+	try {
+		process.stdout.write('\x07');
+	} catch {
+		// stdout can already be closed during shutdown - a missed bell is harmless
+	}
+}
+
 function sendNativeNotification(title: string, message: string): void {
 	switch (process.platform) {
 		case 'darwin':
@@ -185,6 +200,10 @@ export function sendNotification(event: NotificationEvent): void {
 	// TUI, stdout is captured by Ink so this is harmless.
 	if (process.env.NANOCODER_DAEMON_PROCESS) {
 		console.log(`Notification fired: event=${event} title="${title}"`);
+	}
+
+	if (_config.bell) {
+		ringTerminalBell();
 	}
 
 	sendNativeNotification(title, message);


### PR DESCRIPTION
## Description

Every notifier we shipped was desktop-only - terminal-notifier, osascript,
notify-send, the PowerShell balloon. None of them reach a user driving Nanocoder
over SSH, inside tmux, or from a remote container, so a long run finishing was
silent for exactly the people most likely to have switched windows while waiting.

Adds `bell` to NotificationsConfig, beside `sound`, rather than a separate
top-level flag: the existing generating -> idle transition in useNotifications
already fires generationComplete, and the per-event toggles already say which
moments the user cares about. The bell is one more output channel for those same
events, not a new trigger.

BEL is a non-printing control character, so writing it mid-render does not move
the cursor or disturb Ink's frame. The write is skipped when stdout is not a TTY,
which keeps piped output, CI runs, and the daemon's redirected log free of stray
control bytes.

Also corrects the notification docs, which placed the preference under a
`nanocoder.notifications` namespace. It is read from the top-level
`notifications` key, so a config written at the documented path was silently
ignored.

Closes #931.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

`.changeset/notifications-terminal-bell.md`, `minor`.

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully) 
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it (#931)
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging
