### PR TITLE
Fix args variable in parameter-less custom commands

### DIFF
--- a/.changeset/raw-command-args.md
+++ b/.changeset/raw-command-args.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed `{{args}}` in custom commands without declared parameters so it receives the raw command arguments instead of an empty string. Closes #1035.

--- a/source/custom-commands/executor.spec.ts
+++ b/source/custom-commands/executor.spec.ts
@@ -78,6 +78,15 @@ test('execute includes args variable with all arguments', t => {
 	t.true(result.includes('hello world'));
 });
 
+test('execute includes args variable without declared parameters', t => {
+	const command = createTestCommand({
+		content: 'All args: {{args}}',
+	});
+
+	const result = executor.execute(command, ['hello', 'world']);
+	t.true(result.includes('All args: hello world'));
+});
+
 test('execute wraps the prompt with the command name', t => {
 	const command = createTestCommand();
 

--- a/source/custom-commands/executor.ts
+++ b/source/custom-commands/executor.ts
@@ -22,10 +22,10 @@ export class CustomCommandExecutor {
 				variables[name] =
 					provided !== undefined && provided !== '' ? provided : defaultValue;
 			});
-
-			// Also provide all args as a single variable
-			variables['args'] = args.join(' ');
 		}
+
+		// Also provide all args as a single variable
+		variables['args'] = args.join(' ');
 
 		// Add some default context variables
 		variables['cwd'] = process.cwd();


### PR DESCRIPTION
## Description

Fixes #1035.

Custom commands without declared parameters now receive the aggregate `{{args}}` variable, matching commands that do declare parameters. The regression test covers a parameter-less command invoked with multiple arguments.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] Regression coverage added in `executor.spec.ts`
- [x] All existing tests pass (`pnpm run test:all` — 6,712 passed, 1 skipped)
- [x] Focused executor tests pass (18 passed)

### Manual Testing

- [ ] Tested with Ollama (not applicable)
- [ ] Tested with OpenRouter (not applicable)
- [ ] Tested with OpenAI-compatible API (not applicable)
- [ ] Tested MCP integration (not applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it (I posted a claim on the unassigned issue before starting)
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (not needed; changeset included)
- [x] No breaking changes
- [x] Appropriate logging added (not applicable; no new runtime event)

Additional checks: TypeScript typecheck, Biome formatting/lint, build, Knip, and dependency audit all passed. The repository gate skipped Semgrep because it was unavailable locally.
