### PR TITLE
fix(search): prune .nanocoderignore during the walk, type the unsorted visitor

### DIFF
--- a/.changeset/ripgrep-file-search.md
+++ b/.changeset/ripgrep-file-search.md
@@ -7,3 +7,5 @@ File search (path matching and content search) is now backed by `ripgrep` instea
 Search also respects `.nanocoderignore` and binary files again, matching `list_directory` and file autocomplete.
 
 A failed search now reports the failure instead of returning an empty result set.
+
+`.nanocoderignore` directories are skipped during the walk rather than filtered afterwards, so a large ignored directory can no longer crowd real files out of the results.

--- a/source/utils/file-search.spec.ts
+++ b/source/utils/file-search.spec.ts
@@ -409,6 +409,73 @@ test.serial(
 );
 
 test.serial(
+	'a .nanocoderignore directory is pruned during traversal, not just filtered from results',
+	async t => {
+		const testDir = createTempDir('test-file-search-nanocoderignore-prune-temp');
+
+		try {
+			mkdirSync(join(testDir, 'fixtures'), {recursive: true});
+			mkdirSync(join(testDir, 'src'), {recursive: true});
+			writeFileSync(join(testDir, '.nanocoderignore'), 'fixtures/\n');
+			// Sorts before src/, so a JS-side filter alone would let these 20 spend
+			// the whole scan budget and crowd keep.ts out of the results entirely.
+			for (let index = 0; index < 20; index++) {
+				writeFileSync(
+					join(testDir, 'fixtures', `f${String(index).padStart(2, '0')}.txt`),
+					'noise',
+				);
+			}
+			writeFileSync(join(testDir, 'src', 'keep.ts'), 'export {};');
+
+			const seen: string[] = [];
+			const result = await walkProjectEntries(
+				testDir,
+				undefined,
+				entry => {
+					seen.push(entry.relativePath);
+					return false;
+				},
+				{includeDirectories: false, maxRawFilesScanned: 5},
+			);
+
+			t.true(seen.includes('src/keep.ts'));
+			t.false(seen.some(entry => entry.startsWith('fixtures/')));
+			t.false(result.truncated);
+		} finally {
+			rmSync(testDir, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
+	'walkProjectEntries rejects an async onEntry under sorted: false rather than racing it',
+	async t => {
+		const testDir = createTempDir('test-file-search-async-visitor-temp');
+
+		try {
+			mkdirSync(testDir, {recursive: true});
+			writeFileSync(join(testDir, 'a.txt'), 'hello\n');
+
+			// The overloads make this a compile error; this guards the runtime
+			// backstop for callers without type checking.
+			const asyncVisitor = async () => false;
+			await t.throwsAsync(
+				() =>
+					walkProjectEntries(
+						testDir,
+						undefined,
+						asyncVisitor as unknown as () => boolean,
+						{sorted: false},
+					),
+				{message: /onEntry must be synchronous/},
+			);
+		} finally {
+			rmSync(testDir, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
 	'findMatchingPaths lets .nanocoderignore un-ignore a DEFAULT_IGNORE_DIRS entry',
 	async t => {
 		const testDir = createTempDir('test-file-search-nanocoderignore-unignore-temp');

--- a/source/utils/file-search.ts
+++ b/source/utils/file-search.ts
@@ -6,7 +6,11 @@ import ignore from 'ignore';
 import {LRUCache} from 'lru-cache';
 
 import {BINARY_FILE_EXTENSIONS} from '@/constants';
-import {DEFAULT_IGNORE_DIRS, loadGitignore} from '@/utils/gitignore-loader';
+import {
+	DEFAULT_IGNORE_DIRS,
+	findNanocoderIgnoreFile,
+	loadGitignore,
+} from '@/utils/gitignore-loader';
 import {getLogger} from '@/utils/logging';
 import {resolveRipgrepPath} from '@/utils/ripgrep-path';
 
@@ -234,6 +238,23 @@ function defaultIgnoreGlobs(
 	return globs;
 }
 
+/**
+ * Hands .nanocoderignore to rg so it prunes during traversal.
+ *
+ * The JS-side `projectIgnore.ignores()` filter downstream would drop these
+ * paths anyway, but only after rg had walked them and after they had already
+ * spent budget against `maxRawFilesScanned` - a large ignored fixtures
+ * directory could crowd real files out of the results entirely.
+ *
+ * rg applies `--ignore-file` rules after .gitignore and after `.ignore`, which
+ * is the layering {@link loadGitignore} documents. Omitted when the file does
+ * not exist: rg warns on a missing path, and every search would carry it.
+ */
+function nanocoderIgnoreFileArgs(cwd: string): string[] {
+	const ignoreFile = findNanocoderIgnoreFile(cwd);
+	return ignoreFile ? ['--ignore-file', ignoreFile] : [];
+}
+
 async function assertPathExists(candidatePath: string): Promise<void> {
 	await lstat(candidatePath);
 }
@@ -284,6 +305,21 @@ async function runRipgrep(
 
 		child.stdout.setEncoding('utf8');
 		child.stdout.on('data', (chunk: string) => {
+			// This runs on the stream's event loop turn, not inside the promise
+			// executor, so a throw from onLine would escape as an uncaught
+			// exception and take the process down instead of failing the search.
+			try {
+				consumeChunk(chunk);
+			} catch (err) {
+				// Reusing killedForLimit to ignore any chunks still in flight. The
+				// promise is already rejected, so the close handler's resolve is a no-op.
+				killedForLimit = true;
+				child.kill();
+				reject(err instanceof Error ? err : new Error(String(err)));
+			}
+		});
+
+		function consumeChunk(chunk: string): void {
 			if (killedForLimit) {
 				return;
 			}
@@ -340,7 +376,7 @@ async function runRipgrep(
 
 				newlineIndex = lineRemainder.indexOf('\n');
 			}
-		});
+		}
 
 		child.stderr.setEncoding('utf8');
 		child.stderr.on('data', (chunk: string) => {
@@ -534,15 +570,34 @@ async function walkEmptyDirectories(
 }
 
 export interface WalkProjectEntriesOptions {
+	/** Emit directory entries alongside files. Defaults to true. */
 	includeDirectories?: boolean;
 	signal?: AbortSignal;
 	maxRawFilesScanned?: number;
-	// Unsorted streams results early but isn't guaranteed faster - rg's discovery order is non-deterministic.
+	/**
+	 * Sort entries by path. Defaults to true.
+	 *
+	 * Unsorted streams results early but isn't guaranteed faster - rg's
+	 * discovery order is non-deterministic.
+	 *
+	 * `sorted: false` reads entries off rg's stdout as it arrives, so `onEntry`
+	 * MUST be synchronous there: returning a promise would let the stream run
+	 * ahead of the callback. The overloads below make that a compile error, and
+	 * {@link emitEntrySync} throws if a JS caller slips one through anyway.
+	 */
 	sorted?: boolean;
 }
 
+/** `onEntry` shape accepted when entries stream in unsorted - no promises. */
+export type SyncProjectEntryVisitor = (entry: ProjectEntry) => boolean;
+
+/** `onEntry` shape accepted when entries are sorted and emitted one at a time. */
+export type ProjectEntryVisitor = (
+	entry: ProjectEntry,
+) => boolean | Promise<boolean>;
+
 function emitEntrySync(
-	onEntry: (entry: ProjectEntry) => boolean | Promise<boolean>,
+	onEntry: ProjectEntryVisitor,
 	entry: ProjectEntry,
 ): boolean {
 	const stop = onEntry(entry);
@@ -558,7 +613,7 @@ async function walkUnsortedFileStream(
 	cwd: string,
 	rootPath: string,
 	args: string[],
-	onEntry: (entry: ProjectEntry) => boolean | Promise<boolean>,
+	onEntry: ProjectEntryVisitor,
 	includeDirectories: boolean,
 	projectIgnore: ReturnType<typeof loadGitignore>,
 	signal: AbortSignal | undefined,
@@ -574,6 +629,8 @@ async function walkUnsortedFileStream(
 		}
 
 		const relativeFile = normalizePathForMatch(path.relative(cwd, file));
+		// rg already pruned these via --ignore-file; kept as a backstop because
+		// its matcher and the `ignore` package are separate implementations.
 		if (projectIgnore.ignores(relativeFile)) {
 			return false;
 		}
@@ -644,10 +701,29 @@ async function walkUnsortedFileStream(
 	return {truncated: hitMaxLines || hitDirCap};
 }
 
+/**
+ * Walk every non-ignored file (and, by default, directory) under `startPath`,
+ * calling `onEntry` for each. Return true from `onEntry` to stop the walk.
+ *
+ * With `sorted: false`, entries stream straight off rg's stdout and `onEntry`
+ * must be synchronous - see {@link WalkProjectEntriesOptions.sorted}.
+ */
 export async function walkProjectEntries(
 	cwd: string,
 	startPath: string | undefined,
-	onEntry: (entry: ProjectEntry) => boolean | Promise<boolean>,
+	onEntry: SyncProjectEntryVisitor,
+	options: WalkProjectEntriesOptions & {sorted: false},
+): Promise<{truncated: boolean}>;
+export async function walkProjectEntries(
+	cwd: string,
+	startPath: string | undefined,
+	onEntry: ProjectEntryVisitor,
+	options?: WalkProjectEntriesOptions & {sorted?: true},
+): Promise<{truncated: boolean}>;
+export async function walkProjectEntries(
+	cwd: string,
+	startPath: string | undefined,
+	onEntry: ProjectEntryVisitor,
 	options: WalkProjectEntriesOptions = {},
 ): Promise<{truncated: boolean}> {
 	const {
@@ -667,6 +743,7 @@ export async function walkProjectEntries(
 		'--no-require-git',
 		'--no-config',
 		...(sorted ? ['--sort', 'path'] : []),
+		...nanocoderIgnoreFileArgs(cwd),
 		...defaultIgnoreGlobs(projectIgnore),
 		'--',
 		rootPath,
@@ -1000,7 +1077,11 @@ export async function searchProjectContents(
 	if (include) {
 		args.push('-g', include);
 	}
-	args.push(...defaultIgnoreGlobs(projectIgnore), ...binaryExcludeGlobs());
+	args.push(
+		...nanocoderIgnoreFileArgs(cwd),
+		...defaultIgnoreGlobs(projectIgnore),
+		...binaryExcludeGlobs(),
+	);
 	const normalizedContextLines = Math.max(0, contextLines ?? 0);
 	if (normalizedContextLines > 0) {
 		args.push('--context', String(normalizedContextLines));

--- a/source/utils/gitignore-loader.ts
+++ b/source/utils/gitignore-loader.ts
@@ -37,6 +37,23 @@ const DEFAULT_IGNORE_DIRS = [
 	'.hg', // Mercurial
 ];
 
+const NANOCODER_IGNORE_FILENAME = '.nanocoderignore';
+
+/**
+ * Absolute path to the workspace's .nanocoderignore, or undefined when there
+ * isn't one.
+ *
+ * Exists so callers that hand the file to an external tool - ripgrep's
+ * `--ignore-file`, say - resolve it the same way {@link loadGitignore} does
+ * rather than re-deriving the filename.
+ */
+export function findNanocoderIgnoreFile(
+	workspaceRoot: string,
+): string | undefined {
+	const candidate = join(workspaceRoot, NANOCODER_IGNORE_FILENAME);
+	return existsSync(candidate) ? candidate : undefined;
+}
+
 export interface LoadGitignoreOptions {
 	/**
 	 * Whether to layer .nanocoderignore on top of .gitignore. Defaults to true.
@@ -76,7 +93,7 @@ export function loadGitignore(
 	const {nanocoderIgnore = true} = options;
 	const ig = ignore();
 	const gitignorePath = join(workspaceRoot, '.gitignore');
-	const nanocoderignorePath = join(workspaceRoot, '.nanocoderignore');
+	const nanocoderignorePath = join(workspaceRoot, NANOCODER_IGNORE_FILENAME);
 
 	// Always ignore common directories
 	ig.add(DEFAULT_IGNORE_DIRS);


### PR DESCRIPTION
The two remaining non-blocking items from the #928 review, plus a process-crash bug that writing the second test uncovered.

## 1. `.nanocoderignore` pruned during traversal

It was only applied as a JS filter over rg's output, so ignored paths were still walked and still spent budget against `maxRawFilesScanned`. A large ignored directory sorting before `src/` could consume the whole 50k cap and crowd real files out of the results entirely.

Now passed to rg as `--ignore-file`. rg applies those rules after `.gitignore` and `.ignore`, which is exactly the layering `loadGitignore` documents, so `!` negations keep working. Verified against rg 15 before wiring it up.

The JS filter stays as a backstop: rg's matcher and the `ignore` package are separate implementations, and silently diverging on which files are visible is worse than one redundant check. Omitted when the file does not exist, since rg warns on a missing path and every search would carry it.

`findNanocoderIgnoreFile` is new in `gitignore-loader.ts` so the filename lives in one place rather than being re-derived.

## 2. `sorted: false` visitor contract

`onEntry must be synchronous when sorted: false` existed only in a throw message. Overloads now make an async callback a compile error, and the option carries real docs. Confirmed the type actually bites: async + `sorted: false` errors, while sync + `sorted: false` and async + default both compile.

## 3. The bug that fell out of testing item 2

`emitEntrySync` throws from the stdout `data` handler, which runs on the stream's event loop turn rather than inside the promise executor. The throw escaped as an **uncaught exception and took the process down** instead of rejecting the search. AVA reported it as `1 uncaught exception`, not a failed assertion.

So the runtime backstop was worse than the thing it guarded against. Chunk consumption is now wrapped, and any throw routes to `reject`. This also covers a JSON.parse or callback throw from any other caller.

## Tests

Both new tests verified to fail against the pre-change code:

- `a .nanocoderignore directory is pruned during traversal, not just filtered from results` - 20 ignored files sorting ahead of one real file, with `maxRawFilesScanned: 5`. Without `--ignore-file` the real file never surfaces. This asserts the pruning property rather than just the filtering one, which the existing tests already covered.
- `walkProjectEntries rejects an async onEntry under sorted: false rather than racing it` - crashes the test process without the fix in item 3, rejects cleanly with it.

50 file-search tests pass, plus `gitignore-loader`, `file-autocomplete` and `repo-map` (63). `tsc --noEmit`, biome and knip clean.

## Changeset

Amended `.changeset/ripgrep-file-search.md` again rather than adding an entry - #928 still has not released, and only the pruning change is user-observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBj99nj4yUg8QnewgVfFGs
