### PR TITLE
fix: preserve repeated pasted text

### DIFF
--- a/.changeset/bright-pastes-repeat.md
+++ b/.changeset/bright-pastes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Replace every matching pasted-text occurrence with a placeholder and restore repeated placeholders before model submission.

--- a/.changeset/bright-pastes-repeat.md
+++ b/.changeset/bright-pastes-repeat.md
@@ -2,4 +2,4 @@
 "@nanocollective/nanocoder": patch
 ---
 
-Replace every matching pasted-text occurrence with a placeholder and restore repeated placeholders before model submission.
+Preserve every copy of repeated pasted text through placeholder display, chunked updates, and prompt assembly.

--- a/source/hooks/useInputState.spec.tsx
+++ b/source/hooks/useInputState.spec.tsx
@@ -278,6 +278,23 @@ test('deletePlaceholder removes only the targeted duplicate', t => {
 	]);
 });
 
+test('deletePlaceholder removes every occurrence owned by one entry', t => {
+	const {hook, instance} = setupTest();
+	const placeholder = createPastePlaceholder('paste_1', 'first', '1');
+
+	hook.setInputState({
+		displayValue: `${placeholder.displayText} and ${placeholder.displayText}`,
+		placeholderContent: {paste_1: placeholder},
+	});
+	instance.rerender(<TestComponent />);
+
+	currentHook!.deletePlaceholder('paste_1');
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, ' and ');
+	t.deepEqual(currentHook!.currentState.placeholderContent, {});
+});
+
 // Test setInputState
 test('setInputState updates current state', t => {
 	const {hook, instance} = setupTest();
@@ -753,6 +770,36 @@ test('chunked paste updates existing placeholder', t => {
 
 	// If a placeholder was created, the content should be managed
 	t.truthy(currentHook!.currentState);
+});
+
+test('chunked paste relabels every repeated placeholder occurrence', t => {
+	const {hook, instance} = setupTest();
+	const originalPaste = 'x'.repeat(801);
+
+	hook.updateInput(originalPaste);
+	instance.rerender(<TestComponent />);
+
+	const pasteId = Object.keys(currentHook!.currentState.placeholderContent)[0];
+	t.is(pasteId, 'paste_1');
+	const placeholder = currentHook!.currentState.placeholderContent[pasteId];
+	const repeatedState: InputState = {
+		displayValue: `${placeholder.displayText} and ${placeholder.displayText}`,
+		placeholderContent: currentHook!.currentState.placeholderContent,
+	};
+
+	currentHook!.setInputState(repeatedState);
+	instance.rerender(<TestComponent />);
+	currentHook!.updateInput(`${repeatedState.displayValue}tail`);
+	instance.rerender(<TestComponent />);
+
+	const updated = currentHook!.currentState.placeholderContent[
+		pasteId
+	] as PastePlaceholderContent;
+	t.is(updated.content, `${originalPaste}tail`);
+	t.is(
+		currentHook!.currentState.displayValue,
+		`${updated.displayText} and ${updated.displayText}`,
+	);
 });
 
 // Test paste detection with multiline

--- a/source/hooks/useInputState.ts
+++ b/source/hooks/useInputState.ts
@@ -122,7 +122,7 @@ export function useInputState() {
 					};
 
 					// Replace old placeholder with updated one in display value
-					const newDisplayValue = currentState.displayValue.replace(
+					const newDisplayValue = currentState.displayValue.replaceAll(
 						oldPlaceholder,
 						newPlaceholder,
 					);
@@ -188,7 +188,7 @@ export function useInputState() {
 							},
 						};
 
-						const newDisplayValue = currentState.displayValue.replace(
+						const newDisplayValue = currentState.displayValue.replaceAll(
 							oldPlaceholder,
 							newPlaceholder,
 						);
@@ -302,21 +302,25 @@ export function useInputState() {
 				return;
 			}
 
-			// Locate the placeholder by its own display text rather than rebuilding
-			// a pattern from the id: ids are namespaced keys, not display labels.
-			const occurrence = findPlaceholderOccurrences(
+			// Locate every occurrence by its display text rather than rebuilding a
+			// pattern from the id: ids are namespaced keys, not display labels.
+			const occurrences = findPlaceholderOccurrences(
 				currentState.displayValue,
 				currentState.placeholderContent,
-			).find(candidate => candidate.id === placeholderId);
+			).filter(candidate => candidate.id === placeholderId);
+
+			let newDisplayValue = currentState.displayValue;
+			for (let i = occurrences.length - 1; i >= 0; i--) {
+				const {start, end} = occurrences[i];
+				newDisplayValue =
+					newDisplayValue.slice(0, start) + newDisplayValue.slice(end);
+			}
 
 			const newPlaceholderContent = {...currentState.placeholderContent};
 			delete newPlaceholderContent[placeholderId];
 
 			pushToUndoStack({
-				displayValue: occurrence
-					? currentState.displayValue.slice(0, occurrence.start) +
-						currentState.displayValue.slice(occurrence.end)
-					: currentState.displayValue,
+				displayValue: newDisplayValue,
 				placeholderContent: newPlaceholderContent,
 			});
 		},

--- a/source/utils/atomic-deletion.spec.ts
+++ b/source/utils/atomic-deletion.spec.ts
@@ -262,3 +262,26 @@ test('handleAtomicDeletion removes the second of two identical placeholders', t 
 	t.is(result!.displayValue, '[@a.ts] and ');
 	t.deepEqual(Object.keys(result!.placeholderContent), ['file_1']);
 });
+
+test('handleAtomicDeletion keeps content used by another repeated occurrence', t => {
+	const displayText = '[Paste #1: 4 chars]';
+	const placeholder = {
+		type: PlaceholderType.PASTE,
+		displayText,
+		content: 'body',
+		originalSize: 4,
+	} as PastePlaceholderContent;
+	const previousState: InputState = {
+		displayValue: `${displayText} and ${displayText}`,
+		placeholderContent: {paste_1: placeholder},
+	};
+
+	const result = handleAtomicDeletion(
+		previousState,
+		`${displayText} and [Paste #1: 4 chars`,
+	);
+
+	t.truthy(result);
+	t.is(result!.displayValue, `${displayText} and `);
+	t.deepEqual(result!.placeholderContent, {paste_1: placeholder});
+});

--- a/source/utils/atomic-deletion.ts
+++ b/source/utils/atomic-deletion.ts
@@ -36,10 +36,11 @@ export function handleAtomicDeletion(
 	const deletionEnd = deletionStart + deletedChars;
 
 	// Check if any placeholder was affected by this deletion
-	for (const occurrence of findPlaceholderOccurrences(
+	const occurrences = findPlaceholderOccurrences(
 		previousText,
 		previousState.placeholderContent,
-	)) {
+	);
+	for (const occurrence of occurrences) {
 		const {start, end} = occurrence;
 
 		if (
@@ -51,7 +52,14 @@ export function handleAtomicDeletion(
 			const newDisplayValue =
 				previousText.slice(0, start) + previousText.slice(end);
 			const newPlaceholderContent = {...previousState.placeholderContent};
-			delete newPlaceholderContent[occurrence.id];
+			const hasAnotherOccurrence = occurrences.some(
+				candidate =>
+					candidate.id === occurrence.id &&
+					(candidate.start !== start || candidate.end !== end),
+			);
+			if (!hasAnotherOccurrence) {
+				delete newPlaceholderContent[occurrence.id];
+			}
 
 			return {
 				displayValue: newDisplayValue,

--- a/source/utils/paste-utils.spec.ts
+++ b/source/utils/paste-utils.spec.ts
@@ -5,6 +5,7 @@ import {tmpdir} from 'os';
 import {join} from 'path';
 import test from 'ava';
 import {handlePaste} from './paste-utils';
+import {assemblePrompt} from './prompt-processor';
 import {clearAppConfig, reloadAppConfig} from '../config';
 
 // Tests for handlePaste utility function
@@ -101,7 +102,7 @@ test('handlePaste replaces pasted text with placeholder in display value', t => 
 	t.false(result!.displayValue.includes('x'.repeat(10))); // Original text should be gone
 });
 
-test('handlePaste replaces every occurrence of repeated pasted text', t => {
+test('repeated pasted text survives the complete prompt round trip', t => {
 	const pastedText = 'x'.repeat(802);
 	const currentDisplayValue = `prefix ${pastedText} middle ${pastedText} suffix`;
 	const currentPlaceholderContent: Record<string, PlaceholderContent> = {};
@@ -113,12 +114,13 @@ test('handlePaste replaces every occurrence of repeated pasted text', t => {
 	);
 
 	t.truthy(result);
-	const placeholder = result!.placeholderContent['1'].displayText;
+	const placeholder = result!.placeholderContent.paste_1.displayText;
 	t.is(
 		result!.displayValue,
 		`prefix ${placeholder} middle ${placeholder} suffix`,
 	);
 	t.false(result!.displayValue.includes(pastedText));
+	t.is(assemblePrompt(result!), currentDisplayValue);
 });
 
 test('handlePaste preserves existing pasted content', t => {

--- a/source/utils/paste-utils.spec.ts
+++ b/source/utils/paste-utils.spec.ts
@@ -101,6 +101,26 @@ test('handlePaste replaces pasted text with placeholder in display value', t => 
 	t.false(result!.displayValue.includes('x'.repeat(10))); // Original text should be gone
 });
 
+test('handlePaste replaces every occurrence of repeated pasted text', t => {
+	const pastedText = 'x'.repeat(802);
+	const currentDisplayValue = `prefix ${pastedText} middle ${pastedText} suffix`;
+	const currentPlaceholderContent: Record<string, PlaceholderContent> = {};
+
+	const result = handlePaste(
+		pastedText,
+		currentDisplayValue,
+		currentPlaceholderContent,
+	);
+
+	t.truthy(result);
+	const placeholder = result!.placeholderContent['1'].displayText;
+	t.is(
+		result!.displayValue,
+		`prefix ${placeholder} middle ${placeholder} suffix`,
+	);
+	t.false(result!.displayValue.includes(pastedText));
+});
+
 test('handlePaste preserves existing pasted content', t => {
 	const existingPlaceholderContent: Record<string, PlaceholderContent> = {
 		'123': {

--- a/source/utils/paste-utils.ts
+++ b/source/utils/paste-utils.ts
@@ -75,9 +75,9 @@ export function handlePaste(
 	};
 
 	// For CLI paste detection, we need to replace the pasted text in the display value
-	// If the pasted text is at the end, replace it. Otherwise append the placeholder.
+	// Replace every exact occurrence, or append the placeholder if none is present.
 	const newDisplayValue = currentDisplayValue.includes(pastedText)
-		? currentDisplayValue.replace(pastedText, placeholder)
+		? currentDisplayValue.replaceAll(pastedText, placeholder)
 		: currentDisplayValue + placeholder;
 
 	return {

--- a/source/utils/placeholders.spec.ts
+++ b/source/utils/placeholders.spec.ts
@@ -83,6 +83,37 @@ test('findPlaceholderOccurrences gives each duplicate its own entry', t => {
 	);
 });
 
+test('findPlaceholderOccurrences reuses one entry for repeated display text', t => {
+	const content = {paste_1: paste('[Paste #1: 4 chars]')};
+
+	const occurrences = findPlaceholderOccurrences(
+		'[Paste #1: 4 chars] [Paste #1: 4 chars]',
+		content,
+	);
+
+	t.deepEqual(
+		occurrences.map(o => o.id),
+		['paste_1', 'paste_1'],
+	);
+});
+
+test('findPlaceholderOccurrences keeps longest-match priority after reuse', t => {
+	const content = {
+		file_1: file('[@a.ts] extended'),
+		file_2: file('[@a.ts]'),
+	};
+
+	const occurrences = findPlaceholderOccurrences(
+		'[@a.ts] extended [@a.ts] extended',
+		content,
+	);
+
+	t.deepEqual(
+		occurrences.map(o => o.id),
+		['file_1', 'file_1'],
+	);
+});
+
 test('findPlaceholderOccurrences prefers the longest matching display text', t => {
 	const content = {
 		file_1: file('[@a.ts]'),

--- a/source/utils/placeholders.ts
+++ b/source/utils/placeholders.ts
@@ -89,9 +89,10 @@ function resolveDisplayText(id: string, content: PlaceholderContent): string {
 /**
  * Locate every placeholder in `text` by scanning for its display text.
  *
- * Each entry claims at most one occurrence, so two placeholders that render
- * identically (the same file mentioned twice) map to distinct positions
- * instead of both resolving to the first match.
+ * Entries with the same display text claim distinct positions first. Once all
+ * matching entries have been claimed, later occurrences reuse the first entry.
+ * This keeps duplicate file mentions distinct while allowing one paste entry
+ * to represent repeated copies of the same pasted text.
  */
 export function findPlaceholderOccurrences(
 	text: string,
@@ -109,10 +110,15 @@ export function findPlaceholderOccurrences(
 
 	let index = 0;
 	while (index < text.length) {
-		const hit = candidates.find(
-			([id, displayText]) =>
-				!claimed.has(id) && text.startsWith(displayText, index),
+		const firstMatch = candidates.find(([, displayText]) =>
+			text.startsWith(displayText, index),
 		);
+		const hit = firstMatch
+			? (candidates.find(
+					([id, displayText]) =>
+						displayText === firstMatch[1] && !claimed.has(id),
+				) ?? firstMatch)
+			: undefined;
 
 		if (!hit) {
 			index++;

--- a/source/utils/prompt-processor.spec.ts
+++ b/source/utils/prompt-processor.spec.ts
@@ -26,6 +26,23 @@ test('assemblePrompt - replaces placeholder with paste content', t => {
 	t.is(result, 'Hello Hello World');
 });
 
+test('assemblePrompt - restores every repeated paste placeholder', t => {
+	const inputState: InputState = {
+		displayValue: '[Paste #1: 11 chars] and [Paste #1: 11 chars]',
+		placeholderContent: {
+			1: {
+				type: PlaceholderType.PASTE,
+				content: 'Hello World',
+				displayText: '[Paste #1: 11 chars]',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	t.is(result, 'Hello World and Hello World');
+});
+
 test('assemblePrompt - replaces placeholder with file content', t => {
 	const inputState: InputState = {
 		displayValue: 'File: [File #1: example.txt]',

--- a/source/utils/prompt-processor.spec.ts
+++ b/source/utils/prompt-processor.spec.ts
@@ -26,59 +26,6 @@ test('assemblePrompt - replaces placeholder with paste content', t => {
 	t.is(result, 'Hello Hello World');
 });
 
-test('assemblePrompt - restores every repeated paste placeholder', t => {
-	const inputState: InputState = {
-		displayValue: '[Paste #1: 11 chars] and [Paste #1: 11 chars]',
-		placeholderContent: {
-			1: {
-				type: PlaceholderType.PASTE,
-				content: 'Hello World',
-				displayText: '[Paste #1: 11 chars]',
-			},
-		},
-	};
-
-	const result = assemblePrompt(inputState);
-
-	t.is(result, 'Hello World and Hello World');
-});
-
-test('assemblePrompt - preserves dollar tokens in placeholder content', t => {
-	const replacementContent = "literal $& $1 $` $' $$";
-	const inputState: InputState = {
-		displayValue: '[Paste #1: 21 chars]',
-		placeholderContent: {
-			1: {
-				type: PlaceholderType.PASTE,
-				content: replacementContent,
-				displayText: '[Paste #1: 21 chars]',
-			},
-		},
-	};
-
-	const result = assemblePrompt(inputState);
-
-	t.is(result, replacementContent);
-});
-
-test('assemblePrompt - preserves dollar tokens through the legacy fallback', t => {
-	const replacementContent = "literal $& $1 $` $' $$";
-	const inputState: InputState = {
-		displayValue: '[Paste #1: 21 chars]',
-		placeholderContent: {
-			1: {
-				type: PlaceholderType.PASTE,
-				content: replacementContent,
-				displayText: '',
-			},
-		},
-	};
-
-	const result = assemblePrompt(inputState);
-
-	t.is(result, replacementContent);
-});
-
 test('assemblePrompt - replaces placeholder with file content', t => {
 	const inputState: InputState = {
 		displayValue: 'File: [File #1: example.txt]',

--- a/source/utils/prompt-processor.spec.ts
+++ b/source/utils/prompt-processor.spec.ts
@@ -43,6 +43,42 @@ test('assemblePrompt - restores every repeated paste placeholder', t => {
 	t.is(result, 'Hello World and Hello World');
 });
 
+test('assemblePrompt - preserves dollar tokens in placeholder content', t => {
+	const replacementContent = "literal $& $1 $` $' $$";
+	const inputState: InputState = {
+		displayValue: '[Paste #1: 21 chars]',
+		placeholderContent: {
+			1: {
+				type: PlaceholderType.PASTE,
+				content: replacementContent,
+				displayText: '[Paste #1: 21 chars]',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	t.is(result, replacementContent);
+});
+
+test('assemblePrompt - preserves dollar tokens through the legacy fallback', t => {
+	const replacementContent = "literal $& $1 $` $' $$";
+	const inputState: InputState = {
+		displayValue: '[Paste #1: 21 chars]',
+		placeholderContent: {
+			1: {
+				type: PlaceholderType.PASTE,
+				content: replacementContent,
+				displayText: '',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	t.is(result, replacementContent);
+});
+
 test('assemblePrompt - replaces placeholder with file content', t => {
 	const inputState: InputState = {
 		displayValue: 'File: [File #1: example.txt]',


### PR DESCRIPTION
## Description

Fixes #1039.

Repeated pasted text is now compressed consistently in the display value and restored consistently before model submission. Updating both sides of the placeholder round trip prevents the second occurrence from remaining raw or leaking an unresolved placeholder into the prompt.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a patch changeset describing the fix

## Testing

### Automated Tests

- [x] Added regression tests for repeated raw text and repeated placeholders
- [x] `pnpm exec ava source/utils/paste-utils.spec.ts source/utils/prompt-processor.spec.ts`, 16 passed
- [x] `pnpm run test:types`
- [x] `pnpm run build`
- [x] `pnpm exec ava source/cli-integration.spec.ts`, 7 passed after the required build
- [x] `pnpm test:all` ran every test; its only initial failures were those 7 CLI integration tests because the fresh clone had no `dist/cli.js`

### Manual Testing

- [ ] Provider-specific manual testing, not applicable to this string transformation

## Checklist

- [x] Commented on the open issue before starting; the issue is not assigned
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation is unchanged because behavior and configuration are unchanged
- [x] No breaking changes
- [x] No logging change is needed for this pure string transformation
