### PR TITLE
Fix/atomic deletion boundary

### DIFF
--- a/source/utils/atomic-deletion.spec.ts
+++ b/source/utils/atomic-deletion.spec.ts
@@ -106,6 +106,42 @@ test('handleAtomicDeletion returns null for normal deletions', t => {
 	t.is(result, null);
 });
 
+test('handleAtomicDeletion ignores deletion immediately before placeholder', t => {
+	const previousState: InputState = {
+		displayValue: 'x[Paste #123: 100 chars] more',
+		placeholderContent: {
+			'123': {
+				type: PlaceholderType.PASTE,
+				displayText: '[Paste #123: 100 chars]',
+				content: 'content',
+				originalSize: 100,
+			} as PastePlaceholderContent,
+		},
+	};
+
+	const result = handleAtomicDeletion(previousState, '[Paste #123: 100 chars] more');
+
+	t.is(result, null);
+});
+
+test('handleAtomicDeletion ignores deletion immediately after placeholder', t => {
+	const previousState: InputState = {
+		displayValue: '[Paste #123: 100 chars]x more',
+		placeholderContent: {
+			'123': {
+				type: PlaceholderType.PASTE,
+				displayText: '[Paste #123: 100 chars]',
+				content: 'content',
+				originalSize: 100,
+			} as PastePlaceholderContent,
+		},
+	};
+
+	const result = handleAtomicDeletion(previousState, '[Paste #123: 100 chars] more');
+
+	t.is(result, null);
+});
+
 test('handleAtomicDeletion returns null for additions', t => {
 	const previousState: InputState = {
 		displayValue: 'Short text',
@@ -143,6 +179,24 @@ test('findPlaceholderAtPosition finds placeholder ID', t => {
 	t.is(result3, null);
 });
 
+test('findPlaceholderAtPosition uses cursor boundaries', t => {
+	const text = 'Before [Paste #789: 300 chars] after';
+	const content = {
+		paste_789: {
+			type: PlaceholderType.PASTE,
+			displayText: '[Paste #789: 300 chars]',
+			content: 'code',
+			originalSize: 300,
+		} as PastePlaceholderContent,
+	};
+	const placeholderStart = text.indexOf('[Paste #789: 300 chars]');
+	const placeholderEnd = placeholderStart + '[Paste #789: 300 chars]'.length;
+
+	t.is(findPlaceholderAtPosition(text, placeholderStart, content), null);
+	t.is(findPlaceholderAtPosition(text, placeholderStart + 1, content), 'paste_789');
+	t.is(findPlaceholderAtPosition(text, placeholderEnd, content), 'paste_789');
+});
+
 test('wouldPartiallyDeletePlaceholder detects partial deletion', t => {
 	const text = 'Text [Paste #123: 100 chars] more';
 	const content = {
@@ -168,6 +222,26 @@ test('wouldPartiallyDeletePlaceholder detects partial deletion', t => {
 	// Deletion outside placeholder
 	const result3 = wouldPartiallyDeletePlaceholder(text, 0, 4, content); // Delete "Text"
 	t.false(result3);
+});
+
+test('wouldPartiallyDeletePlaceholder treats touching boundaries as non-overlap', t => {
+	const text = 'Text [Paste #123: 100 chars] more';
+	const content = {
+		paste_123: {
+			type: PlaceholderType.PASTE,
+			displayText: '[Paste #123: 100 chars]',
+			content: 'code',
+			originalSize: 100,
+		} as PastePlaceholderContent,
+	};
+	const placeholderStart = text.indexOf('[Paste #123: 100 chars]');
+	const placeholderEnd = placeholderStart + '[Paste #123: 100 chars]'.length;
+
+	t.false(
+		wouldPartiallyDeletePlaceholder(text, placeholderStart - 1, 1, content),
+	);
+	t.false(wouldPartiallyDeletePlaceholder(text, placeholderEnd, 1, content));
+	t.true(wouldPartiallyDeletePlaceholder(text, placeholderEnd - 1, 1, content));
 });
 
 // Integration test showing complete flow

--- a/source/utils/atomic-deletion.ts
+++ b/source/utils/atomic-deletion.ts
@@ -2,6 +2,18 @@ import type {InputState, PlaceholderContent} from '../types/hooks';
 import {findPlaceholderOccurrences} from './placeholders';
 
 /**
+ * Returns true when two half-open ranges, [start, end), share any characters.
+ */
+function rangesOverlap(
+	firstStart: number,
+	firstEnd: number,
+	secondStart: number,
+	secondEnd: number,
+): boolean {
+	return firstStart < secondEnd && firstEnd > secondStart;
+}
+
+/**
  * Detect if a text change represents a deletion that should be atomic
  * Returns the modified InputState if atomic deletion occurred, null otherwise
  */
@@ -42,11 +54,7 @@ export function handleAtomicDeletion(
 	)) {
 		const {start, end} = occurrence;
 
-		if (
-			(deletionStart >= start && deletionStart < end) ||
-			(deletionEnd > start && deletionEnd <= end) ||
-			(deletionStart <= start && deletionEnd >= end)
-		) {
+		if (rangesOverlap(deletionStart, deletionEnd, start, end)) {
 			// Deletion affects this placeholder - remove it atomically
 			const newDisplayValue =
 				previousText.slice(0, start) + previousText.slice(end);
@@ -76,7 +84,7 @@ export function findPlaceholderAtPosition(
 		text,
 		placeholderContent,
 	)) {
-		if (position >= start && position <= end) {
+		if (position > start && position <= end) {
 			return id;
 		}
 	}
@@ -100,13 +108,7 @@ export function wouldPartiallyDeletePlaceholder(
 		text,
 		placeholderContent,
 	)) {
-		// Check for overlap
-		const overlapsStart = deletionStart >= start && deletionStart < end;
-		const overlapsEnd = deletionEnd > start && deletionEnd <= end;
-		const spansPast = deletionStart < start && deletionEnd > start;
-		const spansOver = deletionStart < end && deletionEnd > end;
-
-		const hasOverlap = overlapsStart || overlapsEnd || spansPast || spansOver;
+		const hasOverlap = rangesOverlap(deletionStart, deletionEnd, start, end);
 		const completeOverlap = deletionStart <= start && deletionEnd >= end;
 
 		if (hasOverlap && !completeOverlap) {


### PR DESCRIPTION
## Description

Fixes #977

Consolidates atomic deletion overlap checks around an explicit half-open `[start, end)` range helper and clarifies cursor boundary behavior for placeholder lookup. The deletion behavior is preserved, while the cursor-position helper now treats the position before a placeholder as outside and the backspace position immediately after it as inside.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Ran:

```bash
./node_modules/.bin/ava source/utils/atomic-deletion.spec.ts
./node_modules/.bin/biome check source/utils/atomic-deletion.ts source/utils/atomic-deletion.spec.ts
./node_modules/.bin/tsc --noEmit