### PR TITLE
fix(events): expand brace patterns in subscription globs

### DIFF
--- a/.changeset/glob-brace-alternation.md
+++ b/.changeset/glob-brace-alternation.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed skill subscriptions never firing for a brace pattern such as `*.{ts,tsx}`. The event router's glob matcher escaped `{`, `}` and `,` as literals, so the pattern only matched a path that literally contained the braces. Braces now expand to an alternation, and an unbalanced brace stays literal rather than building a regex that would throw. Negation (`!`) is still unsupported. Closes #1012.

--- a/source/events/event-router.spec.ts
+++ b/source/events/event-router.spec.ts
@@ -153,6 +153,34 @@ test('matchesFilter on kind mismatch returns false', t => {
 	t.false(matchesFilter(sub, event));
 });
 
+test('matchGlob: brace alternation', t => {
+	t.true(matchGlob('*.{ts,tsx}', 'app.tsx'));
+	t.true(matchGlob('*.{ts,tsx}', 'app.ts'));
+	t.false(matchGlob('*.{ts,tsx}', 'app.js'));
+
+	t.true(matchGlob('src/**/*.{ts,tsx}', 'src/a/b/app.tsx'));
+	t.false(matchGlob('src/**/*.{ts,tsx}', 'src/a/b/app.css'));
+
+	// A single alternative and more than two both hold.
+	t.true(matchGlob('{docs}/**', 'docs/intro.md'));
+	t.true(matchGlob('*.{js,ts,tsx,mts}', 'a.mts'));
+
+	// `*` still stops at a directory boundary inside an alternative.
+	t.false(matchGlob('*.{ts,tsx}', 'src/app.ts'));
+});
+
+test('matchGlob: unbalanced braces stay literal instead of throwing', t => {
+	t.notThrows(() => matchGlob('docs/{a', 'docs/{a'));
+	t.true(matchGlob('docs/{a', 'docs/{a'));
+	t.false(matchGlob('docs/{a', 'docs/a'));
+	t.true(matchGlob('a}b', 'a}b'));
+});
+
+test('matchGlob: a comma outside braces is literal', t => {
+	t.true(matchGlob('a,b.md', 'a,b.md'));
+	t.false(matchGlob('a,b.md', 'a.md'));
+});
+
 test('matchGlob: basic patterns', t => {
 	t.true(matchGlob('docs/**', 'docs/intro.md'));
 	t.true(matchGlob('docs/**', 'docs/deep/sub/file.md'));

--- a/source/events/event-router.ts
+++ b/source/events/event-router.ts
@@ -112,20 +112,47 @@ export function toPosixPath(path: string): string {
 }
 
 // Minimal glob -> regex matcher: enough for `docs/<star><star>`,
-// `src/<star><star>/*.ts`, `<star><star>/*.md`, literal paths, and `?`
-// single-character wildcards. Step 9 brings chokidar (and its picomatch dep)
-// into the tree, at which point we can swap this for picomatch and delete
-// the helper. Until then this is sufficient to make the router unit-testable.
+// `src/<star><star>/*.ts`, `<star><star>/*.md`, literal paths, `?`
+// single-character wildcards, and `{a,b}` alternation. Negation (`!`) is not
+// supported. chokidar 5 depends only on readdirp, so picomatch is no longer in
+// the tree and swapping to it would mean taking a new direct dependency.
 export function matchGlob(pattern: string, path: string): boolean {
 	const regex = globToRegex(toPosixPath(pattern));
 	return regex.test(toPosixPath(path));
 }
 
+/**
+ * Whether every `{` in the pattern has a matching `}`. An unbalanced brace is
+ * treated as a literal, which is what the matcher did before alternation
+ * existed, rather than building a regex that would throw.
+ */
+function hasBalancedBraces(pattern: string): boolean {
+	let depth = 0;
+	for (const ch of pattern) {
+		if (ch === '{') depth++;
+		else if (ch === '}') {
+			depth--;
+			if (depth < 0) return false;
+		}
+	}
+	return depth === 0;
+}
+
 function globToRegex(pattern: string): RegExp {
+	const alternation = hasBalancedBraces(pattern);
+	let depth = 0;
 	let out = '';
 	for (let i = 0; i < pattern.length; i++) {
 		const ch = pattern[i];
-		if (ch === '*') {
+		if (alternation && ch === '{') {
+			out += '(?:';
+			depth++;
+		} else if (alternation && ch === '}' && depth > 0) {
+			out += ')';
+			depth--;
+		} else if (alternation && ch === ',' && depth > 0) {
+			out += '|';
+		} else if (ch === '*') {
 			const next = pattern[i + 1];
 			if (next === '*') {
 				// `**` matches any characters including `/`
@@ -160,7 +187,8 @@ function globToRegex(pattern: string): RegExp {
 	}
 	// `out` is built by the escape loop above: every character is either a
 	// literal escaped with `\\`, or one of the fixed substrings `[^/]`, `.*`,
-	// `[^/]*`, `[^/]`. There is no user-supplied raw regex syntax in `out`.
+	// `[^/]*`, `(?:`, `|`, `)`. There is no user-supplied raw regex syntax in
+	// `out`, and the braces were checked for balance before any group opened.
 	// The shape is bounded by the glob length, so ReDoS is not reachable.
 	// nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
 	return new RegExp(`^${out}$`);


### PR DESCRIPTION
## Description

A skill subscribing with `*.{ts,tsx}` never fired. `globToRegex` escaped `{`, `}` and `,` as regex literals, so the pattern only matched a path that literally contained the braces.

Braces now expand to an alternation, so `*.{ts,tsx}` matches `app.ts` and `app.tsx` and still refuses `app.js`.

## On the picomatch suggestion

The issue asks for a swap to `picomatch`, and the comment above the matcher says the same:

> Step 9 brings chokidar (and its picomatch dep) into the tree, at which point we can swap this for picomatch and delete the helper.

That premise no longer holds. chokidar 4 dropped glob support along with picomatch, and the installed chokidar declares only one dependency:

```
chokidar 5.0.0
deps: {"readdirp":"^5.0.0"}
```

`require.resolve('picomatch')` fails from the app. So the swap would now mean taking a new direct dependency rather than reusing one already in the tree, which felt like your call rather than mine. I fixed the matcher instead and corrected the comment so it no longer promises a swap that does not follow from chokidar.

Happy to redo this as a picomatch dependency if you would rather have the full glob surface, including negation. That would be a bigger change than this one and would delete the helper.

## Type of Change

- [x] Bug fix

## Behaviour notes

- An unbalanced brace keeps the old literal behaviour instead of building a regex that would throw. Patterns come from user-authored skill frontmatter, so a malformed one should not take the router down. `docs/{a` still matches the literal path `docs/{a`.
- A comma outside braces stays literal, so `a,b.md` is unchanged.
- Negation (`!`) is still unsupported. The issue mentions it in passing, but the title and the reproduction are brace expansion, so I left it alone rather than widen the change.

## Tests

Three cases added to `source/events/event-router.spec.ts`: the alternation itself, unbalanced braces staying literal, and a literal comma outside braces.

The alternation test fails on `main` and passes here:

```text
# against main
✘ [fail]: matchGlob: brace alternation
  1 test failed
```

The other two pass either way by design. They pin behaviour this change must not break, rather than behaviour it adds.

## Commands run

```text
$ npx ava source/events/event-router.spec.ts
  16 tests passed

$ pnpm run test:all
✅ AVA tests passed
✅ Knip check passed
✅ Audit passed
⚠️  Semgrep not installed - skipping security scan
✅ Everything passes!
```

Not run: Semgrep, which is not installed here. Worth noting since `globToRegex` carries a `nosemgrep` line, and I extended that comment to cover the new fixed substrings rather than leaving it describing the old set.

Platform: macOS, Node 24, pnpm 11.

---
<table><tr>
<td><img src="https://github.com/rascal-sl.png?size=48" width="40" height="40" /></td>
<td><strong>Tisankan Jeyakumar</strong><br/>
<img src="https://img.shields.io/badge/Developed-Verified-2ea44f?style=flat-square&logo=github&logoColor=white" alt="Developed and verified" /></td>
</tr></table>
