### PR TITLE
fix web search timeout error handling

### DIFF
--- a/source/tools/web-search.spec.tsx
+++ b/source/tools/web-search.spec.tsx
@@ -480,6 +480,29 @@ test('executeWebSearch throws timeout error on timeout', async t => {
 	}
 });
 
+test('executeWebSearch treats TimeoutError as timeout', async t => {
+	if (!executeWebSearch) {
+		t.pass('Skipping test - web-search module not available');
+		return;
+	}
+
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = (() => {
+		const error = new Error('The operation was aborted due to timeout');
+		error.name = 'TimeoutError';
+		throw error;
+	}) as any;
+
+	try {
+		await t.throwsAsync(
+			async () => await executeWebSearch({query: 'test'}, 'test-key'),
+			{message: /timeout/i},
+		);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
 test('executeWebSearch throws on network error', async t => {
 	if (!executeWebSearch) {
 		t.pass('Skipping test - web-search module not available');

--- a/source/tools/web-search.tsx
+++ b/source/tools/web-search.tsx
@@ -90,7 +90,10 @@ export const executeWebSearch = async (
 
 		return formattedResults;
 	} catch (error: unknown) {
-		if (error instanceof Error && error.name === 'AbortError') {
+		if (
+			error instanceof Error &&
+			(error.name === 'AbortError' || error.name === 'TimeoutError')
+		) {
 			throw new Error('Search request timeout');
 		}
 


### PR DESCRIPTION
## Description

Fixes `web_search` timeout handling so errors named `TimeoutError` are classified as search request timeouts. Previously, only `AbortError` was handled, so standard fetch timeout errors from `AbortSignal.timeout()` could be misclassified.

closes #971 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Ran:

```bash
./node_modules/.bin/biome check source/tools/web-search.tsx source/tools/web-search.spec.tsx
./node_modules/.bin/tsc --noEmit
./node_modules/.bin/ava source/tools/web-search.spec.tsx