### PR TITLE
fix(tui): align DevelopmentModeIndicator with input box border (#1110)

### DIFF
--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -132,6 +132,50 @@ test('UserInput renders development mode indicator', t => {
 	unmount();
 });
 
+// Serial: this test mutates the global process.stdout.columns. Run alone so the
+// forced width can't leak into a concurrently-rendering sibling test.
+test.serial(
+	'UserInput aligns the mode indicator with the input box left border',
+	t => {
+		const originalColumns = process.stdout.columns;
+		Object.defineProperty(process.stdout, 'columns', {
+			value: 100,
+			configurable: true,
+		});
+
+		try {
+			const {lastFrame, unmount} = render(
+				<TestWrapper>
+					<UserInput developmentMode="normal" />
+				</TestWrapper>,
+			);
+
+			const output = stripAnsi(lastFrame() ?? '');
+			const lines = output.split('\n');
+
+			const borderLine = lines.find(line => line.includes('╭'));
+			const modeLine = lines.find(line => line.includes('normal mode on'));
+			t.truthy(borderLine, 'Should find the input box top border');
+			t.truthy(modeLine, 'Should find the mode indicator line');
+
+			const borderIndent = borderLine!.indexOf('╭');
+			const modeIndent = modeLine!.search(/\S/);
+			t.is(
+				modeIndent,
+				borderIndent,
+				'Mode indicator text should start at the same column as the input box border',
+			);
+
+			unmount();
+		} finally {
+			Object.defineProperty(process.stdout, 'columns', {
+				value: originalColumns,
+				configurable: true,
+			});
+		}
+	},
+);
+
 test('UserInput renders auto-accept mode indicator', t => {
 	const {lastFrame, unmount} = render(
 		<TestWrapper>

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -1112,17 +1112,24 @@ export default function UserInput({
 					<Text color={colors.secondary}> · ctrl-x remove last</Text>
 				</Box>
 			)}
-			{/* Development mode indicator - always visible */}
-			<DevelopmentModeIndicator
-				developmentMode={developmentMode}
-				colors={colors}
-				contextPercentUsed={contextPercentUsed ?? null}
-				contextSource={contextSource ?? null}
-				sessionName={sessionName}
-				tune={tune}
-				currentModel={currentModel}
-				activeEditor={activeEditor}
-			/>
+			{/* Development mode indicator - always visible. marginLeft matches the
+			2-col margin promptWidth (actualWidth - 4, centered) leaves to the
+			left of the input box, so the indicator's text lines up with the
+			box's left border instead of sitting flush against the terminal
+			edge. Left-only (not paddingX) so it doesn't eat further into the
+			indicator's own actualWidth-based truncation budget. */}
+			<Box marginLeft={2}>
+				<DevelopmentModeIndicator
+					developmentMode={developmentMode}
+					colors={colors}
+					contextPercentUsed={contextPercentUsed ?? null}
+					contextSource={contextSource ?? null}
+					sessionName={sessionName}
+					tune={tune}
+					currentModel={currentModel}
+					activeEditor={activeEditor}
+				/>
+			</Box>
 		</>
 	);
 }


### PR DESCRIPTION
Closes #1110. Wraps DevelopmentModeIndicator in `<Box marginLeft={2}>` so the status bar lines up with the input box's left border. Targets `feature/new-ui`. build + typecheck green.