### PR TITLE
feat(welcome): redesign welcome screen with responsive layout

### DIFF
--- a/.changeset/welcome-redesign-949.md
+++ b/.changeset/welcome-redesign-949.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Redesigned the welcome screen: a gradient block wordmark (full NANOCODER from 90 columns, a compact NC monogram below that), version line, centered quick-action menu, and a branch/directory location line — all centered on one axis at every terminal size, with vertical centering on tall terminals. The prompt input now spans the full terminal width and resizes live with the window, and the boot summary no longer duplicates information the welcome screen already shows. Closes #949.

--- a/source/app/components/app-container.spec.tsx
+++ b/source/app/components/app-container.spec.tsx
@@ -19,9 +19,8 @@ test('createStaticComponents includes welcome message when shouldShowWelcome is 
 	};
 
 	const components = createStaticComponents(props);
-	t.is(components.length, 2); // Welcome + BootSummary
+	t.is(components.length, 1); // Only welcome — boot summary is suppressed when welcome is shown
 	t.is((components[0] as React.ReactElement).key, 'welcome');
-	t.is((components[1] as React.ReactElement).key, 'boot-summary');
 
 	// Render and verify the components display correctly
 	const {lastFrame, unmount} = renderWithTheme(<>{components}</>);

--- a/source/app/components/app-container.tsx
+++ b/source/app/components/app-container.tsx
@@ -47,17 +47,19 @@ function BootSummary({
 	provider,
 	model,
 	mode,
+	hideGit = false,
 }: {
 	provider: string;
 	model: string;
 	mode?: DevelopmentMode;
+	hideGit?: boolean;
 }): React.ReactElement {
 	const {colors} = useTheme();
 	const {isNarrow} = useResponsiveTerminal();
 	const configPath = getClosestConfigFile('agents.config.json');
 	const shortConfig = homeRelative(configPath);
 	const modeLabel = mode ? DEVELOPMENT_MODE_LABELS[mode] : undefined;
-	const gitStatus = getGitStatusSummarySync();
+	const gitStatus = hideGit ? null : getGitStatusSummarySync();
 	const gitLabel = gitStatus ? formatBootSummaryGitLabel(gitStatus) : undefined;
 
 	// Narrow terminals: provider + model + mode on the first line, with the
@@ -148,6 +150,8 @@ export function createStaticComponents({
 	// Boot summary header: always in interactive mode (for config path
 	// visibility), and in run mode we include the active development mode
 	// so it's obvious what the agent is executing under.
+	// When the welcome banner is visible we hide git from the boot summary
+	// to avoid duplicating the centered location line inside the welcome.
 	if (currentProvider || currentModel) {
 		components.push(
 			<Box key="boot-summary" flexDirection="column" marginBottom={1}>
@@ -155,6 +159,7 @@ export function createStaticComponents({
 					provider={currentProvider}
 					model={currentModel}
 					mode={nonInteractiveMode ? developmentMode : undefined}
+					hideGit={shouldShowWelcome}
 				/>
 			</Box>,
 		);

--- a/source/app/components/app-container.tsx
+++ b/source/app/components/app-container.tsx
@@ -47,19 +47,17 @@ function BootSummary({
 	provider,
 	model,
 	mode,
-	hideGit = false,
 }: {
 	provider: string;
 	model: string;
 	mode?: DevelopmentMode;
-	hideGit?: boolean;
 }): React.ReactElement {
 	const {colors} = useTheme();
 	const {isNarrow} = useResponsiveTerminal();
 	const configPath = getClosestConfigFile('agents.config.json');
 	const shortConfig = homeRelative(configPath);
 	const modeLabel = mode ? DEVELOPMENT_MODE_LABELS[mode] : undefined;
-	const gitStatus = hideGit ? null : getGitStatusSummarySync();
+	const gitStatus = getGitStatusSummarySync();
 	const gitLabel = gitStatus ? formatBootSummaryGitLabel(gitStatus) : undefined;
 
 	// Narrow terminals: provider + model + mode on the first line, with the
@@ -147,19 +145,16 @@ export function createStaticComponents({
 		components.push(<WelcomeMessage key="welcome" />);
 	}
 
-	// Boot summary header: always in interactive mode (for config path
-	// visibility), and in run mode we include the active development mode
-	// so it's obvious what the agent is executing under.
-	// When the welcome banner is visible we hide git from the boot summary
-	// to avoid duplicating the centered location line inside the welcome.
-	if (currentProvider || currentModel) {
+	// Boot summary header: only in non-interactive / run mode. The welcome
+	// already shows cwd, branch, and version, so the boot summary would just
+	// duplicate that info when the user is at the welcome screen.
+	if (!shouldShowWelcome && (currentProvider || currentModel)) {
 		components.push(
 			<Box key="boot-summary" flexDirection="column" marginBottom={1}>
 				<BootSummary
 					provider={currentProvider}
 					model={currentModel}
 					mode={nonInteractiveMode ? developmentMode : undefined}
-					hideGit={shouldShowWelcome}
 				/>
 			</Box>,
 		);

--- a/source/app/components/chat-history.tsx
+++ b/source/app/components/chat-history.tsx
@@ -120,8 +120,10 @@ export const ChatHistory = React.memo(function ChatHistory({
 		};
 	}, [fullscreen, scrollActive, scrollBy]);
 
-	// Fresh welcome should be live-responsive (Image4 break) — Static is frozen.
-	// When no messages yet, render welcome outside Static so resize re-centers.
+	// The welcome banner must react to terminal resizes (recentering on every
+	// row), but <Static> content is frozen after first paint. Until the first
+	// message arrives, render the welcome in the live region instead so it
+	// stays responsive; once history exists, it goes through Static as usual.
 	// Only for the real welcome banner (key="welcome") — keep test fixtures
 	// like static-marker inside Static so existing tests stay stable.
 	const hasWelcome = staticComponents.some(

--- a/source/app/components/chat-history.tsx
+++ b/source/app/components/chat-history.tsx
@@ -120,18 +120,25 @@ export const ChatHistory = React.memo(function ChatHistory({
 		};
 	}, [fullscreen, scrollActive, scrollBy]);
 
-	// Fullscreen: the banner renders in regular flow as the first row of the
-	// scrolling content (it clips away with old history, like OpenClaude).
-	// Inline: the banner stays INSIDE Static so it prints exactly once into
-	// the terminal's native scrollback — rendering it in the live region was
-	// the original "banner disappears" bug: Ink erases and rewrites the
-	// whole non-Static region on every keystroke, and clips its top first
-	// once it outgrows the terminal.
-	const banner = fullscreen ? staticComponents[0] : undefined;
-	const frozenComponents = React.useMemo(
-		() => (fullscreen ? staticComponents.slice(1) : staticComponents),
-		[fullscreen, staticComponents],
+	// Fresh welcome should be live-responsive (Image4 break) — Static is frozen.
+	// When no messages yet, render welcome outside Static so resize re-centers.
+	// Only for the real welcome banner (key="welcome") — keep test fixtures
+	// like static-marker inside Static so existing tests stay stable.
+	const hasWelcome = staticComponents.some(
+		c =>
+			c != null &&
+			typeof c === 'object' &&
+			'key' in c &&
+			(c as {key: unknown}).key === 'welcome',
 	);
+	const isFreshInline =
+		!fullscreen && queuedComponents.length === 0 && hasWelcome;
+	const banner = fullscreen ? staticComponents[0] : undefined;
+	const frozenComponents = React.useMemo(() => {
+		if (fullscreen) return staticComponents.slice(1);
+		if (isFreshInline) return [];
+		return staticComponents;
+	}, [fullscreen, staticComponents, isFreshInline]);
 
 	const chatQueueProps = React.useMemo(
 		() => ({
@@ -139,7 +146,7 @@ export const ChatHistory = React.memo(function ChatHistory({
 			queuedComponents,
 			renderLastQueuedComponentLive,
 			clearKey,
-			disableStatic: fullscreen,
+			disableStatic: fullscreen || isFreshInline,
 		}),
 		[
 			frozenComponents,
@@ -147,6 +154,7 @@ export const ChatHistory = React.memo(function ChatHistory({
 			renderLastQueuedComponentLive,
 			clearKey,
 			fullscreen,
+			isFreshInline,
 		],
 	);
 
@@ -154,6 +162,14 @@ export const ChatHistory = React.memo(function ChatHistory({
 		<>
 			{startChat && banner && (
 				<RenderErrorBoundary label="banner">{banner}</RenderErrorBoundary>
+			)}
+
+			{startChat && isFreshInline && (
+				<Box flexDirection="column">
+					{staticComponents.map((c, i) => (
+						<RenderErrorBoundary key={`fresh-${i}`}>{c}</RenderErrorBoundary>
+					))}
+				</Box>
 			)}
 
 			{startChat && <ChatQueue {...chatQueueProps} />}

--- a/source/app/components/chat-input.spec.tsx
+++ b/source/app/components/chat-input.spec.tsx
@@ -119,7 +119,8 @@ test('ChatInput keeps UserInput visible while a tool is executing', t => {
 	const {lastFrame, unmount} = renderWithTheme(<ChatInput {...props} />);
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /hat would you like me to help with\?/);
+	// New minimal header removed — input shows short placeholder instead
+	t.regex(output!, /Ask anything\.\.\./);
 	t.regex(output!, /Press Esc to cancel/);
 	unmount();
 });

--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -557,7 +557,9 @@ test('UserInput renders help text when not disabled', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /What would you like me to help with\?/);
+	// New design: heading removed, shorter placeholder inside rounded border
+	t.regex(output!, /Ask anything\.\.\./);
+	t.notRegex(output!, /What would you like me to help with\?/);
 	unmount();
 });
 
@@ -571,6 +573,7 @@ test('UserInput hides help text when disabled', t => {
 	const output = lastFrame();
 	t.truthy(output);
 	t.notRegex(output!, /What would you like me to help with\?/);
+	t.notRegex(output!, /Ask anything\.\.\./);
 	unmount();
 });
 

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -41,6 +41,10 @@ import type {ActiveEditorState} from '@/vscode/vscode-server';
 
 const MAX_COMMAND_COMPLETION_ROWS = 10;
 
+// Prompt box width bounds: scales with the terminal between these caps.
+const PROMPT_WIDTH_MIN = 40;
+const PROMPT_WIDTH_MAX = 96;
+
 interface ChatProps {
 	onSubmit?: (
 		message: string,
@@ -102,9 +106,18 @@ export default function UserInput({
 	const inputState = useInputState();
 	const uiState = useUIStateContext();
 	const {boxWidth, isNarrow, actualWidth, truncate} = useResponsiveTerminal();
+	// Prompt is centered with intentional whitespace. It scales with the
+	// terminal (60% of width, 40-96 cols) but always leaves a 4-col margin —
+	// a box wider than the terminal is what shatters its border rounding.
+	const promptWidth = Math.min(
+		PROMPT_WIDTH_MAX,
+		Math.max(PROMPT_WIDTH_MIN, Math.round(actualWidth * 0.6)),
+		boxWidth,
+		actualWidth - 4,
+	);
 	// Must match the wrapWidth passed to TextInput below — both sides use it to
 	// decide whether Up/Down means line navigation or history.
-	const inputWrapWidth = boxWidth - 3;
+	const inputWrapWidth = promptWidth - 4;
 	const [textInputKey, setTextInputKey] = useState(0);
 	const completionJustSelectedRef = useRef(false);
 	// Input value for which the user dismissed the completion menu with Escape,
@@ -963,137 +976,129 @@ export default function UserInput({
 
 	return (
 		<>
-			{!isBashMode ? (
-				<Box marginTop={1}>
-					<Text color={colors.primary} bold>
-						What would you like me to help with?
-					</Text>
-				</Box>
-			) : (
+			{isBashMode && (
 				<Text color={colors.tool} bold>
 					Bash mode
 				</Text>
 			)}
 
-			<Box
-				flexDirection="column"
-				marginTop={1}
-				backgroundColor={colors.base}
-				width={boxWidth}
-				padding={1}
-				borderStyle="bold"
-				borderLeft={true}
-				borderRight={false}
-				borderTop={false}
-				borderBottom={false}
-				borderLeftColor={isBashMode ? colors.tool : colors.primary}
-			>
-				{/* Input row */}
-				<Box>
-					{input.length === 0 && (
-						<Text color={isBashMode ? colors.tool : textColor}>{'>'} </Text>
-					)}
-					<TextInput
-						key={textInputKey}
-						value={input}
-						onChange={handleInputChange}
-						onEdgeArrow={handleHistoryNavigation}
-						onSubmit={handleSubmit}
-						onEnter={handleSubmit}
-						placeholder="/ commands, ! bash, ↑/↓ history"
-						focus={effectiveFocus}
-						wrapWidth={inputWrapWidth}
-						handleEnter={false}
-					/>
-				</Box>
-
-				{showClearMessage && (
-					<Text color={colors.secondary}>Press escape again to clear</Text>
-				)}
-
-				{showCompletions && completions.length > 0 && (
-					<Box flexDirection="column" marginTop={1}>
-						<Text color={colors.secondary}>Available commands:</Text>
-						{commandCompletionWindow.items.map((completion, index) => {
-							const completionIndex = commandCompletionWindow.start + index;
-							const isSelected = completionIndex === selectedCompletionIndex;
-							return (
-								<Text
-									key={`${completion.isCustom ? 'custom' : 'built-in'}-${completion.name}`}
-									color={
-										isSelected
-											? colors.info
-											: completion.isCustom
-												? colors.info
-												: colors.primary
-									}
-									bold={isSelected}
-								>
-									{isSelected ? '▸ ' : '  '}/{completion.name}
-								</Text>
-							);
-						})}
-						{completions.length > MAX_COMMAND_COMPLETION_ROWS && (
-							<Text color={colors.secondary}>
-								Showing {commandCompletionWindow.start + 1}-
-								{commandCompletionWindow.end} of {completions.length}
-							</Text>
+			<Box width={actualWidth} alignItems="center" flexDirection="column">
+				<Box
+					flexDirection="column"
+					marginTop={1}
+					width={promptWidth}
+					paddingX={1}
+					paddingY={0}
+					borderStyle="round"
+					borderColor={isBashMode ? colors.tool : colors.primary}
+				>
+					{/* Input row */}
+					<Box>
+						{input.length === 0 && (
+							<Text color={isBashMode ? colors.tool : textColor}>{'>'} </Text>
 						)}
+						<TextInput
+							key={textInputKey}
+							value={input}
+							onChange={handleInputChange}
+							onEdgeArrow={handleHistoryNavigation}
+							onSubmit={handleSubmit}
+							onEnter={handleSubmit}
+							placeholder="Ask anything..."
+							focus={effectiveFocus}
+							wrapWidth={inputWrapWidth}
+							handleEnter={false}
+						/>
 					</Box>
-				)}
-				{isFileAutocompleteMode && fileCompletions.length > 0 && (
-					<Box flexDirection="column" marginTop={1}>
-						<Text color={colors.secondary}>
-							File suggestions (↑/↓ to navigate, Tab to select):
-						</Text>
-						{fileCompletions.slice(0, 5).map((file, index) => (
-							<Text
-								key={index}
-								color={
-									index === selectedFileIndex ? colors.info : colors.primary
-								}
-								bold={index === selectedFileIndex}
-							>
-								{index === selectedFileIndex ? '▸ ' : '  '}
-								{file.path}
-							</Text>
-						))}
-					</Box>
-				)}
-				{queuedMessages.length > 0 && (
-					<Box flexDirection="column" marginTop={1}>
-						<Text color={colors.secondary}>
-							Queued messages (↑/↓ select, Enter edit, Del remove):
-						</Text>
-						{queuedMessages.map((message, index) => {
-							const isSelected = index === selectedQueuedIndex;
-							return (
-								<Text
-									key={message.id}
-									color={isSelected ? colors.info : colors.primary}
-									bold={isSelected}
-								>
-									{isSelected ? '▸ ' : '  '}
-									{formatQueuedMessage(message)}
-								</Text>
-							);
-						})}
-					</Box>
-				)}
-				{isBusy && (
-					<Box marginTop={1}>
-						<Text color={colors.secondary}>
-							<Spinner type="dots" /> Press Esc to cancel
-							{onToggleCompactDisplay && (
-								<Text>
-									{' '}
-									· ctrl-o {compactToolDisplay ? 'expand' : 'compact'}{' '}
-									{isNarrow ? '' : 'tool results'}
+
+					{showClearMessage && (
+						<Text color={colors.secondary}>Press escape again to clear</Text>
+					)}
+
+					{showCompletions && completions.length > 0 && (
+						<Box flexDirection="column" marginTop={1}>
+							<Text color={colors.secondary}>Available commands:</Text>
+							{commandCompletionWindow.items.map((completion, index) => {
+								const completionIndex = commandCompletionWindow.start + index;
+								const isSelected = completionIndex === selectedCompletionIndex;
+								return (
+									<Text
+										key={`${completion.isCustom ? 'custom' : 'built-in'}-${completion.name}`}
+										color={
+											isSelected
+												? colors.info
+												: completion.isCustom
+													? colors.info
+													: colors.primary
+										}
+										bold={isSelected}
+									>
+										{isSelected ? '▸ ' : '  '}/{completion.name}
+									</Text>
+								);
+							})}
+							{completions.length > MAX_COMMAND_COMPLETION_ROWS && (
+								<Text color={colors.secondary}>
+									Showing {commandCompletionWindow.start + 1}-
+									{commandCompletionWindow.end} of {completions.length}
 								</Text>
 							)}
-						</Text>
-					</Box>
-				)}
+						</Box>
+					)}
+					{isFileAutocompleteMode && fileCompletions.length > 0 && (
+						<Box flexDirection="column" marginTop={1}>
+							<Text color={colors.secondary}>
+								File suggestions (↑/↓ to navigate, Tab to select):
+							</Text>
+							{fileCompletions.slice(0, 5).map((file, index) => (
+								<Text
+									key={index}
+									color={
+										index === selectedFileIndex ? colors.info : colors.primary
+									}
+									bold={index === selectedFileIndex}
+								>
+									{index === selectedFileIndex ? '▸ ' : '  '}
+									{file.path}
+								</Text>
+							))}
+						</Box>
+					)}
+					{queuedMessages.length > 0 && (
+						<Box flexDirection="column" marginTop={1}>
+							<Text color={colors.secondary}>
+								Queued messages (↑/↓ select, Enter edit, Del remove):
+							</Text>
+							{queuedMessages.map((message, index) => {
+								const isSelected = index === selectedQueuedIndex;
+								return (
+									<Text
+										key={message.id}
+										color={isSelected ? colors.info : colors.primary}
+										bold={isSelected}
+									>
+										{isSelected ? '▸ ' : '  '}
+										{formatQueuedMessage(message)}
+									</Text>
+								);
+							})}
+						</Box>
+					)}
+					{isBusy && (
+						<Box marginTop={1}>
+							<Text color={colors.secondary}>
+								<Spinner type="dots" /> Press Esc to cancel
+								{onToggleCompactDisplay && (
+									<Text>
+										{' '}
+										· ctrl-o {compactToolDisplay ? 'expand' : 'compact'}{' '}
+										{isNarrow ? '' : 'tool results'}
+									</Text>
+								)}
+							</Text>
+						</Box>
+					)}
+				</Box>
 			</Box>
 
 			{attachments.length > 0 && (

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -41,10 +41,8 @@ import type {ActiveEditorState} from '@/vscode/vscode-server';
 
 const MAX_COMMAND_COMPLETION_ROWS = 10;
 
-// Prompt box width bounds: scales with the terminal between these caps.
-// 40 keeps narrow terminals legible, 140 leaves a small margin on ultrawide.
+// Prompt box width floor: keeps narrow terminals legible.
 const PROMPT_WIDTH_MIN = 40;
-const PROMPT_WIDTH_MAX = 140;
 
 interface ChatProps {
 	onSubmit?: (
@@ -107,13 +105,10 @@ export default function UserInput({
 	const inputState = useInputState();
 	const uiState = useUIStateContext();
 	const {isNarrow, actualWidth, truncate} = useResponsiveTerminal();
-	// Prompt scales with the terminal — fills the row on wide screens and
-	// stays legible on narrow. Always leaves a 4-col margin so the rounded
-	// border never wraps and shatters (the bug behind the old 38-col layout).
-	const promptWidth = Math.min(
-		PROMPT_WIDTH_MAX,
-		Math.max(PROMPT_WIDTH_MIN, actualWidth - 4),
-	);
+	// Prompt spans the full terminal width at every size (minus a 4-col
+	// margin so the rounded border never wraps and shatters), floored at 40
+	// cols for legibility on tiny terminals.
+	const promptWidth = Math.max(PROMPT_WIDTH_MIN, actualWidth - 4);
 	// Must match the wrapWidth passed to TextInput below — both sides use it to
 	// decide whether Up/Down means line navigation or history.
 	const inputWrapWidth = promptWidth - 4;

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -42,8 +42,9 @@ import type {ActiveEditorState} from '@/vscode/vscode-server';
 const MAX_COMMAND_COMPLETION_ROWS = 10;
 
 // Prompt box width bounds: scales with the terminal between these caps.
+// 40 keeps narrow terminals legible, 140 leaves a small margin on ultrawide.
 const PROMPT_WIDTH_MIN = 40;
-const PROMPT_WIDTH_MAX = 96;
+const PROMPT_WIDTH_MAX = 140;
 
 interface ChatProps {
 	onSubmit?: (
@@ -105,15 +106,13 @@ export default function UserInput({
 	const {colors} = useTheme();
 	const inputState = useInputState();
 	const uiState = useUIStateContext();
-	const {boxWidth, isNarrow, actualWidth, truncate} = useResponsiveTerminal();
-	// Prompt is centered with intentional whitespace. It scales with the
-	// terminal (60% of width, 40-96 cols) but always leaves a 4-col margin —
-	// a box wider than the terminal is what shatters its border rounding.
+	const {isNarrow, actualWidth, truncate} = useResponsiveTerminal();
+	// Prompt scales with the terminal — fills the row on wide screens and
+	// stays legible on narrow. Always leaves a 4-col margin so the rounded
+	// border never wraps and shatters (the bug behind the old 38-col layout).
 	const promptWidth = Math.min(
 		PROMPT_WIDTH_MAX,
-		Math.max(PROMPT_WIDTH_MIN, Math.round(actualWidth * 0.6)),
-		boxWidth,
-		actualWidth - 4,
+		Math.max(PROMPT_WIDTH_MIN, actualWidth - 4),
 	);
 	// Must match the wrapWidth passed to TextInput below — both sides use it to
 	// decide whether Up/Down means line navigation or history.

--- a/source/components/welcome-message.spec.tsx
+++ b/source/components/welcome-message.spec.tsx
@@ -8,7 +8,6 @@ import WelcomeMessage from './welcome-message';
 
 console.log('\nwelcome-message.spec.tsx');
 
-// Read version from package.json dynamically to avoid hardcoding
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const packageJson = JSON.parse(
@@ -17,18 +16,17 @@ const packageJson = JSON.parse(
 const VERSION = packageJson.version;
 
 // ============================================================================
-// Narrow Terminal Tests (width < 80)
+// Narrow Terminal Tests (width < 90 → text logo per mock ladder)
 // ============================================================================
 
 test('WelcomeMessage renders compact layout for narrow terminal', t => {
 	const originalColumns = process.stdout.columns;
-	process.stdout.columns = 50; // Narrow terminal
+	process.stdout.columns = 50;
 
 	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
 
 	const output = lastFrame();
 	t.truthy(output);
-	// BigText renders ASCII art, so we check the output is rendered
 	t.true(output!.length > 0);
 
 	process.stdout.columns = originalColumns;
@@ -42,13 +40,14 @@ test('WelcomeMessage shows version in narrow layout', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	// Version from package.json should be displayed
 	t.regex(output!, new RegExp(VERSION.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+	// Footer shows nanocoder + version, not title banner
+	t.regex(output!, /nanocoder/);
 
 	process.stdout.columns = originalColumns;
 });
 
-test('WelcomeMessage shows quick tips in narrow layout', t => {
+test('WelcomeMessage shows centered welcome and location in narrow layout', t => {
 	const originalColumns = process.stdout.columns;
 	process.stdout.columns = 50;
 
@@ -56,15 +55,18 @@ test('WelcomeMessage shows quick tips in narrow layout', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /Quick tips/);
-	t.regex(output!, /Use natural language/);
-	t.regex(output!, /\/help for commands/);
-	t.regex(output!, /Ctrl\+C to quit/);
+	t.regex(output!, /Welcome to Nanocoder/);
+	t.regex(output!, /local-first coding agent/);
+	// Location line centered with branch + dir (no NC shorthand)
+	t.regex(output!, /⎇/);
+	// Menu present when rows >=24
+	t.regex(output!, /Resume session/);
+	t.regex(output!, /Help/);
 
 	process.stdout.columns = originalColumns;
 });
 
-test('WelcomeMessage has bordered box in narrow layout', t => {
+test('WelcomeMessage has no hero box in narrow layout', t => {
 	const originalColumns = process.stdout.columns;
 	process.stdout.columns = 50;
 
@@ -72,26 +74,29 @@ test('WelcomeMessage has bordered box in narrow layout', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	// Check for border characters
-	t.regex(output!, /│/); // Vertical border
-	t.regex(output!, /[═─]/); // Horizontal border
+	// New design removed TitledBox hero — should NOT contain old box text
+	t.notRegex(output!, /Tips for getting started/);
+	t.notRegex(output!, /Quick tips/);
+	// Small pixel logo (tiny) for 50-90, not spaced text
+	t.regex(output!, /█/);
 
 	process.stdout.columns = originalColumns;
 });
 
 // ============================================================================
-// Normal Terminal Tests (80 <= width < 120)
+// Normal Terminal Tests (80 <= width < 90 still text logo per 90 threshold)
 // ============================================================================
 
-test('WelcomeMessage renders full layout for normal terminal', t => {
+test('WelcomeMessage renders text logo for normal terminal (<90 cols)', t => {
 	const originalColumns = process.stdout.columns;
-	process.stdout.columns = 80; // Normal terminal
+	process.stdout.columns = 80;
 
 	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
 
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /Nanocoder/); // Should show full logo
+	// 80 < 90 → slick block-style logo (box-drawing glyphs), not spaced text
+	t.regex(output!, /[╭━]/);
 
 	process.stdout.columns = originalColumns;
 });
@@ -105,12 +110,13 @@ test('WelcomeMessage shows welcome message for normal terminal', t => {
 	const output = lastFrame();
 	t.truthy(output);
 	t.regex(output!, /Welcome to Nanocoder/);
+	t.regex(output!, /local-first coding agent/);
 	t.regex(output!, new RegExp(VERSION.replace(/\./g, '\\.')));
 
 	process.stdout.columns = originalColumns;
 });
 
-test('WelcomeMessage shows concise tips for normal terminal', t => {
+test('WelcomeMessage shows menu for normal terminal', t => {
 	const originalColumns = process.stdout.columns;
 	process.stdout.columns = 80;
 
@@ -118,16 +124,17 @@ test('WelcomeMessage shows concise tips for normal terminal', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /Tips for getting started/);
-	t.regex(output!, /1\. Use natural language to describe your task\./);
-	t.regex(output!, /2\. Ask for file analysis, editing, bash commands and more\./);
-	t.regex(output!, /3\. Be specific for best results\./);
-	t.regex(output!, /4\. Type \/exit or press Ctrl\+C to quit\./);
+	t.regex(output!, /Resume session/);
+	t.regex(output!, /Select model/);
+	t.regex(output!, /Quit/);
+	// New design footer has mode + version
+	t.regex(output!, /nanocoder/);
+	t.regex(output!, new RegExp(VERSION.replace(/\./g, '\\.')));
 
 	process.stdout.columns = originalColumns;
 });
 
-test('WelcomeMessage shows help command for normal terminal', t => {
+test('WelcomeMessage shows location and shortcuts for normal terminal', t => {
 	const originalColumns = process.stdout.columns;
 	process.stdout.columns = 80;
 
@@ -135,29 +142,20 @@ test('WelcomeMessage shows help command for normal terminal', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /\/help for help/);
+	t.regex(output!, /⎇/);
+	t.regex(output!, /\/resume/);
+	t.regex(output!, /\/model/);
+	t.regex(output!, /\/help/);
+	t.regex(output!, /\/exit/);
 
 	process.stdout.columns = originalColumns;
 });
 
 // ============================================================================
-// Wide Terminal Tests (width >= 120)
+// Wide Terminal Tests (width >= 90 → full BigText art)
 // ============================================================================
 
-test('WelcomeMessage renders full layout for wide terminal', t => {
-	const originalColumns = process.stdout.columns;
-	process.stdout.columns = 120; // Wide terminal
-
-	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
-
-	const output = lastFrame();
-	t.truthy(output);
-	t.regex(output!, /Nanocoder/); // Full logo
-
-	process.stdout.columns = originalColumns;
-});
-
-test('WelcomeMessage shows verbose tips for wide terminal', t => {
+test('WelcomeMessage renders full art logo for wide terminal', t => {
 	const originalColumns = process.stdout.columns;
 	process.stdout.columns = 120;
 
@@ -165,8 +163,25 @@ test('WelcomeMessage shows verbose tips for wide terminal', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /1\. Use natural language to describe what you want to build\./);
-	t.regex(output!, /3\. Be specific as you would with another engineer for best results\./);
+	// Large art (simple) renders with _ | \ etc, small (tiny) with █ — either is art
+	t.regex(output!, /[_█]/);
+	t.regex(output!, /Welcome to Nanocoder/);
+
+	process.stdout.columns = originalColumns;
+});
+
+test('WelcomeMessage shows centered footer for wide terminal', t => {
+	const originalColumns = process.stdout.columns;
+	process.stdout.columns = 120;
+
+	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /nanocoder/);
+	t.regex(output!, new RegExp(VERSION.replace(/\./g, '\\.')));
+	// Mode in footer (normal)
+	t.regex(output!, /normal/);
 
 	process.stdout.columns = originalColumns;
 });
@@ -207,53 +222,109 @@ test('WelcomeMessage displays gradient text', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	// BigText and Gradient should render something
 	t.true(output!.length > 0);
 
 	process.stdout.columns = originalColumns;
 });
 
 // ============================================================================
-// Edge Cases
+// Edge Cases — responsive ladder rows
 // ============================================================================
 
 test('WelcomeMessage handles boundary at width 80', t => {
 	const originalColumns = process.stdout.columns;
-	process.stdout.columns = 80; // Boundary between narrow and normal
+	process.stdout.columns = 80;
 
 	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
 
 	const output = lastFrame();
 	t.truthy(output);
-	// At width 80, should be normal, not narrow
-	t.regex(output!, /Nanocoder/); // Full logo for normal
+	// 80 → slick block-style logo
+	t.regex(output!, /[╭━]/);
 
 	process.stdout.columns = originalColumns;
 });
 
-test('WelcomeMessage handles boundary at width 120', t => {
+test('WelcomeMessage handles boundary at width 90', t => {
 	const originalColumns = process.stdout.columns;
-	process.stdout.columns = 120; // Boundary between normal and wide
+	process.stdout.columns = 90;
 
 	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
 
 	const output = lastFrame();
 	t.truthy(output);
-	// At width 120, should be wide
-	t.regex(output!, /as you would with another engineer/); // Wide tip
+	// At 90 should switch to large art (simple)
+	t.regex(output!, /[_█]/);
 
 	process.stdout.columns = originalColumns;
+});
+
+test('WelcomeMessage trims menu when rows < 24', t => {
+	const originalColumns = process.stdout.columns;
+	const originalRows = process.stdout.rows;
+	process.stdout.columns = 100;
+	// @ts-ignore mock rows
+	process.stdout.rows = 23;
+
+	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
+
+	const output = lastFrame();
+	t.truthy(output);
+	// MIN menu only Help/Quit when short
+	t.notRegex(output!, /Resume session/);
+	t.regex(output!, /Help/);
+	t.regex(output!, /Quit/);
+
+	process.stdout.columns = originalColumns;
+	process.stdout.rows = originalRows;
+});
+
+test('WelcomeMessage hides menu when rows < 15', t => {
+	const originalColumns = process.stdout.columns;
+	const originalRows = process.stdout.rows;
+	process.stdout.columns = 100;
+	// @ts-ignore
+	process.stdout.rows = 14;
+
+	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.notRegex(output!, /Resume session/);
+	t.notRegex(output!, /Help/);
+	t.regex(output!, /Welcome to Nanocoder/);
+
+	process.stdout.columns = originalColumns;
+	process.stdout.rows = originalRows;
+});
+
+test('WelcomeMessage hides logo when rows < 16', t => {
+	const originalColumns = process.stdout.columns;
+	const originalRows = process.stdout.rows;
+	process.stdout.columns = 100;
+	// @ts-ignore
+	process.stdout.rows = 14;
+
+	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.notRegex(output!, /N A N O C O D E R/);
+	t.notRegex(output!, /█/);
+	t.regex(output!, /Welcome to Nanocoder/);
+
+	process.stdout.columns = originalColumns;
+	process.stdout.rows = originalRows;
 });
 
 test('WelcomeMessage handles very narrow terminal', t => {
 	const originalColumns = process.stdout.columns;
-	process.stdout.columns = 30; // Very narrow
+	process.stdout.columns = 30;
 
 	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
 
 	const output = lastFrame();
 	t.truthy(output);
-	// BigText renders ASCII art, so we check the output is rendered
 	t.true(output!.length > 0);
 
 	process.stdout.columns = originalColumns;
@@ -261,13 +332,13 @@ test('WelcomeMessage handles very narrow terminal', t => {
 
 test('WelcomeMessage handles very wide terminal', t => {
 	const originalColumns = process.stdout.columns;
-	process.stdout.columns = 200; // Very wide
+	process.stdout.columns = 200;
 
 	const {lastFrame} = renderWithTheme(<WelcomeMessage />);
 
 	const output = lastFrame();
 	t.truthy(output);
-	t.regex(output!, /Nanocoder/);
+	t.regex(output!, /[_█]/);
 
 	process.stdout.columns = originalColumns;
 });

--- a/source/components/welcome-message.spec.tsx
+++ b/source/components/welcome-message.spec.tsx
@@ -180,8 +180,6 @@ test('WelcomeMessage shows centered footer for wide terminal', t => {
 	t.truthy(output);
 	t.regex(output!, /nanocoder/);
 	t.regex(output!, new RegExp(VERSION.replace(/\./g, '\\.')));
-	// Mode in footer (normal)
-	t.regex(output!, /normal/);
 
 	process.stdout.columns = originalColumns;
 });

--- a/source/components/welcome-message.spec.tsx
+++ b/source/components/welcome-message.spec.tsx
@@ -87,7 +87,7 @@ test('WelcomeMessage has no hero box in narrow layout', t => {
 // Normal Terminal Tests (80 <= width < 90 still text logo per 90 threshold)
 // ============================================================================
 
-test('WelcomeMessage renders text logo for normal terminal (<90 cols)', t => {
+test('WelcomeMessage renders NC monogram at widths below 82', t => {
 	const originalColumns = process.stdout.columns;
 	process.stdout.columns = 80;
 
@@ -95,8 +95,8 @@ test('WelcomeMessage renders text logo for normal terminal (<90 cols)', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	// 80 < 90 → slick block-style logo (box-drawing glyphs), not spaced text
-	t.regex(output!, /[╭━]/);
+	// 80 < 82 → falls back to NC monogram in block font
+	t.regex(output!, /█/);
 
 	process.stdout.columns = originalColumns;
 });
@@ -239,8 +239,8 @@ test('WelcomeMessage handles boundary at width 80', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	// 80 → slick block-style logo
-	t.regex(output!, /[╭━]/);
+	// NC block monogram is identical at every width
+	t.regex(output!, /█/);
 
 	process.stdout.columns = originalColumns;
 });
@@ -253,7 +253,7 @@ test('WelcomeMessage handles boundary at width 90', t => {
 
 	const output = lastFrame();
 	t.truthy(output);
-	// At 90 should switch to large art (simple)
+	// At 90 the full NANOCODER block wordmark renders (threshold is 90)
 	t.regex(output!, /[_█]/);
 
 	process.stdout.columns = originalColumns;

--- a/source/components/welcome-message.tsx
+++ b/source/components/welcome-message.tsx
@@ -21,24 +21,21 @@ const packageJson = JSON.parse(
 	fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'),
 ) as {version: string};
 
-// Block-style logo at every size: ASCII can't shrink, so each width tier gets
-// the largest block-family font that fits (widths measured for "NANOCODER").
-// min = glyph width + wrap margin (cfonts wraps against the real terminal width).
-const LOGO_TIERS = [
-	{min: 90, font: 'block'},
-	{min: 62, font: 'slick'},
-	{min: 50, font: 'shade'},
-] as const;
+// One block-style wordmark everywhere: the full "NANOCODER" renders in the
+// block font on terminals from 90 cols up; below that we fall back to "NC"
+// so the monogram never wraps. Same block font in both cases — just a
+// shorter glyph string on narrow screens.
+const BLOCK_NANOCODER_WIDTH = 90;
+const LOGO_FULL = 'NANOCODER';
+const LOGO_SHORT = 'NC';
+const LOGO_FONT = 'block';
 
-type LogoKind = (typeof LOGO_TIERS)[number]['font'] | 'text';
+type LogoKind = 'block';
 
 // Approximate rendered height per tier (glyph rows + cfonts blank padding),
 // used only for the 1/3-top vertical centering estimate.
 const LOGO_ROW_HEIGHTS: Record<LogoKind, number> = {
 	block: 9,
-	slick: 8,
-	shade: 9,
-	text: 1,
 };
 
 const MENU_FULL: Array<[string, string]> = [
@@ -63,11 +60,12 @@ export default memo(function WelcomeMessage() {
 	const cwd = homeRelative(process.cwd());
 	const gitStatus = getGitStatusSummarySync();
 
-	// Pick the largest block-style logo that fits; very short terminals skip it
-	// to protect the menu rows.
-	let logoKind: LogoKind | null = null;
+	// Block wordmark in every screen — full NANOCODER on wide terminals, NC
+	// monogram on narrow (same block font, just shorter string). Short
+	// terminals (rows < 16) skip it to protect the menu rows.
+	let logoText: string | null = null;
 	if (rows >= 16) {
-		logoKind = LOGO_TIERS.find(tier => actualWidth >= tier.min)?.font ?? 'text';
+		logoText = actualWidth >= BLOCK_NANOCODER_WIDTH ? LOGO_FULL : LOGO_SHORT;
 	}
 
 	let menu: Array<[string, string]> = [];
@@ -76,7 +74,7 @@ export default memo(function WelcomeMessage() {
 	}
 
 	// Vertical centering: mimic mock's 1/3 top, 2/3 bottom when tall enough
-	const logoRows = logoKind ? LOGO_ROW_HEIGHTS[logoKind] : 0;
+	const logoRows = logoText ? LOGO_ROW_HEIGHTS.block : 0;
 	const welcomeRows = 2; // Welcome + subtitle
 	const locationRows = 1;
 	const menuRows = menu.length;
@@ -128,21 +126,15 @@ export default memo(function WelcomeMessage() {
 					<Text key={`pad-${i}`}> </Text>
 				))}
 
-			{logoKind && (
+			{logoText && (
 				<Box justifyContent={justify} width={termW}>
-					{logoKind === 'text' ? (
-						<Gradient colors={[colors.primary, colors.tool]}>
-							<Text bold>N A N O C O D E R</Text>
-						</Gradient>
-					) : (
-						<Gradient colors={[colors.primary, colors.tool]}>
-							<BigText text="NANOCODER" font={logoKind} />
-						</Gradient>
-					)}
+					<Gradient colors={[colors.primary, colors.tool]}>
+						<BigText text={logoText} font={LOGO_FONT} />
+					</Gradient>
 				</Box>
 			)}
 
-			<Box justifyContent={justify} width={termW} marginTop={logoKind ? 1 : 0}>
+			<Box justifyContent={justify} width={termW} marginTop={logoText ? 1 : 0}>
 				<Text>
 					<Text color={colors.text} bold>
 						nanocoder

--- a/source/components/welcome-message.tsx
+++ b/source/components/welcome-message.tsx
@@ -5,7 +5,6 @@ import Gradient from 'ink-gradient';
 import path from 'path';
 import {memo} from 'react';
 import {fileURLToPath} from 'url';
-import {loadDefaultMode} from '@/config/index';
 import {useResponsiveTerminal, useTerminalRows} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
 import {
@@ -56,7 +55,6 @@ export default memo(function WelcomeMessage() {
 	const {colors} = useTheme();
 
 	const version = packageJson.version;
-	const mode = loadDefaultMode() ?? 'normal';
 	const cwd = homeRelative(process.cwd());
 	const gitStatus = getGitStatusSummarySync();
 
@@ -134,7 +132,7 @@ export default memo(function WelcomeMessage() {
 				</Box>
 			)}
 
-			<Box justifyContent={justify} width={termW} marginTop={logoText ? 1 : 0}>
+			<Box justifyContent={justify} width={termW}>
 				<Text>
 					<Text color={colors.text} bold>
 						nanocoder
@@ -192,12 +190,6 @@ export default memo(function WelcomeMessage() {
 					})}
 				</Box>
 			)}
-
-			<Box width={termW} justifyContent="center" marginTop={1}>
-				<Text color={colors.secondary} dimColor>
-					{mode}
-				</Text>
-			</Box>
 		</Box>
 	);
 });

--- a/source/components/welcome-message.tsx
+++ b/source/components/welcome-message.tsx
@@ -143,6 +143,14 @@ export default memo(function WelcomeMessage() {
 			)}
 
 			<Box justifyContent={justify} width={termW} marginTop={logoKind ? 1 : 0}>
+				<Text>
+					<Text color={colors.text} bold>
+						nanocoder
+					</Text>
+					<Text color={colors.secondary}> v{version}</Text>
+				</Text>
+			</Box>
+			<Box justifyContent={justify} width={termW} marginTop={1}>
 				<Text color={colors.text} bold>
 					Welcome to Nanocoder
 				</Text>
@@ -193,20 +201,9 @@ export default memo(function WelcomeMessage() {
 				</Box>
 			)}
 
-			<Box
-				width={termW}
-				justifyContent="space-between"
-				marginTop={1}
-				paddingX={1}
-			>
+			<Box width={termW} justifyContent="center" marginTop={1}>
 				<Text color={colors.secondary} dimColor>
 					{mode}
-				</Text>
-				<Text>
-					<Text color={colors.text} bold>
-						nanocoder
-					</Text>
-					<Text color={colors.secondary}> v{version}</Text>
 				</Text>
 			</Box>
 		</Box>

--- a/source/components/welcome-message.tsx
+++ b/source/components/welcome-message.tsx
@@ -29,13 +29,9 @@ const LOGO_FULL = 'NANOCODER';
 const LOGO_SHORT = 'NC';
 const LOGO_FONT = 'block';
 
-type LogoKind = 'block';
-
-// Approximate rendered height per tier (glyph rows + cfonts blank padding),
+// Rendered height of the block wordmark (glyph rows + cfonts blank padding),
 // used only for the 1/3-top vertical centering estimate.
-const LOGO_ROW_HEIGHTS: Record<LogoKind, number> = {
-	block: 9,
-};
+const LOGO_ROWS = 9;
 
 const MENU_FULL: Array<[string, string]> = [
 	['Resume session', '/resume'],
@@ -71,8 +67,9 @@ export default memo(function WelcomeMessage() {
 		menu = rows < 24 ? MENU_MIN : MENU_FULL;
 	}
 
-	// Vertical centering: mimic mock's 1/3 top, 2/3 bottom when tall enough
-	const logoRows = logoText ? LOGO_ROW_HEIGHTS.block : 0;
+	// Vertical centering: roughly 1/3 of the empty space above the content
+	// and 2/3 below, when the terminal is tall enough
+	const logoRows = logoText ? LOGO_ROWS : 0;
 	const welcomeRows = 2; // Welcome + subtitle
 	const locationRows = 1;
 	const menuRows = menu.length;
@@ -93,11 +90,10 @@ export default memo(function WelcomeMessage() {
 			? Math.max(...menu.map(([l, k]) => l.length + k.length)) + 4
 			: 0;
 
-	// Full terminal width for every row — the mockup centers all content on one
-	// shared axis, so the wordmark and the text below it must share the same
-	// center. A capped box would sit left of the centered logo on wide screens.
+	// Full terminal width for every row so the wordmark and the text below it
+	// share one center axis — a capped box would sit left of the centered
+	// logo on wide screens.
 	const termW = actualWidth;
-	// Centered at every size — narrow looks like wide, per the mockup
 	const justify = 'center';
 
 	// Location line must fit even when stale (e.g., 44-char branch·dir in 50-col term).

--- a/source/components/welcome-message.tsx
+++ b/source/components/welcome-message.tsx
@@ -5,98 +5,210 @@ import Gradient from 'ink-gradient';
 import path from 'path';
 import {memo} from 'react';
 import {fileURLToPath} from 'url';
-import {TitledBoxWithPreferences} from '@/components/ui/titled-box';
-import {getNanocoderShape} from '@/config/preferences';
-import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {loadDefaultMode} from '@/config/index';
+import {useResponsiveTerminal, useTerminalRows} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
-import type {NanocoderShape} from '@/types/ui';
+import {
+	formatGitStatusSummary,
+	getGitStatusSummarySync,
+} from '@/tools/git/utils';
+import {homeRelative, truncateMiddle} from '@/utils/path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Read package.json once at module load time to avoid repeated file reads
 const packageJson = JSON.parse(
 	fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'),
 ) as {version: string};
 
-const DEFAULT_SHAPE: NanocoderShape = 'tiny';
+// Block-style logo at every size: ASCII can't shrink, so each width tier gets
+// the largest block-family font that fits (widths measured for "NANOCODER").
+// min = glyph width + wrap margin (cfonts wraps against the real terminal width).
+const LOGO_TIERS = [
+	{min: 90, font: 'block'},
+	{min: 62, font: 'slick'},
+	{min: 50, font: 'shade'},
+] as const;
+
+type LogoKind = (typeof LOGO_TIERS)[number]['font'] | 'text';
+
+// Approximate rendered height per tier (glyph rows + cfonts blank padding),
+// used only for the 1/3-top vertical centering estimate.
+const LOGO_ROW_HEIGHTS: Record<LogoKind, number> = {
+	block: 9,
+	slick: 8,
+	shade: 9,
+	text: 1,
+};
+
+const MENU_FULL: Array<[string, string]> = [
+	['Resume session', '/resume'],
+	['Select model', '/model'],
+	['Help', '/help'],
+	['Quit', '/exit'],
+];
+
+const MENU_MIN: Array<[string, string]> = [
+	['Help', '/help'],
+	['Quit', '/exit'],
+];
 
 export default memo(function WelcomeMessage() {
-	const {boxWidth, isNarrow, isNormal} = useResponsiveTerminal();
+	const {actualWidth} = useResponsiveTerminal();
+	const rows = useTerminalRows();
 	const {colors} = useTheme();
 
-	// Get the user's preferred nanocoder shape or use default
-	const nanocoderShape = getNanocoderShape() ?? DEFAULT_SHAPE;
+	const version = packageJson.version;
+	const mode = loadDefaultMode() ?? 'normal';
+	const cwd = homeRelative(process.cwd());
+	const gitStatus = getGitStatusSummarySync();
+
+	// Pick the largest block-style logo that fits; very short terminals skip it
+	// to protect the menu rows.
+	let logoKind: LogoKind | null = null;
+	if (rows >= 16) {
+		logoKind = LOGO_TIERS.find(tier => actualWidth >= tier.min)?.font ?? 'text';
+	}
+
+	let menu: Array<[string, string]> = [];
+	if (rows >= 15) {
+		menu = rows < 24 ? MENU_MIN : MENU_FULL;
+	}
+
+	// Vertical centering: mimic mock's 1/3 top, 2/3 bottom when tall enough
+	const logoRows = logoKind ? LOGO_ROW_HEIGHTS[logoKind] : 0;
+	const welcomeRows = 2; // Welcome + subtitle
+	const locationRows = 1;
+	const menuRows = menu.length;
+	const footerRows = 1;
+	const gaps = 3; // between logo/welcome, welcome/location, location/menu, menu/footer
+	const contentRows =
+		logoRows + welcomeRows + locationRows + menuRows + footerRows + gaps;
+	const topPad = Math.max(0, Math.floor((rows - contentRows - 1) / 3));
+
+	const branchLabel = (() => {
+		if (!gitStatus) return null;
+		const {branch, marker} = formatGitStatusSummary(gitStatus);
+		return marker ? `${branch} (${marker})` : branch;
+	})();
+
+	const colW =
+		menu.length > 0
+			? Math.max(...menu.map(([l, k]) => l.length + k.length)) + 4
+			: 0;
+
+	// Full terminal width for every row — the mockup centers all content on one
+	// shared axis, so the wordmark and the text below it must share the same
+	// center. A capped box would sit left of the centered logo on wide screens.
+	const termW = actualWidth;
+	// Centered at every size — narrow looks like wide, per the mockup
+	const justify = 'center';
+
+	// Location line must fit even when stale (e.g., 44-char branch·dir in 50-col term).
+	// Branch shrinks too: 2 (⎇ ) + 3 ( · ) + 10 (cwd min) = 15 reserved cols,
+	// +1 safety col — some fonts render ⎇/· wider than ink measures them.
+	const locationDisplay = (() => {
+		if (!branchLabel) {
+			return {
+				branchLabel: null as string | null,
+				cwd: truncateMiddle(cwd, Math.max(10, termW - 5)),
+			};
+		}
+		const branchBudget = Math.max(6, termW - 16);
+		const shortBranch = truncateMiddle(branchLabel, branchBudget);
+		const branchPart = `⎇ ${shortBranch} · `;
+		const cwdBudget = Math.max(10, termW - branchPart.length - 3);
+		return {branchLabel: shortBranch, cwd: truncateMiddle(cwd, cwdBudget)};
+	})();
 
 	return (
-		<>
-			{/* Narrow terminal: simple text without boxes */}
-			{isNarrow ? (
-				<>
-					<Gradient colors={[colors.primary, colors.tool]}>
-						<BigText text="NC" font={nanocoderShape} />
-					</Gradient>
-					<Box
-						flexDirection="column"
-						marginBottom={1}
-						borderStyle="round"
-						borderColor={colors.primary}
-						paddingY={1}
-						paddingX={2}
-					>
-						<Box marginBottom={1}>
-							<Text color={colors.primary} bold>
-								✻ Version {packageJson.version} ✻
-							</Text>
-						</Box>
+		<Box flexDirection="column" width={termW} marginBottom={1}>
+			{topPad > 0 &&
+				Array.from({length: topPad}).map((_, i) => (
+					<Text key={`pad-${i}`}> </Text>
+				))}
 
-						<Text color={colors.text}>Quick tips:</Text>
-						<Text color={colors.secondary}>• Use natural language</Text>
-						<Text color={colors.secondary}>• /help for commands</Text>
-						<Text color={colors.secondary}>• Ctrl+C to quit</Text>
-					</Box>
-				</>
-			) : (
-				/* Normal/Wide terminal: full version with TitledBoxWithPreferences */
-				<>
-					<Gradient colors={[colors.primary, colors.tool]}>
-						<BigText text="Nanocoder" font={nanocoderShape} />
-					</Gradient>
-
-					<TitledBoxWithPreferences
-						title={`✻ Welcome to Nanocoder ${packageJson.version} ✻`}
-						width={boxWidth}
-						borderColor={colors.primary}
-						paddingX={2}
-						paddingY={1}
-						flexDirection="column"
-						marginBottom={1}
-					>
-						<Box paddingBottom={1}>
-							<Text color={colors.text}>Tips for getting started:</Text>
-						</Box>
-						<Box paddingBottom={1} flexDirection="column">
-							<Text color={colors.secondary}>
-								{isNormal
-									? '1. Use natural language to describe your task.'
-									: '1. Use natural language to describe what you want to build.'}
-							</Text>
-							<Text color={colors.secondary}>
-								2. Ask for file analysis, editing, bash commands and more.
-							</Text>
-							<Text color={colors.secondary}>
-								{isNormal
-									? '3. Be specific for best results.'
-									: '3. Be specific as you would with another engineer for best results.'}
-							</Text>
-							<Text color={colors.secondary}>
-								4. Type /exit or press Ctrl+C to quit.
-							</Text>
-						</Box>
-						<Text color={colors.text}>/help for help</Text>
-					</TitledBoxWithPreferences>
-				</>
+			{logoKind && (
+				<Box justifyContent={justify} width={termW}>
+					{logoKind === 'text' ? (
+						<Gradient colors={[colors.primary, colors.tool]}>
+							<Text bold>N A N O C O D E R</Text>
+						</Gradient>
+					) : (
+						<Gradient colors={[colors.primary, colors.tool]}>
+							<BigText text="NANOCODER" font={logoKind} />
+						</Gradient>
+					)}
+				</Box>
 			)}
-		</>
+
+			<Box justifyContent={justify} width={termW} marginTop={logoKind ? 1 : 0}>
+				<Text color={colors.text} bold>
+					Welcome to Nanocoder
+				</Text>
+			</Box>
+			<Box justifyContent={justify} width={termW}>
+				<Text color={colors.secondary}>local-first coding agent</Text>
+			</Box>
+
+			<Box justifyContent={justify} width={termW} marginTop={1}>
+				<Text>
+					{locationDisplay.branchLabel ? (
+						<>
+							<Text color={colors.primary}>
+								⎇ {locationDisplay.branchLabel}
+							</Text>
+							<Text color={colors.secondary}> · </Text>
+							<Text color={colors.secondary}>{locationDisplay.cwd}</Text>
+						</>
+					) : (
+						<Text color={colors.secondary}>{locationDisplay.cwd}</Text>
+					)}
+				</Text>
+			</Box>
+
+			{menu.length > 0 && (
+				<Box
+					flexDirection="column"
+					alignItems="center"
+					width={termW}
+					marginTop={1}
+				>
+					{menu.map(([label, key]) => {
+						const gap = Math.max(3, colW - label.length - key.length);
+						return (
+							<Box key={label} justifyContent={justify} width={termW}>
+								<Text>
+									<Text color={colors.text} bold>
+										{label}
+									</Text>
+									<Text>{' '.repeat(gap)}</Text>
+									<Text color={colors.secondary} dimColor>
+										{key}
+									</Text>
+								</Text>
+							</Box>
+						);
+					})}
+				</Box>
+			)}
+
+			<Box
+				width={termW}
+				justifyContent="space-between"
+				marginTop={1}
+				paddingX={1}
+			>
+				<Text color={colors.secondary} dimColor>
+					{mode}
+				</Text>
+				<Text>
+					<Text color={colors.text} bold>
+						nanocoder
+					</Text>
+					<Text color={colors.secondary}> v{version}</Text>
+				</Text>
+			</Box>
+		</Box>
 	);
 });

--- a/source/hooks/useAppHandlers.spec.tsx
+++ b/source/hooks/useAppHandlers.spec.tsx
@@ -308,6 +308,51 @@ test.serial('handleToggleDevelopmentMode uses fallback if modeProviders is not c
 	});
 });
 
+test.serial('handleToggleDevelopmentMode does not toast when landing on normal', async t => {
+	const config = {
+		nanocoder: {
+			providers: [{name: 'test-provider', models: ['model-1']}],
+			modeProviders: {
+				normal: {provider: 'test-provider', model: 'model-1'}
+			}
+		}
+	};
+
+	await withMockConfig(config, {}, async () => {
+		// plan → normal: normal has a model override, but restoring the user's
+		// own default model is not news — the status bar flip is the feedback.
+		const {handlers, spies} = setup({developmentMode: 'plan'});
+		handlers.handleToggleDevelopmentMode();
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		t.is(spies.addToChatQueue.calls.length, 0);
+		t.is(spies.handleModelSelect.calls.length, 1);
+	});
+});
+
+test.serial('handleToggleDevelopmentMode suppresses identical repeated model toasts', async t => {
+	const config = {
+		nanocoder: {
+			providers: [{name: 'test-provider', models: ['model-1']}],
+			modeProviders: {
+				'auto-accept': {provider: 'test-provider', model: 'model-1'}
+			}
+		}
+	};
+
+	await withMockConfig(config, {}, async () => {
+		const {handlers, spies} = setup({developmentMode: 'normal'});
+		// Rapid Shift+Tab presses all re-enter auto-accept before props update;
+		// the identical "[auto-accept mode → model-1]" toast must queue once.
+		for (let i = 0; i < 3; i++) {
+			handlers.handleToggleDevelopmentMode();
+			await new Promise(resolve => setTimeout(resolve, 0));
+		}
+
+		t.is(spies.addToChatQueue.calls.length, 1);
+	});
+});
+
 test('handleToggleDevelopmentMode preserves headless mode', t => {
 	// Headless is entered by the daemon for triggered runs, not by the user.
 	// Shift+Tab cycles only through user-facing modes; if `developmentMode`

--- a/source/hooks/useAppHandlers.tsx
+++ b/source/hooks/useAppHandlers.tsx
@@ -159,6 +159,9 @@ export interface AppHandlers {
  */
 export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 	const logger = getLogger();
+	// Last mode-switch model toast, so rapid Shift+Tab cycling doesn't stack
+	// identical lines in scrollback (the handler races ahead of prop updates).
+	const lastModeToastRef = React.useRef<string | null>(null);
 
 	// Clear messages handler
 	const clearMessages = React.useMemo(
@@ -274,11 +277,16 @@ export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 
 				// Show a subtle toast when entering a mode that enforces a specific model,
 				// since programmatic switches suppress the default "Model changed to..." toast.
-				if (modeConfig) {
+				// Landing back on normal only restores the user's own default — the status
+				// bar flip is feedback enough, so no toast there.
+				const modeToast =
+					nextMode === 'normal' ? null : `[${nextMode} mode → ${targetModel}]`;
+				if (modeConfig && modeToast && modeToast !== lastModeToastRef.current) {
+					lastModeToastRef.current = modeToast;
 					props.addToChatQueue(
 						<SuccessMessage
 							key={generateKey('mode-model-override')}
-							message={`[${nextMode} mode → ${targetModel}]`}
+							message={modeToast}
 							hideBox={true}
 						/>,
 					);


### PR DESCRIPTION
## Description

Closes #949.

**Welcome screen updates:**
- Gradient block wordmark: full `NANOCODER` on terminals ≥90 cols, compact `NC` monogram below that — same block font, and it never wraps
- Version line under the logo; quick-action menu and the branch/dir location line all share one full-width center axis, so narrow looks like wide
- Vertical centering on tall terminals (⅓ top, ⅔ bottom); the menu trims itself on short ones
- The boot summary is hidden while the welcome is visible (it duplicated cwd/branch/version); it still shows in run mode

**Prompt input**
- Spans the full terminal width at every size (40-col floor, 4-col safety margin so the rounded border never wraps) and resizes live with the window

**Also fixed while in here**
- Shift+Tab mode cycling no longer stacks identical `[mode → model]` lines: landing on normal stays silent (the status bar is the feedback) and repeated identical toasts are suppressed

**One implementation note:** the welcome lives in ink's `<Static>`, which freezes after first paint. Until the first message arrives it now renders in the live region instead, so resizing the window actually re-centers it. Once history exists it goes through Static as usual.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Demo

https://github.com/user-attachments/assets/e3dbf0b2-0da8-4c91-99cf-90d125007802



## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

Note: 4 git-tool tests (`git-diff`, `getGitStatusSummarySync`) fail on a clean `main` checkout too — they spawn temp repos and the repo's own commit-msg hook rejects their fixture commits in this environment. Unrelated to this PR.

### Manual Testing

Visually verified the welcome at 38–200 cols: centered at every width, no wrapping or overflow, logo never breaks, prompt follows resizes. Provider/MCP flows are untouched by this UI-only change.

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))


