### PR TITLE
Fix error resolution detection during message compression

### DIFF
--- a/.changeset/fix-error-resolution-context.md
+++ b/.changeset/fix-error-resolution-context.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed message compression so resolution text only marks an error resolved when it appears after that error.

--- a/source/utils/message-compression.spec.ts
+++ b/source/utils/message-compression.spec.ts
@@ -424,6 +424,25 @@ test('compressMessages extracts error information from tool results', t => {
 	t.true(toolMsg?.content?.includes('Error') ?? false);
 });
 
+test('compressMessages ignores resolution text that appears before an error', t => {
+	const tokenizer = createMockTokenizer();
+	const messages: Message[] = [
+		createToolMessage(
+			'execute_bash',
+			'Earlier command completed successfully\nError: ENOENT\nNo such file or directory',
+		),
+		createUserMessage('Recent'),
+	];
+
+	const result = compressMessages(messages, tokenizer, {
+		mode: 'default',
+		keepRecentMessages: 1,
+	});
+
+	const toolMsg = result.compressedMessages[0];
+	t.true(toolMsg?.content?.includes('Resolved: no') ?? false);
+});
+
 test('compressMessages detects success in tool results', t => {
 	const tokenizer = createMockTokenizer();
 	const messages: Message[] = [

--- a/source/utils/message-compression.ts
+++ b/source/utils/message-compression.ts
@@ -301,12 +301,13 @@ function extractErrorInfo(content: string): {
 				}
 			}
 
-			// Check if resolved
+			// Check if resolved after the error occurred
+			const resolutionContext = content.slice(
+				content.indexOf(match[0]) + match[0].length,
+			);
 			const resolved =
-				/fixed|resolved|success|working/i.test(content) &&
-				!/failed|error|broken/i.test(
-					content.slice(content.indexOf(match[0]) + match[0].length),
-				);
+				/fixed|resolved|success|working/i.test(resolutionContext) &&
+				!/failed|error|broken/i.test(resolutionContext);
 
 			return {
 				type: errorType,


### PR DESCRIPTION
## Description

Fixes message-compression error resolution detection so words such as `success`, `fixed`, or `resolved` only count when they appear after the matched error, rather than anywhere earlier in the tool output.

Fixes #1041.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] Added a regression test in `source/utils/message-compression.spec.ts`
- [x] `pnpm exec ava source/utils/message-compression.spec.ts` — 25 passed
- [x] `pnpm test:format`
- [x] `pnpm test:types`
- [x] `pnpm test:lint`
- [x] `pnpm test:knip`

### Manual Testing

Not applicable; this is deterministic message-compression logic.

## Checklist

- [x] Assigned for the open issue
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No documentation update needed
- [x] No breaking changes
- [x] No additional logging needed for this pure utility fix
