### PR TITLE
fix: correct read_file metadata_only check

### DIFF
--- a/.changeset/read-file-metadata-fix.md
+++ b/.changeset/read-file-metadata-fix.md
@@ -1,0 +1,5 @@
+---
+"nanocoder": patch
+---
+
+Fix read_file metadata_only check to correctly parse the 'File Information for' prefix and respect the metadata_only argument.

--- a/source/tools/read-file.spec.tsx
+++ b/source/tools/read-file.spec.tsx
@@ -1120,3 +1120,33 @@ test.serial('read_file metadata_only shows converted binary encoding for DOCX', 
 		rmSync(testDir, {recursive: true, force: true});
 	}
 });
+
+test('ReadFileFormatter correctly identifies metadata_only results', async t => {
+	const testDir = join(process.cwd(), 'test-metadata-formatter-temp');
+	try {
+		mkdirSync(testDir, { recursive: true });
+		const content = Array.from({ length: 100 }, (_, index) => `line-${index + 1}`).join('\n');
+		writeFileSync(join(testDir, 'small.ts'), content);
+
+		const formatter = readFileTool.formatter;
+		if (!formatter) {
+			t.fail('Formatter is not defined');
+			return;
+		}
+
+		const element = await formatter(
+			{ path: join(testDir, 'small.ts'), metadata_only: true },
+			`File Information for "test-metadata-formatter-temp/small.ts"\n==================================================\n\nType: file\nSize: 1000 bytes\nLast Modified: 2023-01-01T00:00:00.000Z\nLines: 100`
+		);
+		const { lastFrame } = render(
+			<TestThemeProvider>{element}</TestThemeProvider>
+		);
+
+		const output = lastFrame();
+		t.truthy(output);
+		t.regex(stripAnsi(output!), /metadata only/);
+		t.regex(stripAnsi(output!), /Total lines:\s*100/);
+	} finally {
+		rmSync(testDir, { recursive: true, force: true });
+	}
+});

--- a/source/tools/read-file.tsx
+++ b/source/tools/read-file.tsx
@@ -328,10 +328,11 @@ const readFileFormatter = async (
 
 			// Detect if this was a metadata-only response
 			const isMetadataOnly =
-				(result?.startsWith('File:') ?? false) &&
+				(result?.startsWith('File Information for') ?? false) &&
 				!args.start_line &&
 				!args.end_line &&
-				totalLines > FILE_READ_PREVIEW_THRESHOLD_LINES;
+				((args.metadata_only ?? false) ||
+					totalLines > FILE_READ_PREVIEW_THRESHOLD_LINES);
 			const isTruncated = result?.includes('[Truncated at line ') ?? false;
 
 			// Calculate what was actually read


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))


Root cause: The check to determine if a file read was metadata-only in `source/tools/read-file.tsx` was expecting the result string to start with `"File:"`, but the actual format starts with `"File Information for"`. Furthermore, the original check ignored the `metadata_only` flag entirely and instead incorrectly assumed a large file triggered a metadata-only read.

Fix: I updated the `isMetadataOnly` condition in `source/tools/read-file.tsx` to properly check that `result` starts with `"File Information for"`. I also updated the rest of the condition to include `args.metadata_only` as a valid trigger, while still supporting the auto-fallback behavior for large files. I also added a test and a changeset to confirm correct functionality.

Validation: 
- `pnpm run build`
- `pnpm test:format`
- `pnpm test:lint`
- `pnpm test:types`
- `pnpm test:knip`
- `pnpm test:ava`
All passing.

Fixes https://github.com/Nano-Collective/nanocoder/issues/970


Fixes #970


