### PR TITLE
fix(search): reject any failed ripgrep run, not just recognized ones

### DIFF
--- a/.changeset/ripgrep-file-search.md
+++ b/.changeset/ripgrep-file-search.md
@@ -5,3 +5,5 @@
 File search (path matching and content search) is now backed by `ripgrep` instead of a hand-rolled JS walker.
 
 Search also respects `.nanocoderignore` and binary files again, matching `list_directory` and file autocomplete.
+
+A failed search now reports the failure instead of returning an empty result set.

--- a/source/utils/file-search.spec.ts
+++ b/source/utils/file-search.spec.ts
@@ -1,4 +1,4 @@
-import {mkdirSync, rmSync, symlinkSync, writeFileSync} from 'node:fs';
+import {chmodSync, mkdirSync, rmSync, symlinkSync, writeFileSync} from 'node:fs';
 import {writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
@@ -8,7 +8,6 @@ import {
 	findMatchingPaths,
 	GLOB_TOKEN_CACHE_MAX_TOKENS,
 	globTokenCache,
-	isFatalRipgrepError,
 	matchesGlob,
 	searchProjectContents,
 	SearchTimeoutError,
@@ -1101,14 +1100,34 @@ test.serial(
 	},
 );
 
-test(
-	'isFatalRipgrepError recognizes a build of ripgrep with no PCRE2 support (real on Linux ARM)',
-	t => {
-		t.true(
-			isFatalRipgrepError(
-				'rg: PCRE2 is not available in this build of ripgrep',
-			),
-		);
+// chmod 0o000 does not stop root, and Windows ignores the mode entirely.
+const unreadableDirTest =
+	process.platform === 'win32' || process.getuid?.() === 0
+		? test.serial.skip
+		: test.serial;
+
+unreadableDirTest(
+	'walkProjectEntries surfaces an unreadable search root instead of reporting no files',
+	async t => {
+		const testDir = createTempDir('test-file-search-unreadable-temp');
+		const lockedDir = join(testDir, 'locked');
+
+		try {
+			mkdirSync(lockedDir, {recursive: true});
+			writeFileSync(join(lockedDir, 'a.txt'), 'hello\n');
+			// rg exits 2 with "Permission denied (os error 13)" on an empty stdout. That
+			// message is in no allowlist, so gating rejection on recognized stderr would
+			// report this as an ordinary empty result.
+			chmodSync(lockedDir, 0o000);
+
+			await t.throwsAsync(
+				() => walkProjectEntries(testDir, lockedDir, () => false),
+				{message: /ripgrep exited with code 2/},
+			);
+		} finally {
+			chmodSync(lockedDir, 0o755);
+			rmSync(testDir, {recursive: true, force: true});
+		}
 	},
 );
 

--- a/source/utils/file-search.ts
+++ b/source/utils/file-search.ts
@@ -249,23 +249,6 @@ function binaryExcludeGlobs(): string[] {
 	return globs;
 }
 
-const FATAL_RIPGREP_ERROR_PATTERNS = [
-	/regex parse error/,
-	/error parsing glob/,
-	/PCRE2: error compiling pattern/,
-	/PCRE2 is not available in this build of ripgrep/,
-	/grep config error: unknown encoding/,
-];
-
-/** @internal Exported for direct unit testing only. */
-export function isFatalRipgrepError(stderr: string): boolean {
-	const firstLine = stderr.split('\n')[0]?.trim() ?? '';
-	if (firstLine.startsWith('the literal')) {
-		return true;
-	}
-	return FATAL_RIPGREP_ERROR_PATTERNS.some(pattern => pattern.test(stderr));
-}
-
 interface RunRipgrepResult {
 	stdout: string;
 	hitMaxLines: boolean;
@@ -396,14 +379,22 @@ async function runRipgrep(
 				reject(new Error(`ripgrep terminated by signal ${closeSignal}`));
 				return;
 			}
-			// Exit 1 = no matches. Exit 2 can be a recoverable mid-scan warning; only fail if empty.
-			if (
-				code !== null &&
-				code > 1 &&
-				stdout.length === 0 &&
-				isFatalRipgrepError(stderr)
-			) {
-				reject(new Error(`ripgrep exited with code ${code}: ${stderr.trim()}`));
+			// Exit 1 = no matches. Exit 2 with output is a recoverable mid-scan warning
+			// (one unreadable subdirectory, say) - rg scanned the rest, so keep it.
+			//
+			// Exit 2 with nothing on stdout means the search never produced anything:
+			// an unreadable root, a rejected argument, a build without PCRE2 (real on
+			// Linux ARM). Deliberately no stderr allowlist here - anything rg says that
+			// nobody enumerated would otherwise fall through to `resolve('')`, and every
+			// caller reads that as a genuine "no results" rather than a failure.
+			if (code !== null && code > 1 && stdout.length === 0) {
+				reject(
+					new Error(
+						`ripgrep exited with code ${code}: ${
+							stderr.trim() || 'no error output'
+						}`,
+					),
+				);
 				return;
 			}
 			resolve({stdout, hitMaxLines: false});


### PR DESCRIPTION
Follow-up to #928. That review asked for the error check in `runRipgrep` to be inverted so `code > 1 && stdout.length === 0` rejects regardless of whether stderr is recognized. The system `rg` probe was dropped as requested, but this half was not, so the gate still read:

```ts
if (code !== null && code > 1 && stdout.length === 0 && isFatalRipgrepError(stderr)) {
```

`isFatalRipgrepError` matched five hardcoded patterns. Any rg failure outside that list resolved with an empty stdout, and `find_files`, `search_file_contents`, `@`-autocomplete and `/repomap` all read that as a genuine "no results".

The concrete case remaining after #928: `rg --files` on a directory the process cannot read exits 2 with `Permission denied (os error 13)` and an empty stdout. That string is in no pattern, so today the search silently reports zero files.

## Change

Reject whenever rg exits > 1 with nothing on stdout, with the rg stderr in the message.

Exit 2 *with* output is still a recoverable mid-scan warning, so a tree containing one unreadable subdirectory keeps the results from everywhere else. Worth noting the two modes differ here: `--files` writes nothing on a failed root, while `--json` always emits a trailing `summary` object, so content search only takes this path on a pre-scan failure (bad regex, rejected argument, a build without PCRE2).

`FATAL_RIPGREP_ERROR_PATTERNS` and `isFatalRipgrepError` become unreachable. Their only remaining caller was a unit test, so both are deleted rather than left as a test-only island that knip does not flag.

## Trade-off

A search whose root is entirely unreadable now throws where it previously returned "no matches". That is the intended behavior change: an error the user can act on beats a permanent silent zero.

## Tests

New: `walkProjectEntries surfaces an unreadable search root instead of reporting no files`. Verified it fails against the pre-change `file-search.ts` and passes after. Skipped on Windows and under uid 0, since neither honors `chmod 0o000`.

Dropped: the `isFatalRipgrepError` predicate test. The behavior it guarded (a build without PCRE2 must not look like an empty result) is now covered structurally, since every empty-stdout failure rejects.

`source/utils/file-search.spec.ts` 48 passed, plus `ripgrep-path`, `file-autocomplete` and `repo-map` specs, `tsc --noEmit`, biome and knip clean.

## Changeset

Amended `.changeset/ripgrep-file-search.md` rather than adding a new entry, since #928 has not been released yet and a separate "fix" line would describe repairing behavior no user ever saw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBj99nj4yUg8QnewgVfFGs