### PR TITLE
fix: correct boundary inclusiveness in atomic deletion

### DIFF
--- a/.changeset/pr-977-fix-boundary.md
+++ b/.changeset/pr-977-fix-boundary.md
@@ -1,0 +1,5 @@
+---
+"nanocoder": patch
+---
+
+Fix atomic-deletion boundary off-by-one errors

--- a/source/utils/atomic-deletion.spec.ts
+++ b/source/utils/atomic-deletion.spec.ts
@@ -133,6 +133,11 @@ test('findPlaceholderAtPosition finds placeholder ID', t => {
 	// Position after placeholder
 	const result3 = findPlaceholderAtPosition(text, 35); // In "after"
 	t.is(result3, null);
+
+	// Position exactly at the end boundary (should not match)
+	// placeholder ends at index 30
+	const result4 = findPlaceholderAtPosition(text, 30);
+	t.is(result4, null);
 });
 
 test('wouldPartiallyDeletePlaceholder detects partial deletion', t => {
@@ -152,6 +157,16 @@ test('wouldPartiallyDeletePlaceholder detects partial deletion', t => {
 	// Deletion outside placeholder
 	const result3 = wouldPartiallyDeletePlaceholder(text, 0, 4); // Delete "Text"
 	t.false(result3);
+
+	// Boundary edge: delete exactly the space after placeholder (ends at 28)
+	// deletionStart = 28, length = 1
+	const result4 = wouldPartiallyDeletePlaceholder(text, 28, 1);
+	t.false(result4);
+
+	// Boundary edge: delete exactly the space before placeholder (ends at 5)
+	// deletionStart = 4, length = 1
+	const result5 = wouldPartiallyDeletePlaceholder(text, 4, 1);
+	t.false(result5);
 });
 
 // Integration test showing complete flow

--- a/source/utils/atomic-deletion.ts
+++ b/source/utils/atomic-deletion.ts
@@ -46,7 +46,7 @@ export function handleAtomicDeletion(
 
 		if (
 			(deletionStart >= placeholderStart && deletionStart < placeholderEnd) ||
-			(deletionEnd > placeholderStart && deletionEnd <= placeholderEnd) ||
+			(deletionEnd > placeholderStart && deletionEnd < placeholderEnd) ||
 			(deletionStart <= placeholderStart && deletionEnd >= placeholderEnd)
 		) {
 			// Deletion affects this placeholder - remove it atomically
@@ -79,7 +79,7 @@ export function findPlaceholderAtPosition(
 		const placeholderStart = match.index;
 		const placeholderEnd = placeholderStart + match[0].length;
 
-		if (position >= placeholderStart && position <= placeholderEnd) {
+		if (position >= placeholderStart && position < placeholderEnd) {
 			return match[1]; // Return the placeholder ID
 		}
 	}
@@ -108,7 +108,7 @@ export function wouldPartiallyDeletePlaceholder(
 		const overlapsStart =
 			deletionStart >= placeholderStart && deletionStart < placeholderEnd;
 		const overlapsEnd =
-			deletionEnd > placeholderStart && deletionEnd <= placeholderEnd;
+			deletionEnd > placeholderStart && deletionEnd < placeholderEnd;
 		const spansPast =
 			deletionStart < placeholderStart && deletionEnd > placeholderStart;
 		const spansOver =

--- a/source/utils/paste-roundtrip.spec.ts
+++ b/source/utils/paste-roundtrip.spec.ts
@@ -164,7 +164,7 @@ function handleAtomicDeletion(
 
 		if (
 			(deletionStart >= placeholderStart && deletionStart < placeholderEnd) ||
-			(deletionEnd > placeholderStart && deletionEnd <= placeholderEnd) ||
+			(deletionEnd > placeholderStart && deletionEnd < placeholderEnd) ||
 			(deletionStart <= placeholderStart && deletionEnd >= placeholderEnd)
 		) {
 			// Deletion affects this placeholder - remove it atomically


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause: Boundary checks for placeholders inconsistently used `<=` instead of strict `<` against `placeholderEnd`, meaning operations ending exactly at the edge were incorrectly flagged as overlapping.
Fix: Replaced `deletionEnd <= placeholderEnd` and `position <= placeholderEnd` with `<` operators in `source/utils/atomic-deletion.ts` (and its duplicated spec version). Added exact boundary test cases. Also added a changeset.
Validation: Ran `pnpm run build`, `pnpm test:format`, `pnpm test:lint`, `pnpm test:types`, `pnpm test:knip`, and `pnpm test:ava`. All checks passed successfully.
Fixes https://github.com/Nano-Collective/nanocoder/issues/977

Fixes #977
