### PR TITLE
Fix custom tools on Windows

### DIFF
--- a/.changeset/swift-cats-swim.md
+++ b/.changeset/swift-cats-swim.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed custom tools on Windows so their default command shell receives its `/c` switch. Closes #1028.

--- a/source/custom-tools/handler.spec.ts
+++ b/source/custom-tools/handler.spec.ts
@@ -76,6 +76,18 @@ test('runScript: captures stdout', async t => {
 	t.is(result, 'EXIT_CODE: 0\nhello world');
 });
 
+const testOnWindows = process.platform === 'win32' ? test : test.skip;
+
+testOnWindows('runScript: invokes cmd with its Windows command switch', async t => {
+	const result = await runScript('echo hello from cmd', {
+		cwd: testDir,
+		env: process.env,
+		shell: process.env.ComSpec || 'cmd.exe',
+		timeoutMs: 5_000,
+	});
+	t.is(result, 'EXIT_CODE: 0\nhello from cmd');
+});
+
 test('runScript: non-zero exit returns output with EXIT_CODE prefix', async t => {
 	const result = await runScript(`echo oops >&2; exit 3`, {
 		cwd: testDir,

--- a/source/custom-tools/handler.ts
+++ b/source/custom-tools/handler.ts
@@ -53,7 +53,13 @@ export function runScript(
 	options: RunOptions,
 ): Promise<string> {
 	return new Promise((resolvePromise, rejectPromise) => {
-		const child = spawn(options.shell, ['-c', script], {
+		const shellName = options.shell.split(/[\\/]/).pop()?.toLowerCase();
+		const args =
+			process.platform === 'win32' &&
+			(shellName === 'cmd' || shellName === 'cmd.exe')
+				? ['/c', script]
+				: ['-c', script];
+		const child = spawn(options.shell, args, {
 			cwd: options.cwd,
 			env: options.env,
 			stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Problem

On Windows, a custom tool without an explicit shell resolves to `cmd.exe`, but the runner passed it the POSIX `-c` switch. `cmd.exe -c` opens the command interpreter instead of running the tool body.

## Fix

Detect the Windows command interpreter by its executable name and pass `/c`; keep `-c` for POSIX shells, including explicitly configured `bash` and `sh` tools. Added a Windows-only regression test that runs a real custom-tool command through `cmd.exe`, plus the required patch changeset.

Fixes #1028.

## User impact

Default custom tools now execute their body on Windows instead of opening an idle command prompt process.

## Verification

- Passed the new Windows regression against the local `cmd.exe`.
- Passed TypeScript type checking, Biome format, and Biome lint checks.
- `pnpm build` completed TypeScript compilation, then stopped at the existing Windows-only `cp`/`chmod` shell commands.
- The pre-existing handler suite is not Windows portable: baseline has nine unrelated failures from hard-coded `/bin/sh` paths and a case-sensitive `PATH` assertion; the new regression changed from failing to passing.