### PR TITLE
fix: remove duplicate compressed message assignment

### DIFF
--- a/source/hooks/chat-handler/conversation/conversation-loop.tsx
+++ b/source/hooks/chat-handler/conversation/conversation-loop.tsx
@@ -592,7 +592,6 @@ export const processAssistantResponse = async (
 				// Replace the local array so subsequent tool-result builders
 				// and recursive calls see the compressed messages instead of
 				// the pre-compression copy.
-				updatedMessages = compressed;
 				compactionOccurred = true;
 			}
 		}


### PR DESCRIPTION
## Description

Removes the redundant updatedMessages = compressed assignment in conversation-loop.tsx.
updatedMessages is already assigned to compressed earlier in the auto-compaction flow, so the second assignment is unnecessary.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [x] Verified the CLI still runs successfully
- [x] Ran `pnpm test:types`
- [x] Ran `pnpm test:lint`

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

Closes #980
