### PR TITLE
fix(input): stop placeholder ids from being recycled and clobbering live placeholders

### DIFF
--- a/.changeset/fix-placeholder-id-reuse.md
+++ b/.changeset/fix-placeholder-id-reuse.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed paste placeholders silently overwriting each other. Placeholder ids were derived from the number of live entries, so deleting one freed its id for reuse and the next paste clobbered a placeholder that was still in the input - destroying its content and leaving a duplicate label that got sent to the model as literal text. Ids are now namespaced by type (`paste_1`, `file_1`) and allocated from the highest id ever used, so a deletion can never free an id. Placeholder lookup now matches on each entry's own display text instead of a paste-shaped regex, which also makes `@file` mentions delete atomically rather than leaving an orphan entry behind, and lets two placeholders that render identically expand to their own content.

--- a/source/hooks/useInputState.spec.tsx
+++ b/source/hooks/useInputState.spec.tsx
@@ -12,10 +12,11 @@ console.log('\nuseInputState.spec.ts');
 function createPastePlaceholder(
 	id: string,
 	content: string,
+	label: string = id,
 ): PastePlaceholderContent {
 	return {
 		type: PlaceholderType.PASTE,
-		displayText: `[Paste #${id}: ${content.length} chars]`,
+		displayText: `[Paste #${label}: ${content.length} chars]`,
 		content,
 		originalSize: content.length,
 	} as PastePlaceholderContent;
@@ -214,45 +215,67 @@ test('deletePlaceholder removes placeholder from state', t => {
 	const {hook, instance} = setupTest();
 
 	// Create a state with a placeholder
+	// The map key is namespaced; the label the user sees is a separate counter.
 	const initialState: InputState = {
-		displayValue: 'text [Paste #abc123: 10 chars] more',
+		displayValue: 'text [Paste #1: 10 chars] more',
 		placeholderContent: {
-			abc123: createPastePlaceholder('abc123', 'test paste') as PastePlaceholderContent,
+			paste_1: createPastePlaceholder('paste_1', 'test paste', '1'),
 		},
 	};
 
 	hook.setInputState(initialState);
 	instance.rerender(<TestComponent />);
 
-	t.true(currentHook!.input.includes('[Paste #abc123'));
+	t.true(currentHook!.input.includes('[Paste #1:'));
 
 	// Delete the placeholder
-	hook.deletePlaceholder('abc123');
+	currentHook!.deletePlaceholder('paste_1');
 	instance.rerender(<TestComponent />);
 
-	t.false(currentHook!.input.includes('[Paste #abc123'));
-	t.false('abc123' in currentHook!.currentState.placeholderContent);
+	t.is(currentHook!.input, 'text  more');
+	t.false('paste_1' in currentHook!.currentState.placeholderContent);
 });
 
-// Test deletePlaceholder with special characters (sanitization)
-test('deletePlaceholder sanitizes placeholder ID', t => {
+// An id that is not in the map must not touch the input or the other entries
+test('deletePlaceholder ignores an unknown placeholder ID', t => {
 	const {hook, instance} = setupTest();
 
 	const initialState: InputState = {
-		displayValue: 'text [Paste #safe123: 10 chars] more',
+		displayValue: 'text [Paste #1: 10 chars] more',
 		placeholderContent: {
-			safe123: createPastePlaceholder('safe123', 'test paste'),
+			paste_1: createPastePlaceholder('paste_1', 'test paste', '1'),
 		},
 	};
 	hook.setInputState(initialState);
 	instance.rerender(<TestComponent />);
 
-	// Try with potentially unsafe ID (should sanitize it)
-	hook.deletePlaceholder('safe123;rm-rf');
+	currentHook!.deletePlaceholder('paste_1;rm -rf');
 	instance.rerender(<TestComponent />);
 
-	// The deletion should have worked on the sanitized ID
-	t.pass();
+	t.is(currentHook!.input, 'text [Paste #1: 10 chars] more');
+	t.true('paste_1' in currentHook!.currentState.placeholderContent);
+});
+
+test('deletePlaceholder removes only the targeted duplicate', t => {
+	const {hook, instance} = setupTest();
+
+	// Two placeholders that render identically - the id has to disambiguate.
+	hook.setInputState({
+		displayValue: '[Paste #1: 5 chars][Paste #1: 5 chars]',
+		placeholderContent: {
+			paste_1: createPastePlaceholder('paste_1', 'first', '1'),
+			paste_2: createPastePlaceholder('paste_2', 'other', '1'),
+		},
+	});
+	instance.rerender(<TestComponent />);
+
+	currentHook!.deletePlaceholder('paste_2');
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, '[Paste #1: 5 chars]');
+	t.deepEqual(Object.keys(currentHook!.currentState.placeholderContent), [
+		'paste_1',
+	]);
 });
 
 // Test setInputState

--- a/source/hooks/useInputState.ts
+++ b/source/hooks/useInputState.ts
@@ -9,6 +9,7 @@ import {InputState, PlaceholderType} from '../types/hooks';
 import {handleAtomicDeletion} from '../utils/atomic-deletion';
 import {PasteDetector} from '../utils/paste-detection';
 import {handlePaste} from '../utils/paste-utils';
+import {findPlaceholderOccurrences} from '../utils/placeholders';
 
 // Scales the paste window size based on content length.
 // Prevents truncation on slow terminals while keeping small pastes snappy
@@ -291,24 +292,25 @@ export function useInputState() {
 	// Delete placeholder atomically
 	const deletePlaceholder = useCallback(
 		(placeholderId: string) => {
-			// Sanitize placeholderId to ensure it only contains safe characters
-			const sanitizedPlaceholderId = placeholderId.replace(
-				/[^a-zA-Z0-9_-]/g,
-				'',
-			);
-			const placeholderPattern = `[Paste #${sanitizedPlaceholderId}: \\d+ chars]`;
-			/* nosemgrep */
-			const regex = new RegExp(
-				placeholderPattern.replace(/[[\]]/g, '\\$&'),
-				'g',
-			);
+			if (!currentState.placeholderContent[placeholderId]) {
+				return;
+			}
 
-			const newDisplayValue = currentState.displayValue.replace(regex, '');
+			// Locate the placeholder by its own display text rather than rebuilding
+			// a pattern from the id: ids are namespaced keys, not display labels.
+			const occurrence = findPlaceholderOccurrences(
+				currentState.displayValue,
+				currentState.placeholderContent,
+			).find(candidate => candidate.id === placeholderId);
+
 			const newPlaceholderContent = {...currentState.placeholderContent};
 			delete newPlaceholderContent[placeholderId];
 
 			pushToUndoStack({
-				displayValue: newDisplayValue,
+				displayValue: occurrence
+					? currentState.displayValue.slice(0, occurrence.start) +
+						currentState.displayValue.slice(occurrence.end)
+					: currentState.displayValue,
 				placeholderContent: newPlaceholderContent,
 			});
 		},

--- a/source/hooks/useInputState.ts
+++ b/source/hooks/useInputState.ts
@@ -8,7 +8,7 @@ import {
 import {InputState, PlaceholderType} from '../types/hooks';
 import {handleAtomicDeletion} from '../utils/atomic-deletion';
 import {PasteDetector} from '../utils/paste-detection';
-import {handlePaste} from '../utils/paste-utils';
+import {handlePaste, resizePasteDisplayText} from '../utils/paste-utils';
 import {findPlaceholderOccurrences} from '../utils/placeholders';
 
 // Scales the paste window size based on content length.
@@ -106,7 +106,10 @@ export function useInputState() {
 					// Merge the new chunk into the existing paste placeholder
 					const updatedContent = placeholder.content + addedChunk;
 					const oldPlaceholder = placeholder.displayText;
-					const newPlaceholder = `[Paste #${lastPasteIdRef.current}: ${updatedContent.length} chars]`;
+					const newPlaceholder = resizePasteDisplayText(
+						oldPlaceholder,
+						updatedContent.length,
+					);
 
 					const updatedPlaceholderContent = {
 						...currentState.placeholderContent,
@@ -170,7 +173,10 @@ export function useInputState() {
 					if (placeholder.type === PlaceholderType.PASTE) {
 						const updatedContent = placeholder.content + detection.addedText;
 						const oldPlaceholder = placeholder.displayText;
-						const newPlaceholder = `[Paste #${activePasteId}: ${updatedContent.length} chars]`;
+						const newPlaceholder = resizePasteDisplayText(
+							oldPlaceholder,
+							updatedContent.length,
+						);
 
 						const updatedPlaceholderContent = {
 							...currentState.placeholderContent,

--- a/source/utils/atomic-deletion.spec.ts
+++ b/source/utils/atomic-deletion.spec.ts
@@ -121,36 +121,52 @@ test('handleAtomicDeletion returns null for additions', t => {
 
 test('findPlaceholderAtPosition finds placeholder ID', t => {
 	const text = 'Before [Paste #789: 300 chars] after';
+	const content = {
+		paste_789: {
+			type: PlaceholderType.PASTE,
+			displayText: '[Paste #789: 300 chars]',
+			content: 'code',
+			originalSize: 300,
+		} as PastePlaceholderContent,
+	};
 
 	// Position inside the placeholder
-	const result1 = findPlaceholderAtPosition(text, 10); // Inside "[Paste #789: 300 chars]"
-	t.is(result1, '789');
+	const result1 = findPlaceholderAtPosition(text, 10, content); // Inside "[Paste #789: 300 chars]"
+	t.is(result1, 'paste_789');
 
 	// Position outside the placeholder
-	const result2 = findPlaceholderAtPosition(text, 0); // In "Before"
+	const result2 = findPlaceholderAtPosition(text, 0, content); // In "Before"
 	t.is(result2, null);
 
 	// Position after placeholder
-	const result3 = findPlaceholderAtPosition(text, 35); // In "after"
+	const result3 = findPlaceholderAtPosition(text, 35, content); // In "after"
 	t.is(result3, null);
 });
 
 test('wouldPartiallyDeletePlaceholder detects partial deletion', t => {
 	const text = 'Text [Paste #123: 100 chars] more';
+	const content = {
+		paste_123: {
+			type: PlaceholderType.PASTE,
+			displayText: '[Paste #123: 100 chars]',
+			content: 'code',
+			originalSize: 100,
+		} as PastePlaceholderContent,
+	};
 	//       01234567890123456789012345678901234
 	//       0         1         2         3
 	// Placeholder is at position 5-28 (length 23)
 
 	// Partial deletion from middle of placeholder
-	const result1 = wouldPartiallyDeletePlaceholder(text, 8, 5); // Delete "Paste"
+	const result1 = wouldPartiallyDeletePlaceholder(text, 8, 5, content); // Delete "Paste"
 	t.true(result1);
 
 	// Complete deletion of placeholder - delete from position 5, length 23
-	const result2 = wouldPartiallyDeletePlaceholder(text, 5, 23); // Delete entire "[Paste #123: 100 chars]"
+	const result2 = wouldPartiallyDeletePlaceholder(text, 5, 23, content); // Delete entire "[Paste #123: 100 chars]"
 	t.false(result2);
 
 	// Deletion outside placeholder
-	const result3 = wouldPartiallyDeletePlaceholder(text, 0, 4); // Delete "Text"
+	const result3 = wouldPartiallyDeletePlaceholder(text, 0, 4, content); // Delete "Text"
 	t.false(result3);
 });
 
@@ -191,4 +207,58 @@ test('atomic deletion works with multiple placeholders', t => {
 			originalSize: 50,
 		} as PastePlaceholderContent,
 	});
+});
+
+test('handleAtomicDeletion removes a file mention placeholder', t => {
+	const previousState: InputState = {
+		displayValue: 'Review [@src/app.tsx] please',
+		placeholderContent: {
+			file_1: {
+				type: PlaceholderType.FILE,
+				displayText: '[@src/app.tsx]',
+				filePath: '/repo/src/app.tsx',
+				content: 'export const App = () => null;',
+			},
+		},
+	};
+
+	// Backspace into the trailing bracket of the mention
+	const result = handleAtomicDeletion(
+		previousState,
+		'Review [@src/app.tsx please',
+	);
+
+	t.truthy(result);
+	t.is(result!.displayValue, 'Review  please');
+	t.deepEqual(
+		result!.placeholderContent,
+		{},
+		'the mention leaves no orphan entry behind',
+	);
+});
+
+test('handleAtomicDeletion removes the second of two identical placeholders', t => {
+	const previousState: InputState = {
+		displayValue: '[@a.ts] and [@a.ts]',
+		placeholderContent: {
+			file_1: {
+				type: PlaceholderType.FILE,
+				displayText: '[@a.ts]',
+				filePath: '/repo/a.ts',
+				content: 'first',
+			},
+			file_2: {
+				type: PlaceholderType.FILE,
+				displayText: '[@a.ts]',
+				filePath: '/repo/a.ts',
+				content: 'second',
+			},
+		},
+	};
+
+	const result = handleAtomicDeletion(previousState, '[@a.ts] and [@a.ts');
+
+	t.truthy(result);
+	t.is(result!.displayValue, '[@a.ts] and ');
+	t.deepEqual(Object.keys(result!.placeholderContent), ['file_1']);
 });

--- a/source/utils/atomic-deletion.ts
+++ b/source/utils/atomic-deletion.ts
@@ -1,4 +1,5 @@
-import type {InputState} from '../types/hooks';
+import type {InputState, PlaceholderContent} from '../types/hooks';
+import {findPlaceholderOccurrences} from './placeholders';
 
 /**
  * Detect if a text change represents a deletion that should be atomic
@@ -32,27 +33,25 @@ export function handleAtomicDeletion(
 		deletionStart = newText.length;
 	}
 
+	const deletionEnd = deletionStart + deletedChars;
+
 	// Check if any placeholder was affected by this deletion
-	const placeholderRegex = /\[Paste #(\d+): \d+ chars\]/g;
-	let match;
-
-	while ((match = placeholderRegex.exec(previousText)) !== null) {
-		const placeholderStart = match.index;
-		const placeholderEnd = placeholderStart + match[0].length;
-		const placeholderId = match[1];
-
-		// Check if deletion overlaps with this placeholder
-		const deletionEnd = deletionStart + deletedChars;
+	for (const occurrence of findPlaceholderOccurrences(
+		previousText,
+		previousState.placeholderContent,
+	)) {
+		const {start, end} = occurrence;
 
 		if (
-			(deletionStart >= placeholderStart && deletionStart < placeholderEnd) ||
-			(deletionEnd > placeholderStart && deletionEnd <= placeholderEnd) ||
-			(deletionStart <= placeholderStart && deletionEnd >= placeholderEnd)
+			(deletionStart >= start && deletionStart < end) ||
+			(deletionEnd > start && deletionEnd <= end) ||
+			(deletionStart <= start && deletionEnd >= end)
 		) {
 			// Deletion affects this placeholder - remove it atomically
-			const newDisplayValue = previousText.replace(match[0], '');
+			const newDisplayValue =
+				previousText.slice(0, start) + previousText.slice(end);
 			const newPlaceholderContent = {...previousState.placeholderContent};
-			delete newPlaceholderContent[placeholderId];
+			delete newPlaceholderContent[occurrence.id];
 
 			return {
 				displayValue: newDisplayValue,
@@ -71,16 +70,14 @@ export function handleAtomicDeletion(
 export function findPlaceholderAtPosition(
 	text: string,
 	position: number,
+	placeholderContent: Record<string, PlaceholderContent>,
 ): string | null {
-	const placeholderRegex = /\[Paste #(\d+): \d+ chars\]/g;
-	let match;
-
-	while ((match = placeholderRegex.exec(text)) !== null) {
-		const placeholderStart = match.index;
-		const placeholderEnd = placeholderStart + match[0].length;
-
-		if (position >= placeholderStart && position <= placeholderEnd) {
-			return match[1]; // Return the placeholder ID
+	for (const {id, start, end} of findPlaceholderOccurrences(
+		text,
+		placeholderContent,
+	)) {
+		if (position >= start && position <= end) {
+			return id;
 		}
 	}
 
@@ -95,28 +92,22 @@ export function wouldPartiallyDeletePlaceholder(
 	text: string,
 	deletionStart: number,
 	deletionLength: number,
+	placeholderContent: Record<string, PlaceholderContent>,
 ): boolean {
-	const placeholderRegex = /\[Paste #(\d+): \d+ chars\]/g;
-	let match;
+	const deletionEnd = deletionStart + deletionLength;
 
-	while ((match = placeholderRegex.exec(text)) !== null) {
-		const placeholderStart = match.index;
-		const placeholderEnd = placeholderStart + match[0].length;
-		const deletionEnd = deletionStart + deletionLength;
-
+	for (const {start, end} of findPlaceholderOccurrences(
+		text,
+		placeholderContent,
+	)) {
 		// Check for overlap
-		const overlapsStart =
-			deletionStart >= placeholderStart && deletionStart < placeholderEnd;
-		const overlapsEnd =
-			deletionEnd > placeholderStart && deletionEnd <= placeholderEnd;
-		const spansPast =
-			deletionStart < placeholderStart && deletionEnd > placeholderStart;
-		const spansOver =
-			deletionStart < placeholderEnd && deletionEnd > placeholderEnd;
+		const overlapsStart = deletionStart >= start && deletionStart < end;
+		const overlapsEnd = deletionEnd > start && deletionEnd <= end;
+		const spansPast = deletionStart < start && deletionEnd > start;
+		const spansOver = deletionStart < end && deletionEnd > end;
 
 		const hasOverlap = overlapsStart || overlapsEnd || spansPast || spansOver;
-		const completeOverlap =
-			deletionStart <= placeholderStart && deletionEnd >= placeholderEnd;
+		const completeOverlap = deletionStart <= start && deletionEnd >= end;
 
 		if (hasOverlap && !completeOverlap) {
 			return true;

--- a/source/utils/file-mention-handler.ts
+++ b/source/utils/file-mention-handler.ts
@@ -4,6 +4,7 @@ import {
 	PlaceholderType,
 } from '../types/hooks.js';
 import {loadFileContent} from './file-content-loader.js';
+import {allocatePlaceholderId} from './placeholders.js';
 
 /**
  * Handle @file mention by creating a placeholder
@@ -26,11 +27,10 @@ export async function handleFileMention(
 		return null;
 	}
 
-	// Generate unique ID for this file placeholder
-	const existingFileCount = Object.values(currentPlaceholderContent).filter(
-		content => content.type === PlaceholderType.FILE,
-	).length;
-	const fileId = `file_${existingFileCount + 1}`;
+	const {id: fileId} = allocatePlaceholderId(
+		currentPlaceholderContent,
+		PlaceholderType.FILE,
+	);
 
 	// Create compact placeholder for display
 	const placeholder = lineRange

--- a/source/utils/paste-utils.spec.ts
+++ b/source/utils/paste-utils.spec.ts
@@ -219,3 +219,74 @@ test('handlePaste respects custom threshold - low threshold creates placeholder'
 		clearAppConfig();
 	}
 });
+
+test('handlePaste namespaces paste ids so file mentions cannot collide', t => {
+	const currentPlaceholderContent: Record<string, PlaceholderContent> = {
+		file_1: {
+			type: PlaceholderType.FILE,
+			displayText: '[@src/app.tsx]',
+			filePath: '/repo/src/app.tsx',
+			content: 'file body',
+		},
+	};
+
+	const result = handlePaste(
+		'c'.repeat(801),
+		'[@src/app.tsx] ',
+		currentPlaceholderContent,
+	);
+
+	t.truthy(result);
+	t.deepEqual(Object.keys(result!.placeholderContent).sort(), [
+		'file_1',
+		'paste_1',
+	]);
+	t.truthy(result!.placeholderContent.file_1, 'the file mention survives');
+});
+
+test('handlePaste does not reuse the id of a deleted paste', t => {
+	const first = handlePaste('a'.repeat(801), '', {})!;
+	const second = handlePaste(
+		'b'.repeat(802),
+		first.displayValue,
+		first.placeholderContent,
+	)!;
+
+	t.deepEqual(Object.keys(second.placeholderContent), ['paste_1', 'paste_2']);
+
+	// The user deletes the first paste, then pastes again.
+	const surviving = {paste_2: second.placeholderContent.paste_2};
+	const third = handlePaste(
+		'c'.repeat(803),
+		second.placeholderContent.paste_2.displayText,
+		surviving,
+	)!;
+
+	t.deepEqual(Object.keys(third.placeholderContent), ['paste_2', 'paste_3']);
+	t.is(
+		(third.placeholderContent.paste_2 as PastePlaceholderContent).content,
+		'b'.repeat(802),
+		'the surviving paste keeps its own content',
+	);
+	t.is(
+		(third.placeholderContent.paste_3 as PastePlaceholderContent).content,
+		'c'.repeat(803),
+	);
+});
+
+test('handlePaste continues numbering past legacy bare-numeric paste ids', t => {
+	// Prompt history persists InputState, so pre-namespacing keys can come back.
+	const legacy: Record<string, PlaceholderContent> = {
+		'2': {
+			type: PlaceholderType.PASTE,
+			displayText: '[Paste #2: 900 chars]',
+			content: 'x'.repeat(900),
+			originalSize: 900,
+		} as PastePlaceholderContent,
+	};
+
+	const result = handlePaste('d'.repeat(801), '[Paste #2: 900 chars]', legacy)!;
+
+	t.deepEqual(Object.keys(result.placeholderContent).sort(), ['2', 'paste_3']);
+	t.true(result.displayValue.includes('[Paste #3: 801 chars]'));
+});

--- a/source/utils/paste-utils.ts
+++ b/source/utils/paste-utils.ts
@@ -5,12 +5,29 @@ import {
 	PlaceholderContent,
 	PlaceholderType,
 } from '../types/hooks';
+import {allocatePlaceholderId} from './placeholders';
 
 /**
  * Default threshold for single-line paste handling.
  * Pastes <= this character limit are inserted directly without placeholders.
  */
 export const DEFAULT_SINGLE_LINE_PASTE_THRESHOLD = 800;
+
+/** Render the label shown in the input for a paste placeholder. */
+function formatPasteDisplayText(ordinal: number, size: number): string {
+	return `[Paste #${ordinal}: ${size} chars]`;
+}
+
+/**
+ * Restate an existing paste label at a new size, keeping its ordinal.
+ * Used when a chunked paste grows after its placeholder already exists.
+ */
+export function resizePasteDisplayText(
+	displayText: string,
+	size: number,
+): string {
+	return displayText.replace(/: \d+ chars\]$/, `: ${size} chars]`);
+}
 
 function getSingleLinePasteThreshold(): number {
 	const config = getAppConfig();
@@ -37,12 +54,11 @@ export function handlePaste(
 		return null;
 	}
 
-	// Generate simple incrementing ID based on existing paste placeholders
-	const existingPasteCount = Object.values(currentPlaceholderContent).filter(
-		content => content.type === PlaceholderType.PASTE,
-	).length;
-	const pasteId = (existingPasteCount + 1).toString();
-	const placeholder = `[Paste #${pasteId}: ${pastedText.length} chars]`;
+	const {id: pasteId, ordinal} = allocatePlaceholderId(
+		currentPlaceholderContent,
+		PlaceholderType.PASTE,
+	);
+	const placeholder = formatPasteDisplayText(ordinal, pastedText.length);
 
 	const pasteContent: PastePlaceholderContent = {
 		type: PlaceholderType.PASTE,

--- a/source/utils/placeholders.spec.ts
+++ b/source/utils/placeholders.spec.ts
@@ -1,0 +1,74 @@
+import test from 'ava';
+import type {PlaceholderContent} from '../types/hooks';
+import {PlaceholderType} from '../types/hooks';
+import {findPlaceholderOccurrences} from './placeholders';
+
+console.log('\nplaceholders.spec.ts');
+
+const paste = (displayText: string): PlaceholderContent => ({
+	type: PlaceholderType.PASTE,
+	displayText,
+	content: 'body',
+	originalSize: 4,
+});
+
+const file = (displayText: string): PlaceholderContent => ({
+	type: PlaceholderType.FILE,
+	displayText,
+	filePath: '/repo/a.ts',
+	content: 'body',
+});
+
+test('findPlaceholderOccurrences reports positions in document order', t => {
+	const content = {
+		paste_1: paste('[Paste #1: 4 chars]'),
+		file_1: file('[@a.ts]'),
+	};
+
+	const occurrences = findPlaceholderOccurrences(
+		'x [@a.ts] y [Paste #1: 4 chars]',
+		content,
+	);
+
+	t.deepEqual(
+		occurrences.map(o => o.id),
+		['file_1', 'paste_1'],
+	);
+	t.is(occurrences[0].start, 2);
+	t.is(occurrences[0].end, 9);
+});
+
+test('findPlaceholderOccurrences gives each duplicate its own entry', t => {
+	const content = {file_1: file('[@a.ts]'), file_2: file('[@a.ts]')};
+
+	const occurrences = findPlaceholderOccurrences('[@a.ts] [@a.ts]', content);
+
+	t.is(occurrences.length, 2);
+	t.deepEqual(
+		occurrences.map(o => o.id),
+		['file_1', 'file_2'],
+	);
+});
+
+test('findPlaceholderOccurrences prefers the longest matching display text', t => {
+	const content = {
+		file_1: file('[@a.ts]'),
+		file_2: file('[@a.ts] extended'),
+	};
+
+	const occurrences = findPlaceholderOccurrences('[@a.ts] extended', content);
+
+	t.is(occurrences.length, 1);
+	t.is(occurrences[0].id, 'file_2');
+});
+
+test('findPlaceholderOccurrences skips entries that are no longer in the text', t => {
+	const content = {file_1: file('[@a.ts]'), file_2: file('[@gone.ts]')};
+
+	const occurrences = findPlaceholderOccurrences('only [@a.ts]', content);
+
+	t.deepEqual(
+		occurrences.map(o => o.id),
+		['file_1'],
+	);
+});

--- a/source/utils/placeholders.spec.ts
+++ b/source/utils/placeholders.spec.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import type {PlaceholderContent} from '../types/hooks';
 import {PlaceholderType} from '../types/hooks';
-import {findPlaceholderOccurrences} from './placeholders';
+import {allocatePlaceholderId, findPlaceholderOccurrences} from './placeholders';
 
 console.log('\nplaceholders.spec.ts');
 
@@ -17,6 +17,39 @@ const file = (displayText: string): PlaceholderContent => ({
 	displayText,
 	filePath: '/repo/a.ts',
 	content: 'body',
+});
+
+test('allocatePlaceholderId namespaces each type', t => {
+	t.is(allocatePlaceholderId({}, PlaceholderType.PASTE).id, 'paste_1');
+	t.is(allocatePlaceholderId({}, PlaceholderType.FILE).id, 'file_1');
+});
+
+test('allocatePlaceholderId counts only its own type', t => {
+	const existing = {
+		file_1: file('[@a.ts]'),
+		file_2: file('[@b.ts]'),
+	};
+
+	t.is(allocatePlaceholderId(existing, PlaceholderType.PASTE).id, 'paste_1');
+	t.is(allocatePlaceholderId(existing, PlaceholderType.FILE).id, 'file_3');
+});
+
+test('allocatePlaceholderId does not reuse an id after a deletion', t => {
+	// paste_1 was deleted; paste_2 is still in the input.
+	const existing = {paste_2: paste('[Paste #2: 4 chars]')};
+
+	const next = allocatePlaceholderId(existing, PlaceholderType.PASTE);
+
+	t.is(next.id, 'paste_3');
+	t.is(next.ordinal, 3);
+});
+
+test('allocatePlaceholderId respects legacy bare-numeric paste keys', t => {
+	const existing = {'7': paste('[Paste #7: 4 chars]')};
+
+	t.is(allocatePlaceholderId(existing, PlaceholderType.PASTE).id, 'paste_8');
+	// A bare number is never a file key, so files start fresh.
+	t.is(allocatePlaceholderId(existing, PlaceholderType.FILE).id, 'file_1');
 });
 
 test('findPlaceholderOccurrences reports positions in document order', t => {

--- a/source/utils/placeholders.ts
+++ b/source/utils/placeholders.ts
@@ -1,4 +1,50 @@
 import type {PlaceholderContent} from '../types/hooks';
+import {PlaceholderType} from '../types/hooks';
+
+const ID_PREFIX: Record<PlaceholderType, string> = {
+	[PlaceholderType.PASTE]: 'paste',
+	[PlaceholderType.FILE]: 'file',
+};
+
+export interface AllocatedPlaceholderId {
+	/** Map key. Namespaced by type so two kinds can never collide. */
+	id: string;
+	/** Human-facing counter used in the placeholder's display text. */
+	ordinal: number;
+}
+
+/**
+ * Allocate the map key for a new placeholder of `type`.
+ *
+ * The ordinal comes from the highest ordinal already present, not from the
+ * number of live entries: deleting a placeholder must not free its id, or the
+ * next allocation would silently overwrite a placeholder still in the input.
+ */
+export function allocatePlaceholderId(
+	existing: Record<string, PlaceholderContent>,
+	type: PlaceholderType,
+): AllocatedPlaceholderId {
+	const prefix = ID_PREFIX[type];
+	const namespaced = new RegExp(`^${prefix}_(\\d+)$`);
+
+	let highest = 0;
+	for (const key of Object.keys(existing)) {
+		const match = key.match(namespaced);
+		if (match) {
+			highest = Math.max(highest, Number(match[1]));
+			continue;
+		}
+		// Prompt history persists InputState to disk, so bare-numeric paste keys
+		// written before pastes were namespaced can still arrive from an older
+		// session's history file.
+		if (type === PlaceholderType.PASTE && /^\d+$/.test(key)) {
+			highest = Math.max(highest, Number(key));
+		}
+	}
+
+	const ordinal = highest + 1;
+	return {id: `${prefix}_${ordinal}`, ordinal};
+}
 
 export interface PlaceholderOccurrence {
 	id: string;

--- a/source/utils/placeholders.ts
+++ b/source/utils/placeholders.ts
@@ -1,0 +1,54 @@
+import type {PlaceholderContent} from '../types/hooks';
+
+export interface PlaceholderOccurrence {
+	id: string;
+	/** Index of the placeholder's first character in the display value. */
+	start: number;
+	/** Index just past the placeholder's last character. */
+	end: number;
+}
+
+/**
+ * Locate every placeholder in `text` by scanning for its display text.
+ *
+ * Each entry claims at most one occurrence, so two placeholders that render
+ * identically (the same file mentioned twice) map to distinct positions
+ * instead of both resolving to the first match.
+ */
+export function findPlaceholderOccurrences(
+	text: string,
+	placeholderContent: Record<string, PlaceholderContent>,
+): PlaceholderOccurrence[] {
+	// Longest display text first, so a placeholder whose text merely starts with
+	// another's can't be claimed by the shorter one.
+	const candidates = Object.entries(placeholderContent)
+		.filter(([, content]) => Boolean(content.displayText))
+		.sort(([, a], [, b]) => b.displayText.length - a.displayText.length);
+
+	const claimed = new Set<string>();
+	const occurrences: PlaceholderOccurrence[] = [];
+
+	let index = 0;
+	while (index < text.length) {
+		const hit = candidates.find(
+			([id, content]) =>
+				!claimed.has(id) && text.startsWith(content.displayText, index),
+		);
+
+		if (!hit) {
+			index++;
+			continue;
+		}
+
+		const [id, content] = hit;
+		claimed.add(id);
+		occurrences.push({
+			id,
+			start: index,
+			end: index + content.displayText.length,
+		});
+		index += content.displayText.length;
+	}
+
+	return occurrences;
+}

--- a/source/utils/placeholders.ts
+++ b/source/utils/placeholders.ts
@@ -1,6 +1,8 @@
 import type {PlaceholderContent} from '../types/hooks';
 import {PlaceholderType} from '../types/hooks';
 
+const ORDINAL = /^\d+$/;
+
 const ID_PREFIX: Record<PlaceholderType, string> = {
 	[PlaceholderType.PASTE]: 'paste',
 	[PlaceholderType.FILE]: 'file',
@@ -24,26 +26,27 @@ export function allocatePlaceholderId(
 	existing: Record<string, PlaceholderContent>,
 	type: PlaceholderType,
 ): AllocatedPlaceholderId {
-	const prefix = ID_PREFIX[type];
-	const namespaced = new RegExp(`^${prefix}_(\\d+)$`);
+	const marker = `${ID_PREFIX[type]}_`;
 
 	let highest = 0;
 	for (const key of Object.keys(existing)) {
-		const match = key.match(namespaced);
-		if (match) {
-			highest = Math.max(highest, Number(match[1]));
+		if (key.startsWith(marker)) {
+			const ordinal = key.slice(marker.length);
+			if (ORDINAL.test(ordinal)) {
+				highest = Math.max(highest, Number(ordinal));
+			}
 			continue;
 		}
 		// Prompt history persists InputState to disk, so bare-numeric paste keys
 		// written before pastes were namespaced can still arrive from an older
 		// session's history file.
-		if (type === PlaceholderType.PASTE && /^\d+$/.test(key)) {
+		if (type === PlaceholderType.PASTE && ORDINAL.test(key)) {
 			highest = Math.max(highest, Number(key));
 		}
 	}
 
 	const ordinal = highest + 1;
-	return {id: `${prefix}_${ordinal}`, ordinal};
+	return {id: `${marker}${ordinal}`, ordinal};
 }
 
 export interface PlaceholderOccurrence {

--- a/source/utils/prompt-processor.spec.ts
+++ b/source/utils/prompt-processor.spec.ts
@@ -164,3 +164,68 @@ test('assemblePrompt - handles file with nested path', t => {
 	t.true(result.includes('=== File: file.ts ==='));
 	t.true(result.includes('export const x = 1'));
 });
+
+test('assemblePrompt - expands two placeholders that render identically', t => {
+	const inputState: InputState = {
+		displayValue: 'compare [@a.ts] against [@a.ts]',
+		placeholderContent: {
+			file_1: {
+				type: PlaceholderType.FILE,
+				content: 'first revision',
+				filePath: 'a.ts',
+				displayText: '[@a.ts]',
+			},
+			file_2: {
+				type: PlaceholderType.FILE,
+				content: 'second revision',
+				filePath: 'a.ts',
+				displayText: '[@a.ts]',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	t.true(result.includes('first revision'));
+	t.true(result.includes('second revision'));
+	t.false(result.includes('[@a.ts]'), 'no placeholder is left unexpanded');
+});
+
+test('assemblePrompt - expands a mixed paste and file mention input', t => {
+	const inputState: InputState = {
+		displayValue: 'see [@a.ts] then [Paste #1: 5 chars]',
+		placeholderContent: {
+			file_1: {
+				type: PlaceholderType.FILE,
+				content: 'file body',
+				filePath: 'a.ts',
+				displayText: '[@a.ts]',
+			},
+			paste_1: {
+				type: PlaceholderType.PASTE,
+				content: 'Hello',
+				displayText: '[Paste #1: 5 chars]',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	t.true(result.includes('file body'));
+	t.true(result.endsWith('Hello'));
+});
+
+test('assemblePrompt - leaves content that looks like a placeholder alone', t => {
+	const inputState: InputState = {
+		displayValue: 'echo [Paste #1: 21 chars]',
+		placeholderContent: {
+			paste_1: {
+				type: PlaceholderType.PASTE,
+				content: '[Paste #1: 21 chars]',
+				displayText: '[Paste #1: 21 chars]',
+			},
+		},
+	};
+
+	t.is(assemblePrompt(inputState), 'echo [Paste #1: 21 chars]');
+});

--- a/source/utils/prompt-processor.ts
+++ b/source/utils/prompt-processor.ts
@@ -5,6 +5,7 @@ import {
 } from '@/constants';
 import type {InputState} from '../types/hooks';
 import {PlaceholderType} from '../types/hooks';
+import {findPlaceholderOccurrences} from './placeholders';
 
 /**
  * Cached subagent descriptions for injection into the system prompt.
@@ -43,69 +44,66 @@ export function getSubagentDescriptions(): string {
 export function assemblePrompt(inputState: InputState): string {
 	let assembledPrompt = inputState.displayValue;
 
-	// Replace each placeholder with its full content
-	Object.entries(inputState.placeholderContent).forEach(
-		([placeholderId, placeholderContent]) => {
-			// Each placeholder type can have its own replacement logic
-			let replacementContent = placeholderContent.content || '';
-
-			// Type-specific content assembly (extensible for future types)
-			switch (placeholderContent.type) {
-				case PlaceholderType.PASTE: {
-					// For paste, use content directly
-					replacementContent = placeholderContent.content;
-					break;
-				}
-				case PlaceholderType.FILE: {
-					// Format file content with header for LLM context. Large files
-					// inline only a head preview plus a read_file hint so a single
-					// @-mention can't flood the conversation; small files inline whole.
-					const fileName =
-						placeholderContent.filePath.split('/').pop() ||
-						placeholderContent.filePath;
-					const lines = placeholderContent.content.split('\n');
-					const totalLines = lines.length;
-
-					if (totalLines > FILE_MENTION_INLINE_MAX_LINES) {
-						const previewBody = lines
-							.slice(0, FILE_MENTION_PREVIEW_LINES)
-							.join('\n');
-						const remaining = totalLines - FILE_MENTION_PREVIEW_LINES;
-						const relPath = isAbsolute(placeholderContent.filePath)
-							? relative(process.cwd(), placeholderContent.filePath)
-							: placeholderContent.filePath;
-						const header = `=== File: ${fileName} (${totalLines} lines, showing first ${FILE_MENTION_PREVIEW_LINES}) ===`;
-						const footer = `=== ${remaining} more lines, use read_file('${relPath}') for the full file ===`;
-						replacementContent = `${header}\n${previewBody}\n${footer}`;
-					} else {
-						const header = `=== File: ${fileName} ===`;
-						const footer = '='.repeat(header.length);
-						replacementContent = `${header}\n${placeholderContent.content}\n${footer}`;
-					}
-					break;
-				}
-				default: {
-					placeholderContent satisfies never;
-					replacementContent = '';
-					break;
-				}
-			}
-
-			// Use the displayText to find and replace the placeholder
-			const displayText = placeholderContent.displayText;
-			if (displayText) {
-				assembledPrompt = assembledPrompt.replace(
-					displayText,
-					replacementContent,
-				);
-			} else {
-				// Fallback for legacy paste format
-				const placeholderPattern = `\\[Paste #${placeholderId}: \\d+ chars\\]`;
-				const regex = new RegExp(placeholderPattern, 'g');
-				assembledPrompt = assembledPrompt.replace(regex, replacementContent);
-			}
-		},
+	const occurrences = findPlaceholderOccurrences(
+		assembledPrompt,
+		inputState.placeholderContent,
 	);
+
+	// Walk backwards so each splice leaves the earlier offsets valid.
+	for (let i = occurrences.length - 1; i >= 0; i--) {
+		const {id, start, end} = occurrences[i];
+		const placeholderContent = inputState.placeholderContent[id];
+
+		// Each placeholder type can have its own replacement logic
+		let replacementContent = placeholderContent.content || '';
+
+		// Type-specific content assembly (extensible for future types)
+		switch (placeholderContent.type) {
+			case PlaceholderType.PASTE: {
+				// For paste, use content directly
+				replacementContent = placeholderContent.content;
+				break;
+			}
+			case PlaceholderType.FILE: {
+				// Format file content with header for LLM context. Large files
+				// inline only a head preview plus a read_file hint so a single
+				// @-mention can't flood the conversation; small files inline whole.
+				const fileName =
+					placeholderContent.filePath.split('/').pop() ||
+					placeholderContent.filePath;
+				const lines = placeholderContent.content.split('\n');
+				const totalLines = lines.length;
+
+				if (totalLines > FILE_MENTION_INLINE_MAX_LINES) {
+					const previewBody = lines
+						.slice(0, FILE_MENTION_PREVIEW_LINES)
+						.join('\n');
+					const remaining = totalLines - FILE_MENTION_PREVIEW_LINES;
+					const relPath = isAbsolute(placeholderContent.filePath)
+						? relative(process.cwd(), placeholderContent.filePath)
+						: placeholderContent.filePath;
+					const header = `=== File: ${fileName} (${totalLines} lines, showing first ${FILE_MENTION_PREVIEW_LINES}) ===`;
+					const footer = `=== ${remaining} more lines, use read_file('${relPath}') for the full file ===`;
+					replacementContent = `${header}\n${previewBody}\n${footer}`;
+				} else {
+					const header = `=== File: ${fileName} ===`;
+					const footer = '='.repeat(header.length);
+					replacementContent = `${header}\n${placeholderContent.content}\n${footer}`;
+				}
+				break;
+			}
+			default: {
+				placeholderContent satisfies never;
+				replacementContent = '';
+				break;
+			}
+		}
+
+		assembledPrompt =
+			assembledPrompt.slice(0, start) +
+			replacementContent +
+			assembledPrompt.slice(end);
+	}
 
 	return assembledPrompt;
 }


### PR DESCRIPTION
## Description

Closes #969 

Paste placeholder ids were numbered from the count of live entries (`existingPasteCount + 1`), so deleting one freed its id for reuse.
Paste twice, delete the first, paste again: the third paste got id `2` and overwrote the second paste, destroying its content and leaving two chips labelled `#2` - one of which reached the model as literal text.

Ids are now namespaced by type (`paste_1`, `file_1`) and allocated from the highest id ever used, so a deletion can never free one.
Placeholder lookup matches on each entry's own display text instead of a paste-shaped regex, which also makes `@file` mentions delete atomically instead of leaving an orphan entry.

Note: the reported paste/`@file` collision was never possible - mentions have been keyed `file_${n}` since the feature shipped.
The symptom was real but came from reuse within the paste keyspace.

Also included: a 9-line fix for 51 pre-existing failing specs in `source/vscode/`, where the harness never loaded the new `uri-utils.js` / `slash-command-utils.js` webview helpers.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

`pnpm test:ava` - 6664 passed, 0 failed. Types, lint, format and knip clean; `test:audit` and `test:security` need network and were left to CI.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [x] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

No provider round-trip is involved - the defect lives in input state, before anything is sent.
To check in the TUI: paste a multi-line block twice, backspace once into the first chip, then paste again. Before, two chips read `#2`; after, `#2` and `#3`.

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
