### PR TITLE
fix: Correctly handle web_search TimeoutError

### DIFF
--- a/.changeset/fix-web-search-timeout.md
+++ b/.changeset/fix-web-search-timeout.md
@@ -1,0 +1,5 @@
+---
+"nanocoder": patch
+---
+
+Fix web_search TimeoutError not correctly captured as a timeout error

--- a/source/tools/web-search.spec.tsx
+++ b/source/tools/web-search.spec.tsx
@@ -480,6 +480,29 @@ test('executeWebSearch throws timeout error on timeout', async t => {
 	}
 });
 
+test('executeWebSearch throws timeout error on TimeoutError', async t => {
+	if (!executeWebSearch) {
+		t.pass('Skipping test - web-search module not available');
+		return;
+	}
+
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = (() => {
+		const error = new Error('The operation was aborted due to timeout');
+		error.name = 'TimeoutError';
+		throw error;
+	}) as any;
+
+	try {
+		await t.throwsAsync(
+			async () => await executeWebSearch({query: 'test'}, 'test-key'),
+			{message: /timeout/i},
+		);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
 test('executeWebSearch throws on network error', async t => {
 	if (!executeWebSearch) {
 		t.pass('Skipping test - web-search module not available');

--- a/source/tools/web-search.tsx
+++ b/source/tools/web-search.tsx
@@ -90,7 +90,10 @@ export const executeWebSearch = async (
 
 		return formattedResults;
 	} catch (error: unknown) {
-		if (error instanceof Error && error.name === 'AbortError') {
+		if (
+			error instanceof Error &&
+			(error.name === 'AbortError' || error.name === 'TimeoutError')
+		) {
 			throw new Error('Search request timeout');
 		}
 


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause: The error handler in `executeWebSearch` was only checking for `error.name === 'AbortError'`. However, standard fetch with `AbortSignal.timeout()` throws a `DOMException` with `error.name === 'TimeoutError'`.

Fix: Updated the catch block in `source/tools/web-search.tsx` to handle both `AbortError` and `TimeoutError`. A regression test mock throwing a `TimeoutError` was also added in `source/tools/web-search.spec.tsx` to verify this behavior correctly triggering a generic "Search request timeout" error as intended.

Validation: 
```bash
pnpm run build
pnpm test:format
pnpm test:lint
pnpm test:types
pnpm test:knip
pnpm test:ava source/tools/web-search.spec.tsx
```
All commands succeeded and output indicated no format or lint issues. The 39 web search tests passed properly, including the new regression test.

Fixes https://github.com/Nano-Collective/nanocoder/issues/971

Fixes #971
