### PR TITLE
fix: derive fetch url truncation label

### DIFF
--- a/.changeset/big-states-wink.md
+++ b/.changeset/big-states-wink.md
@@ -1,0 +1,6 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix fetch_url truncation warning to display the content limit in characters.
+  

--- a/source/tools/fetch-url.spec.tsx
+++ b/source/tools/fetch-url.spec.tsx
@@ -3,8 +3,6 @@ import {render} from 'ink-testing-library';
 import React from 'react';
 import {themes} from '../config/themes';
 import {ThemeContext} from '../hooks/useTheme';
-import {MAX_URL_CONTENT_BYTES} from '../constants';
-import {formatSize} from '../components/file-explorer/utils';
 
 console.log(`\nfetch-url.spec.tsx – ${React.version}`);
 
@@ -327,8 +325,7 @@ test('formatter shows truncation warning when content is truncated', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	const expectedLabel = `Content was truncated to ${formatSize(MAX_URL_CONTENT_BYTES)}`;
-	t.regex(output!, new RegExp(expectedLabel.replace('.', '\\.')));
+	t.true(output!.includes('Content was truncated to 100,000 characters'));
 });
 
 test('formatter renders without result (before execution)', t => {

--- a/source/tools/fetch-url.spec.tsx
+++ b/source/tools/fetch-url.spec.tsx
@@ -3,6 +3,8 @@ import {render} from 'ink-testing-library';
 import React from 'react';
 import {themes} from '../config/themes';
 import {ThemeContext} from '../hooks/useTheme';
+import {MAX_URL_CONTENT_BYTES} from '../constants';
+import {formatSize} from '../components/file-explorer/utils';
 
 console.log(`\nfetch-url.spec.tsx – ${React.version}`);
 
@@ -325,7 +327,8 @@ test('formatter shows truncation warning when content is truncated', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /Content was truncated to 100KB/);
+	const expectedLabel = `Content was truncated to ${formatSize(MAX_URL_CONTENT_BYTES)}`;
+	t.regex(output!, new RegExp(expectedLabel.replace('.', '\\.')));
 });
 
 test('formatter renders without result (before execution)', t => {

--- a/source/tools/fetch-url.tsx
+++ b/source/tools/fetch-url.tsx
@@ -3,7 +3,6 @@
 // only users who actually invoke `fetch_url` pay the cost.
 import {Box, Text} from 'ink';
 import React from 'react';
-import {formatSize} from '@/components/file-explorer/utils';
 import {DEFAULT_TERMINAL_COLUMNS, MAX_URL_CONTENT_BYTES} from '@/constants';
 import {useTheme} from '@/hooks/useTheme';
 import type {NanocoderToolExport} from '@/types/core';
@@ -114,7 +113,8 @@ function FetchUrlFormatterComponent({
 					{wasTruncated && (
 						<Box>
 							<Text color={colors.warning}>
-								⚠ Content was truncated to {formatSize(MAX_URL_CONTENT_BYTES)}
+								⚠ Content was truncated to{' '}
+								{MAX_URL_CONTENT_BYTES.toLocaleString()} characters
 							</Text>
 						</Box>
 					)}

--- a/source/tools/fetch-url.tsx
+++ b/source/tools/fetch-url.tsx
@@ -3,6 +3,7 @@
 // only users who actually invoke `fetch_url` pay the cost.
 import {Box, Text} from 'ink';
 import React from 'react';
+import {formatSize} from '@/components/file-explorer/utils';
 import {DEFAULT_TERMINAL_COLUMNS, MAX_URL_CONTENT_BYTES} from '@/constants';
 import {useTheme} from '@/hooks/useTheme';
 import type {NanocoderToolExport} from '@/types/core';
@@ -113,7 +114,7 @@ function FetchUrlFormatterComponent({
 					{wasTruncated && (
 						<Box>
 							<Text color={colors.warning}>
-								⚠ Content was truncated to 100KB
+								⚠ Content was truncated to {formatSize(MAX_URL_CONTENT_BYTES)}
 							</Text>
 						</Box>
 					)}


### PR DESCRIPTION
## Description

Brief description of what this PR does

Fix the hardcoded `100KB` truncation warning in `fetch-url` by deriving the displayed size from `MAX_URL_CONTENT_BYTES` using the existing `formatSize` utility. Also updates the related formatter test to verify the dynamic value.

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
