### PR TITLE
fix: keep custom-tool cwd inside the project

### DIFF
--- a/.changeset/custom-tool-cwd-containment.md
+++ b/.changeset/custom-tool-cwd-containment.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+Custom tool `cwd` now stays inside the project after symlink and `${VAR}` resolution, matching file-tool containment. Closes #1027.

--- a/source/custom-tools/handler.spec.ts
+++ b/source/custom-tools/handler.spec.ts
@@ -1,6 +1,6 @@
-import {mkdirSync, rmSync} from 'node:fs';
+import {mkdirSync, rmSync, symlinkSync} from 'node:fs';
 import {tmpdir} from 'node:os';
-import {join} from 'node:path';
+import {join, resolve} from 'node:path';
 import test from 'ava';
 import {buildHandler, expandVars, mergeEnv, resolveCwd, runScript} from './handler';
 import type {CustomToolMetadata} from '@/types/custom-tools';
@@ -64,6 +64,54 @@ test('resolveCwd handles missing paths by falling back to projectRoot', t => {
 	const projectRoot = '/tmp';
 	t.is(resolveCwd('/definitely/not/a/path/abc123', projectRoot), projectRoot);
 	t.is(resolveCwd(undefined, projectRoot), projectRoot);
+});
+
+test('resolveCwd keeps an in-project relative directory', t => {
+	const root = join(tmpdir(), `nanocoder-custom-tools-cwd-in-${Date.now()}`);
+	mkdirSync(join(root, 'scripts'), {recursive: true});
+	t.teardown(() => rmSync(root, {recursive: true, force: true}));
+	t.is(resolveCwd('./scripts', root), resolve(root, 'scripts'));
+});
+
+test('resolveCwd falls back when cwd is a symlink out of the project', t => {
+	const root = join(tmpdir(), `nanocoder-custom-tools-cwd-link-${Date.now()}`);
+	const outside = join(tmpdir(), `nanocoder-custom-tools-cwd-out-${Date.now()}`);
+	mkdirSync(root);
+	mkdirSync(outside);
+	t.teardown(() => {
+		rmSync(root, {recursive: true, force: true});
+		rmSync(outside, {recursive: true, force: true});
+	});
+	symlinkSync(outside, join(root, 'scripts'));
+	t.is(resolveCwd('./scripts', root), root);
+});
+
+test('resolveCwd falls back for an absolute path outside the project', t => {
+	const root = join(tmpdir(), `nanocoder-custom-tools-cwd-root-${Date.now()}`);
+	const outside = join(tmpdir(), `nanocoder-custom-tools-cwd-abs-${Date.now()}`);
+	mkdirSync(root);
+	mkdirSync(outside);
+	t.teardown(() => {
+		rmSync(root, {recursive: true, force: true});
+		rmSync(outside, {recursive: true, force: true});
+	});
+	t.is(resolveCwd(outside, root), root);
+});
+
+test('resolveCwd falls back for ${HOME} outside the project', t => {
+	const root = join(tmpdir(), `nanocoder-custom-tools-cwd-home-root-${Date.now()}`);
+	const fakeHome = join(tmpdir(), `nanocoder-custom-tools-home-${Date.now()}`);
+	mkdirSync(root);
+	mkdirSync(fakeHome);
+	const prev = process.env.HOME;
+	t.teardown(() => {
+		rmSync(root, {recursive: true, force: true});
+		rmSync(fakeHome, {recursive: true, force: true});
+		if (prev === undefined) delete process.env.HOME;
+		else process.env.HOME = prev;
+	});
+	process.env.HOME = fakeHome;
+	t.is(resolveCwd('${HOME}', root), root);
 });
 
 test('runScript: captures stdout', async t => {

--- a/source/custom-tools/handler.ts
+++ b/source/custom-tools/handler.ts
@@ -1,6 +1,6 @@
 import {spawn} from 'node:child_process';
-import {existsSync} from 'node:fs';
-import {isAbsolute, resolve} from 'node:path';
+import {existsSync, realpathSync} from 'node:fs';
+import {isAbsolute, resolve, sep} from 'node:path';
 import {TRUNCATION_OUTPUT_LIMIT} from '@/constants';
 import {renderBody} from '@/custom-tools/template';
 import type {CustomToolMetadata} from '@/types/custom-tools';
@@ -127,7 +127,8 @@ function formatScriptOutput(
  * Resolve the working directory with `${VAR}` substitution from process.env.
  * Relative paths resolve against the project root. Returns the project root
  * if the configured directory doesn't exist (so we don't hard-fail on a
- * stale checkout).
+ * stale checkout), or if the real path leaves the project (symlink, absolute,
+ * or `${HOME}` — same containment file tools already enforce).
  */
 export function resolveCwd(
 	configured: string | undefined,
@@ -138,7 +139,18 @@ export function resolveCwd(
 	const absolute = isAbsolute(expanded)
 		? expanded
 		: resolve(projectRoot, expanded);
-	return existsSync(absolute) ? absolute : projectRoot;
+	if (!existsSync(absolute)) return projectRoot;
+	return isInsideProject(absolute, projectRoot) ? absolute : projectRoot;
+}
+
+function isInsideProject(target: string, projectRoot: string): boolean {
+	try {
+		const realRoot = realpathSync(projectRoot);
+		const realTarget = realpathSync(target);
+		return realTarget === realRoot || realTarget.startsWith(realRoot + sep);
+	} catch {
+		return false;
+	}
 }
 
 /**


### PR DESCRIPTION
## Description

Custom tool `cwd` was used as-is whenever the path existed. A symlink, an absolute path, or `${HOME}` could put the shell outside the project with no warning.

`resolveCwd` now realpath-checks against the project root, same idea as the file tools. If the real path is outside (or missing), it falls back to the project root.

Closes #1027.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

N/A this is cwd resolution before spawn. Covered by the unit tests above.

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

No extra logging  missing cwd already fell back quietly, same for an out-of-project cwd.