### PR TITLE
feat: add /whoami and /auth commands

### DIFF
--- a/.changeset/whoami-command.md
+++ b/.changeset/whoami-command.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Add `/whoami` and `/auth` diagnostic commands to show active provider, model, masked API key and base URL.

--- a/source/commands/lazy-registry.ts
+++ b/source/commands/lazy-registry.ts
@@ -139,6 +139,16 @@ export const lazyCommands: LazyCommand[] = [
 		load: () => import('@/commands/status').then(m => m.statusCommand),
 	},
 	{
+		name: 'whoami',
+		description: 'Show active provider configuration, API keys, and base URLs',
+		load: () => import('@/commands/whoami').then(m => m.whoamiCommand),
+	},
+	{
+		name: 'auth',
+		description: 'Show active provider configuration, API keys, and base URLs',
+		load: () => import('@/commands/whoami').then(m => m.authCommand),
+	},
+	{
 		name: 'setup-config',
 		description: 'Open a configuration file in your editor',
 		load: () =>

--- a/source/commands/whoami.spec.tsx
+++ b/source/commands/whoami.spec.tsx
@@ -1,0 +1,9 @@
+import test from 'ava';
+import {maskApiKey} from './whoami';
+
+test('maskApiKey hides middle characters', t => {
+	t.is(maskApiKey('sk-1234567890abcdef'), 'sk-1...cdef');
+	t.is(maskApiKey('short'), '********');
+	t.is(maskApiKey(), 'Not set');
+	t.is(maskApiKey('dummy-key'), 'Not set');
+});

--- a/source/commands/whoami.tsx
+++ b/source/commands/whoami.tsx
@@ -1,0 +1,51 @@
+import {Box, Text} from 'ink';
+import {loadProviderConfigs} from '@/client-factory';
+import type {Command} from '@/types/index';
+
+export function maskApiKey(key?: string): string {
+	if (!key || key === 'dummy-key') return 'Not set';
+	if (key.length <= 8) return '********';
+	const start = key.substring(0, 4);
+	const end = key.substring(key.length - 4);
+	return `${start}...${end}`;
+}
+
+export const whoamiCommand: Command = {
+	name: 'whoami',
+	description: 'Show active provider configuration, API keys, and base URLs',
+	handler: (_args, _messages, metadata) => {
+		const providers = loadProviderConfigs();
+		const currentProvider = providers.find(p => p.name === metadata.provider);
+
+		if (!currentProvider) {
+			return Promise.resolve(
+				<Box flexDirection="column" paddingY={1} paddingX={2}>
+					<Text color="red">Unknown provider: {metadata.provider}</Text>
+				</Box>,
+			);
+		}
+
+		return Promise.resolve(
+			<Box
+				flexDirection="column"
+				paddingY={1}
+				paddingX={2}
+				borderStyle="round"
+				borderColor="blue"
+			>
+				<Text bold>Active Configuration</Text>
+				<Text>Provider: {metadata.provider}</Text>
+				<Text>Model: {metadata.model}</Text>
+				{currentProvider.config.baseURL && (
+					<Text>Base URL: {currentProvider.config.baseURL}</Text>
+				)}
+				<Text>API Key: {maskApiKey(currentProvider.config.apiKey)}</Text>
+			</Box>,
+		);
+	},
+};
+
+export const authCommand: Command = {
+	...whoamiCommand,
+	name: 'auth',
+};


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))


Root cause: Users have no quick way to check their active provider, model, masked API key, and base URLs.
Fix: Created the `/whoami` command (and `/auth` alias) in `source/commands/whoami.tsx` that extracts this info from `metadata` and `loadProviderConfigs`. Includes a secure API key masking helper with unit tests.
Validation: Ran pnpm run build, pnpm test:format, pnpm test:lint, pnpm test:types, pnpm test:knip, and pnpm test:ava which all pass successfully.
Fixes https://github.com/Nano-Collective/nanocoder/issues/937


Fixes #937


