### PR TITLE
Fix {{args}} substitution without declared parameters

### DIFF
--- a/.changeset/fix-parameterless-command-args.md
+++ b/.changeset/fix-parameterless-command-args.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed `{{args}}` substitution for custom commands that do not declare explicit parameters.

--- a/source/custom-commands/executor.spec.ts
+++ b/source/custom-commands/executor.spec.ts
@@ -78,6 +78,13 @@ test('execute includes args variable with all arguments', t => {
 	t.true(result.includes('hello world'));
 });
 
+test('execute includes args variable without declared parameters', t => {
+	const command = createTestCommand({content: 'All args: {{args}}'});
+
+	const result = executor.execute(command, ['hello', 'world']);
+	t.true(result.includes('All args: hello world'));
+});
+
 test('execute wraps the prompt with the command name', t => {
 	const command = createTestCommand();
 

--- a/source/custom-commands/executor.ts
+++ b/source/custom-commands/executor.ts
@@ -22,10 +22,10 @@ export class CustomCommandExecutor {
 				variables[name] =
 					provided !== undefined && provided !== '' ? provided : defaultValue;
 			});
-
-			// Also provide all args as a single variable
-			variables['args'] = args.join(' ');
 		}
+
+		// Also provide all args as a single variable
+		variables['args'] = args.join(' ');
 
 		// Add some default context variables
 		variables['cwd'] = process.cwd();


### PR DESCRIPTION
## Description

Fixes `{{args}}` substitution for custom commands that do not declare explicit parameters.

Previously, `variables['args']` was only populated inside the `metadata.parameters` branch, so parameter-less commands left `{{args}}` unsubstituted. This moves the aggregate `args` variable outside that conditional and adds a regression test.

Fixes #1035.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] Added a regression test for `{{args}}` with no declared parameters
- [x] `source/custom-commands/executor.spec.ts`: 18/18 passing
- [x] Full AVA run completed once with 6,712 passing and 1 skipped
- [x] Biome format/lint, TypeScript, VS Code TypeScript, Knip, and audit pass
- [ ] `pnpm test:all` completes successfully

`pnpm test:all` is currently blocked by an unrelated filesystem watcher timing test: `source/events/sources/file-watcher.spec.ts` times out after 2000ms. The same isolated failure reproduces on a clean `upstream/main` worktree, so it is not introduced by this change.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (not applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (not needed for this behavioral fix)
- [x] No breaking changes
- [x] Appropriate logging added (not applicable; no new logging path)
