### PR TITLE
fix(acp): claim turns before async prompt setup

### DIFF
--- a/.changeset/quiet-turns-claim.md
+++ b/.changeset/quiet-turns-claim.md
@@ -2,4 +2,4 @@
 "@nanocollective/nanocoder": patch
 ---
 
-Fixed ACP prompts racing with each other by claiming session turns before asynchronous setup begins, preventing overlapping prompts from corrupting turn state. Closes #1038.
+Fixed ACP prompts racing with each other by claiming session turns before asynchronous setup begins, preventing overlapping prompts from corrupting turn state. Built-in slash-command replies are kept in persisted session history for replay, while command-only sessions are not saved. Closes #1038.

--- a/.changeset/quiet-turns-claim.md
+++ b/.changeset/quiet-turns-claim.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed ACP prompts racing with each other by claiming session turns before asynchronous setup begins, preventing overlapping prompts from corrupting turn state. Closes #1038.

--- a/source/acp/acp-agent.spec.ts
+++ b/source/acp/acp-agent.spec.ts
@@ -470,15 +470,12 @@ test('AcpAgent.prompt - rejects an overlapping prompt before the first async bou
 	await t.throwsAsync(
 		agent.prompt({
 			sessionId: session.sessionId,
-		prompt: [{type: 'text', text: 'second'}],
+			prompt: [{type: 'text', text: 'second'}],
 		}),
 		{message: `Prompt already in progress for session: ${session.sessionId}`},
 	);
 
-	t.is(
-		agent['sessions'].get(session.sessionId)!.abortController,
-		controller,
-	);
+	t.is(agent['sessions'].get(session.sessionId)!.abortController, controller);
 	t.is((await first).stopReason, 'end_turn');
 });
 
@@ -625,27 +622,37 @@ test('AcpAgent.prompt - a built-in command exchange stays out of model context',
 	t.deepEqual(convertToModelMessages(messages), []);
 });
 
-test.serial('AcpAgent.prompt - built-in replies are not persisted', async t => {
-	const {agent} = createAgent();
-	await sessionManager.initialize();
-	const session = await agent.newSession({cwd: '/tmp'});
+test.serial(
+	'AcpAgent.prompt - built-in replies persist with sessions but do not create one alone',
+	async t => {
+		const {agent} = createAgent();
+		await sessionManager.initialize();
+		const commandOnlySession = await agent.newSession({cwd: '/tmp'});
 
-	await agent.prompt({
-		sessionId: session.sessionId,
-		prompt: [{type: 'text', text: 'real prompt'}],
-	});
-	await agent.prompt({
-		sessionId: session.sessionId,
-		prompt: [{type: 'text', text: '/help'}],
-	});
+		await agent.prompt({
+			sessionId: commandOnlySession.sessionId,
+			prompt: [{type: 'text', text: '/help'}],
+		});
+		t.falsy(await sessionManager.readSession(commandOnlySession.sessionId));
 
-	const persisted = await sessionManager.readSession(session.sessionId);
-	t.truthy(persisted);
-	t.true(
-		persisted!.messages.every(m => !m.displayOnly),
-		'display-only built-in replies must not be written to disk',
-	);
-});
+		const session = await agent.newSession({cwd: '/tmp'});
+		await agent.prompt({
+			sessionId: session.sessionId,
+			prompt: [{type: 'text', text: 'real prompt'}],
+		});
+		await agent.prompt({
+			sessionId: session.sessionId,
+			prompt: [{type: 'text', text: '/help'}],
+		});
+
+		const persisted = await sessionManager.readSession(session.sessionId);
+		t.truthy(persisted);
+		t.true(
+			persisted!.messages.some(m => m.displayOnly),
+			'display-only built-in replies must remain in session history',
+		);
+	},
+);
 
 test('AcpAgent.prompt - a genuinely unknown command still reports unrecognized', async t => {
 	const reply = await promptForBuiltinReply('/definitelynotacommand');

--- a/source/acp/acp-agent.spec.ts
+++ b/source/acp/acp-agent.spec.ts
@@ -457,6 +457,26 @@ test('AcpAgent.prompt - throws on unknown session', async t => {
 	);
 });
 
+test('AcpAgent.prompt - rejects an overlapping prompt before the first async boundary', async t => {
+	const {agent} = createAgent();
+	const session = await agent.newSession({cwd: '/tmp'});
+
+	const first = agent.prompt({
+		sessionId: session.sessionId,
+		prompt: [{type: 'text', text: 'first'}],
+	});
+
+	await t.throwsAsync(
+		agent.prompt({
+			sessionId: session.sessionId,
+		prompt: [{type: 'text', text: 'second'}],
+		}),
+		{message: `Prompt already in progress for session: ${session.sessionId}`},
+	);
+
+	await first;
+});
+
 
 test('AcpAgent.prompt - propagates API errors cleanly', async t => {
 	const {agent} = createAgent();

--- a/source/acp/acp-agent.spec.ts
+++ b/source/acp/acp-agent.spec.ts
@@ -465,6 +465,7 @@ test('AcpAgent.prompt - rejects an overlapping prompt before the first async bou
 		sessionId: session.sessionId,
 		prompt: [{type: 'text', text: 'first'}],
 	});
+	const controller = agent['sessions'].get(session.sessionId)!.abortController;
 
 	await t.throwsAsync(
 		agent.prompt({
@@ -474,9 +475,12 @@ test('AcpAgent.prompt - rejects an overlapping prompt before the first async bou
 		{message: `Prompt already in progress for session: ${session.sessionId}`},
 	);
 
-	await first;
+	t.is(
+		agent['sessions'].get(session.sessionId)!.abortController,
+		controller,
+	);
+	t.is((await first).stopReason, 'end_turn');
 });
-
 
 test('AcpAgent.prompt - propagates API errors cleanly', async t => {
 	const {agent} = createAgent();
@@ -619,6 +623,28 @@ test('AcpAgent.prompt - a built-in command exchange stays out of model context',
 	t.is(messages.length, 2);
 	t.true(messages.every(m => m.displayOnly));
 	t.deepEqual(convertToModelMessages(messages), []);
+});
+
+test.serial('AcpAgent.prompt - built-in replies are not persisted', async t => {
+	const {agent} = createAgent();
+	await sessionManager.initialize();
+	const session = await agent.newSession({cwd: '/tmp'});
+
+	await agent.prompt({
+		sessionId: session.sessionId,
+		prompt: [{type: 'text', text: 'real prompt'}],
+	});
+	await agent.prompt({
+		sessionId: session.sessionId,
+		prompt: [{type: 'text', text: '/help'}],
+	});
+
+	const persisted = await sessionManager.readSession(session.sessionId);
+	t.truthy(persisted);
+	t.true(
+		persisted!.messages.every(m => !m.displayOnly),
+		'display-only built-in replies must not be written to disk',
+	);
 });
 
 test('AcpAgent.prompt - a genuinely unknown command still reports unrecognized', async t => {

--- a/source/acp/acp-agent.ts
+++ b/source/acp/acp-agent.ts
@@ -192,177 +192,176 @@ export class AcpAgent implements Agent {
 
 		session.beginTurn();
 
-		const {text: userText, images} = await acpContentToUserMessage(
-			params.prompt,
-			{
-				conn: this.conn,
-				sessionId: params.sessionId,
-				canReadTextFile: this.clientCapabilities?.fs?.readTextFile ?? false,
-			},
-		);
-		logger.info(
-			`ACP prompt: session=${params.sessionId} text=${userText.slice(0, 100)} images=${images.length}`,
-		);
+		try {
+			const {text: userText, images} = await acpContentToUserMessage(
+				params.prompt,
+				{
+					conn: this.conn,
+					sessionId: params.sessionId,
+					canReadTextFile: this.clientCapabilities?.fs?.readTextFile ?? false,
+				},
+			);
+			logger.info(
+				`ACP prompt: session=${params.sessionId} text=${userText.slice(0, 100)} images=${images.length}`,
+			);
 
-		// Prepend active workspace context (e.g. the file focused in VS Code) so
-		// the model always knows what the user is looking at.
-		let contextualUserText = userText;
+			// Prepend active workspace context (e.g. the file focused in VS Code) so
+			// the model always knows what the user is looking at.
+			let contextualUserText = userText;
 
-		// Slash command interception
-		const trimmedUserText = userText.trim();
-		if (trimmedUserText.startsWith('/')) {
-			const commandName = trimmedUserText.split(/\s+/)[0].substring(1);
+			// Slash command interception
+			const trimmedUserText = userText.trim();
+			if (trimmedUserText.startsWith('/')) {
+				const commandName = trimmedUserText.split(/\s+/)[0].substring(1);
 
-			// If the 'command name' contains a slash, it's likely a file path (e.g. /home/user/file.ts)
-			// not a slash command. Skip command interception.
-			if (!commandName.includes('/')) {
-				const command =
-					this.initContext.customCommandLoader?.getCommand(commandName);
+				// If the 'command name' contains a slash, it's likely a file path (e.g. /home/user/file.ts)
+				// not a slash command. Skip command interception.
+				if (!commandName.includes('/')) {
+					const command =
+						this.initContext.customCommandLoader?.getCommand(commandName);
 
-				if (command) {
-					// Custom user-defined command — expand its instructions into the prompt
-					const commandInstruction = `### ${command.fullName}\n\n${command.content}`;
-					contextualUserText = `${contextualUserText}\n\n## Included Command Instructions\n\n${commandInstruction}\n\nPlease follow these instructions for the user's request above.`;
-				} else {
-					// Check for built-in commands that have special ACP handling
-					const sendBuiltinReply = (msg: string) => {
-						session.messages = [
-							...session.messages,
-							{
-								role: 'user',
-								content: contextualUserText,
-								displayOnly: true,
-							},
-							{role: 'assistant', content: msg, displayOnly: true},
-						];
-						this.conn.sessionUpdate({
-							sessionId: params.sessionId,
-							update: {
-								sessionUpdate: 'agent_message_chunk',
-								content: {type: 'text', text: msg},
-							},
-						});
-						return {stopReason: 'end_turn' as const};
-					};
+					if (command) {
+						// Custom user-defined command — expand its instructions into the prompt
+						const commandInstruction = `### ${command.fullName}\n\n${command.content}`;
+						contextualUserText = `${contextualUserText}\n\n## Included Command Instructions\n\n${commandInstruction}\n\nPlease follow these instructions for the user's request above.`;
+					} else {
+						// Check for built-in commands that have special ACP handling
+						const sendBuiltinReply = (msg: string) => {
+							session.messages = [
+								...session.messages,
+								{
+									role: 'user',
+									content: contextualUserText,
+									displayOnly: true,
+								},
+								{role: 'assistant', content: msg, displayOnly: true},
+							];
+							this.conn.sessionUpdate({
+								sessionId: params.sessionId,
+								update: {
+									sessionUpdate: 'agent_message_chunk',
+									content: {type: 'text', text: msg},
+								},
+							});
+							return {stopReason: 'end_turn' as const};
+						};
 
-					if (commandName === 'clear') {
-						// Clear the conversation history and action timeline
-						session.messages = [];
-						await session.timeline.clear();
-						const msg = 'Conversation cleared.';
-						this.conn.sessionUpdate({
-							sessionId: params.sessionId,
-							update: {
-								sessionUpdate: 'agent_message_chunk',
-								content: {type: 'text', text: msg},
-							},
-						});
-						return {stopReason: 'end_turn'};
+						if (commandName === 'clear') {
+							// Clear the conversation history and action timeline
+							session.messages = [];
+							await session.timeline.clear();
+							const msg = 'Conversation cleared.';
+							this.conn.sessionUpdate({
+								sessionId: params.sessionId,
+								update: {
+									sessionUpdate: 'agent_message_chunk',
+									content: {type: 'text', text: msg},
+								},
+							});
+							return {stopReason: 'end_turn'};
+						}
+
+						if (commandName === 'help') {
+							const customCmds =
+								this.initContext.customCommandLoader?.getAllCommands() ?? [];
+							const customList =
+								customCmds.length > 0
+									? customCmds
+											.map(
+												c =>
+													`- \`/${c.fullName}\` — ${c.metadata.description || 'custom command'}`,
+											)
+											.join('\n')
+									: '';
+							const msg = [
+								'**Available slash commands in VS Code GUI:**',
+								'',
+								'- `/clear` — Clear the current conversation',
+								'- `/copy` — Copy the last assistant response',
+								'- `/copy code` — Copy the last code block from the last response',
+								'- `/help` — Show this help message',
+								'',
+								'**Not available in VS Code GUI** (CLI-only):',
+								'- `/init`, `/theme`, `/context-max`, `/compact`, `/usage`, and other interactive commands',
+								'',
+								customList ? `**Your custom commands:**\n${customList}` : '',
+							]
+								.filter(Boolean)
+								.join('\n');
+							return sendBuiltinReply(msg);
+						}
+
+						// `/copy` is normally intercepted by the webview before it
+						// reaches us, but `/help` advertises it, so a client without
+						// that interception must not get "unrecognized command".
+						if (commandName === 'copy') {
+							const msg =
+								'`/copy` is handled by the chat view. Type it in the Nanocoder chat input (or press Ctrl+Alt+Shift+C / Cmd+Alt+Shift+C for the last code block).';
+							return sendBuiltinReply(msg);
+						}
+
+						if (['model', 'provider'].includes(commandName)) {
+							const msg = `Use the ${commandName} selector in the chat header to switch ${commandName}s.`;
+							return sendBuiltinReply(msg);
+						}
+
+						if (commandName === 'settings') {
+							const msg =
+								'Use the Settings tab in the Nanocoder sidebar (the gear icon in the view title bar, or `Nanocoder: Settings` in the Command Palette).';
+							return sendBuiltinReply(msg);
+						}
+
+						if (
+							['init', 'theme', 'compact', 'context-max', 'usage'].includes(
+								commandName,
+							)
+						) {
+							const msg = `The \`/${commandName}\` command is only available in the interactive CLI (\`nanocoder\` in a terminal). It is not supported in the VS Code GUI.`;
+							return sendBuiltinReply(msg);
+						}
+
+						// Truly unrecognized command
+						const errorMsg = `Unrecognized slash command: \`/${commandName}\`. Type \`/help\` to see available commands.`;
+						return sendBuiltinReply(errorMsg);
 					}
-
-					if (commandName === 'help') {
-						const customCmds =
-							this.initContext.customCommandLoader?.getAllCommands() ?? [];
-						const customList =
-							customCmds.length > 0
-								? customCmds
-										.map(
-											c =>
-												`- \`/${c.fullName}\` — ${c.metadata.description || 'custom command'}`,
-										)
-										.join('\n')
-								: '';
-						const msg = [
-							'**Available slash commands in VS Code GUI:**',
-							'',
-							'- `/clear` — Clear the current conversation',
-							'- `/copy` — Copy the last assistant response',
-							'- `/copy code` — Copy the last code block from the last response',
-							'- `/help` — Show this help message',
-							'',
-							'**Not available in VS Code GUI** (CLI-only):',
-							'- `/init`, `/theme`, `/context-max`, `/compact`, `/usage`, and other interactive commands',
-							'',
-							customList ? `**Your custom commands:**\n${customList}` : '',
-						]
-							.filter(Boolean)
-							.join('\n');
-						return sendBuiltinReply(msg);
-					}
-
-					// `/copy` is normally intercepted by the webview before it
-					// reaches us, but `/help` advertises it, so a client without
-					// that interception must not get "unrecognized command".
-					if (commandName === 'copy') {
-						const msg =
-							'`/copy` is handled by the chat view. Type it in the Nanocoder chat input (or press Ctrl+Alt+Shift+C / Cmd+Alt+Shift+C for the last code block).';
-						return sendBuiltinReply(msg);
-					}
-
-					if (['model', 'provider'].includes(commandName)) {
-						const msg = `Use the ${commandName} selector in the chat header to switch ${commandName}s.`;
-						return sendBuiltinReply(msg);
-					}
-
-					if (commandName === 'settings') {
-						const msg =
-							'Use the Settings tab in the Nanocoder sidebar (the gear icon in the view title bar, or `Nanocoder: Settings` in the Command Palette).';
-						return sendBuiltinReply(msg);
-					}
-
-					if (
-						['init', 'theme', 'compact', 'context-max', 'usage'].includes(
-							commandName,
-						)
-					) {
-						const msg = `The \`/${commandName}\` command is only available in the interactive CLI (\`nanocoder\` in a terminal). It is not supported in the VS Code GUI.`;
-						return sendBuiltinReply(msg);
-					}
-
-					// Truly unrecognized command
-					const errorMsg = `Unrecognized slash command: \`/${commandName}\`. Type \`/help\` to see available commands.`;
-					return sendBuiltinReply(errorMsg);
 				}
 			}
-		}
 
-		if (session.activeFile) {
-			contextualUserText = `[Active file: ${session.activeFile}]\n\n${contextualUserText}`;
-		}
-
-		session.messages = [
-			...session.messages,
-			{
-				role: 'user',
-				content: contextualUserText,
-				...(images.length > 0 ? {images} : {}),
-			},
-		];
-
-		if (session.baseSystemMessage) {
-			const projectContext = await appendRelevantProjectContextWithCount(
-				session.baseSystemMessage.content,
-				userText,
-				session.getMemoryFinder(),
-				getProjectContextPreferences(),
-			);
-			session.systemMessage = {
-				role: 'system',
-				content: projectContext.systemPrompt,
-			};
-			setLastBuiltPrompt(projectContext.systemPrompt);
-			if (projectContext.memoryCount > 0) {
-				logger.info(
-					`ACP recall: session=${params.sessionId} count=${projectContext.memoryCount}`,
-				);
+			if (session.activeFile) {
+				contextualUserText = `[Active file: ${session.activeFile}]\n\n${contextualUserText}`;
 			}
-		}
 
-		const config = getAppConfig();
-		const nonInteractiveAlwaysAllow = config.alwaysAllow ?? [];
+			session.messages = [
+				...session.messages,
+				{
+					role: 'user',
+					content: contextualUserText,
+					...(images.length > 0 ? {images} : {}),
+				},
+			];
 
-		session.turnActive = true;
-		try {
+			if (session.baseSystemMessage) {
+				const projectContext = await appendRelevantProjectContextWithCount(
+					session.baseSystemMessage.content,
+					userText,
+					session.getMemoryFinder(),
+					getProjectContextPreferences(),
+				);
+				session.systemMessage = {
+					role: 'system',
+					content: projectContext.systemPrompt,
+				};
+				setLastBuiltPrompt(projectContext.systemPrompt);
+				if (projectContext.memoryCount > 0) {
+					logger.info(
+						`ACP recall: session=${params.sessionId} count=${projectContext.memoryCount}`,
+					);
+				}
+			}
+
+			const config = getAppConfig();
+			const nonInteractiveAlwaysAllow = config.alwaysAllow ?? [];
+
 			return await runAcpConversation({
 				session,
 				client: this.initContext.client,

--- a/source/acp/acp-agent.ts
+++ b/source/acp/acp-agent.ts
@@ -881,7 +881,7 @@ export class AcpAgent implements Agent {
 
 			// We only want user/assistant messages for the title generation/saving
 			const saveableMessages = session.messages.filter(
-				m => m.role === 'user' || m.role === 'assistant',
+				m => (m.role === 'user' || m.role === 'assistant') && !m.displayOnly,
 			);
 
 			if (saveableMessages.length === 0) {
@@ -911,15 +911,17 @@ export class AcpAgent implements Agent {
 				provider: this.initContext.client.getProviderConfig().name || 'openai',
 				model: this.initContext.client.getCurrentModel() || 'gpt-4o',
 				workingDirectory: session.cwd,
-				messages: session.messages.map(m => {
-					if (m.role === 'user' && typeof m.content === 'string') {
-						return {
-							...m,
-							content: m.content.replace(/^\[Active file: [^\]]+\]\n\n/, ''),
-						};
-					}
-					return m;
-				}), // We save the raw AcpSession messages with UI prefix stripped
+				messages: session.messages
+					.filter(m => !m.displayOnly)
+					.map(m => {
+						if (m.role === 'user' && typeof m.content === 'string') {
+							return {
+								...m,
+								content: m.content.replace(/^\[Active file: [^\]]+\]\n\n/, ''),
+							};
+						}
+						return m;
+					}), // We save the raw AcpSession messages with UI prefix stripped
 			});
 		} catch (error) {
 			logger.error(`Failed to save session to disk: ${error}`);

--- a/source/acp/acp-agent.ts
+++ b/source/acp/acp-agent.ts
@@ -911,17 +911,15 @@ export class AcpAgent implements Agent {
 				provider: this.initContext.client.getProviderConfig().name || 'openai',
 				model: this.initContext.client.getCurrentModel() || 'gpt-4o',
 				workingDirectory: session.cwd,
-				messages: session.messages
-					.filter(m => !m.displayOnly)
-					.map(m => {
-						if (m.role === 'user' && typeof m.content === 'string') {
-							return {
-								...m,
-								content: m.content.replace(/^\[Active file: [^\]]+\]\n\n/, ''),
-							};
-						}
-						return m;
-					}), // We save the raw AcpSession messages with UI prefix stripped
+				messages: session.messages.map(m => {
+					if (m.role === 'user' && typeof m.content === 'string') {
+						return {
+							...m,
+							content: m.content.replace(/^\[Active file: [^\]]+\]\n\n/, ''),
+						};
+					}
+					return m;
+				}), // We save the raw AcpSession messages with UI prefix stripped
 			});
 		} catch (error) {
 			logger.error(`Failed to save session to disk: ${error}`);

--- a/source/acp/acp-session.spec.ts
+++ b/source/acp/acp-session.spec.ts
@@ -125,7 +125,7 @@ test('AcpSession - cancel leaves the session signal aborted', t => {
 	t.true(session.abortController.signal.aborted);
 });
 
-test('AcpSession - beginTurn creates fresh abort controller', t => {
+test('AcpSession - beginTurn creates a fresh controller and marks the turn active', t => {
 	const session = new AcpSession({
 		sessionId: 'test-id',
 		cwd: '/tmp',
@@ -136,6 +136,7 @@ test('AcpSession - beginTurn creates fresh abort controller', t => {
 	session.beginTurn();
 	t.not(session.abortController, cancelled);
 	t.false(session.abortController.signal.aborted);
+	t.true(session.turnActive);
 });
 
 test('AcpSession - cancel after beginTurn aborts the turn controller', t => {

--- a/source/acp/acp-session.ts
+++ b/source/acp/acp-session.ts
@@ -49,5 +49,6 @@ export class AcpSession {
 
 	beginTurn(): void {
 		this.abortController = new AbortController();
+		this.turnActive = true;
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1038.

`AcpAgent.prompt()` now claims a session turn synchronously when `beginTurn()` is called, before content conversion or any other asynchronous setup. This makes the existing overlap check effective for concurrent prompts and prevents the second prompt from replacing the first turn's abort controller.

The prompt cleanup boundary now also covers setup and built-in command paths, so conversion failures and early returns release the active-turn state.

## Tests

- `pnpm exec ava source/acp/acp-session.spec.ts source/acp/acp-agent.spec.ts`
- `pnpm run test:types`
- `pnpm run test:types:vscode`
- `pnpm run test:format`
- `pnpm run test:lint`
- `pnpm run test:knip`
- `git diff --check`

The repository's aggregate `test:all` script cannot run on Windows because it invokes the Bash-only `./scripts/test.sh`; the direct full AVA run also has pre-existing CLI/ACP integration failures and timeout outside this change.
