### PR TITLE
fix: ignore non-positive paste deltas

### DIFF
--- a/.changeset/fix-paste-detection-deletions.md
+++ b/.changeset/fix-paste-detection-deletions.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed paste detection reporting sliced text after a user deletes or leaves input unchanged, so only newly added input is inspected. Closes #979.

--- a/source/utils/paste-detection.spec.ts
+++ b/source/utils/paste-detection.spec.ts
@@ -58,6 +58,29 @@ test('PasteDetector does not detect manual typing', async t => {
 	t.is(result2.method, 'none');
 });
 
+test('PasteDetector ignores deletions without returning sliced garbage', t => {
+	const detector = new PasteDetector();
+
+	detector.detectPaste('hello world');
+	const result = detector.detectPaste('hello');
+
+	t.false(result.isPaste);
+	t.is(result.method, 'none');
+	t.is(result.addedText, '');
+	t.is(result.details.charsAdded, -6);
+});
+
+test('PasteDetector ignores unchanged input without returning text', t => {
+	const detector = new PasteDetector();
+
+	detector.detectPaste('hello');
+	const result = detector.detectPaste('hello');
+
+	t.false(result.isPaste);
+	t.is(result.addedText, '');
+	t.is(result.details.charsAdded, 0);
+});
+
 test('PasteDetector reset clears state', t => {
 	const detector = new PasteDetector();
 

--- a/source/utils/paste-detection.ts
+++ b/source/utils/paste-detection.ts
@@ -51,9 +51,6 @@ export class PasteDetector {
 		const currentLineCount = newText.split('\n').length;
 		const linesAdded = currentLineCount - previousLineCount;
 
-		// Get the added text (assuming it's at the end)
-		const addedText = newText.slice(this.lastInputLength);
-
 		// Update tracking
 		this.lastInputTime = currentTime;
 		this.lastInputLength = newText.length;
@@ -63,6 +60,19 @@ export class PasteDetector {
 			charsAdded,
 			linesAdded,
 		};
+
+		// Deletions and unchanged input do not contain added text to inspect.
+		if (charsAdded <= 0) {
+			return {
+				isPaste: false,
+				method: 'none',
+				addedText: '',
+				details,
+			};
+		}
+
+		// Get the added text (assuming it's at the end)
+		const addedText = newText.slice(this.lastInputLength - charsAdded);
 
 		// Method 1: Rate-based detection (fast input)
 		if (


### PR DESCRIPTION
## Summary

- return no added text when paste detection sees a deletion or unchanged input
- preserve paste detection for positive character deltas
- add regression coverage for deletion and non-positive deltas

Fixes #979

## Verification

- `pnpm exec ava source/utils/paste-detection.spec.ts`
- `pnpm test:types`
- `pnpm exec biome check source/utils/paste-detection.ts source/utils/paste-detection.spec.ts`