### PR TITLE
Use minimal tool profile for unknown model ids

### DIFF
--- a/.changeset/fix-unknown-model-tool-profile.md
+++ b/.changeset/fix-unknown-model-tool-profile.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Changed automatic tool-profile fallback for unknown model ids from `full` to the safer `minimal` profile.

--- a/source/tools/tool-profiles.spec.ts
+++ b/source/tools/tool-profiles.spec.ts
@@ -141,9 +141,12 @@ test('inferToolProfile - MoE ids size by total params, not active count', t => {
 	t.is(inferToolProfile('Qwen3-235B-A22B'), 'full');
 });
 
-test('inferToolProfile - cloud/unknown models default to full', t => {
-	t.is(inferToolProfile('claude-opus-4-8'), 'full');
-	t.is(inferToolProfile('gpt-4o'), 'full');
+test('inferToolProfile - unknown model ids default to minimal', t => {
+	t.is(inferToolProfile('claude-opus-4-8'), 'minimal');
+	t.is(inferToolProfile('gpt-4o'), 'minimal');
+});
+
+test('inferToolProfile - missing model defaults to full', t => {
 	t.is(inferToolProfile(undefined), 'full');
 	t.is(inferToolProfile(''), 'full');
 });
@@ -157,14 +160,15 @@ test('resolveToolProfile - passes through concrete profiles unchanged', t => {
 test('resolveToolProfile - resolves auto from the model', t => {
 	t.is(resolveToolProfile('auto', 'llama3.2:1b'), 'nano');
 	t.is(resolveToolProfile('auto', 'qwen2.5-coder:7b'), 'minimal');
-	t.is(resolveToolProfile('auto', 'gpt-4o'), 'full');
+	t.is(resolveToolProfile('auto', 'gpt-4o'), 'minimal');
 });
 
 test('auto profile resolves via the profile helpers too', t => {
 	t.true(isSingleToolProfile('auto', 'llama3.2:1b'));
 	t.true(isNanoProfile('auto', 'llama3.2:1b'));
 	t.false(isNanoProfile('auto', 'gpt-4o'));
-	t.deepEqual(getToolsForProfile('auto', 'gpt-4o'), []);
+	t.true(isSingleToolProfile('auto', 'gpt-4o'));
+	t.true(getToolsForProfile('auto', 'gpt-4o').includes('agent'));
 	t.true(getToolsForProfile('auto', 'qwen2.5-coder:7b').includes('agent'));
 });
 
@@ -181,6 +185,7 @@ test('TOOL_PROFILE_DESCRIPTIONS - has entries for all profiles', t => {
 
 test('TOOL_PROFILE_TOOLTIPS - has entries for all profiles', t => {
 	t.truthy(TOOL_PROFILE_TOOLTIPS.auto);
+	t.true(TOOL_PROFILE_TOOLTIPS.auto.includes('unknown model ids get minimal'));
 	t.truthy(TOOL_PROFILE_TOOLTIPS.full);
 	t.truthy(TOOL_PROFILE_TOOLTIPS.minimal);
 	t.truthy(TOOL_PROFILE_TOOLTIPS.nano);

--- a/source/tools/tool-profiles.ts
+++ b/source/tools/tool-profiles.ts
@@ -37,7 +37,7 @@ export const TOOL_PROFILE_DESCRIPTIONS: Record<ToolProfile, string> = {
 };
 
 export const TOOL_PROFILE_TOOLTIPS: Record<ToolProfile, string> = {
-	auto: 'Resolves from the model size: tiny models get nano, small models get minimal, larger/cloud models get full. Switching models re-resolves automatically.',
+	auto: 'Resolves from the model size: tiny models get nano, small models get minimal, large models get full, and unknown model ids get minimal. Switching models re-resolves automatically.',
 	full: 'No filtering. All registered tools including MCP servers.',
 	minimal:
 		'8 core tools (edit, bash, search, agent) with slim prompt and single-tool enforcement. Recommended for small models.',
@@ -74,14 +74,14 @@ function modelParamsBillions(model: string): number | null {
 /**
  * Infer a concrete profile from the active model id.
  *
- * Small local models benefit from a slim tool set and prompt; large or
- * cloud-hosted models (no size hint in the id) get the full surface.
+ * Small models benefit from a slim tool set and prompt; large models get the
+ * full surface, while unknown model ids use the safer minimal profile.
  */
 export function inferToolProfile(model?: string): ConcreteProfile {
 	if (!model) return 'full';
 
 	const params = modelParamsBillions(model);
-	if (params === null) return 'full'; // cloud / unknown — assume capable
+	if (params === null) return 'minimal'; // unknown size — prefer the safer slim profile
 	if (params <= 4) return 'nano';
 	if (params <= 15) return 'minimal';
 	return 'full';


### PR DESCRIPTION
## Description

Change automatic tool-profile inference so model ids with no recognizable size hint use the safer `minimal` profile instead of `full`. A completely missing model still defaults to `full`, preserving startup behavior before a model is known.

Fixes #1013.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a patch changeset

## Testing

- [x] Updated regression coverage for unknown model ids and missing-model behavior
- [x] `pnpm exec ava source/tools/tool-profiles.spec.ts` — 24 passed
- [x] `pnpm test:types`
- [x] `pnpm test:format`
- [x] `pnpm test:lint`
- [x] `pnpm test:knip`
- [x] `pnpm test:audit`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes
