### PR TITLE
fix(skills): reject unsupported skill subscription targets

### DIFF
--- a/.changeset/fix-skill-subscription-targets.md
+++ b/.changeset/fix-skill-subscription-targets.md
@@ -2,4 +2,4 @@
 "@nanocollective/nanocoder": patch
 ---
 
-Allowed `skill:<name>` subscription targets in skill manifests. This fixes manifest parsing, bundle loading, and event-router registration for cross-skill subscriptions while keeping unresolved command, agent, and tool targets rejected. Thanks to @1cbyc. Closes #1011.
+Reject unsupported `skill:<name>` subscription targets with a clear error instead of registering subscriptions that cannot dispatch. Thanks to @1cbyc. Closes #1011.

--- a/.changeset/fix-skill-subscription-targets.md
+++ b/.changeset/fix-skill-subscription-targets.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Allowed `skill:<name>` subscription targets in skill manifests. This fixes manifest parsing, bundle loading, and event-router registration for cross-skill subscriptions while keeping unresolved command, agent, and tool targets rejected. Thanks to @1cbyc. Closes #1011.

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -128,6 +128,11 @@ A multi-verb bundle is natural:
 Subscriptions can declare on member frontmatter (target is implicit
 `self`) or on the bundle manifest (target is explicit `kind:name`):
 
+Accepted manifest target kinds are `command:`, `agent:`, and `tool:`.
+`skill:` is parsed for forward compatibility, but registering it today
+raises a clear "not supported yet" error instead of loading a dead
+subscription.
+
 ```yaml
 # bundle manifest, multiple targets in one place
 subscribe:

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -128,11 +128,6 @@ A multi-verb bundle is natural:
 Subscriptions can declare on member frontmatter (target is implicit
 `self`) or on the bundle manifest (target is explicit `kind:name`):
 
-Accepted manifest target kinds are `command:`, `agent:`, and `tool:`.
-`skill:` is parsed for forward compatibility, but registering it today
-raises a clear "not supported yet" error instead of loading a dead
-subscription.
-
 ```yaml
 # bundle manifest, multiple targets in one place
 subscribe:
@@ -144,6 +139,11 @@ subscribe:
     target: command:weekly-report
     cron: "0 9 * * MON"
 ```
+
+Accepted manifest target kinds are `command:`, `agent:`, and `tool:`.
+`skill:` is parsed for forward compatibility, but registering it today
+raises a clear "not supported yet" error instead of loading a dead
+subscription.
 
 v1 event kinds: `file.changed` (filter: `paths`, `eventKinds`) and
 `schedule.cron` (filter: `cron`).

--- a/source/skills/bundle-loader.spec.ts
+++ b/source/skills/bundle-loader.spec.ts
@@ -178,6 +178,31 @@ subscribe:
 );
 
 test.serial(
+	'manifest subscription accepts skill targets without local member resolution',
+	async t => {
+		await withTempEnv(async ({projectRoot}) => {
+			const bundleRoot = join(projectRoot, '.nanocoder', 'skills');
+			await makeBundle(bundleRoot, 'cross-skill-sub', {
+				'skill.yaml': `
+name: cross-skill-sub
+description: Cross-skill subscription.
+subscribe:
+  - kind: file.changed
+    target: skill:some-other-skill
+    paths: ["src/**"]
+`,
+			});
+
+			const loader = new BundleLoader(projectRoot);
+			const {skills, errors} = await loader.load();
+			t.deepEqual(errors, []);
+			t.is(skills.length, 1);
+			t.is(skills[0]?.subscribe?.[0]?.target, 'skill:some-other-skill');
+		});
+	},
+);
+
+test.serial(
 	'frontmatter subscription target is resolved to the owning member',
 	async t => {
 		await withTempEnv(async ({projectRoot}) => {

--- a/source/skills/bundle-loader.spec.ts
+++ b/source/skills/bundle-loader.spec.ts
@@ -178,26 +178,27 @@ subscribe:
 );
 
 test.serial(
-	'manifest subscription accepts skill targets without local member resolution',
+	'manifest subscription with skill target is rejected with a clear error',
 	async t => {
 		await withTempEnv(async ({projectRoot}) => {
 			const bundleRoot = join(projectRoot, '.nanocoder', 'skills');
-			await makeBundle(bundleRoot, 'cross-skill-sub', {
+			await makeBundle(bundleRoot, 'docs', {
 				'skill.yaml': `
-name: cross-skill-sub
-description: Cross-skill subscription.
+name: docs
+description: dangling subscription.
 subscribe:
   - kind: file.changed
-    target: skill:some-other-skill
+    target: skill:docs
     paths: ["src/**"]
 `,
 			});
 
 			const loader = new BundleLoader(projectRoot);
 			const {skills, errors} = await loader.load();
-			t.deepEqual(errors, []);
 			t.is(skills.length, 1);
-			t.is(skills[0]?.subscribe?.[0]?.target, 'skill:some-other-skill');
+			t.is(skills[0]?.subscribe ?? undefined, undefined);
+			t.is(errors.length, 1);
+			t.regex(errors[0]?.message ?? '', /not supported yet/);
 		});
 	},
 );

--- a/source/skills/bundle-loader.ts
+++ b/source/skills/bundle-loader.ts
@@ -447,7 +447,13 @@ function mergeSubscriptions(
 				errors.push(`subscribe[${i}].target "${target ?? ''}" is malformed.`);
 				return;
 			}
-			if (!target.startsWith('skill:') && !memberRefs.has(target)) {
+			if (target.startsWith('skill:')) {
+				errors.push(
+					`subscribe[${i}].target "${target}" is not supported yet; use a command, agent, or tool member target instead.`,
+				);
+				return;
+			}
+			if (!memberRefs.has(target)) {
 				errors.push(
 					`subscribe[${i}].target "${target}" does not resolve to a member of this bundle.`,
 				);

--- a/source/skills/bundle-loader.ts
+++ b/source/skills/bundle-loader.ts
@@ -60,7 +60,7 @@ interface LoadedMember<T> {
 	frontmatterSubscribe?: SkillTrigger[];
 }
 
-const TARGET_REGEX = /^(command|agent|tool):([a-z][a-z0-9_-]*)$/;
+const TARGET_REGEX = /^(command|agent|tool|skill):([a-z][a-z0-9_-]*)$/;
 
 export class BundleLoader {
 	constructor(
@@ -447,7 +447,7 @@ function mergeSubscriptions(
 				errors.push(`subscribe[${i}].target "${target ?? ''}" is malformed.`);
 				return;
 			}
-			if (!memberRefs.has(target)) {
+			if (!target.startsWith('skill:') && !memberRefs.has(target)) {
 				errors.push(
 					`subscribe[${i}].target "${target}" does not resolve to a member of this bundle.`,
 				);

--- a/source/skills/dispatcher.spec.ts
+++ b/source/skills/dispatcher.spec.ts
@@ -10,7 +10,10 @@ import {
 
 console.log(`\ndispatcher.spec.ts`);
 
-function fileChangedSub(target: {kind: 'agent' | 'command' | 'tool'; name: string}): Subscription {
+function fileChangedSub(target: {
+	kind: 'agent' | 'command' | 'tool' | 'skill';
+	name: string;
+}): Subscription {
 	return {
 		id: 'sub-1',
 		kind: 'file.changed',
@@ -142,6 +145,30 @@ test('dispatch: tool target is reported as unsupported', async t => {
 	);
 	t.is(unsupported.length, 1);
 	t.regex(unsupported[0] ?? '', /tool targets/);
+});
+
+test('dispatch: skill target is reported as unsupported', async t => {
+	const unsupported: string[] = [];
+	const dispatcher = new SkillDispatcher({
+		buildExecutor: () => ({
+			async execute() {
+				return {
+					subagentName: 'no',
+					output: '',
+					success: false,
+					executionTimeMs: 0,
+				};
+			},
+		}),
+		onUnsupportedTarget: (_sub, reason) => unsupported.push(reason),
+	});
+
+	await dispatcher.dispatch(
+		fileChangedSub({kind: 'skill', name: 'docs'}),
+		fileEvent(),
+	);
+	t.is(unsupported.length, 1);
+	t.regex(unsupported[0] ?? '', /skill targets/);
 });
 
 test('modeForSubscription: confirm=true → plan, otherwise headless', t => {

--- a/source/skills/dispatcher.spec.ts
+++ b/source/skills/dispatcher.spec.ts
@@ -168,7 +168,10 @@ test('dispatch: skill target is reported as unsupported', async t => {
 		fileEvent(),
 	);
 	t.is(unsupported.length, 1);
-	t.regex(unsupported[0] ?? '', /skill targets/);
+	t.is(
+		unsupported[0],
+		'skill targets are rejected at registration and should never reach dispatch',
+	);
 });
 
 test('modeForSubscription: confirm=true → plan, otherwise headless', t => {

--- a/source/skills/dispatcher.ts
+++ b/source/skills/dispatcher.ts
@@ -94,6 +94,13 @@ export class SkillDispatcher implements SubscriptionDispatcher {
 			await this.dispatchAgent(subscription, event);
 			return;
 		}
+		if (target.kind === 'skill') {
+			this.options.onUnsupportedTarget?.(
+				subscription,
+				'skill targets are resolved earlier by the registrar',
+			);
+			return;
+		}
 		if (target.kind === 'command') {
 			this.options.onUnsupportedTarget?.(
 				subscription,

--- a/source/skills/dispatcher.ts
+++ b/source/skills/dispatcher.ts
@@ -108,6 +108,13 @@ export class SkillDispatcher implements SubscriptionDispatcher {
 			);
 			return;
 		}
+		if (target.kind === 'skill') {
+			this.options.onUnsupportedTarget?.(
+				subscription,
+				'skill targets are deferred until skill-level dispatch is implemented',
+			);
+			return;
+		}
 	}
 
 	private async dispatchAgent(

--- a/source/skills/dispatcher.ts
+++ b/source/skills/dispatcher.ts
@@ -97,7 +97,7 @@ export class SkillDispatcher implements SubscriptionDispatcher {
 		if (target.kind === 'skill') {
 			this.options.onUnsupportedTarget?.(
 				subscription,
-				'skill targets are resolved earlier by the registrar',
+				'skill targets are rejected at registration and should never reach dispatch',
 			);
 			return;
 		}
@@ -112,13 +112,6 @@ export class SkillDispatcher implements SubscriptionDispatcher {
 			this.options.onUnsupportedTarget?.(
 				subscription,
 				'tool targets are deferred until a real use case lands',
-			);
-			return;
-		}
-		if (target.kind === 'skill') {
-			this.options.onUnsupportedTarget?.(
-				subscription,
-				'skill targets are deferred until skill-level dispatch is implemented',
 			);
 			return;
 		}

--- a/source/skills/manifest-parser.spec.ts
+++ b/source/skills/manifest-parser.spec.ts
@@ -131,6 +131,19 @@ subscribe:
 	);
 });
 
+test('accepts skill subscription targets', t => {
+	const m = parseSkillManifestContent(`
+name: k8s
+description: ok
+subscribe:
+  - kind: file.changed
+    target: skill:cluster-docs
+    paths: ["src/**"]
+`);
+
+	t.is(m.subscribe?.[0]?.target, 'skill:cluster-docs');
+});
+
 test('rejects absolute path in subscribe.paths', t => {
 	t.throws(
 		() =>

--- a/source/skills/manifest-parser.ts
+++ b/source/skills/manifest-parser.ts
@@ -20,7 +20,7 @@ import type {
 import {parseYamlObject} from '@/utils/frontmatter';
 
 const SKILL_NAME_REGEX = /^[a-z][a-z0-9-]*$/;
-const TARGET_REGEX = /^(command|agent|tool):[a-z][a-z0-9_-]*$/;
+const TARGET_REGEX = /^(command|agent|tool|skill):[a-z][a-z0-9_-]*$/;
 const VALID_VISIBILITIES: ReadonlySet<SkillToolVisibility> = new Set([
 	'global',
 	'scoped',
@@ -148,7 +148,7 @@ function parseManifestSubscribe(value: unknown): SkillTrigger[] | undefined {
 		}
 		if (!TARGET_REGEX.test(trig.target)) {
 			throw new SkillManifestParseError(
-				`subscribe[${i}].target "${trig.target}" must match ${TARGET_REGEX} (e.g. "agent:foo", "command:bar", "tool:baz")`,
+				`subscribe[${i}].target "${trig.target}" must match ${TARGET_REGEX} (e.g. "agent:foo", "command:bar", "tool:baz", "skill:qux")`,
 			);
 		}
 		if (trig.kind === 'file.changed' && trig.paths) {

--- a/source/skills/registrar.spec.ts
+++ b/source/skills/registrar.spec.ts
@@ -278,23 +278,20 @@ test('subscriptions are registered with the event router', async t => {
 	t.is(deps.dispatchCalls[0]?.sub.id, r.subscriptionIds[0]);
 });
 
-test('skill subscription targets are registered with the event router', t => {
+test('skill targets are rejected with a clear message', t => {
 	const deps = makeDeps();
 	const skill = bundleSkill({
 		subscribe: [
 			{
 				kind: 'file.changed',
-				target: 'skill:some-other-skill',
+				target: 'skill:docs',
 				paths: ['docs/**'],
 			},
 		],
 	});
 
 	const r = registerSkills([skill], deps);
-	t.deepEqual(r.collisions, []);
-	t.is(r.subscriptionIds.length, 1);
-	t.deepEqual(deps.eventRouter.listByKind('file.changed')[0]?.target, {
-		kind: 'skill',
-		name: 'some-other-skill',
-	});
+	t.deepEqual(r.subscriptionIds, []);
+	t.is(r.collisions.length, 1);
+	t.regex(r.collisions[0]?.message ?? '', /not supported yet/);
 });

--- a/source/skills/registrar.spec.ts
+++ b/source/skills/registrar.spec.ts
@@ -277,3 +277,24 @@ test('subscriptions are registered with the event router', async t => {
 	t.is(deps.dispatchCalls.length, 1);
 	t.is(deps.dispatchCalls[0]?.sub.id, r.subscriptionIds[0]);
 });
+
+test('skill subscription targets are registered with the event router', t => {
+	const deps = makeDeps();
+	const skill = bundleSkill({
+		subscribe: [
+			{
+				kind: 'file.changed',
+				target: 'skill:some-other-skill',
+				paths: ['docs/**'],
+			},
+		],
+	});
+
+	const r = registerSkills([skill], deps);
+	t.deepEqual(r.collisions, []);
+	t.is(r.subscriptionIds.length, 1);
+	t.deepEqual(deps.eventRouter.listByKind('file.changed')[0]?.target, {
+		kind: 'skill',
+		name: 'some-other-skill',
+	});
+});

--- a/source/skills/registrar.ts
+++ b/source/skills/registrar.ts
@@ -35,6 +35,7 @@ import type {
 	SkillMemberKind,
 	SkillMemberRef,
 	SkillPriority,
+	SkillTargetKind,
 	SkillTrigger,
 } from '@/types/skills';
 import {formatError} from '@/utils/error-formatter';
@@ -170,16 +171,17 @@ function subscribeSkillTriggers(
 	if (!skill.subscribe) return {subscriptionIds, collisions};
 
 	skill.subscribe.forEach((trig, index) => {
-		const subscription = buildSubscription(skill, trig, index);
-		if (!subscription) {
+		const built = buildSubscription(skill, trig, index);
+		if (!built.ok) {
 			collisions.push({
 				skill: skill.name,
 				kind: 'subscription',
 				name: trig.target ?? `subscribe[${index}]`,
-				message: `subscribe[${index}].target "${trig.target ?? ''}" is malformed.`,
+				message: built.error,
 			});
 			return;
 		}
+		const subscription = built.subscription;
 		try {
 			eventRouter.subscribe(subscription);
 			subscriptionIds.push(subscription.id);
@@ -251,24 +253,45 @@ function buildSubscription(
 	skill: Skill,
 	trig: SkillTrigger,
 	index: number,
-): Subscription | null {
+): {ok: true; subscription: Subscription} | {ok: false; error: string} {
 	// Manifest-form subscriptions carry an explicit target. Frontmatter-form
 	// subscriptions on single-file skills omit target - we resolve it to the
 	// skill's single member.
 	const explicit = trig.target;
-	let kind: SkillMemberKind;
+	let kind: SkillTargetKind;
 	let name: string;
 
 	if (explicit) {
 		const match = TARGET_REGEX.exec(explicit);
-		if (!match) return null;
+		if (!match) {
+			return {
+				ok: false,
+				error: `subscribe[${index}].target "${explicit}" is malformed.`,
+			};
+		}
+		if (match[1] === 'skill') {
+			return {
+				ok: false,
+				error: `subscribe[${index}].target "${explicit}" is not supported yet; use a command, agent, or tool member target instead.`,
+			};
+		}
 		kind = match[1] as SkillMemberKind;
 		const matched = match[2];
-		if (!matched) return null;
+		if (!matched) {
+			return {
+				ok: false,
+				error: `subscribe[${index}].target "${explicit}" is malformed.`,
+			};
+		}
 		name = matched;
 	} else {
 		const implicit = resolveImplicitTarget(skill);
-		if (!implicit) return null;
+		if (!implicit) {
+			return {
+				ok: false,
+				error: `subscribe[${index}].target is required for bundles and single-file skills with zero or multiple members.`,
+			};
+		}
 		kind = implicit.kind;
 		name = implicit.name;
 	}
@@ -290,18 +313,21 @@ function buildSubscription(
 		if (trig.paths) filter.paths = trig.paths;
 		if (trig.eventKinds) filter.eventKinds = trig.eventKinds;
 		return {
-			...base,
-			kind: 'file.changed',
-			...(Object.keys(filter).length > 0 ? {filter} : {}),
+			ok: true,
+			subscription: {
+				...base,
+				kind: 'file.changed',
+				...(Object.keys(filter).length > 0 ? {filter} : {}),
+			},
 		};
 	}
 	if (trig.kind === 'schedule.cron') {
 		const filter: ScheduleCronFilter = {cron: trig.cron};
-		return {
-			...base,
-			kind: 'schedule.cron',
-			filter,
-		};
+		return {ok: true, subscription: {...base, kind: 'schedule.cron', filter}};
 	}
-	return null;
+	const _exhaustive: never = trig;
+	return {
+		ok: false,
+		error: `subscribe[${index}] has unsupported kind "${String(_exhaustive)}".`,
+	};
 }

--- a/source/skills/registrar.ts
+++ b/source/skills/registrar.ts
@@ -59,7 +59,7 @@ export interface RegisterResult {
 	subscriptionIds: SubscriptionId[];
 }
 
-const TARGET_REGEX = /^(command|agent|tool):([a-z][a-z0-9_-]*)$/;
+const TARGET_REGEX = /^(command|agent|tool|skill):([a-z][a-z0-9_-]*)$/;
 
 export function registerSkills(
 	skills: Skill[],

--- a/source/types/skills.ts
+++ b/source/types/skills.ts
@@ -15,7 +15,8 @@ import type {SubagentConfig} from '@/subagents/types';
 import type {CustomCommand} from '@/types/commands';
 import type {ToolEntry} from '@/types/core';
 
-export type SkillMemberKind = 'command' | 'agent' | 'tool' | 'skill';
+export type SkillMemberKind = 'command' | 'agent' | 'tool';
+export type SkillTargetKind = SkillMemberKind | 'skill';
 
 /**
  * Resolved reference to a single skill member. The string form used in YAML
@@ -23,7 +24,7 @@ export type SkillMemberKind = 'command' | 'agent' | 'tool' | 'skill';
  * registrar before subscriptions are dispatched.
  */
 export interface SkillMemberRef {
-	kind: SkillMemberKind;
+	kind: SkillTargetKind;
 	name: string;
 }
 

--- a/source/types/skills.ts
+++ b/source/types/skills.ts
@@ -15,7 +15,7 @@ import type {SubagentConfig} from '@/subagents/types';
 import type {CustomCommand} from '@/types/commands';
 import type {ToolEntry} from '@/types/core';
 
-export type SkillMemberKind = 'command' | 'agent' | 'tool';
+export type SkillMemberKind = 'command' | 'agent' | 'tool' | 'skill';
 
 /**
  * Resolved reference to a single skill member. The string form used in YAML


### PR DESCRIPTION
## Summary

- Parse `skill:<name>` subscription targets at the manifest boundary for forward compatibility.
- Reject every skill target during bundle loading and registration with an explicit unsupported-target error, so no dead subscription can be registered.
- Keep the dispatcher defensive with one reachable skill branch whose message reflects the registration invariant.
- Document the currently supported target kinds and include a patch changeset.

Fixes #1011

## Validation

Rebased onto current `main` (`bf456ad0`).

- Hosted CI: 7,663 tests passed and 11 skipped.
- Hosted line coverage: 92.46%, above the 92.24% `main` baseline.
- TypeScript, formatting, linting, Knip, build, changeset validation, config schema freshness, VS Code packaging, dependency audit, Semgrep, and CodeQL all passed.
- Local focused skill/event suite: 53 tests passed.

Co-authored-by: insisong <emmanuelisaacnsisong@gmail.com>