### PR TITLE
fix(acp): allow 5-6 ask_user options to match the CLI

### DIFF
--- a/.changeset/acp-ask-user-option-limit.md
+++ b/.changeset/acp-ask-user-option-limit.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed `ask_user` rejecting 5-6 options over ACP. The tool schema allows 2-6 options, but the ACP path used by the VS Code extension capped them at 4, so an identical prompt succeeded in the CLI and failed in the editor. The bound now matches the schema, and the error string returned to the model says "2-6" rather than telling it the limit is 4 and pushing it to retry with a needlessly narrowed list. Closes #1036.

--- a/source/acp/acp-conversation.spec.ts
+++ b/source/acp/acp-conversation.spec.ts
@@ -1445,6 +1445,94 @@ test('runAcpConversation - ask_user fails cleanly when no usable options', async
 	t.true(toolMsg?.content.startsWith('Error:'));
 });
 
+// The ACP option bound has to match the `ask_user` tool schema (2-6), otherwise
+// identical prompts succeed in the CLI and fail in the VS Code extension.
+test('runAcpConversation - ask_user accepts six options', async t => {
+	const conn = {
+		sessionUpdate: async () => {},
+		requestPermission: async (p: any) => ({
+			outcome: {outcome: 'selected', optionId: p.options[5].optionId},
+		}),
+	} as unknown as AgentSideConnection;
+
+	const session = createMockSession(conn);
+	const askCall = createMockToolCall(
+		'ask_user',
+		{question: 'Pick one', options: ['A', 'B', 'C', 'D', 'E', 'F']},
+		'call-ask',
+	);
+	const {client} = createMockClient([
+		{
+			choices: [{message: {content: '', tool_calls: [askCall]}}],
+			toolsDisabled: false,
+		},
+	]);
+	const toolManager = {
+		getAvailableToolNames: () => ['ask_user'],
+		getFilteredTools: () => ({}),
+		hasTool: (n: string) => n === 'ask_user',
+		getToolEntry: () => ({approval: false}),
+		isReadOnly: () => true,
+	};
+
+	await runAcpConversation({
+		session,
+		client,
+		toolManager: toolManager as any,
+		conn,
+		nonInteractiveAlwaysAllow: [],
+	});
+
+	const toolMsg = session.messages.find(
+		(m: any) => m.role === 'tool' && m.name === 'ask_user',
+	);
+	t.is(toolMsg?.content, 'F');
+});
+
+test('runAcpConversation - ask_user rejects more than six options', async t => {
+	const conn = {
+		sessionUpdate: async () => {},
+		requestPermission: async () => {
+			t.fail('should not prompt the client for an out-of-range option list');
+			return {outcome: {outcome: 'cancelled'}};
+		},
+	} as unknown as AgentSideConnection;
+
+	const session = createMockSession(conn);
+	const askCall = createMockToolCall(
+		'ask_user',
+		{question: 'Pick one', options: ['A', 'B', 'C', 'D', 'E', 'F', 'G']},
+		'call-ask',
+	);
+	const {client} = createMockClient([
+		{
+			choices: [{message: {content: '', tool_calls: [askCall]}}],
+			toolsDisabled: false,
+		},
+	]);
+	const toolManager = {
+		getAvailableToolNames: () => ['ask_user'],
+		getFilteredTools: () => ({}),
+		hasTool: (n: string) => n === 'ask_user',
+		getToolEntry: () => ({approval: false}),
+		isReadOnly: () => true,
+	};
+
+	await runAcpConversation({
+		session,
+		client,
+		toolManager: toolManager as any,
+		conn,
+		nonInteractiveAlwaysAllow: [],
+	});
+
+	const toolMsg = session.messages.find(
+		(m: any) => m.role === 'tool' && m.name === 'ask_user',
+	);
+	t.true(toolMsg?.content.startsWith('Error:'));
+	t.true(toolMsg?.content.includes('2-6'));
+});
+
 // ============================================================================
 // Action timeline capture
 // ============================================================================

--- a/source/acp/acp-conversation.ts
+++ b/source/acp/acp-conversation.ts
@@ -594,8 +594,8 @@ async function handleAskUser(
 	const options = normalizeQuestionOptions(args.options);
 
 	let content: string;
-	if (!question || options.length < 2 || options.length > 4) {
-		content = 'Error: ask_user requires a question and 2-4 string options.';
+	if (!question || options.length < 2 || options.length > 6) {
+		content = 'Error: ask_user requires a question and 2-6 string options.';
 		await emitToolCallUpdate(session, conn, toolCall, 'failed', content);
 	} else {
 		await emitToolCallUpdate(session, conn, toolCall, 'in_progress');


### PR DESCRIPTION
## Description

`ask_user` accepted a different number of options depending on the interface. The tool schema (`source/tools/ask-question.tsx:67`) allows 2-6 options, but the ACP path used by the VS Code extension rejected anything above 4 — so an identical prompt succeeded in the terminal and failed in the editor. This aligns the ACP bound with the schema.

Fixes #1036

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

`.changeset/acp-ask-user-option-limit.md`, patch.

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Two regression tests in `source/acp/acp-conversation.spec.ts` covering both sides of the boundary: six options round-trip the user's selection back to the model; seven fail with the `2-6` error and never prompt the client. Full suite is 6713 passing, 1 skipped.

Note that `pnpm test:all` needs `pnpm run build` first — the specs in `source/cli-integration.spec.ts` shell out to `dist/cli.js` and fail with `MODULE_NOT_FOUND` on a clean tree.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Left unchecked deliberately. This changes argument validation that runs on the agent side after the model returns a tool call and before any client round-trip, so behaviour is identical across providers — there is no provider-specific path to exercise. The surface worth a human pass is the VS Code extension over ACP: prompt for a 5- or 6-option question and confirm the buttons render and the selection comes back.

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))