### PR TITLE
fix(update): detect errors despite success summaries

### DIFF
--- a/.changeset/fix-update-error-detection.md
+++ b/.changeset/fix-update-error-detection.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed update command error detection when later output reports zero errors. Thanks to @anisayakmitra-in. Closes #974.

--- a/source/commands/update.spec.tsx
+++ b/source/commands/update.spec.tsx
@@ -185,6 +185,11 @@ test('hasCommandFailed: does not false positive on "no errors found"', t => {
 	t.false(hasCommandFailed(output));
 });
 
+test('hasCommandFailed: detects an error before a later "0 errors" summary', t => {
+	const output = 'EXIT_CODE: 0\nerror: update failed\nBuild completed with 0 errors';
+	t.true(hasCommandFailed(output));
+});
+
 test('hasCommandFailed: detects "error:" at start of line', t => {
 	const output = 'EXIT_CODE: 1\nSTDERR:\nerror: something went wrong';
 	t.true(hasCommandFailed(output));

--- a/source/commands/update.tsx
+++ b/source/commands/update.tsx
@@ -46,11 +46,6 @@ export function hasCommandFailed(output: string): boolean {
 
 	for (const pattern of criticalErrors) {
 		if (pattern.test(normalized)) {
-			// Additional check: avoid false positives for success messages
-			// like "0 errors", "error-free", "no errors found"
-			if (/0\s*errors?|error-?free|no\s*errors?\s*found/i.test(normalized)) {
-				continue;
-			}
 			return true;
 		}
 	}


### PR DESCRIPTION
## Summary

Detects a real error even when later output contains a benign summary such as 0 errors.

## Changes

- Remove the global success-phrase suppression after an error pattern is found.
- Add a regression test for an error followed by a later 0 errors summary.

Closes #974

## Validation

- pnpm test:ava source/commands/update.spec.tsx (26 passing)
- Biome check on changed files
- pnpm test:types