### PR TITLE
fix(subagents): preserve object tool output

### DIFF
--- a/.changeset/curvy-tools-smile.md
+++ b/.changeset/curvy-tools-smile.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed subagent tool results that return structured data without `llmContent` so the complete output is preserved for the model instead of being passed as `undefined`. Closes #1033.

--- a/source/subagents/subagent-executor.spec.ts
+++ b/source/subagents/subagent-executor.spec.ts
@@ -23,7 +23,7 @@ function createMockToolManager(
 			handler: (
 				args: unknown,
 				options?: ToolExecutionContext,
-			) => Promise<string>;
+			) => Promise<unknown>;
 			readOnly: boolean;
 			needsApproval?: boolean;
 		}
@@ -173,6 +173,42 @@ test.serial('executes tool calls and returns final response', async t => {
 
 	t.true(result.success);
 	t.is(result.output, 'Found the file with 100 lines');
+});
+
+test.serial('stringifies structured tool output without llmContent', async t => {
+	const toolManager = createMockToolManager({
+		read_file: {
+			handler: async () => ({someField: 'value'}),
+			readOnly: true,
+		},
+	});
+	const toolResults: Message[] = [];
+	const client = createMockClient(
+		[
+			{
+				content: '',
+				tool_calls: [{
+					id: 'tc-structured',
+					function: {name: 'read_file', arguments: '{}'},
+				}],
+			},
+			{content: 'The tool returned structured data.'},
+		],
+		messages => {
+			const toolMessage = messages.find(message => message.role === 'tool');
+			if (toolMessage) toolResults.push(toolMessage);
+		},
+	);
+
+	const executor = new SubagentExecutor(toolManager, client);
+	const result = await executor.execute({
+		subagent_type: 'explore',
+		description: 'Read structured data',
+	});
+
+	t.true(result.success);
+	t.is(result.output, 'The tool returned structured data.');
+	t.is(toolResults[0]?.content, '{"someField":"value"}');
 });
 
 test.serial('forwards the parent execution context to subagent tools', async t => {

--- a/source/subagents/subagent-executor.ts
+++ b/source/subagents/subagent-executor.ts
@@ -709,7 +709,10 @@ export class SubagentExecutor {
 			});
 			// Subagents converse in text, so collapse structured output to its
 			// text representation.
-			const content = typeof result === 'string' ? result : result.llmContent;
+			const content =
+				typeof result === 'string'
+					? result
+					: (result.llmContent ?? JSON.stringify(result));
 			return truncateToolResult(content);
 		} catch (error) {
 			// Handler validation failures surface here too (the handler is


### PR DESCRIPTION
## Summary

Fixes #1033.

When a subagent tool returns a structured object without `llmContent`, the executor now serializes that object as the model-visible tool result instead of passing `undefined` into the next model request. Existing string results and explicit `llmContent` values retain their precedence.

## Tests

- `pnpm exec ava source/subagents/subagent-executor.spec.ts` (31 passed)
- `pnpm run test:types`
- `pnpm run test:format`
- `pnpm run test:lint`
- `git diff --check`

The repository's aggregate `test:all` script is Bash-only and cannot run directly on Windows.
