### PR TITLE
fix: capture files when git HEAD is unborn

### DIFF
--- a/.changeset/unborn-head-diff-single-spawn.md
+++ b/.changeset/unborn-head-diff-single-spawn.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed the checkpoint file scan spawning an extra `git` process on every call. Detecting a repository with no commits used to run `git rev-parse --verify HEAD` before every diff, so the common case — a repository that has commits — paid for a probe that could only ever succeed. Since the scan runs on each checkpoint and twice per ACP tool call, that was a spawn per invocation for a branch almost never taken. The diff is now attempted directly and the unborn case is handled when it fails, which costs one spawn instead of two and leaves the captured file list unchanged. Files in a repository without commits, staged or untracked, are still captured, and a directory that is not a git repository at all still reports git as unavailable so checkpointing is skipped rather than recording an empty snapshot.

--- a/source/services/file-snapshot.spec.ts
+++ b/source/services/file-snapshot.spec.ts
@@ -1,4 +1,4 @@
-import {execFile, execSync} from 'child_process';
+import {execFile, execFileSync} from 'child_process';
 import {chmodSync, existsSync} from 'fs';
 import * as path from 'path';
 import {promisify} from 'util';
@@ -535,21 +535,54 @@ test.serial('FileSnapshotService getModifiedFiles returns array', async t => {
 	}
 });
 
+/**
+ * These are the first git-invoking tests in this file.
+ *
+ * The exact `deepEqual` assertions below are sensitive to a contributor's
+ * global git config: `core.excludesFile` adds ignore rules to the nested repo,
+ * and `init.templateDir` can seed it with extra files. Both apply to a repo
+ * created inside a temp dir.
+ *
+ * `GIT_CONFIG_GLOBAL` and `-c` only cover the `init` process. The service runs
+ * its own `git` children, which this test cannot pass an environment to, and
+ * `-c` is not persisted into the new repo. So neutralise the setting in the
+ * repo's own config, which every later call against it reads.
+ */
+function initGitRepo(cwd: string): void {
+	execFileSync('git', ['init'], {
+		cwd,
+		stdio: 'pipe',
+		env: {...process.env, GIT_CONFIG_GLOBAL: '/dev/null'},
+	});
+	execFileSync('git', ['config', 'core.excludesFile', '/dev/null'], {
+		cwd,
+		stdio: 'pipe',
+	});
+}
+
 test.serial(
 	'FileSnapshotService returns untracked files from a repository without commits',
 	async t => {
 		const tempDir = await createTempDir();
 		try {
-			execSync('git init', {cwd: tempDir, stdio: 'pipe'});
+			initGitRepo(tempDir);
 			await createTestFile(tempDir, 'file.txt', 'new file');
 			await createTestFile(tempDir, 'nested/other.txt', 'nested file');
 			await createTestFile(tempDir, 'ignored.txt', 'ignored');
 			await createTestFile(tempDir, '.gitignore', 'ignored.txt\n');
 
 			const service = new FileSnapshotService(tempDir);
-			const files = service.getModifiedFiles();
+			const result = service.getModifiedFilesResult();
 
-			t.deepEqual(files.sort(), ['.gitignore', 'file.txt', 'nested/other.txt']);
+			// `available` is the assertion that matters beyond the file list:
+			// acp-timeline skips checkpointing entirely when it is false, which
+			// is exactly how an unborn repo used to read.
+			t.true(result.available);
+			t.false(result.truncated);
+			t.deepEqual(
+				[...result.files].sort(),
+				['.gitignore', 'file.txt', 'nested/other.txt'],
+			);
 		} finally {
 			await cleanupTempDir(tempDir);
 		}
@@ -561,22 +594,22 @@ test.serial(
 	async t => {
 		const tempDir = await createTempDir();
 		try {
-			execSync('git init', {cwd: tempDir, stdio: 'pipe'});
+			initGitRepo(tempDir);
 			await createTestFile(tempDir, 'staged.txt', 'staged file');
 			await createTestFile(tempDir, 'nested/also-staged.txt', 'nested staged');
 			await createTestFile(tempDir, 'ignored.txt', 'ignored');
 			await createTestFile(tempDir, '.gitignore', 'ignored.txt\n');
-			execSync('git add .', {cwd: tempDir, stdio: 'pipe'});
+			execFileSync('git', ['add', '.'], {cwd: tempDir, stdio: 'pipe'});
 
 			const service = new FileSnapshotService(tempDir);
 			const result = service.getModifiedFilesResult();
 
 			t.true(result.available);
-			t.deepEqual(result.files.sort(), [
-				'.gitignore',
-				'nested/also-staged.txt',
-				'staged.txt',
-			]);
+			t.false(result.truncated);
+			t.deepEqual(
+				[...result.files].sort(),
+				['.gitignore', 'nested/also-staged.txt', 'staged.txt'],
+			);
 		} finally {
 			await cleanupTempDir(tempDir);
 		}

--- a/source/services/file-snapshot.ts
+++ b/source/services/file-snapshot.ts
@@ -1,4 +1,4 @@
-import {execFileSync, execSync} from 'child_process';
+import {execFileSync} from 'child_process';
 import {existsSync} from 'fs';
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -138,29 +138,37 @@ export class FileSnapshotService {
 		available: boolean;
 	} {
 		try {
-			let hasHead = true;
+			// This scan runs on every checkpoint and twice per ACP tool call, so
+			// the common path - HEAD exists - must cost a single spawn. Rather
+			// than probing with `git rev-parse --verify HEAD` first, ask for the
+			// diff and let the unborn case fail.
+			let modifiedOutput = '';
 			try {
-				execSync('git rev-parse --verify HEAD', {
-					cwd: this.workspaceRoot,
-					stdio: ['pipe', 'pipe', 'pipe'],
-				});
-			} catch {
-				hasHead = false;
-			}
-
-			// An unborn branch has no HEAD to diff against, but its index can still be
-			// full (`git init && git add .`), so diff the index instead of skipping.
-			const modifiedOutput = execSync(
-				hasHead ? 'git diff --name-only HEAD' : 'git diff --name-only --cached',
-				{
+				modifiedOutput = execFileSync('git', ['diff', '--name-only', 'HEAD'], {
 					cwd: this.workspaceRoot,
 					encoding: 'utf-8',
 					stdio: ['pipe', 'pipe', 'pipe'],
-				},
-			).trim();
+				}).trim();
+			} catch {
+				// Unborn HEAD: nothing to diff against, but the index can still be
+				// full (`git init && git add .`, or `git checkout --orphan`, which
+				// starts fully populated), and `git ls-files --others` excludes
+				// anything already staged. Diff the index so a staged tree is
+				// captured rather than silently skipped.
+				modifiedOutput = execFileSync(
+					'git',
+					['diff', '--name-only', '--cached'],
+					{
+						cwd: this.workspaceRoot,
+						encoding: 'utf-8',
+						stdio: ['pipe', 'pipe', 'pipe'],
+					},
+				).trim();
+			}
 
-			const untrackedOutput = execSync(
-				'git ls-files --others --exclude-standard',
+			const untrackedOutput = execFileSync(
+				'git',
+				['ls-files', '--others', '--exclude-standard'],
 				{
 					cwd: this.workspaceRoot,
 					encoding: 'utf-8',


### PR DESCRIPTION
Closes #1010.

## Summary

- detect whether `HEAD` exists before asking Git for tracked modifications
- continue collecting untracked files with `git ls-files --others --exclude-standard` when `HEAD` is unborn
- add a regression test for a new repository containing root, nested, and ignored files

## Why this works

An unborn `HEAD` means there are no tracked files to diff, but it does not prevent `git ls-files --others --exclude-standard` from listing untracked files. The existing ignore filtering and checkpoint file limit remain unchanged. In repositories with a valid `HEAD`, the existing `git diff --name-only HEAD` path still runs.

## Tests

- `pnpm run test:ava source/services/file-snapshot.spec.ts` — 28 passed, including `FileSnapshotService finds untracked files when git HEAD is unborn`
- `pnpm run test:types` — passed
- `pnpm exec biome check source/services/file-snapshot.ts source/services/file-snapshot.spec.ts` — passed
- `pnpm run build` — passed
