### PR TITLE
add fix(lsp): resolve verification promise on early process exit to p…

### DIFF
--- a/source/lsp/server-discovery.ts
+++ b/source/lsp/server-discovery.ts
@@ -328,6 +328,7 @@ function verifyLSPServerWithCommunication(
 			// A clean exit can also indicate success for some servers
 			// However, for LSP servers waiting for input, an immediate exit is often a failure
 			// The 'spawn' event is a more reliable indicator for our purpose
+			resolve(false);
 		});
 	});
 }


### PR DESCRIPTION
## Description

Fixes a hang in `verifyLSPServerWithCommunication` (source/lsp/server-discovery.ts): the `exit` handler cleared the timeout but never resolved the promise, so LSP discovery could stall if a server's process exited before the `spawn` event fired. The handler now calls `resolve(false)`.

Fixes #1037

## Type of Change

- [x] Bug fix

## Changeset

- [x] Ran `pnpm changeset --empty` (internal fix, no changelog entry needed)

## Testing

### Automated Tests

- [x] All existing tests pass (`pnpm run test:ava source/lsp/server-discovery.spec.ts`)

### Manual Testing

- [x] Verified via a standalone reproduction (mocked child process emitting only `exit`): confirmed the promise hung before the fix and resolves to `false` immediately after
- [x] Ran the real `discoverLanguageServers()` end-to-end against a fake crashing binary on `PATH` — no hang, correct output

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes
