### PR TITLE
fix: standardize tool-approval error kind to single source of truth

### DIFF
--- a/source/app.spec.tsx
+++ b/source/app.spec.tsx
@@ -1,4 +1,5 @@
 import test from 'ava';
+import {TOOL_APPROVAL_REQUIRED_KIND} from '@/constants';
 import {isNonInteractiveModeComplete} from './app/helpers';
 import {VALID_MODES} from './app/types';
 
@@ -219,7 +220,7 @@ test('Non-interactive mode: exits with tool-approval reason when tool approval r
 	);
 
 	t.true(shouldExit, 'Should exit when tool approval is required');
-	t.is(reason, 'tool-approval', 'Exit reason should be tool-approval');
+	t.is(reason, TOOL_APPROVAL_REQUIRED_KIND, 'Exit reason should be tool-approval-required');
 });
 
 test('Non-interactive mode: CLI parsing without run command', t => {

--- a/source/app.spec.tsx
+++ b/source/app.spec.tsx
@@ -197,8 +197,8 @@ test('Non-interactive mode: CLI parsing with complex prompt', t => {
 	t.is(prompt, 'create a new file with content');
 });
 
-test('Non-interactive mode: exits with tool-approval reason when tool approval required', t => {
-	// Test that we exit with tool-approval reason when a message indicates tool approval is required
+test('Non-interactive mode: exits with tool-approval-required reason when tool approval required', t => {
+	// Test that we exit with tool-approval-required reason when a message indicates tool approval is required
 	const appStateToolApprovalRequired = {
 		isThinking: false,
 		isToolExecuting: false,
@@ -220,7 +220,11 @@ test('Non-interactive mode: exits with tool-approval reason when tool approval r
 	);
 
 	t.true(shouldExit, 'Should exit when tool approval is required');
-	t.is(reason, TOOL_APPROVAL_REQUIRED_KIND, 'Exit reason should be tool-approval-required');
+	t.is(
+		reason,
+		TOOL_APPROVAL_REQUIRED_KIND,
+		'Exit reason should be tool-approval-required',
+	);
 });
 
 test('Non-interactive mode: CLI parsing without run command', t => {

--- a/source/app/helpers.spec.ts
+++ b/source/app/helpers.spec.ts
@@ -19,7 +19,7 @@ test('isNonInteractiveModeComplete returns timeout when time exceeded', t => {
 	t.is(result.reason, 'timeout');
 });
 
-test('isNonInteractiveModeComplete returns tool-approval when tool approval required', t => {
+test('isNonInteractiveModeComplete returns tool-approval-required when tool approval required', t => {
 	const state: NonInteractiveModeState = {
 		isToolExecuting: false,
 		isToolConfirmationMode: false,

--- a/source/app/helpers.spec.ts
+++ b/source/app/helpers.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {TOOL_APPROVAL_REQUIRED_PREFIX} from '@/constants';
+import {TOOL_APPROVAL_REQUIRED_KIND, TOOL_APPROVAL_REQUIRED_PREFIX} from '@/constants';
 import {isNonInteractiveModeComplete} from './helpers';
 import type {NonInteractiveModeState} from './types';
 
@@ -38,7 +38,7 @@ test('isNonInteractiveModeComplete returns tool-approval when tool approval requ
 
 	const result = isNonInteractiveModeComplete(state, startTime, maxTime);
 	t.true(result.shouldExit);
-	t.is(result.reason, 'tool-approval');
+	t.is(result.reason, TOOL_APPROVAL_REQUIRED_KIND);
 });
 
 test('isNonInteractiveModeComplete returns error when error messages present', t => {

--- a/source/app/helpers.ts
+++ b/source/app/helpers.ts
@@ -1,4 +1,7 @@
-import {TOOL_APPROVAL_REQUIRED_PREFIX} from '@/constants';
+import {
+	TOOL_APPROVAL_REQUIRED_KIND,
+	TOOL_APPROVAL_REQUIRED_PREFIX,
+} from '@/constants';
 import type {
 	NonInteractiveCompletionResult,
 	NonInteractiveModeState,
@@ -35,7 +38,7 @@ export function isNonInteractiveModeComplete(
 	}
 
 	if (hasToolApprovalRequired) {
-		return {shouldExit: true, reason: 'tool-approval'};
+		return {shouldExit: true, reason: TOOL_APPROVAL_REQUIRED_KIND};
 	}
 
 	if (hasErrorMessages) {

--- a/source/app/helpers.ts
+++ b/source/app/helpers.ts
@@ -58,9 +58,10 @@ export function isNonInteractiveModeComplete(
 
 /**
  * Maps a non-interactive exit reason to the corresponding process exit code.
- * Used by both the Ink runtime (`useNonInteractiveMode`) and the headless
- * plain shell (`runPlainShell`) to stay in sync.
+ * Used by the Ink runtime (`useNonInteractiveMode`) for the interactive
+ * non-interactive path. The headless plain shell (`runPlainShell`) has its
+ * own intentionally distinct mapping (exit 2 for tool-approval-required).
  */
 export function getExitCodeForReason(reason: NonInteractiveExitReason): number {
-	return reason === 'error' || reason === 'tool-approval-required' ? 1 : 0;
+	return reason === 'error' || reason === TOOL_APPROVAL_REQUIRED_KIND ? 1 : 0;
 }

--- a/source/app/helpers.ts
+++ b/source/app/helpers.ts
@@ -4,6 +4,7 @@ import {
 } from '@/constants';
 import type {
 	NonInteractiveCompletionResult,
+	NonInteractiveExitReason,
 	NonInteractiveModeState,
 } from './types';
 
@@ -53,4 +54,13 @@ export function isNonInteractiveModeComplete(
 	}
 
 	return {shouldExit: false, reason: null};
+}
+
+/**
+ * Maps a non-interactive exit reason to the corresponding process exit code.
+ * Used by both the Ink runtime (`useNonInteractiveMode`) and the headless
+ * plain shell (`runPlainShell`) to stay in sync.
+ */
+export function getExitCodeForReason(reason: NonInteractiveExitReason): number {
+	return reason === 'error' || reason === 'tool-approval-required' ? 1 : 0;
 }

--- a/source/app/types.ts
+++ b/source/app/types.ts
@@ -1,4 +1,3 @@
-import {TOOL_APPROVAL_REQUIRED_KIND} from '@/constants';
 import type {Session} from '@/session/session-manager';
 import type {DevelopmentMode} from '@/types/core';
 
@@ -64,7 +63,7 @@ export type NonInteractiveExitReason =
 	| 'complete'
 	| 'timeout'
 	| 'error'
-	| typeof TOOL_APPROVAL_REQUIRED_KIND
+	| 'tool-approval-required'
 	| null;
 
 /**

--- a/source/app/types.ts
+++ b/source/app/types.ts
@@ -1,3 +1,4 @@
+import {TOOL_APPROVAL_REQUIRED_KIND} from '@/constants';
 import type {Session} from '@/session/session-manager';
 import type {DevelopmentMode} from '@/types/core';
 
@@ -63,7 +64,7 @@ export type NonInteractiveExitReason =
 	| 'complete'
 	| 'timeout'
 	| 'error'
-	| 'tool-approval'
+	| typeof TOOL_APPROVAL_REQUIRED_KIND
 	| null;
 
 /**

--- a/source/cli-harness.spec.ts
+++ b/source/cli-harness.spec.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import {TOOL_APPROVAL_REQUIRED_KIND} from '@/constants';
+import type {NonInteractiveExitReason} from '@/app/types';
+import {getExitCodeForReason} from '@/app/helpers';
 import {
 	CLITestHarness,
 	createCLITestHarness,
@@ -276,29 +277,23 @@ test('CLI args parsing: nonInteractiveMode is false without run command', t => {
 	t.false(nonInteractiveMode);
 });
 
-type ExitReason = 'complete' | 'timeout' | 'error' | typeof TOOL_APPROVAL_REQUIRED_KIND | null;
-
-function getExitCodeForReason(reason: ExitReason): number {
-	return reason === 'error' || reason === TOOL_APPROVAL_REQUIRED_KIND ? 1 : 0;
-}
-
 test('Exit code mapping: complete reason uses exit code 0', t => {
-	const reason: ExitReason = 'complete';
+	const reason: NonInteractiveExitReason = 'complete';
 	t.is(getExitCodeForReason(reason), 0);
 });
 
 test('Exit code mapping: error reason uses exit code 1', t => {
-	const reason: ExitReason = 'error';
+	const reason: NonInteractiveExitReason = 'error';
 	t.is(getExitCodeForReason(reason), 1);
 });
 
 test('Exit code mapping: tool-approval-required reason uses exit code 1', t => {
-	const reason: ExitReason = TOOL_APPROVAL_REQUIRED_KIND;
+	const reason: NonInteractiveExitReason = 'tool-approval-required';
 	t.is(getExitCodeForReason(reason), 1);
 });
 
 test('Exit code mapping: timeout reason uses exit code 0', t => {
-	const reason: ExitReason = 'timeout';
+	const reason: NonInteractiveExitReason = 'timeout';
 	t.is(getExitCodeForReason(reason), 0);
 });
 

--- a/source/cli-harness.spec.ts
+++ b/source/cli-harness.spec.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import {TOOL_APPROVAL_REQUIRED_KIND} from '@/constants';
 import {
 	CLITestHarness,
 	createCLITestHarness,
@@ -275,10 +276,10 @@ test('CLI args parsing: nonInteractiveMode is false without run command', t => {
 	t.false(nonInteractiveMode);
 });
 
-type ExitReason = 'complete' | 'timeout' | 'error' | 'tool-approval' | null;
+type ExitReason = 'complete' | 'timeout' | 'error' | typeof TOOL_APPROVAL_REQUIRED_KIND | null;
 
 function getExitCodeForReason(reason: ExitReason): number {
-	return reason === 'error' || reason === 'tool-approval' ? 1 : 0;
+	return reason === 'error' || reason === TOOL_APPROVAL_REQUIRED_KIND ? 1 : 0;
 }
 
 test('Exit code mapping: complete reason uses exit code 0', t => {
@@ -291,8 +292,8 @@ test('Exit code mapping: error reason uses exit code 1', t => {
 	t.is(getExitCodeForReason(reason), 1);
 });
 
-test('Exit code mapping: tool-approval reason uses exit code 1', t => {
-	const reason: ExitReason = 'tool-approval';
+test('Exit code mapping: tool-approval-required reason uses exit code 1', t => {
+	const reason: ExitReason = TOOL_APPROVAL_REQUIRED_KIND;
 	t.is(getExitCodeForReason(reason), 1);
 });
 

--- a/source/constants.ts
+++ b/source/constants.ts
@@ -103,7 +103,7 @@ export const TIPS = [
 export const TOKEN_THRESHOLD_WARNING_PERCENT = 80;
 export const TOKEN_THRESHOLD_CRITICAL_PERCENT = 95;
 
-// === NON-INTERACTIVE NOTICES ===
+// === TOOL APPROVAL ===
 // Non-interactive runs can't prompt, so a tool needing approval ends the run.
 // The notice is display-only chrome, but `isNonInteractiveModeComplete` detects
 // it by content to pick exit reason "tool-approval-required" — share the prefix
@@ -114,7 +114,7 @@ export const TOOL_APPROVAL_REQUIRED_PREFIX = 'Tool approval required for: ';
 // Single source of truth — use this constant instead of a bare string in both
 // PlainConversationOutcome.kind and NonInteractiveExitReason so that
 // comparisons and grep patterns never diverge.
-export const TOOL_APPROVAL_REQUIRED_KIND = 'tool-approval-required' as const;
+export const TOOL_APPROVAL_REQUIRED_KIND = 'tool-approval-required';
 
 // === OUTPUT TRUNCATION ===
 export const TRUNCATION_OUTPUT_LIMIT = 2000;

--- a/source/constants.ts
+++ b/source/constants.ts
@@ -106,9 +106,15 @@ export const TOKEN_THRESHOLD_CRITICAL_PERCENT = 95;
 // === NON-INTERACTIVE NOTICES ===
 // Non-interactive runs can't prompt, so a tool needing approval ends the run.
 // The notice is display-only chrome, but `isNonInteractiveModeComplete` detects
-// it by content to pick exit reason "tool-approval" — share the prefix so a
-// reword can't silently break that exit path.
+// it by content to pick exit reason "tool-approval-required" — share the prefix
+// so a reword can't silently break that exit path.
 export const TOOL_APPROVAL_REQUIRED_PREFIX = 'Tool approval required for: ';
+
+// Canonical string literal for the tool-approval-required outcome/exit-reason.
+// Single source of truth — use this constant instead of a bare string in both
+// PlainConversationOutcome.kind and NonInteractiveExitReason so that
+// comparisons and grep patterns never diverge.
+export const TOOL_APPROVAL_REQUIRED_KIND = 'tool-approval-required' as const;
 
 // === OUTPUT TRUNCATION ===
 export const TRUNCATION_OUTPUT_LIMIT = 2000;

--- a/source/hooks/chat-handler/conversation/conversation-loop.tsx
+++ b/source/hooks/chat-handler/conversation/conversation-loop.tsx
@@ -11,7 +11,11 @@ import AssistantReasoning from '@/components/assistant-reasoning';
 import {ErrorMessage, InfoMessage} from '@/components/message-box';
 import {getAppConfig, getRetryLimits} from '@/config/index';
 import {getShowUsageFooter} from '@/config/preferences';
-import {MAX_COMPACT_RETRIES, TOOL_APPROVAL_REQUIRED_PREFIX} from '@/constants';
+import {
+	MAX_COMPACT_RETRIES,
+	TOOL_APPROVAL_REQUIRED_KIND,
+	TOOL_APPROVAL_REQUIRED_PREFIX,
+} from '@/constants';
 import {generateKey} from '@/session/key-generator';
 import {
 	parseToolCalls,
@@ -920,7 +924,7 @@ export const processAssistantResponse = async (
 			const errorMsg = `${TOOL_APPROVAL_REQUIRED_PREFIX}${toolNames}. Exiting non-interactive mode`;
 			addToChatQueue(
 				<ErrorMessage
-					key={generateKey('tool-approval-required')}
+					key={generateKey(TOOL_APPROVAL_REQUIRED_KIND)}
 					message={errorMsg}
 					hideBox={true}
 				/>,

--- a/source/hooks/useNonInteractiveMode.ts
+++ b/source/hooks/useNonInteractiveMode.ts
@@ -1,7 +1,11 @@
 import React from 'react';
 import {isNonInteractiveModeComplete} from '@/app/helpers';
 import type {NonInteractiveModeState} from '@/app/types';
-import {TIMEOUT_EXECUTION_MAX_MS, TIMEOUT_OUTPUT_FLUSH_MS} from '@/constants';
+import {
+	TIMEOUT_EXECUTION_MAX_MS,
+	TIMEOUT_OUTPUT_FLUSH_MS,
+	TOOL_APPROVAL_REQUIRED_KIND,
+} from '@/constants';
 import type {DevelopmentMode, LLMClient} from '@/types';
 import {getLogger} from '@/utils/logging';
 import {getShutdownManager} from '@/utils/shutdown';
@@ -124,12 +128,13 @@ export function useNonInteractiveMode({
 					logger.error('Non-interactive mode timed out');
 				} else if (reason === 'error') {
 					logger.error('Non-interactive mode encountered errors');
-				} else if (reason === 'tool-approval') {
+				} else if (reason === TOOL_APPROVAL_REQUIRED_KIND) {
 					// Exit with error code when tool approval is required
 					// Error message already printed by useChatHandler
 				}
 				// Wait a bit to ensure all output is flushed
-				const code = reason === 'error' || reason === 'tool-approval' ? 1 : 0;
+				const code =
+					reason === 'error' || reason === TOOL_APPROVAL_REQUIRED_KIND ? 1 : 0;
 				const timer = setTimeout(() => {
 					void getShutdownManager().gracefulShutdown(code);
 				}, TIMEOUT_OUTPUT_FLUSH_MS);

--- a/source/hooks/useNonInteractiveMode.ts
+++ b/source/hooks/useNonInteractiveMode.ts
@@ -1,11 +1,10 @@
 import React from 'react';
-import {isNonInteractiveModeComplete} from '@/app/helpers';
-import type {NonInteractiveModeState} from '@/app/types';
 import {
-	TIMEOUT_EXECUTION_MAX_MS,
-	TIMEOUT_OUTPUT_FLUSH_MS,
-	TOOL_APPROVAL_REQUIRED_KIND,
-} from '@/constants';
+	getExitCodeForReason,
+	isNonInteractiveModeComplete,
+} from '@/app/helpers';
+import type {NonInteractiveModeState} from '@/app/types';
+import {TIMEOUT_EXECUTION_MAX_MS, TIMEOUT_OUTPUT_FLUSH_MS} from '@/constants';
 import type {DevelopmentMode, LLMClient} from '@/types';
 import {getLogger} from '@/utils/logging';
 import {getShutdownManager} from '@/utils/shutdown';
@@ -128,13 +127,9 @@ export function useNonInteractiveMode({
 					logger.error('Non-interactive mode timed out');
 				} else if (reason === 'error') {
 					logger.error('Non-interactive mode encountered errors');
-				} else if (reason === TOOL_APPROVAL_REQUIRED_KIND) {
-					// Exit with error code when tool approval is required
-					// Error message already printed by useChatHandler
 				}
 				// Wait a bit to ensure all output is flushed
-				const code =
-					reason === 'error' || reason === TOOL_APPROVAL_REQUIRED_KIND ? 1 : 0;
+				const code = getExitCodeForReason(reason);
 				const timer = setTimeout(() => {
 					void getShutdownManager().gracefulShutdown(code);
 				}, TIMEOUT_OUTPUT_FLUSH_MS);

--- a/source/plain/conversation.spec.ts
+++ b/source/plain/conversation.spec.ts
@@ -1,5 +1,6 @@
 import test from "ava";
 import { dropOrphanedToolResults } from "@/ai-sdk-client/converters/message-converter";
+import { TOOL_APPROVAL_REQUIRED_KIND } from "@/constants";
 import { getAppConfig, reloadAppConfig } from "@/config/index";
 import { setToolManagerGetter, setToolRegistryGetter } from "@/message-handler";
 import type { ToolManager } from "@/tools/tool-manager";
@@ -244,8 +245,8 @@ test("returns tool-approval-required when a tool needs approval and mode is not 
 		abortSignal: new AbortController().signal,
 	});
 
-	t.is(outcome.kind, "tool-approval-required");
-	if (outcome.kind === "tool-approval-required") {
+	t.is(outcome.kind, TOOL_APPROVAL_REQUIRED_KIND);
+	if (outcome.kind === TOOL_APPROVAL_REQUIRED_KIND) {
 		t.deepEqual(outcome.toolNames, ["risky_tool"]);
 	}
 });

--- a/source/plain/conversation.spec.ts
+++ b/source/plain/conversation.spec.ts
@@ -1,7 +1,7 @@
 import test from "ava";
 import { dropOrphanedToolResults } from "@/ai-sdk-client/converters/message-converter";
-import { TOOL_APPROVAL_REQUIRED_KIND } from "@/constants";
 import { getAppConfig, reloadAppConfig } from "@/config/index";
+import { TOOL_APPROVAL_REQUIRED_KIND } from "@/constants";
 import { setToolManagerGetter, setToolRegistryGetter } from "@/message-handler";
 import type { ToolManager } from "@/tools/tool-manager";
 import type {

--- a/source/plain/conversation.ts
+++ b/source/plain/conversation.ts
@@ -73,7 +73,7 @@ export type PlainConversationOutcome =
 			usage?: PlainConversationUsage;
 	  }
 	| {
-			kind: typeof TOOL_APPROVAL_REQUIRED_KIND;
+			kind: 'tool-approval-required';
 			toolNames: string[];
 			finalText: string;
 			reasoning: string | null;

--- a/source/plain/conversation.ts
+++ b/source/plain/conversation.ts
@@ -8,6 +8,7 @@ import {
 	getAppConfig,
 	getRetryLimits,
 } from '@/config/index';
+import {TOOL_APPROVAL_REQUIRED_KIND} from '@/constants';
 import {
 	buildAbandonedTurnMessages,
 	partitionUnknownToolCalls,
@@ -72,7 +73,7 @@ export type PlainConversationOutcome =
 			usage?: PlainConversationUsage;
 	  }
 	| {
-			kind: 'tool-approval-required';
+			kind: typeof TOOL_APPROVAL_REQUIRED_KIND;
 			toolNames: string[];
 			finalText: string;
 			reasoning: string | null;
@@ -519,7 +520,7 @@ export async function runPlainConversation(
 
 		if (toolsNeedingApproval.length > 0) {
 			return {
-				kind: 'tool-approval-required',
+				kind: TOOL_APPROVAL_REQUIRED_KIND,
 				toolNames: toolsNeedingApproval,
 				finalText: accumulatedFinalText,
 				reasoning: accumulatedReasoning || null,

--- a/source/plain/shell.spec.ts
+++ b/source/plain/shell.spec.ts
@@ -1,4 +1,5 @@
 import test from "ava";
+import { TOOL_APPROVAL_REQUIRED_KIND } from "@/constants";
 import type { ToolManager } from "@/tools/tool-manager";
 import type { LLMClient } from "@/types/core";
 import type { PlainConversationOutcome } from "./conversation.js";
@@ -354,7 +355,7 @@ test.serial(
 				deps: baseDeps({
 					initializePlain: makeFakeInitializePlain(),
 					runPlainConversation: makeFakeRunPlainConversation({
-						kind: "tool-approval-required",
+						kind: TOOL_APPROVAL_REQUIRED_KIND,
 						toolNames: ["risky_tool"],
 						finalText: "",
 						reasoning: null,
@@ -368,7 +369,7 @@ test.serial(
 		}
 
 		const report = JSON.parse(stdout.get());
-		t.is(report.kind, "tool-approval-required");
+		t.is(report.kind, TOOL_APPROVAL_REQUIRED_KIND);
 		t.is(report.exitCode, 2);
 		t.deepEqual(report.toolNames, ["risky_tool"]);
 		t.is(shutdown.code, 2);
@@ -700,7 +701,7 @@ test.serial(
 				deps: baseDeps({
 					initializePlain: makeFakeInitializePlain(),
 					runPlainConversation: makeFakeRunPlainConversation({
-						kind: "tool-approval-required",
+						kind: TOOL_APPROVAL_REQUIRED_KIND,
 						toolNames: ["risky_tool"],
 						finalText: "",
 						reasoning: null,

--- a/source/plain/shell.ts
+++ b/source/plain/shell.ts
@@ -8,7 +8,10 @@ import {
 import {getAppConfig} from '@/config/index';
 import {loadPreferences, savePreferences} from '@/config/preferences';
 import {resolveTune} from '@/config/tune';
-import {TOOL_APPROVAL_REQUIRED_PREFIX} from '@/constants';
+import {
+	TOOL_APPROVAL_REQUIRED_KIND,
+	TOOL_APPROVAL_REQUIRED_PREFIX,
+} from '@/constants';
 import {runPlainConversation} from '@/plain/conversation';
 import {initializePlain} from '@/plain/initialize';
 import {
@@ -273,7 +276,7 @@ export async function runPlainShell(
 			...(outcome.kind === 'error' && {
 				message: sanitizeOutput(outcome.message),
 			}),
-			...(outcome.kind === 'tool-approval-required' && {
+			...(outcome.kind === TOOL_APPROVAL_REQUIRED_KIND && {
 				toolNames: outcome.toolNames,
 			}),
 		};
@@ -288,7 +291,7 @@ export async function runPlainShell(
 		case 'success':
 			await shutdown(0, deps);
 			return;
-		case 'tool-approval-required':
+		case TOOL_APPROVAL_REQUIRED_KIND:
 			writeError(
 				`${TOOL_APPROVAL_REQUIRED_PREFIX}${outcome.toolNames.join(', ')}. ` +
 					`Re-run with --mode auto-accept or --mode yolo, or add the tools to ` +


### PR DESCRIPTION
## Description

Standardize the tool-approval error kind string literal across the codebase by introducing a single source of truth constant `TOOL_APPROVAL_REQUIRED_KIND` in `source/constants.ts` and replacing all bare `'tool-approval-required'` / `'tool-approval'` string literals with it.

Fixes #1014

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
