### PR TITLE
fix(changeset): correct the package name that blocks release-prepare

### DIFF
--- a/.changeset/fix-web-search-timeout.md
+++ b/.changeset/fix-web-search-timeout.md
@@ -1,5 +1,5 @@
 ---
-"nanocoder": patch
+"@nanocollective/nanocoder": patch
 ---
 
 Fix web_search TimeoutError not correctly captured as a timeout error


### PR DESCRIPTION
The changeset added in #1065 declares `"nanocoder"`, but the workspace package is `"@nanocollective/nanocoder"`. `changeset version` rejects it:

```
Error: Found changeset fix-web-search-timeout for package nanocoder
which is not in the workspace
```

`Prepare Release (Version PR)` has therefore failed on every push to `main` since #1065 landed at 14:02 UTC. The last green run was the commit immediately before it. The Version Packages PR has not updated since, so all 50 pending changesets are stuck and no release can be cut.

This is the only one of the 50 changesets on `main` with a wrong package name; every other one is correct.

## Verification

`pnpm exec changeset status` reproduces the CI failure on the current `main` content and exits 1. With this one-line change it passes:

```
Packages to be bumped:
- minor
  - @nanocollective/nanocoder
```

## Follow-up

`changeset-check` passed on #1065 because it only asserts that a changeset file was added, never that the package name resolves. A `changeset status` gate would catch this on the PR that introduces it rather than silently on `main`. Deliberately not bundled here so this can merge as a fast unblock; opened separately.

No changeset for this PR - it is a chore repairing changeset metadata, so the check bot will comment and can be ignored.
