### PR TITLE
fix: close leftover semantic memory review gaps

### DIFF
--- a/.changeset/semantic-memory-remaining.md
+++ b/.changeset/semantic-memory-remaining.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Wire semantic memory recall into subagent and daemon runs, serialize writes across manager instances and processes, and cap each repo memory file at 500 entries.

--- a/docs/features/semantic-memory.md
+++ b/docs/features/semantic-memory.md
@@ -47,9 +47,15 @@ Retrieval is keyword-based, not a true embeddings/vector search. The "semantic" 
 
 ### Where recall is active
 
-Recall runs on the interactive TUI, on `nanocoder run` / `--plain`, and on `--acp`. Each of those shows a `Recalling N project memories...` notice when memories are injected.
+Recall runs on:
 
-Recall does **not** currently run for subagent runs or for daemon-triggered skill runs. This is a deliberate limitation rather than an oversight: those runs are non-interactive, so nobody is present to notice a bad memory steering the run, and the failure mode is silent. Wiring recall into them is tracked as follow-up work, not shipped behaviour.
+- the interactive TUI
+- `nanocoder run` / `--plain`
+- `--acp`
+- subagent runs (the `agent` tool)
+- daemon-triggered skill runs (they use the same subagent executor)
+
+The TUI, plain shell, and ACP print `Recalling N project memories...` when memories are injected. Subagent and daemon runs inject the same block silently, since there is no chat UI to attach that notice to.
 
 ### Tuning the budget
 
@@ -100,5 +106,7 @@ The filename is a hash of the repository's `git remote origin.url`, or of its ab
 - All branches, worktrees, and local clones that share the same `origin` remote share one memory pool.
 - Forks with a different `origin` get their own, separate pool.
 - This scope isn't currently configurable. If you work across branches with genuinely divergent conventions in the same repository, they'll share memories.
+
+Each repository file is capped at 500 memories. Saving past that drops the oldest entries (by timestamp) so the file cannot grow without bound. Writes to the same file are serialized across manager instances in one process, and locked across processes (TUI and daemon).
 
 Files are written atomically (temp file + rename) with restrictive permissions (`0600` on the file, `0700` on the directory), and nothing ever leaves your machine. Memory content is fenced when injected into the system prompt, with the fence widened as needed so content containing backticks cannot break out of it.

--- a/source/memory/semantic-memory-manager.spec.ts
+++ b/source/memory/semantic-memory-manager.spec.ts
@@ -154,6 +154,53 @@ test('SemanticMemoryManager serializes concurrent writes so none are lost', asyn
 	t.is(memories.length, 10);
 });
 
+test('SemanticMemoryManager serializes concurrent writes across manager instances', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const first = new SemanticMemoryManager({memoryDir: dir, cwd});
+	const second = new SemanticMemoryManager({memoryDir: dir, cwd});
+
+	await Promise.all([
+		...Array.from({length: 10}, (_, i) =>
+			first.addMemory({content: `First instance memory ${i}.`}),
+		),
+		...Array.from({length: 10}, (_, i) =>
+			second.addMemory({content: `Second instance memory ${i}.`}),
+		),
+	]);
+
+	t.is((await first.listMemories()).length, 20);
+});
+
+test('SemanticMemoryManager drops oldest memories when the store cap is exceeded', async t => {
+	const dir = await createTempDir();
+	const cwd = path.join(dir, 'repo');
+	await fs.mkdir(cwd);
+	const manager = new SemanticMemoryManager({
+		memoryDir: dir,
+		cwd,
+		maxStoredMemories: 3,
+	});
+
+	for (const index of [1, 2, 3, 4, 5]) {
+		await manager.addMemory({
+			content: `Auth adapter numbered convention ${index}.`,
+		});
+		await new Promise(resolve => setTimeout(resolve, 5));
+	}
+
+	const memories = await manager.listMemories();
+	t.deepEqual(
+		memories.map(memory => memory.content),
+		[
+			'Auth adapter numbered convention 3.',
+			'Auth adapter numbered convention 4.',
+			'Auth adapter numbered convention 5.',
+		],
+	);
+});
+
 test('SemanticMemoryManager rejects empty memory content', async t => {
 	const dir = await createTempDir();
 	const cwd = path.join(dir, 'repo');

--- a/source/memory/semantic-memory-manager.ts
+++ b/source/memory/semantic-memory-manager.ts
@@ -24,6 +24,64 @@ export interface CreateMemoryInput {
 export interface SemanticMemoryManagerOptions {
 	memoryDir?: string;
 	cwd?: string;
+	maxStoredMemories?: number;
+}
+
+const DEFAULT_MAX_STORED_MEMORIES = 500;
+
+const writeQueues = new Map<string, Promise<unknown>>();
+
+function enqueueByKey<T>(key: string, operation: () => Promise<T>): Promise<T> {
+	const previous = writeQueues.get(key) ?? Promise.resolve();
+	const result = previous.then(operation, operation);
+	writeQueues.set(
+		key,
+		result.then(
+			() => undefined,
+			() => undefined,
+		),
+	);
+	return result;
+}
+
+const LOCK_STALE_MS = 10_000;
+const LOCK_WAIT_MS = 15_000;
+
+async function withExclusiveLock<T>(
+	lockPath: string,
+	operation: () => Promise<T>,
+): Promise<T> {
+	const deadline = Date.now() + LOCK_WAIT_MS;
+	while (true) {
+		try {
+			const handle = await fs.open(lockPath, 'wx', 0o600);
+			try {
+				return await operation();
+			} finally {
+				await handle.close();
+				await fs.unlink(lockPath).catch(() => undefined);
+			}
+		} catch (error) {
+			const code =
+				error instanceof Error && 'code' in error
+					? (error as NodeJS.ErrnoException).code
+					: undefined;
+			if (code !== 'EEXIST') throw error;
+			if (Date.now() >= deadline) {
+				throw new Error(`Timed out waiting for memory file lock: ${lockPath}`);
+			}
+			try {
+				const stat = await fs.stat(lockPath);
+				if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+					await fs.unlink(lockPath);
+					continue;
+				}
+			} catch {
+				// Lock gone; retry create.
+			}
+			await new Promise(resolve => setTimeout(resolve, 20));
+		}
+	}
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -196,21 +254,24 @@ function tokenize(value: string): Set<string> {
 export class SemanticMemoryManager {
 	private readonly memoryDir: string;
 	private readonly cwd: string;
+	private readonly maxStoredMemories: number;
 	private memoryFilePath?: string;
-	private writeQueue: Promise<unknown> = Promise.resolve();
 
 	constructor(options: SemanticMemoryManagerOptions = {}) {
 		this.memoryDir = options.memoryDir ?? path.join(getAppDataPath(), 'memory');
 		this.cwd = options.cwd ?? process.cwd();
+		this.maxStoredMemories = Math.max(
+			1,
+			options.maxStoredMemories ?? DEFAULT_MAX_STORED_MEMORIES,
+		);
 	}
 
 	private mutate<T>(operation: () => Promise<T>): Promise<T> {
-		const result = this.writeQueue.then(operation, operation);
-		this.writeQueue = result.then(
-			() => undefined,
-			() => undefined,
+		return this.getMemoryFilePath().then(filePath =>
+			enqueueByKey(filePath, () =>
+				withExclusiveLock(`${filePath}.lock`, operation),
+			),
 		);
-		return result;
 	}
 
 	async addMemory(input: CreateMemoryInput): Promise<SemanticMemory> {
@@ -332,8 +393,27 @@ export class SemanticMemoryManager {
 		return path.resolve(this.cwd);
 	}
 
+	private capMemories(memories: SemanticMemory[]): SemanticMemory[] {
+		if (memories.length <= this.maxStoredMemories) return memories;
+
+		const keep = new Set(
+			[...memories]
+				.sort((a, b) => {
+					const byTime = b.timestamp.localeCompare(a.timestamp);
+					return byTime !== 0 ? byTime : a.id.localeCompare(b.id);
+				})
+				.slice(0, this.maxStoredMemories)
+				.map(memory => memory.id),
+		);
+
+		return memories.filter(memory => keep.has(memory.id));
+	}
+
 	private async writeMemories(memories: SemanticMemory[]): Promise<void> {
 		const filePath = await this.getMemoryFilePath();
-		await atomicWriteFile(filePath, JSON.stringify(memories, null, 2));
+		await atomicWriteFile(
+			filePath,
+			JSON.stringify(this.capMemories(memories), null, 2),
+		);
 	}
 }

--- a/source/subagents/subagent-executor.spec.ts
+++ b/source/subagents/subagent-executor.spec.ts
@@ -3,7 +3,8 @@ import {SubagentExecutor} from './subagent-executor.js';
 import {getModelContextLimit} from '@/models';
 import {SubagentLoader, getSubagentLoader} from './subagent-loader.js';
 import type {ToolManager} from '@/tools/tool-manager';
-import type {LLMClient, LLMChatResponse} from '@/types/core';
+import type {MemoryFinder} from '@/memory/project-context';
+import type {LLMClient, LLMChatResponse, Message} from '@/types/core';
 import {setGlobalToolApprovalHandler} from '@/utils/tool-approval-queue';
 
 console.log('\nsubagent-executor.spec.ts');
@@ -786,4 +787,80 @@ test('without a resolver, approval falls back to the static parentMode', async t
 	}).needsApprovalForTool('execute_bash', {});
 
 	t.false(await needsApproval);
+});
+
+test.serial('injects relevant project memories into the subagent system prompt', async t => {
+	const toolManager = createMockToolManager();
+	const client = createMockClient([{content: 'Here are the results'}]);
+	let systemPrompt = '';
+	const originalChat = client.chat.bind(client);
+	client.chat = async (messages: Message[], tools, callbacks, signal, modeOverrides) => {
+		systemPrompt = String(messages[0]?.content ?? '');
+		return originalChat(messages, tools, callbacks, signal, modeOverrides);
+	};
+
+	const memoryFinder: MemoryFinder = {
+		findRelevantMemories: async () => [
+			{
+				id: 'mem-1',
+				content: 'Auth flow uses Clerk and avoids middleware.',
+				category: 'architecture',
+				timestamp: '2026-01-01T00:00:00.000Z',
+			},
+		],
+	};
+
+	const executor = new SubagentExecutor(toolManager, client, process.cwd(), 'normal', {
+		memoryFinder,
+		projectContextOptions: {semanticMemoryEnabled: true},
+	});
+
+	const result = await executor.execute({
+		subagent_type: 'explore',
+		description: 'Refactor Clerk auth',
+	});
+
+	t.true(result.success);
+	t.true(systemPrompt.includes('## Project Context'));
+	t.true(systemPrompt.includes('Auth flow uses Clerk and avoids middleware.'));
+});
+
+test.serial('skips subagent memory recall when semantic memory is disabled', async t => {
+	const toolManager = createMockToolManager();
+	const client = createMockClient([{content: 'Here are the results'}]);
+	let systemPrompt = '';
+	const originalChat = client.chat.bind(client);
+	client.chat = async (messages: Message[], tools, callbacks, signal, modeOverrides) => {
+		systemPrompt = String(messages[0]?.content ?? '');
+		return originalChat(messages, tools, callbacks, signal, modeOverrides);
+	};
+
+	let finderCalls = 0;
+	const memoryFinder: MemoryFinder = {
+		findRelevantMemories: async () => {
+			finderCalls++;
+			return [
+				{
+					id: 'mem-1',
+					content: 'Auth flow uses Clerk and avoids middleware.',
+					category: 'architecture',
+					timestamp: '2026-01-01T00:00:00.000Z',
+				},
+			];
+		},
+	};
+
+	const executor = new SubagentExecutor(toolManager, client, process.cwd(), 'normal', {
+		memoryFinder,
+		projectContextOptions: {semanticMemoryEnabled: false},
+	});
+
+	const result = await executor.execute({
+		subagent_type: 'explore',
+		description: 'Refactor Clerk auth',
+	});
+
+	t.true(result.success);
+	t.is(finderCalls, 0);
+	t.false(systemPrompt.includes('## Project Context'));
 });

--- a/source/subagents/subagent-executor.ts
+++ b/source/subagents/subagent-executor.ts
@@ -7,6 +7,13 @@
 
 import {createLLMClient} from '@/client-factory';
 import {getAppConfig} from '@/config/index';
+import {getProjectContextPreferences} from '@/config/preferences';
+import {
+	appendRelevantProjectContextWithCount,
+	type MemoryFinder,
+	type ProjectContextOptions,
+} from '@/memory/project-context';
+import {SemanticMemoryManager} from '@/memory/semantic-memory-manager';
 import {
 	appendSubagentTool,
 	getSubagentProgress,
@@ -59,17 +66,25 @@ export class SubagentExecutor {
 	 * that don't supply a resolver (plain shell, tests).
 	 */
 	private modeResolver?: () => DevelopmentMode;
+	private memoryFinder?: MemoryFinder;
+	private projectContextOptions?: ProjectContextOptions;
 
 	constructor(
 		toolManager: ToolManager,
 		parentClient: LLMClient,
 		projectRoot: string = process.cwd(),
 		parentMode: DevelopmentMode = 'normal',
+		options: {
+			memoryFinder?: MemoryFinder;
+			projectContextOptions?: ProjectContextOptions;
+		} = {},
 	) {
 		this.toolManager = toolManager;
 		this.parentClient = parentClient;
 		this.projectRoot = projectRoot;
 		this.parentMode = parentMode;
+		this.memoryFinder = options.memoryFinder;
+		this.projectContextOptions = options.projectContextOptions;
 	}
 
 	/**
@@ -137,9 +152,18 @@ export class SubagentExecutor {
 
 			const context = this.createSubagentContext(config, task);
 			const filteredTools = this.filterTools(config);
+			const recalled = await appendRelevantProjectContextWithCount(
+				context.systemMessage,
+				this.buildTaskPrompt(task),
+				this.memoryFinder ?? new SemanticMemoryManager({cwd: this.projectRoot}),
+				{
+					...getProjectContextPreferences(),
+					...this.projectContextOptions,
+				},
+			);
 
 			const messages: Message[] = [
-				{role: 'system', content: context.systemMessage},
+				{role: 'system', content: recalled.systemPrompt},
 				...context.initialMessages,
 			];
 


### PR DESCRIPTION
## Description

Closes the three leftover review items on semantic memory (#619):

- Inject relevant memories into subagent runs (and daemon-triggered skills, which use the same executor)
- Serialize writes across manager instances and processes so concurrent saves cannot clobber the JSON file
- Cap each repo memory file at 500 entries (oldest dropped on write)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios


### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))