### PR TITLE
feat(init): add bundled preset configurations

### DIFF
--- a/.changeset/fresh-pandas-initialize.md
+++ b/.changeset/fresh-pandas-initialize.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added bundled React, Next.js, and Rust project presets for `nanocoder init --preset <type>` and `/init --preset <type>`. Presets seed analyzed `AGENTS.md` guidance, stack-specific context ignores, and a `/check` command skill while preserving existing files. Closes #1008.

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -13,7 +13,7 @@ Type `/` in the chat input to see available commands. All commands start with `/
 | Command | Description |
 |---------|-------------|
 | `/help` | Show available commands |
-| `/init` | Initialize project with intelligent analysis, create AGENTS.md and configuration files. Use `/init --force` to regenerate AGENTS.md if it already exists, or `/init --lean` to skip merging `CLAUDE.md` content into the generated AGENTS.md |
+| `/init` | Initialize the project with intelligent analysis and create `AGENTS.md`. Use `/init --preset <react\|nextjs\|rust>` for bundled stack guidance, ignore patterns, and a `/check` command skill; `/init --force` regenerates `AGENTS.md`, and `/init --lean` skips merging `CLAUDE.md` |
 | `/setup-config` | Open a configuration file in your `$EDITOR` (lists project and global config files) |
 | `/clear` | Clear chat history |
 | `/model` | Switch between available models from any configured provider |

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -168,7 +168,7 @@ The AI also has access to task tools and will proactively create and update task
 
 ### Project Setup with `/init`
 
-Run `/init` to analyze your project and generate an `AGENTS.md` file — a project-specific prompt that gives the AI context about your codebase, conventions, and tooling. Use `/init --force` to regenerate it.
+Run `/init` or `nanocoder init` to analyze your project and generate an `AGENTS.md` file — a project-specific prompt that gives the AI context about your codebase, conventions, and tooling. Use `--preset react`, `--preset nextjs`, or `--preset rust` to add bundled stack guidance, a `.nanocoderignore`, and a `/check` command skill. Use `/init --force` to regenerate `AGENTS.md`; existing preset files are preserved.
 
 The `AGENTS.md` file is automatically loaded every session, so the AI always knows how your project works.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -60,6 +60,7 @@ nanocoder -h
 | `--no-alt-screen` | | Force inline mode (the default), even if `alternateScreen: true` is set in your preferences file. |
 | `--continue` | `-c` | Resume the most recent [saved session](../features/session-management.md) for the current directory; starts a fresh session if none exists. Interactive only — errors with `run`. Mutually exclusive with `--resume`. |
 | `--resume [id]` | `-r` | Resume a [saved session](../features/session-management.md) by session ID, 1-based list index, or `last`. With no ID, opens the session picker at startup. Errors if the session is not found. Interactive only — errors with `run`. |
+| `init [--preset <type>]` | | Initialize the current project. Bundled presets: `react`, `nextjs`, and `rust` |
 | `run` | | Run in non-interactive mode |
 
 **Provider/Model Flags:**
@@ -84,6 +85,32 @@ nanocoder --mode normal run "refactor db module"
 ```
 
 If `--mode` is omitted, interactive mode starts in `normal` and `run` mode starts in `auto-accept` (the previous defaults).
+
+## Project Initialization Presets
+
+Initialize a project from the terminal with automatic project analysis:
+
+```bash
+nanocoder init
+```
+
+Add `--preset` to seed stack-specific guidance, context ignore patterns, and a
+`/check` command skill:
+
+```bash
+nanocoder init --preset react
+nanocoder init --preset nextjs
+nanocoder init --preset rust
+```
+
+Every preset creates an analyzed `AGENTS.md`, a `.nanocoderignore`, and
+`.nanocoder/commands/check.md`. Detected project details take precedence over
+preset defaults. Existing files are never silently replaced: an already
+initialized project is refused unless `--force` is passed, `--force` only
+regenerates `AGENTS.md`, and existing preset files are preserved.
+
+The interactive `/init` command accepts the same options, including
+`/init --preset nextjs`, `/init --force`, and `/init --lean`.
 
 ## Interactive Mode
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -104,10 +104,12 @@ nanocoder init --preset rust
 ```
 
 Every preset creates an analyzed `AGENTS.md`, a `.nanocoderignore`, and
-`.nanocoder/commands/check.md`. Detected project details take precedence over
-preset defaults. Existing files are never silently replaced: an already
-initialized project is refused unless `--force` is passed, `--force` only
-regenerates `AGENTS.md`, and existing preset files are preserved.
+`.nanocoder/commands/check.md`. The selected preset supplies the project type
+and fills in stack defaults while detected languages, package scripts, and
+commands remain authoritative where applicable. Existing files are never
+silently replaced: an already initialized project is refused unless `--force`
+is passed, `--force` only regenerates `AGENTS.md`, and existing preset files are
+preserved.
 
 The interactive `/init` command accepts the same options, including
 `/init --preset nextjs`, `/init --force`, and `/init --lean`.

--- a/source/cli-integration.spec.ts
+++ b/source/cli-integration.spec.ts
@@ -1,5 +1,7 @@
 import test from 'ava';
-import {execSync, execFileSync} from 'child_process';
+import {execFileSync, spawnSync} from 'child_process';
+import {mkdtempSync, rmSync, writeFileSync} from 'fs';
+import {tmpdir} from 'os';
 import {join} from 'path';
 import {fileURLToPath} from 'url';
 
@@ -96,4 +98,57 @@ test('CLI integration: help flag takes precedence over other arguments', t => {
 	// Should return help text, not start the app
 	t.true(output.includes('Usage:'));
 	t.true(output.includes('--version'));
+});
+
+test('CLI integration: init help exits successfully with preset guidance', t => {
+	const result = spawnSync(process.execPath, [cliPath, 'init', '--help'], {
+		encoding: 'utf8',
+	});
+
+	t.is(result.status, 0);
+	t.true(result.stdout.includes('Usage: nanocoder init [options]'));
+	t.true(result.stdout.includes('--preset <type>'));
+	t.true(result.stdout.includes('react, nextjs, rust'));
+});
+
+test.serial('CLI integration: init preset succeeds and creates files', t => {
+	const projectPath = mkdtempSync(join(tmpdir(), 'nanocoder-cli-init-'));
+	try {
+		writeFileSync(
+			join(projectPath, 'package.json'),
+			JSON.stringify({scripts: {build: 'vite build'}}),
+		);
+		const result = spawnSync(
+			process.execPath,
+			[cliPath, 'init', '--preset', 'React'],
+			{cwd: projectPath, encoding: 'utf8'},
+		);
+
+		t.is(result.status, 0);
+		t.true(result.stdout.includes('Preset: react'));
+		t.true(result.stdout.includes('Created: AGENTS.md'));
+		t.true(result.stdout.includes('Created: .nanocoderignore'));
+	} finally {
+		rmSync(projectPath, {recursive: true, force: true});
+	}
+});
+
+test.serial('CLI integration: init invalid preset exits with an error', t => {
+	const projectPath = mkdtempSync(join(tmpdir(), 'nanocoder-cli-init-'));
+	try {
+		const result = spawnSync(
+			process.execPath,
+			[cliPath, 'init', '--preset', 'constructor'],
+			{cwd: projectPath, encoding: 'utf8'},
+		);
+
+		t.is(result.status, 1);
+		t.true(
+			result.stderr.includes(
+				'Unknown preset "constructor". Supported presets: react, nextjs, rust.',
+			),
+		);
+	} finally {
+		rmSync(projectPath, {recursive: true, force: true});
+	}
 });

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -58,12 +58,67 @@ if (args[0] === 'daemon') {
 	process.exit(result.exitCode);
 }
 
+// Handle `nanocoder init` without booting the interactive app. The shared
+// initializer is also used by /init, so both entry points keep identical file
+// generation and overwrite behavior.
+if (args[0] === 'init') {
+	if (args.includes('--help') || args.includes('-h')) {
+		console.log(`
+Usage: nanocoder init [options]
+
+Options:
+  --preset <type>   Apply a bundled project preset (react, nextjs, rust)
+  -f, --force       Regenerate AGENTS.md if it already exists
+  --lean            Skip CLAUDE.md when merging existing project guidance
+  -h, --help        Show help for the init command
+
+Examples:
+  nanocoder init
+  nanocoder init --preset react
+  nanocoder init --preset nextjs
+  nanocoder init --preset rust
+  `);
+		process.exit(0);
+	}
+
+	const [{parseInitArguments}, initializer] = await Promise.all([
+		import('@/init/init-args'),
+		import('@/init/initializer'),
+	]);
+	try {
+		const options = parseInitArguments(args.slice(1));
+		const result = initializer.initializeProject({
+			projectPath: process.cwd(),
+			...options,
+		});
+
+		console.log('Nanocoder project initialized successfully.');
+		if (result.preset) console.log(`Preset: ${result.preset}`);
+		for (const file of result.created) console.log(`Created: ${file}`);
+		for (const file of result.preserved) {
+			console.log(`Preserved existing file: ${file}`);
+		}
+		process.exit(0);
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : 'Unknown initialization error';
+		const suffix =
+			error instanceof initializer.ProjectAlreadyInitializedError
+				? ' Use nanocoder init --force to regenerate.'
+				: '';
+		console.error(`${message}${suffix}`);
+		process.exit(1);
+	}
+}
+
 // Handle --help/-h flag — fast path, no heavy imports
 if (args.includes('--help') || args.includes('-h')) {
 	console.log(`
 Usage: nanocoder [options] [command]
 
 Commands:
+  init [options]                  Analyze the project and create AGENTS.md.
+                                  Use --preset <react|nextjs|rust> for bundled defaults.
   copilot login [provider-name]   Log in to GitHub Copilot (device flow). Saves credentials for the "GitHub Copilot" provider.
   daemon <subcommand>             Manage the per-project skill daemon.
                                   Subcommands: start, stop, status, logs, install, uninstall.
@@ -101,6 +156,7 @@ Options:
   run                 Run in non-interactive mode
 
 Examples:
+  nanocoder init --preset nextjs
   nanocoder --provider openrouter --model google/gemini-3.1-flash run "analyze src/app.ts"
   nanocoder --provider ollama --model llama3.1 --context-max 128k
   nanocoder --mode yolo run "refactor database module"

--- a/source/commands/init.spec.tsx
+++ b/source/commands/init.spec.tsx
@@ -1,0 +1,64 @@
+import test from 'ava';
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {render} from 'ink-testing-library';
+import React from 'react';
+import {themes} from '@/config/themes';
+import {ThemeContext} from '@/hooks/useTheme';
+import {TitleShapeContext} from '@/hooks/useTitleShape';
+import {initCommand} from './init.js';
+
+function Providers({children}: {children: React.ReactNode}) {
+	return (
+		<ThemeContext.Provider
+			value={{
+				currentTheme: 'tokyo-night',
+				colors: themes['tokyo-night'].colors,
+				setCurrentTheme: () => {},
+			}}
+		>
+			<TitleShapeContext.Provider
+				value={{currentTitleShape: 'pill', setCurrentTitleShape: () => {}}}
+			>
+				{children}
+			</TitleShapeContext.Provider>
+		</ThemeContext.Provider>
+	);
+}
+
+test.serial('init success renders the selected preset and preserved files', async t => {
+	const originalCwd = process.cwd();
+	const projectPath = mkdtempSync(join(tmpdir(), 'nanocoder-init-render-'));
+	try {
+		writeFileSync(join(projectPath, '.nanocoderignore'), 'keep-me\n');
+		writeFileSync(
+			join(projectPath, 'package.json'),
+			JSON.stringify({scripts: {build: 'vite build'}}),
+		);
+		process.chdir(projectPath);
+
+		const result = await initCommand.handler(['--preset', 'react'], [], {
+			provider: 'test',
+			model: 'test',
+			tokens: 0,
+			getMessageTokens: () => 0,
+		});
+		if (!React.isValidElement(result)) {
+			t.fail('Expected InitSuccess to return a React element');
+			return;
+		}
+
+		const {lastFrame, unmount} = render(<Providers>{result}</Providers>);
+		const output = lastFrame();
+		unmount();
+
+		t.truthy(output);
+		t.true(output?.includes('Preset: react'));
+		t.true(output?.includes('Existing Files Preserved:'));
+		t.true(output?.includes('.nanocoderignore'));
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(projectPath, {recursive: true, force: true});
+	}
+});

--- a/source/commands/init.tsx
+++ b/source/commands/init.tsx
@@ -1,23 +1,27 @@
-import {existsSync, mkdirSync, writeFileSync} from 'fs';
 import {Box, Text} from 'ink';
-import {join} from 'path';
 import React from 'react';
 import {ErrorMessage} from '@/components/message-box';
 import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
 import {getColors} from '@/config/index';
 import {useTerminalWidth} from '@/hooks/useTerminalWidth';
-import {AgentsTemplateGenerator} from '@/init/agents-template-generator';
-import {ExistingRulesExtractor} from '@/init/existing-rules-extractor';
-import {ProjectAnalyzer} from '@/init/project-analyzer';
+import {parseInitArguments} from '@/init/init-args';
+import {
+	initializeProject,
+	ProjectAlreadyInitializedError,
+} from '@/init/initializer';
 import {generateKey} from '@/session/key-generator';
 import {Command} from '@/types/index';
 import {formatError} from '@/utils/error-formatter';
 
 function InitSuccess({
 	created,
+	preserved,
+	preset,
 	analysis,
 }: {
 	created: string[];
+	preserved?: string[];
+	preset?: string;
 	analysis?: {
 		projectType: string;
 		primaryLanguage: string;
@@ -42,6 +46,7 @@ function InitSuccess({
 					✓ Nanocoder project initialized successfully!
 				</Text>
 			</Box>
+			{preset && <Text color={colors.secondary}>• Preset: {preset}</Text>}
 
 			{analysis && (
 				<>
@@ -78,6 +83,21 @@ function InitSuccess({
 				</Text>
 			))}
 
+			{preserved && preserved.length > 0 && (
+				<>
+					<Box marginTop={1} marginBottom={1}>
+						<Text color={colors.text} bold>
+							Existing Files Preserved:
+						</Text>
+					</Box>
+					{preserved.map(item => (
+						<Text key={item} color={colors.secondary}>
+							• {item}
+						</Text>
+					))}
+				</>
+			)}
+
 			<Box marginTop={1} flexDirection="column">
 				<Box marginBottom={1}>
 					<Text color={colors.text}>
@@ -99,72 +119,14 @@ function InitError({message}: {message: string}) {
 export const initCommand: Command = {
 	name: 'init',
 	description:
-		'Initialize nanocoder configuration and analyze project structure. Use --force to regenerate AGENTS.md, --lean to skip CLAUDE.md when generating AGENTS.md.',
+		'Initialize nanocoder configuration and analyze project structure. Use --preset <react|nextjs|rust>, --force to regenerate AGENTS.md, or --lean to skip CLAUDE.md.',
 	handler: (args: string[], _messages, _metadata) => {
 		const cwd = process.cwd();
-		const created: string[] = [];
-		const forceRegenerate = args.includes('--force') || args.includes('-f');
-		// --lean: skip Claude-Code-specific source files (CLAUDE.md) when
-		// generating AGENTS.md. Keeps the generated AGENTS.md smaller and
-		// reduces duplication for users who already have CLAUDE.md.
-		const lean = args.includes('--lean');
 
 		try {
-			// Check if already initialized
-			const agentsPath = join(cwd, 'AGENTS.md');
-			const nanocoderDir = join(cwd, '.nanocoder');
-
-			// Check for existing initialization
-			const hasAgents = existsSync(agentsPath);
-			const hasNanocoder = existsSync(nanocoderDir);
-
-			if (hasAgents && hasNanocoder && !forceRegenerate) {
-				return Promise.resolve(
-					React.createElement(InitError, {
-						key: generateKey('init-error'),
-						message:
-							'Project already initialized. Found AGENTS.md and .nanocoder/ directory. Use /init --force to regenerate.',
-					}),
-				);
-			}
-
-			// Show progress indicator for analysis
-			// Note: In a real implementation, we'd want to show this as a loading state
-			// For now, we'll do the analysis synchronously
-
-			// Analyze the project
-			const analyzer = new ProjectAnalyzer(cwd);
-			const analysis = analyzer.analyze();
-
-			// Extract existing AI configuration files (skip AGENTS.md when force
-			// regenerating; skip CLAUDE.md in lean mode).
-			const rulesExtractor = new ExistingRulesExtractor(
-				cwd,
-				forceRegenerate,
-				lean ? ['CLAUDE.md'] : [],
-			);
-			const existingRules = rulesExtractor.extractExistingRules();
-
-			// Create AGENTS.md based on analysis and existing rules
-			if (!hasAgents || forceRegenerate) {
-				const agentsContent = AgentsTemplateGenerator.generateAgentsMd(
-					analysis,
-					existingRules,
-				);
-				writeFileSync(agentsPath, agentsContent);
-				created.push(hasAgents ? 'AGENTS.md (regenerated)' : 'AGENTS.md');
-
-				// Report found existing rules
-				if (existingRules.length > 0) {
-					const sourceFiles = existingRules.map(r => r.source).join(', ');
-					created.push(`↳ Merged content from: ${sourceFiles}`);
-				}
-			}
-
-			if (!hasNanocoder) {
-				mkdirSync(nanocoderDir, {recursive: true});
-				created.push('.nanocoder/');
-			}
+			const options = parseInitArguments(args);
+			const result = initializeProject({projectPath: cwd, ...options});
+			const {analysis} = result;
 
 			// Prepare analysis summary for display
 			const analysisSummary = {
@@ -179,16 +141,21 @@ export const initCommand: Command = {
 			return Promise.resolve(
 				React.createElement(InitSuccess, {
 					key: generateKey('init-success'),
-					created,
+					created: result.created,
+					preserved: result.preserved,
+					preset: result.preset,
 					analysis: analysisSummary,
 				}),
 			);
 		} catch (error: unknown) {
-			const errorMessage = formatError(error);
+			const errorMessage =
+				error instanceof ProjectAlreadyInitializedError
+					? `${error.message} Use /init --force to regenerate.`
+					: `Failed to initialize project: ${formatError(error)}`;
 			return Promise.resolve(
 				React.createElement(InitError, {
 					key: generateKey('init-error'),
-					message: `Failed to initialize project: ${errorMessage}`,
+					message: errorMessage,
 				}),
 			);
 		}

--- a/source/commands/lazy-registry.ts
+++ b/source/commands/lazy-registry.ts
@@ -104,7 +104,7 @@ export const lazyCommands: LazyCommand[] = [
 	{
 		name: 'init',
 		description:
-			'Initialize nanocoder configuration and analyze project structure. Use --force to regenerate AGENTS.md.',
+			'Initialize nanocoder configuration and analyze project structure. Use --preset <react|nextjs|rust>, --force to regenerate AGENTS.md, or --lean to skip CLAUDE.md.',
 		load: () => import('@/commands/init').then(m => m.initCommand),
 	},
 	{

--- a/source/init/init-args.spec.ts
+++ b/source/init/init-args.spec.ts
@@ -1,0 +1,32 @@
+import test from 'ava';
+import {InitArgumentError, parseInitArguments} from '@/init/init-args';
+
+test('parseInitArguments parses --preset for the init command', t => {
+	t.deepEqual(parseInitArguments(['--preset', 'react']), {
+		forceRegenerate: false,
+		lean: false,
+		preset: 'react',
+	});
+});
+
+test('parseInitArguments parses fused --preset syntax and existing flags', t => {
+	t.deepEqual(parseInitArguments(['--force', '--lean', '--preset=nextjs']), {
+		forceRegenerate: true,
+		lean: true,
+		preset: 'nextjs',
+	});
+});
+
+test('parseInitArguments preserves init behavior without --preset', t => {
+	t.deepEqual(parseInitArguments([]), {
+		forceRegenerate: false,
+		lean: false,
+		preset: undefined,
+	});
+});
+
+test('parseInitArguments rejects --preset without a value', t => {
+	const error = t.throws(() => parseInitArguments(['--preset']));
+	t.true(error instanceof InitArgumentError);
+	t.regex(error.message, /Supported presets: react, nextjs, rust/);
+});

--- a/source/init/init-args.ts
+++ b/source/init/init-args.ts
@@ -1,0 +1,48 @@
+import {supportedPresetNames} from '@/init/preset-registry';
+
+export interface ParsedInitArguments {
+	forceRegenerate: boolean;
+	lean: boolean;
+	preset?: string;
+}
+
+export class InitArgumentError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'InitArgumentError';
+	}
+}
+
+export function parseInitArguments(
+	args: readonly string[],
+): ParsedInitArguments {
+	let preset: string | undefined;
+
+	for (let index = 0; index < args.length; index++) {
+		const argument = args[index];
+		if (argument === '--preset') {
+			const value = args[index + 1];
+			if (!value || value.startsWith('-')) {
+				throw new InitArgumentError(
+					`Missing value for --preset. Supported presets: ${supportedPresetNames.join(', ')}.`,
+				);
+			}
+			preset = value;
+			index++;
+		} else if (argument.startsWith('--preset=')) {
+			const value = argument.slice('--preset='.length);
+			if (!value) {
+				throw new InitArgumentError(
+					`Missing value for --preset. Supported presets: ${supportedPresetNames.join(', ')}.`,
+				);
+			}
+			preset = value;
+		}
+	}
+
+	return {
+		forceRegenerate: args.includes('--force') || args.includes('-f'),
+		lean: args.includes('--lean'),
+		preset,
+	};
+}

--- a/source/init/initializer.spec.ts
+++ b/source/init/initializer.spec.ts
@@ -1,0 +1,167 @@
+import test from 'ava';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {parseCommandFile} from '@/custom-commands/parser';
+import {
+	initializeProject,
+	ProjectAlreadyInitializedError,
+} from '@/init/initializer';
+import {UnknownPresetError} from '@/init/preset-registry';
+
+function createTestProject(): string {
+	return mkdtempSync(join(tmpdir(), 'nanocoder-preset-'));
+}
+
+function removeTestProject(projectPath: string): void {
+	rmSync(projectPath, {recursive: true, force: true});
+}
+
+const presetExpectations = {
+	react: {
+		projectType: 'React Web Application',
+		ignorePattern: '*.tsbuildinfo',
+		commandText: 'React project quality checks',
+	},
+	nextjs: {
+		projectType: 'Next.js Web Application',
+		ignorePattern: 'next-env.d.ts',
+		commandText: 'Next.js project quality checks',
+	},
+	rust: {
+		projectType: 'Rust Application',
+		ignorePattern: '*.profraw',
+		commandText: 'Rust project quality checks',
+	},
+} as const;
+
+for (const [preset, expectation] of Object.entries(presetExpectations)) {
+	test.serial(`initializeProject generates the ${preset} preset`, t => {
+		const projectPath = createTestProject();
+		try {
+			const result = initializeProject({projectPath, preset});
+			const agents = readFileSync(join(projectPath, 'AGENTS.md'), 'utf-8');
+			const ignore = readFileSync(
+				join(projectPath, '.nanocoderignore'),
+				'utf-8',
+			);
+			const command = readFileSync(
+				join(projectPath, '.nanocoder', 'commands', 'check.md'),
+				'utf-8',
+			);
+			const parsedCommand = parseCommandFile(
+				join(projectPath, '.nanocoder', 'commands', 'check.md'),
+			);
+
+			t.is(result.preset, preset);
+			t.true(agents.includes(`**Project Type:** ${expectation.projectType}`));
+			t.true(ignore.includes(expectation.ignorePattern));
+			t.true(command.includes(expectation.commandText));
+			t.true(command.includes('description:'));
+			t.truthy(parsedCommand.metadata.description);
+			t.true(parsedCommand.content.length > 0);
+			t.deepEqual(result.preserved, []);
+		} finally {
+			removeTestProject(projectPath);
+		}
+	});
+}
+
+test.serial('initializeProject keeps existing behavior without a preset', t => {
+	const projectPath = createTestProject();
+	try {
+		const result = initializeProject({projectPath});
+
+		t.true(existsSync(join(projectPath, 'AGENTS.md')));
+		t.true(existsSync(join(projectPath, '.nanocoder')));
+		t.false(existsSync(join(projectPath, '.nanocoderignore')));
+		t.false(
+			existsSync(join(projectPath, '.nanocoder', 'commands', 'check.md')),
+		);
+		t.is(result.preset, undefined);
+		t.deepEqual(result.created, ['AGENTS.md', '.nanocoder/']);
+	} finally {
+		removeTestProject(projectPath);
+	}
+});
+
+test.serial('initializeProject rejects an invalid preset before writing files', t => {
+	const projectPath = createTestProject();
+	try {
+		const error = t.throws(() =>
+			initializeProject({projectPath, preset: 'unknown'}),
+		);
+		t.true(error instanceof UnknownPresetError);
+		t.regex(error.message, /Supported presets: react, nextjs, rust/);
+		t.false(existsSync(join(projectPath, 'AGENTS.md')));
+		t.false(existsSync(join(projectPath, '.nanocoder')));
+	} finally {
+		removeTestProject(projectPath);
+	}
+});
+
+test.serial('initializeProject preserves existing preset files with --force', t => {
+	const projectPath = createTestProject();
+	const existingAgents = '# Existing instructions';
+	const existingIgnore = 'keep-this-ignore\n';
+	const existingCommand = 'keep this command\n';
+	try {
+		mkdirSync(join(projectPath, '.nanocoder', 'commands'), {recursive: true});
+		writeFileSync(join(projectPath, 'AGENTS.md'), existingAgents);
+		writeFileSync(join(projectPath, '.nanocoderignore'), existingIgnore);
+		writeFileSync(
+			join(projectPath, '.nanocoder', 'commands', 'check.md'),
+			existingCommand,
+		);
+
+		const result = initializeProject({
+			projectPath,
+			preset: 'react',
+			forceRegenerate: true,
+		});
+
+		t.not(readFileSync(join(projectPath, 'AGENTS.md'), 'utf-8'), existingAgents);
+		t.is(
+			readFileSync(join(projectPath, '.nanocoderignore'), 'utf-8'),
+			existingIgnore,
+		);
+		t.is(
+			readFileSync(
+				join(projectPath, '.nanocoder', 'commands', 'check.md'),
+				'utf-8',
+			),
+			existingCommand,
+		);
+		t.deepEqual(result.preserved, [
+			'.nanocoderignore',
+			'.nanocoder/commands/check.md',
+		]);
+		t.true(result.created.includes('AGENTS.md (regenerated)'));
+	} finally {
+		removeTestProject(projectPath);
+	}
+});
+
+test.serial('initializeProject refuses an initialized project without --force', t => {
+	const projectPath = createTestProject();
+	try {
+		mkdirSync(join(projectPath, '.nanocoder'));
+		writeFileSync(join(projectPath, 'AGENTS.md'), '# Existing instructions');
+
+		const error = t.throws(() => initializeProject({projectPath}));
+		t.true(error instanceof ProjectAlreadyInitializedError);
+		t.is(
+			readFileSync(join(projectPath, 'AGENTS.md'), 'utf-8'),
+			'# Existing instructions',
+		);
+	} finally {
+		removeTestProject(projectPath);
+	}
+});

--- a/source/init/initializer.spec.ts
+++ b/source/init/initializer.spec.ts
@@ -107,6 +107,76 @@ test.serial('initializeProject rejects an invalid preset before writing files', 
 	}
 });
 
+test.serial(
+	'initializeProject only includes React preset commands backed by package scripts',
+	t => {
+		const projectPath = createTestProject();
+		try {
+			writeFileSync(
+				join(projectPath, 'package.json'),
+				JSON.stringify({
+					dependencies: {react: '^19.0.0'},
+					scripts: {
+						build: 'vite build',
+						test: 'vitest run',
+					},
+				}),
+			);
+
+			const result = initializeProject({projectPath, preset: 'react'});
+			const agents = readFileSync(join(projectPath, 'AGENTS.md'), 'utf-8');
+
+			t.deepEqual(result.analysis.buildCommands, {
+				Build: 'npm run build',
+				Test: 'npm run test',
+			});
+			t.true(agents.includes('npm run build'));
+			t.true(agents.includes('npm run test'));
+			t.false(agents.includes('npm run dev'));
+			t.false(agents.includes('npm run lint'));
+		} finally {
+			removeTestProject(projectPath);
+		}
+	},
+);
+
+test.serial(
+	'initializeProject includes React preset commands whose package scripts exist',
+	t => {
+		const projectPath = createTestProject();
+		try {
+			writeFileSync(
+				join(projectPath, 'package.json'),
+				JSON.stringify({
+					dependencies: {react: '^19.0.0'},
+					scripts: {
+						dev: 'vite',
+						build: 'vite build',
+						test: 'vitest run',
+						lint: 'eslint .',
+					},
+				}),
+			);
+
+			const result = initializeProject({projectPath, preset: 'React'});
+			const agents = readFileSync(join(projectPath, 'AGENTS.md'), 'utf-8');
+
+			t.deepEqual(result.analysis.buildCommands, {
+				Development: 'npm run dev',
+				Build: 'npm run build',
+				Test: 'npm run test',
+				Lint: 'npm run lint',
+			});
+			t.is(result.preset, 'react');
+			for (const command of Object.values(result.analysis.buildCommands)) {
+				t.true(agents.includes(command));
+			}
+		} finally {
+			removeTestProject(projectPath);
+		}
+	},
+);
+
 test.serial('initializeProject preserves existing preset files with --force', t => {
 	const projectPath = createTestProject();
 	const existingAgents = '# Existing instructions';

--- a/source/init/initializer.ts
+++ b/source/init/initializer.ts
@@ -1,5 +1,5 @@
 import {existsSync, mkdirSync, writeFileSync} from 'node:fs';
-import {dirname, isAbsolute, join, normalize} from 'node:path';
+import {dirname, isAbsolute, join, relative, resolve} from 'node:path';
 import {AgentsTemplateGenerator} from '@/init/agents-template-generator';
 import {ExistingRulesExtractor} from '@/init/existing-rules-extractor';
 import {applyPresetToAnalysis, resolvePreset} from '@/init/preset-registry';
@@ -29,15 +29,13 @@ export class ProjectAlreadyInitializedError extends Error {
 }
 
 function resolvePresetPath(projectPath: string, relativePath: string): string {
-	const normalizedPath = normalize(relativePath);
-	if (
-		isAbsolute(relativePath) ||
-		normalizedPath === '..' ||
-		normalizedPath.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
-	) {
+	const projectRoot = resolve(projectPath);
+	const destination = resolve(projectRoot, relativePath);
+	const relativeDestination = relative(projectRoot, destination);
+	if (relativeDestination.startsWith('..') || isAbsolute(relativeDestination)) {
 		throw new Error(`Invalid preset file path: ${relativePath}`);
 	}
-	return join(projectPath, normalizedPath);
+	return destination;
 }
 
 export function initializeProject(

--- a/source/init/initializer.ts
+++ b/source/init/initializer.ts
@@ -1,0 +1,110 @@
+import {existsSync, mkdirSync, writeFileSync} from 'node:fs';
+import {dirname, isAbsolute, join, normalize} from 'node:path';
+import {AgentsTemplateGenerator} from '@/init/agents-template-generator';
+import {ExistingRulesExtractor} from '@/init/existing-rules-extractor';
+import {applyPresetToAnalysis, resolvePreset} from '@/init/preset-registry';
+import {type ProjectAnalysis, ProjectAnalyzer} from '@/init/project-analyzer';
+
+export interface InitializeProjectOptions {
+	projectPath: string;
+	forceRegenerate?: boolean;
+	lean?: boolean;
+	preset?: string;
+}
+
+export interface InitializeProjectResult {
+	created: string[];
+	preserved: string[];
+	analysis: ProjectAnalysis;
+	preset?: string;
+}
+
+export class ProjectAlreadyInitializedError extends Error {
+	constructor() {
+		super(
+			'Project already initialized. Found AGENTS.md and .nanocoder/ directory.',
+		);
+		this.name = 'ProjectAlreadyInitializedError';
+	}
+}
+
+function resolvePresetPath(projectPath: string, relativePath: string): string {
+	const normalizedPath = normalize(relativePath);
+	if (
+		isAbsolute(relativePath) ||
+		normalizedPath === '..' ||
+		normalizedPath.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
+	) {
+		throw new Error(`Invalid preset file path: ${relativePath}`);
+	}
+	return join(projectPath, normalizedPath);
+}
+
+export function initializeProject(
+	options: InitializeProjectOptions,
+): InitializeProjectResult {
+	const {
+		projectPath,
+		forceRegenerate = false,
+		lean = false,
+		preset: presetName,
+	} = options;
+	const preset = presetName ? resolvePreset(presetName) : undefined;
+	const created: string[] = [];
+	const preserved: string[] = [];
+	const agentsPath = join(projectPath, 'AGENTS.md');
+	const nanocoderDir = join(projectPath, '.nanocoder');
+	const hasAgents = existsSync(agentsPath);
+	const hasNanocoder = existsSync(nanocoderDir);
+
+	if (hasAgents && hasNanocoder && !forceRegenerate) {
+		throw new ProjectAlreadyInitializedError();
+	}
+
+	const detectedAnalysis = new ProjectAnalyzer(projectPath).analyze();
+	const analysis = preset
+		? applyPresetToAnalysis(detectedAnalysis, preset)
+		: detectedAnalysis;
+	const existingRules = new ExistingRulesExtractor(
+		projectPath,
+		forceRegenerate,
+		lean ? ['CLAUDE.md'] : [],
+	).extractExistingRules();
+
+	if (!hasAgents || forceRegenerate) {
+		const agentsContent = AgentsTemplateGenerator.generateAgentsMd(
+			analysis,
+			existingRules,
+		);
+		writeFileSync(agentsPath, agentsContent);
+		created.push(hasAgents ? 'AGENTS.md (regenerated)' : 'AGENTS.md');
+
+		if (existingRules.length > 0) {
+			const sourceFiles = existingRules.map(rule => rule.source).join(', ');
+			created.push(`↳ Merged content from: ${sourceFiles}`);
+		}
+	}
+
+	if (!hasNanocoder) {
+		mkdirSync(nanocoderDir, {recursive: true});
+		created.push('.nanocoder/');
+	}
+
+	for (const file of preset?.files ?? []) {
+		const destination = resolvePresetPath(projectPath, file.path);
+		if (existsSync(destination)) {
+			preserved.push(file.path);
+			continue;
+		}
+		mkdirSync(dirname(destination), {recursive: true});
+		writeFileSync(destination, file.content);
+		created.push(file.path);
+	}
+
+	return {
+		created,
+		preserved,
+		analysis,
+		preset: preset?.name,
+	};
+}

--- a/source/init/preset-registry.spec.ts
+++ b/source/init/preset-registry.spec.ts
@@ -1,9 +1,11 @@
 import test from 'ava';
 import {
+	applyPresetToAnalysis,
 	resolvePreset,
 	supportedPresetNames,
 	UnknownPresetError,
 } from '@/init/preset-registry';
+import type {ProjectAnalysis} from '@/init/project-analyzer';
 
 test('preset registry exposes the supported preset names', t => {
 	t.deepEqual(supportedPresetNames, ['react', 'nextjs', 'rust']);
@@ -27,4 +29,62 @@ test('preset registry reports unknown presets and all supported names', t => {
 		error.message,
 		'Unknown preset "vue". Supported presets: react, nextjs, rust.',
 	);
+});
+
+for (const inheritedName of ['constructor', 'toString', '__proto__']) {
+	test(`preset registry rejects inherited property ${inheritedName}`, t => {
+		const error = t.throws(() => resolvePreset(inheritedName));
+		t.true(error instanceof UnknownPresetError);
+		t.is(
+			error.message,
+			`Unknown preset "${inheritedName}". Supported presets: react, nextjs, rust.`,
+		);
+	});
+}
+
+test('preset registry normalizes case and whitespace', t => {
+	t.is(resolvePreset('  React  ').name, 'react');
+});
+
+test('preset registry preserves the user-provided value in errors', t => {
+	const error = t.throws(() => resolvePreset('  Vue  '));
+	t.true(error instanceof UnknownPresetError);
+	t.is(
+		error.message,
+		'Unknown preset "  Vue  ". Supported presets: react, nextjs, rust.',
+	);
+});
+
+test('preset commands require package scripts and detected commands win', t => {
+	const analysis: ProjectAnalysis = {
+		projectPath: '/project',
+		projectName: 'example',
+		languages: {primary: null, secondary: [], all: []},
+		dependencies: {
+			frameworks: [],
+			buildTools: [],
+			testingFrameworks: [],
+			buildInfo: {scripts: {build: 'custom-build'}},
+		},
+		projectType: 'Unknown',
+		keyFiles: {config: [], documentation: [], build: [], test: []},
+		structure: {
+			totalFiles: 0,
+			scannedFiles: 0,
+			directories: [],
+			importantDirectories: [],
+		},
+		buildCommands: {Build: 'pnpm run custom-build'},
+	};
+
+	const result = applyPresetToAnalysis(analysis, resolvePreset('react'));
+	t.deepEqual(result.buildCommands, {Build: 'pnpm run custom-build'});
+});
+
+test('Rust preset keeps Cargo.lock available as project context', t => {
+	const ignoreFile = resolvePreset('rust').files.find(
+		file => file.path === '.nanocoderignore',
+	);
+	t.truthy(ignoreFile);
+	t.false(ignoreFile?.content.includes('Cargo.lock'));
 });

--- a/source/init/preset-registry.spec.ts
+++ b/source/init/preset-registry.spec.ts
@@ -1,0 +1,30 @@
+import test from 'ava';
+import {
+	resolvePreset,
+	supportedPresetNames,
+	UnknownPresetError,
+} from '@/init/preset-registry';
+
+test('preset registry exposes the supported preset names', t => {
+	t.deepEqual(supportedPresetNames, ['react', 'nextjs', 'rust']);
+});
+
+for (const name of supportedPresetNames) {
+	test(`preset registry resolves ${name}`, t => {
+		const preset = resolvePreset(name);
+		t.is(preset.name, name);
+		t.true(preset.files.some(file => file.path === '.nanocoderignore'));
+		t.true(
+			preset.files.some(file => file.path === '.nanocoder/commands/check.md'),
+		);
+	});
+}
+
+test('preset registry reports unknown presets and all supported names', t => {
+	const error = t.throws(() => resolvePreset('vue'));
+	t.true(error instanceof UnknownPresetError);
+	t.is(
+		error.message,
+		'Unknown preset "vue". Supported presets: react, nextjs, rust.',
+	);
+});

--- a/source/init/preset-registry.ts
+++ b/source/init/preset-registry.ts
@@ -24,9 +24,11 @@ export class UnknownPresetError extends Error {
 }
 
 export function resolvePreset(name: string): PresetDefinition {
-	const preset = presets[name as PresetName];
-	if (!preset) throw new UnknownPresetError(name);
-	return preset;
+	const normalizedName = name.trim().toLowerCase();
+	if (!Object.hasOwn(presets, normalizedName)) {
+		throw new UnknownPresetError(name);
+	}
+	return presets[normalizedName as PresetName];
 }
 
 export function applyPresetToAnalysis(
@@ -46,6 +48,16 @@ export function applyPresetToAnalysis(
 		percentage: 100,
 		files: [],
 	};
+	const detectedPackageScripts = analysis.dependencies.buildInfo.scripts ?? {};
+	const presetBuildCommands = Object.fromEntries(
+		Object.entries(preset.buildCommands).filter(([action]) => {
+			const packageScript = preset.packageScripts?.[action];
+			return (
+				packageScript === undefined ||
+				Object.hasOwn(detectedPackageScripts, packageScript)
+			);
+		}),
+	);
 
 	return {
 		...analysis,
@@ -61,7 +73,7 @@ export function applyPresetToAnalysis(
 			frameworks: [...presetFrameworks, ...analysis.dependencies.frameworks],
 		},
 		buildCommands: {
-			...preset.buildCommands,
+			...presetBuildCommands,
 			...analysis.buildCommands,
 		},
 	};

--- a/source/init/preset-registry.ts
+++ b/source/init/preset-registry.ts
@@ -1,0 +1,68 @@
+import type {PresetDefinition, PresetName} from '@/init/presets';
+import type {ProjectAnalysis} from '@/init/project-analyzer';
+import {nextjsPreset} from '@/init/templates/preset-nextjs';
+import {reactPreset} from '@/init/templates/preset-react';
+import {rustPreset} from '@/init/templates/preset-rust';
+
+const presets: Record<PresetName, PresetDefinition> = {
+	react: reactPreset,
+	nextjs: nextjsPreset,
+	rust: rustPreset,
+};
+
+export const supportedPresetNames = Object.freeze(
+	Object.keys(presets) as PresetName[],
+);
+
+export class UnknownPresetError extends Error {
+	constructor(name: string) {
+		super(
+			`Unknown preset "${name}". Supported presets: ${supportedPresetNames.join(', ')}.`,
+		);
+		this.name = 'UnknownPresetError';
+	}
+}
+
+export function resolvePreset(name: string): PresetDefinition {
+	const preset = presets[name as PresetName];
+	if (!preset) throw new UnknownPresetError(name);
+	return preset;
+}
+
+export function applyPresetToAnalysis(
+	analysis: ProjectAnalysis,
+	preset: PresetDefinition,
+): ProjectAnalysis {
+	const existingFrameworkNames = new Set(
+		analysis.dependencies.frameworks.map(framework => framework.name),
+	);
+	const presetFrameworks = preset.frameworks.filter(
+		framework => !existingFrameworkNames.has(framework.name),
+	);
+
+	const primary = analysis.languages.primary ?? {
+		name: preset.primaryLanguage,
+		extensions: [],
+		percentage: 100,
+		files: [],
+	};
+
+	return {
+		...analysis,
+		projectType: preset.projectType,
+		languages: {
+			...analysis.languages,
+			primary,
+			all:
+				analysis.languages.all.length > 0 ? analysis.languages.all : [primary],
+		},
+		dependencies: {
+			...analysis.dependencies,
+			frameworks: [...presetFrameworks, ...analysis.dependencies.frameworks],
+		},
+		buildCommands: {
+			...preset.buildCommands,
+			...analysis.buildCommands,
+		},
+	};
+}

--- a/source/init/presets.ts
+++ b/source/init/presets.ts
@@ -1,0 +1,18 @@
+import type {ProjectAnalysis} from '@/init/project-analyzer';
+
+export type PresetName = 'react' | 'nextjs' | 'rust';
+
+export interface PresetFile {
+	path: string;
+	content: string;
+}
+
+export interface PresetDefinition {
+	name: PresetName;
+	description: string;
+	projectType: string;
+	primaryLanguage: string;
+	frameworks: ProjectAnalysis['dependencies']['frameworks'];
+	buildCommands: Record<string, string>;
+	files: PresetFile[];
+}

--- a/source/init/presets.ts
+++ b/source/init/presets.ts
@@ -14,5 +14,7 @@ export interface PresetDefinition {
 	primaryLanguage: string;
 	frameworks: ProjectAnalysis['dependencies']['frameworks'];
 	buildCommands: Record<string, string>;
+	/** Build-command label to the package.json script required for that command. */
+	packageScripts?: Record<string, string>;
 	files: PresetFile[];
 }

--- a/source/init/templates/preset-nextjs.ts
+++ b/source/init/templates/preset-nextjs.ts
@@ -15,6 +15,12 @@ export const nextjsPreset = {
 		Test: 'npm run test',
 		Lint: 'npm run lint',
 	},
+	packageScripts: {
+		Development: 'dev',
+		Build: 'build',
+		Test: 'test',
+		Lint: 'lint',
+	},
 	files: [
 		{
 			path: '.nanocoderignore',

--- a/source/init/templates/preset-nextjs.ts
+++ b/source/init/templates/preset-nextjs.ts
@@ -1,0 +1,49 @@
+import type {PresetDefinition} from '@/init/presets';
+
+export const nextjsPreset = {
+	name: 'nextjs',
+	description: 'Next.js application defaults and quality checks',
+	projectType: 'Next.js Web Application',
+	primaryLanguage: 'TypeScript',
+	frameworks: [
+		{name: 'Next.js', category: 'web', confidence: 'high'},
+		{name: 'React', category: 'web', confidence: 'high'},
+	],
+	buildCommands: {
+		Development: 'npm run dev',
+		Build: 'npm run build',
+		Test: 'npm run test',
+		Lint: 'npm run lint',
+	},
+	files: [
+		{
+			path: '.nanocoderignore',
+			content: `# Dependency lockfiles and generated framework metadata
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+next-env.d.ts
+*.tsbuildinfo
+
+# Next.js and test output
+.next/
+out/
+coverage/
+`,
+		},
+		{
+			path: '.nanocoder/commands/check.md',
+			content: `---
+description: Run the available Next.js project quality checks
+aliases: [verify]
+category: quality
+---
+
+Inspect package.json and the lockfiles to determine the package manager. Run
+the available type-check, lint, test, and production build scripts in that
+order. Do not invent missing scripts. Pay attention to server/client component
+boundaries and report each failure with the relevant file and line information.
+`,
+		},
+	],
+} satisfies PresetDefinition;

--- a/source/init/templates/preset-react.ts
+++ b/source/init/templates/preset-react.ts
@@ -1,0 +1,44 @@
+import type {PresetDefinition} from '@/init/presets';
+
+export const reactPreset = {
+	name: 'react',
+	description: 'React application defaults and quality checks',
+	projectType: 'React Web Application',
+	primaryLanguage: 'TypeScript',
+	frameworks: [{name: 'React', category: 'web', confidence: 'high'}],
+	buildCommands: {
+		Development: 'npm run dev',
+		Build: 'npm run build',
+		Test: 'npm run test',
+		Lint: 'npm run lint',
+	},
+	files: [
+		{
+			path: '.nanocoderignore',
+			content: `# Dependency lockfiles and generated TypeScript metadata
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+*.tsbuildinfo
+
+# Generated test and build artifacts
+coverage/
+dist/
+`,
+		},
+		{
+			path: '.nanocoder/commands/check.md',
+			content: `---
+description: Run the available React project quality checks
+aliases: [verify]
+category: quality
+---
+
+Inspect package.json and the lockfiles to determine the package manager. Run
+the available type-check, lint, test, and build scripts in that order. Do not
+invent missing scripts. Report each command and summarize any failures with
+the relevant file and line information.
+`,
+		},
+	],
+} satisfies PresetDefinition;

--- a/source/init/templates/preset-react.ts
+++ b/source/init/templates/preset-react.ts
@@ -12,6 +12,12 @@ export const reactPreset = {
 		Test: 'npm run test',
 		Lint: 'npm run lint',
 	},
+	packageScripts: {
+		Development: 'dev',
+		Build: 'build',
+		Test: 'test',
+		Lint: 'lint',
+	},
 	files: [
 		{
 			path: '.nanocoderignore',

--- a/source/init/templates/preset-rust.ts
+++ b/source/init/templates/preset-rust.ts
@@ -1,0 +1,44 @@
+import type {PresetDefinition} from '@/init/presets';
+
+export const rustPreset = {
+	name: 'rust',
+	description: 'Rust project defaults and Cargo quality checks',
+	projectType: 'Rust Application',
+	primaryLanguage: 'Rust',
+	frameworks: [],
+	buildCommands: {
+		Build: 'cargo build',
+		Test: 'cargo test',
+		Lint: 'cargo clippy --all-targets --all-features',
+		Format: 'cargo fmt --check',
+		Run: 'cargo run',
+	},
+	files: [
+		{
+			path: '.nanocoderignore',
+			content: `# Cargo lockfile and generated build output
+Cargo.lock
+target/
+
+# Generated coverage and profiling data
+coverage/
+*.profraw
+*.profdata
+`,
+		},
+		{
+			path: '.nanocoder/commands/check.md',
+			content: `---
+description: Run the standard Rust project quality checks
+aliases: [verify]
+category: quality
+---
+
+Inspect Cargo.toml and repository instructions, then run cargo fmt --check,
+cargo clippy --all-targets --all-features, and cargo test. Add --workspace when
+the manifest defines a workspace. Report each command and summarize failures
+with the relevant crate, file, and line information.
+`,
+		},
+	],
+} satisfies PresetDefinition;

--- a/source/init/templates/preset-rust.ts
+++ b/source/init/templates/preset-rust.ts
@@ -16,8 +16,7 @@ export const rustPreset = {
 	files: [
 		{
 			path: '.nanocoderignore',
-			content: `# Cargo lockfile and generated build output
-Cargo.lock
+			content: `# Generated Cargo build output
 target/
 
 # Generated coverage and profiling data


### PR DESCRIPTION
Closes #1008

## Description

Adds bundled initialization presets through `nanocoder init --preset <type>` and `/init --preset <type>`.

The implementation introduces a typed preset registry with initial presets for React, Next.js, and Rust. Presets augment the existing project analysis and generate stack-aware `AGENTS.md`, `.nanocoderignore`, and `.nanocoder/commands/check.md` files without silently overwriting existing preset files.

Unknown preset names are rejected before files are written and display the supported preset names.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [x] Documentation update

## Changeset

* [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

* [x] New features include passing tests in `.spec.ts/tsx` files
* [ ] All existing tests pass (`pnpm test:all` completes successfully)
* [x] Tests cover both success and error scenarios

Focused test results:

* Preset argument parsing
* React, Next.js, and Rust preset resolution
* Preset file generation
* Invalid preset handling before file creation
* Existing-file preservation
* Default initialization without a preset

All 16 focused tests pass.

Additional successful checks:

* Formatting
* Main TypeScript check
* VS Code TypeScript check
* Lint
* Knip
* `git diff --check`

The complete suite could not be reliably executed locally because parts of it depend on Unix path, shell, symlink, and permission behavior. Linux CI will provide complete repository verification.

### Manual Testing

* [ ] Tested with Ollama
* [ ] Tested with OpenRouter
* [ ] Tested with OpenAI-compatible API
* [ ] Tested MCP integration (if applicable)
* [x] Tested CLI help, preset generation, generated command frontmatter, and invalid preset handling

Provider and MCP testing are not applicable because this change only affects local project initialization and does not invoke an AI provider or MCP server.

## Checklist

* [ ] If this was for an open issue, I was assigned to it
* [x] Code follows project style guidelines
* [ ] Self-review completed
* [x] Documentation updated (if needed)
* [x] No breaking changes (or clearly documented)
* [ ] Appropriate logging added using structured logging (see [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md#logging)](../CONTRIBUTING.md#logging))

Assignment is currently awaiting maintainer confirmation. Structured logging is not applicable because this change does not introduce a runtime service or new operational logging path.