### PR TITLE
fix: reject invalid context limit suffixes

### DIFF
--- a/source/utils/parse-context-limit.spec.ts
+++ b/source/utils/parse-context-limit.spec.ts
@@ -44,3 +44,13 @@ test('parseContextLimit - large value with k suffix', t => {
 test('parseContextLimit - decimal without k suffix', t => {
 	t.is(parseContextLimit('1024.5'), 1025);
 });
+
+test('parseContextLimit - rejects trailing junk after k suffix', t => {
+	t.is(parseContextLimit('10kg'), null);
+	t.is(parseContextLimit('128kb'), null);
+});
+
+test('parseContextLimit - rejects trailing junk after number', t => {
+	t.is(parseContextLimit('128abc'), null);
+	t.is(parseContextLimit('1024.5tokens'), null);
+});

--- a/source/utils/parse-context-limit.ts
+++ b/source/utils/parse-context-limit.ts
@@ -7,18 +7,18 @@
  */
 export function parseContextLimit(value: string): number | null {
 	const trimmed = value.trim().toLowerCase();
-	let multiplier = 1;
-	let numStr = trimmed;
+	const match = /^(\d+(?:\.\d+)?)(k)?$/.exec(trimmed);
 
-	if (trimmed.endsWith('k')) {
-		multiplier = 1000;
-		numStr = trimmed.slice(0, -1);
-	}
-
-	const parsed = Number.parseFloat(numStr);
-	if (Number.isNaN(parsed) || parsed <= 0) {
+	if (!match) {
 		return null;
 	}
 
+	const [, numStr, suffix] = match;
+	const parsed = Number.parseFloat(numStr);
+	if (parsed <= 0) {
+		return null;
+	}
+
+	const multiplier = suffix === 'k' ? 1000 : 1;
 	return Math.round(parsed * multiplier);
 }


### PR DESCRIPTION
## Description

Fixes #973.

Rejects invalid context limit values with trailing junk, such as `10kg`, `128kb`, and `128abc`. Valid values like `8192`, `128k`, `128K`, and `4.5k` still work.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Ran:

```bash
./node_modules/.bin/ava source/utils/parse-context-limit.spec.ts --verbose
./node_modules/.bin/biome check source/utils/parse-context-limit.ts source/utils/parse-context-limit.spec.ts