### PR TITLE
fix(file-ops): keep replacement text literal in string_replace and diff_edit

### DIFF
--- a/.changeset/fix-literal-replacement-dollar-tokens.md
+++ b/.changeset/fix-literal-replacement-dollar-tokens.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed `string_replace` and `diff_edit` corrupting edits whose replacement text contains `$`. Both tools passed the model's replacement straight to `String.prototype.replace`, which treats that argument as a substitution template rather than a literal: `$$` collapsed to a single `$`, `$&` expanded to the matched text, and ``$` ``/`$'` spliced a whole half of the file into the middle of the edit. Those are ordinary characters in shell scripts, Makefiles, CI YAML and anything that builds a regex, so the bytes on disk silently diverged from the diff the user approved. Replacements are now spliced by index, so the approved preview - in the terminal and over ACP - is what lands. Closes #1057.

--- a/source/acp/acp-tool-call.spec.ts
+++ b/source/acp/acp-tool-call.spec.ts
@@ -222,3 +222,24 @@ test('buildToolCallMeta - withDiff true is the default', async t => {
 		rmSync(dir, {recursive: true, force: true});
 	}
 });
+
+test('buildToolCallMeta - string_replace diff shows $ tokens literally', async t => {
+	const dir = mkdtempSync(join(tmpdir(), 'acp-tc-'));
+	const file = join(dir, 'run.sh');
+	writeFileSync(file, '#!/bin/sh\necho "old"\nexit 0\n');
+	const replacement = 'echo "pid=$$ match=$& pre=$` post=$\'"';
+	try {
+		const meta = await buildToolCallMeta(
+			makeCall('string_replace', {
+				path: file,
+				old_str: 'echo "old"',
+				new_str: replacement,
+			}),
+		);
+		// The previewed diff has to be the diff that lands on disk.
+		const diff = meta.content[0] as any;
+		t.is(diff.newText, `#!/bin/sh\n${replacement}\nexit 0\n`);
+	} finally {
+		rmSync(dir, {recursive: true, force: true});
+	}
+});

--- a/source/acp/acp-tool-call.ts
+++ b/source/acp/acp-tool-call.ts
@@ -6,6 +6,7 @@ import type {
 	ToolKind,
 } from '@agentclientprotocol/sdk';
 import type {ToolCall} from '@/types/core';
+import {replaceFirstLiteral} from '@/utils/literal-replace';
 
 export interface AcpToolCallMeta {
 	title: string;
@@ -169,7 +170,7 @@ async function buildStringReplaceDiff(
 		type: 'diff',
 		path: absPath,
 		oldText: current,
-		newText: current.replace(oldStr, newStr),
+		newText: replaceFirstLiteral(current, oldStr, newStr),
 	};
 }
 

--- a/source/tools/file-ops/diff-edit.spec.tsx
+++ b/source/tools/file-ops/diff-edit.spec.tsx
@@ -365,3 +365,43 @@ test('diff_edit description tells models not to wrap diff in code fences', t => 
 		/do not wrap.*code fence|code fence.*do not wrap/i,
 	);
 });
+
+// `$$`, `$&`, "$`" and `$'` are substitution tokens to String.prototype.replace
+// but ordinary characters in the shell scripts and CI YAML models edit.
+test('diff_edit writes $ substitution tokens literally', async t => {
+	const filePath = await createTestFile(
+		'dollars.sh',
+		'#!/bin/sh\necho "old"\nexit 0\n',
+	);
+	const replacement = 'echo "pid=$$ match=$& pre=$` post=$\'"';
+
+	await executeDiffEdit({
+		path: filePath,
+		diff: diffBlock('echo "old"', replacement),
+	});
+
+	t.is(
+		await readFile(filePath, 'utf-8'),
+		`#!/bin/sh\n${replacement}\nexit 0\n`,
+	);
+});
+
+test('diff_edit keeps $ tokens literal across multiple blocks', async t => {
+	const filePath = await createTestFile(
+		'multi.yml',
+		'first: OLD_A\nsecond: OLD_B\n',
+	);
+
+	await executeDiffEdit({
+		path: filePath,
+		diff: [
+			diffBlock('first: OLD_A', 'first: "$&"'),
+			diffBlock('second: OLD_B', "second: \"$`$'\""),
+		].join('\n\n'),
+	});
+
+	t.is(
+		await readFile(filePath, 'utf-8'),
+		'first: "$&"\nsecond: "$`$\'"\n',
+	);
+});

--- a/source/tools/file-ops/diff-edit.tsx
+++ b/source/tools/file-ops/diff-edit.tsx
@@ -10,6 +10,7 @@ import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
 import {getCachedFileContent, invalidateCache} from '@/utils/file-cache';
+import {replaceFirstLiteral} from '@/utils/literal-replace';
 import {validatePath} from '@/utils/path-validators';
 import {hasSeenFile, markFileSeen} from '@/utils/read-tracker';
 import {createFileToolApproval} from '@/utils/tool-approval';
@@ -162,7 +163,7 @@ function applyBlocks(fileContent: string, blocks: DiffEditBlock[]): string {
 			);
 		}
 
-		newContent = newContent.replace(block.search, block.replace);
+		newContent = replaceFirstLiteral(newContent, block.search, block.replace);
 	});
 
 	return newContent;

--- a/source/tools/file-ops/string-replace.spec.tsx
+++ b/source/tools/file-ops/string-replace.spec.tsx
@@ -1029,3 +1029,77 @@ test('string_replace formatter: normalizes tabs to 2 spaces', async t => {
 	t.regex(output!, /string_replace/);
 	t.regex(output!, /Path:/);
 });
+
+// ============================================================================
+// Literal Replacement Tests
+// ============================================================================
+
+// `$$`, `$&`, "$`" and `$'` are ordinary characters in shell scripts,
+// Makefiles and CI YAML, but they are substitution tokens to
+// String.prototype.replace. The replacement must land byte for byte.
+const DOLLAR_TOKENS = 'echo "pid=$$ match=$& pre=$` post=$\'"';
+
+test('string_replace: writes $ substitution tokens literally', async t => {
+	const filePath = await createTestFile(
+		'dollars.sh',
+		'#!/bin/sh\necho "old"\nexit 0\n',
+	);
+
+	await executeStringReplace({
+		path: filePath,
+		old_str: 'echo "old"',
+		new_str: DOLLAR_TOKENS,
+	});
+
+	t.is(
+		await readFile(filePath, 'utf-8'),
+		`#!/bin/sh\n${DOLLAR_TOKENS}\nexit 0\n`,
+	);
+});
+
+test('string_replace: $` and $\' do not splice the rest of the file in', async t => {
+	const filePath = await createTestFile(
+		'halves.txt',
+		'BEFORE\nTARGET\nAFTER\n',
+	);
+
+	await executeStringReplace({
+		path: filePath,
+		old_str: 'TARGET',
+		new_str: "$`$'",
+	});
+
+	const newContent = await readFile(filePath, 'utf-8');
+	t.is(newContent, "BEFORE\n$`$'\nAFTER\n");
+	t.false(newContent.includes('BEFORE\nBEFORE'));
+});
+
+test('string_replace: $ tokens in old_str still match and are removable', async t => {
+	const filePath = await createTestFile(
+		'makefile',
+		'all:\n\t@echo $$HOME $(shell pwd)\n',
+	);
+
+	await executeStringReplace({
+		path: filePath,
+		old_str: '@echo $$HOME $(shell pwd)',
+		new_str: '@echo $$PWD',
+	});
+
+	t.is(await readFile(filePath, 'utf-8'), 'all:\n\t@echo $$PWD\n');
+});
+
+test('string_replace: numbered group tokens stay literal', async t => {
+	const filePath = await createTestFile('groups.sh', 'run "old"\n');
+
+	await executeStringReplace({
+		path: filePath,
+		old_str: 'run "old"',
+		new_str: 'printf "%s\n" "$1" "$2" "$<" "$@"',
+	});
+
+	t.is(
+		await readFile(filePath, 'utf-8'),
+		'printf "%s\n" "$1" "$2" "$<" "$@"\n',
+	);
+});

--- a/source/tools/file-ops/string-replace.tsx
+++ b/source/tools/file-ops/string-replace.tsx
@@ -8,6 +8,7 @@ import type {NanocoderToolExport} from '@/types/core';
 import {jsonSchema, tool} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
 import {getCachedFileContent, invalidateCache} from '@/utils/file-cache';
+import {replaceFirstLiteral} from '@/utils/literal-replace';
 import {validatePath} from '@/utils/path-validators';
 import {hasSeenFile, markFileSeen} from '@/utils/read-tracker';
 import {createFileToolApproval} from '@/utils/tool-approval';
@@ -88,7 +89,7 @@ const executeStringReplace = async (
 		);
 	}
 
-	const newContent = fileContent.replace(old_str, new_str);
+	const newContent = replaceFirstLiteral(fileContent, old_str, new_str);
 	await writeFile(absPath, newContent, 'utf-8');
 	invalidateCache(absPath);
 	// The model now knows the file's current contents, so a follow-up edit is
@@ -162,7 +163,7 @@ const stringReplaceFormatter = async (
 
 			const occurrences = fileContent.split(old_str).length - 1;
 			if (occurrences === 1) {
-				const newContent = fileContent.replace(old_str, new_str);
+				const newContent = replaceFirstLiteral(fileContent, old_str, new_str);
 
 				const changeId = sendFileChangeToVSCode(
 					absPath,

--- a/source/utils/literal-replace.spec.ts
+++ b/source/utils/literal-replace.spec.ts
@@ -1,0 +1,54 @@
+import test from 'ava';
+import {replaceFirstLiteral} from '@/utils/literal-replace';
+
+console.log('\nliteral-replace.spec.ts');
+
+test('replaceFirstLiteral replaces the first occurrence only', t => {
+	t.is(replaceFirstLiteral('a b a b', 'a', 'X'), 'X b a b');
+});
+
+test('replaceFirstLiteral returns the content unchanged when absent', t => {
+	t.is(replaceFirstLiteral('hello', 'nope', 'X'), 'hello');
+});
+
+test('replaceFirstLiteral does not collapse $$', t => {
+	t.is(replaceFirstLiteral('pid=X', 'X', '$$'), 'pid=$$');
+});
+
+test('replaceFirstLiteral does not expand $& into the match', t => {
+	t.is(replaceFirstLiteral('a MATCH b', 'MATCH', '$&'), 'a $& b');
+});
+
+test('replaceFirstLiteral does not expand $` into the prefix', t => {
+	t.is(replaceFirstLiteral('BEFORE|X|AFTER', 'X', '$`'), 'BEFORE|$`|AFTER');
+});
+
+test("replaceFirstLiteral does not expand $' into the suffix", t => {
+	t.is(replaceFirstLiteral('BEFORE|X|AFTER', 'X', "$'"), "BEFORE|$'|AFTER");
+});
+
+test('replaceFirstLiteral keeps group tokens literal', t => {
+	t.is(replaceFirstLiteral('X', 'X', '$1 $<name> $99'), '$1 $<name> $99');
+});
+
+test('replaceFirstLiteral carries every token through in one pass', t => {
+	const replacement = 'echo "pid=$$ match=$& pre=$` post=$\'"';
+
+	t.is(
+		replaceFirstLiteral('#!/bin/sh\necho "old"\nexit 0\n', 'echo "old"', replacement),
+		`#!/bin/sh\n${replacement}\nexit 0\n`,
+	);
+});
+
+test('replaceFirstLiteral handles an empty replacement (deletion)', t => {
+	t.is(replaceFirstLiteral('keep DROP keep', 'DROP ', ''), 'keep keep');
+});
+
+test('replaceFirstLiteral matches String.replace for $-free input', t => {
+	const content = 'alpha\nbeta\ngamma\n';
+
+	t.is(
+		replaceFirstLiteral(content, 'beta', 'BETA'),
+		content.replace('beta', 'BETA'),
+	);
+});

--- a/source/utils/literal-replace.ts
+++ b/source/utils/literal-replace.ts
@@ -1,0 +1,28 @@
+/**
+ * Replace the first occurrence of `search` with `replacement`, treating the
+ * replacement as literal text.
+ *
+ * `String.prototype.replace` runs GetSubstitution over its second argument, so
+ * `$$`, `$&`, "$`" and `$'` are rewritten before the result is produced. Those
+ * are ordinary characters in shell scripts, Makefiles, CI YAML and anything
+ * that builds a regex, so an edit tool that passes model-supplied text straight
+ * to `replace` silently writes bytes nobody approved — and "$`" / `$'` splice
+ * a whole half of the file into the middle of the edit.
+ *
+ * Splicing by index sidesteps substitution parsing entirely and avoids
+ * re-scanning the string for a second pass.
+ */
+export function replaceFirstLiteral(
+	content: string,
+	search: string,
+	replacement: string,
+): string {
+	const index = content.indexOf(search);
+	if (index === -1) {
+		return content;
+	}
+
+	return (
+		content.slice(0, index) + replacement + content.slice(index + search.length)
+	);
+}


### PR DESCRIPTION
## Description

Closes #1057.

`string_replace` and `diff_edit` passed the model's replacement straight to
`String.prototype.replace`. That second argument is a substitution template, not a
literal, so the engine ran `GetSubstitution` over it and rewrote four token sequences
before the bytes reached disk:

| token | became |
|---|---|
| `$$` | a single `$` |
| `$&` | the matched text |
| ``$` `` | everything **before** the match |
| `$'` | everything **after** the match |

The last two duplicate a whole half of the file into the middle of the edit, so the
damage scaled with file size.

These are ordinary characters in shell scripts, Makefiles, docker-compose files, CI
YAML, and anything that builds a regex. The tool reported success and nothing warned
the model or the user, so the approval gate was bypassed by construction: the
confirmation renders `old_str` / `new_str` directly, so the diff the user approved was
not the diff that landed.

### Fix

`replaceFirstLiteral` splices by index, which sidesteps substitution parsing entirely
and avoids re-scanning the string for a second pass. Four call sites:

- `source/tools/file-ops/string-replace.tsx` the write path
- `source/tools/file-ops/string-replace.tsx` the VS Code diff in the formatter
- `source/tools/file-ops/diff-edit.tsx` once per block in `applyBlocks`
- `source/acp/acp-tool-call.ts` the ACP whole-file diff preview

The ACP site is not named in the issue, but it synthesizes the same post-edit content
for the diff shown over ACP and would have desynced from disk the same way. Both
previews now match what is written.

`string-replace-preview.tsx` renders `new_str` directly and needed no change.

Every call site is already guarded by an existing uniqueness check, so the helper's
not-found branch is a defensive no-op rather than a silently skipped edit.

Three production lines changed, plus one 28-line helper.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
