### PR TITLE
fix(tui): align chat transcript with the input box left border (#1112)

### DIFF
--- a/source/app/components/chat-history.spec.tsx
+++ b/source/app/components/chat-history.spec.tsx
@@ -1,3 +1,4 @@
+import {Text} from 'ink';
 import test from 'ava';
 import React from 'react';
 import {wheelEvents} from '@/utils/terminal-mouse';
@@ -17,6 +18,70 @@ function createDefaultProps(
 		...overrides,
 	};
 }
+
+// Serial: mutates the global process.stdout.columns.
+test.serial(
+	'ChatHistory indents the transcript to match the input box left margin (inline/Static path)',
+	t => {
+		const originalColumns = process.stdout.columns;
+		Object.defineProperty(process.stdout, 'columns', {
+			value: 100,
+			configurable: true,
+		});
+
+		try {
+			const props = createDefaultProps({
+				// fullscreen defaults to false, so this exercises the classic
+				// Ink <Static> transcript path, not the fullscreen flow path.
+				queuedComponents: [<Text key="msg-1">Hello world</Text>],
+			});
+			const {lastFrame, unmount} = renderWithTheme(<ChatHistory {...props} />);
+			const output = lastFrame() ?? '';
+			const line = output.split('\n').find(l => l.includes('Hello world'));
+			t.truthy(line, 'Should find the rendered message line');
+			// At width 100, promptWidth = 100 - 4 = 96, so the centering margin
+			// (same one the input box gets) is (100 - 96) / 2 = 2.
+			t.is(line!.search(/\S/), 2);
+			unmount();
+		} finally {
+			Object.defineProperty(process.stdout, 'columns', {
+				value: originalColumns,
+				configurable: true,
+			});
+		}
+	},
+);
+
+// Serial: mutates the global process.stdout.columns.
+test.serial(
+	'ChatHistory indents the transcript to match the input box left margin (fullscreen path)',
+	t => {
+		const originalColumns = process.stdout.columns;
+		Object.defineProperty(process.stdout, 'columns', {
+			value: 100,
+			configurable: true,
+		});
+
+		try {
+			const props = createDefaultProps({
+				fullscreen: true,
+				staticComponents: [<Text key="welcome">banner</Text>],
+				queuedComponents: [<Text key="msg-1">Hello world</Text>],
+			});
+			const {lastFrame, unmount} = renderWithTheme(<ChatHistory {...props} />);
+			const output = lastFrame() ?? '';
+			const line = output.split('\n').find(l => l.includes('Hello world'));
+			t.truthy(line, 'Should find the rendered message line');
+			t.is(line!.search(/\S/), 2);
+			unmount();
+		} finally {
+			Object.defineProperty(process.stdout, 'columns', {
+				value: originalColumns,
+				configurable: true,
+			});
+		}
+	},
+);
 
 test('ChatHistory renders without error', t => {
 	const props = createDefaultProps();

--- a/source/app/components/chat-history.tsx
+++ b/source/app/components/chat-history.tsx
@@ -2,7 +2,7 @@ import {Box, measureElement, Text, useInput} from 'ink';
 import React from 'react';
 import ChatQueue from '@/components/chat-queue';
 import {RenderErrorBoundary} from '@/components/render-error-boundary';
-import {useTerminalRows} from '@/hooks/useTerminalWidth';
+import {usePromptWidth, useTerminalRows} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
 import {wheelEvents} from '@/utils/terminal-mouse';
 
@@ -61,6 +61,11 @@ export const ChatHistory = React.memo(function ChatHistory({
 }: ChatHistoryProps): React.ReactElement {
 	const {colors} = useTheme();
 	const terminalRows = useTerminalRows();
+	// Same left margin the input box gets from centering promptWidth inside
+	// actualWidth (see usePromptWidth), so the transcript tracks the input
+	// box's left border as the terminal resizes instead of sitting flush
+	// against the terminal edge.
+	const {promptMargin} = usePromptWidth();
 	const viewportRef = React.useRef(null);
 	const contentRef = React.useRef(null);
 	const [scrollOffset, setScrollOffset] = React.useState(0);
@@ -149,6 +154,7 @@ export const ChatHistory = React.memo(function ChatHistory({
 			renderLastQueuedComponentLive,
 			clearKey,
 			disableStatic: fullscreen || isFreshInline,
+			leftMargin: promptMargin,
 		}),
 		[
 			frozenComponents,
@@ -157,6 +163,7 @@ export const ChatHistory = React.memo(function ChatHistory({
 			clearKey,
 			fullscreen,
 			isFreshInline,
+			promptMargin,
 		],
 	);
 
@@ -167,7 +174,7 @@ export const ChatHistory = React.memo(function ChatHistory({
 			)}
 
 			{startChat && isFreshInline && (
-				<Box flexDirection="column">
+				<Box flexDirection="column" marginLeft={promptMargin}>
 					{staticComponents.map((c, i) => (
 						<RenderErrorBoundary key={`fresh-${i}`}>{c}</RenderErrorBoundary>
 					))}
@@ -178,11 +185,16 @@ export const ChatHistory = React.memo(function ChatHistory({
 
 			{liveComponent && (
 				// Inline: the live component sits below the absolutely-positioned
-				// <Static>, so it pulls back -1 to share that left edge. Fullscreen:
-				// it renders inside the overflow="hidden" scroll viewport, so it must
-				// stay at the padded column — a negative margin would push it left of
-				// the clip window and Ink would cut off its first character.
-				<Box marginLeft={fullscreen ? 0 : -1} flexDirection="column">
+				// <Static>, so it pulls back -1 to share that left edge, then adds
+				// promptMargin for the same left-align shift as the static items and
+				// the input box. Fullscreen: it renders inside the overflow="hidden"
+				// scroll viewport, so it must stay at/after the padded column — a
+				// negative margin would push it left of the clip window and Ink would
+				// cut off its first character.
+				<Box
+					marginLeft={fullscreen ? promptMargin : promptMargin - 1}
+					flexDirection="column"
+				>
 					<RenderErrorBoundary label="live">
 						{liveComponent}
 					</RenderErrorBoundary>
@@ -207,7 +219,7 @@ export const ChatHistory = React.memo(function ChatHistory({
 		// after the (flexShrink=0) footer takes its natural height.
 		<Box flexGrow={1} flexBasis={0} flexDirection="column" minHeight={0}>
 			{scrollOffset > 0 && (
-				<Box flexShrink={0}>
+				<Box flexShrink={0} marginLeft={promptMargin}>
 					<Text color={colors.secondary}>
 						{`── ↑ ${scrollOffset} rows · PgUp/PgDn · new output returns to bottom ──`}
 					</Text>

--- a/source/components/chat-queue.tsx
+++ b/source/components/chat-queue.tsx
@@ -30,6 +30,7 @@ export default memo(function ChatQueue({
 	renderLastQueuedComponentLive = false,
 	clearKey,
 	disableStatic = false,
+	leftMargin = 0,
 }: ChatQueueProps) {
 	const {staticQueuedComponents, liveQueuedComponents} = useMemo(() => {
 		if (!renderLastQueuedComponentLive) {
@@ -65,7 +66,7 @@ export default memo(function ChatQueue({
 		// viewport's clip window and Ink would slice off the first character of
 		// every line. Keep it in normal flow at the padded column.
 		return (
-			<Box flexDirection="column">
+			<Box flexDirection="column" marginLeft={leftMargin}>
 				{flowComponents.map((component, index) => (
 					<RenderErrorBoundary key={componentKey(component, `flow-${index}`)}>
 						{component}
@@ -91,21 +92,26 @@ export default memo(function ChatQueue({
 			{/* Static content renders at top and persists. <Static> positions its
 			    output absolutely (position:absolute in Ink), so it ignores any
 			    surrounding margin and anchors to the layout origin — a wrapper
-			    marginLeft would not move it horizontally. Leave it unwrapped. */}
+			    marginLeft would not move it horizontally. The left-align margin has
+			    to live on each item instead, inside the render prop. */}
 			{allStaticComponents.length > 0 && (
 				<Static key={clearKey} items={allStaticComponents}>
 					{(component, index) => (
-						<RenderErrorBoundary
+						<Box
 							key={componentKey(component, `static-${index}`)}
+							marginLeft={leftMargin}
 						>
-							{component}
-						</RenderErrorBoundary>
+							<RenderErrorBoundary>{component}</RenderErrorBoundary>
+						</Box>
 					)}
 				</Static>
 			)}
-			{/* Live content renders below */}
+			{/* Live content renders below. marginLeft=-1 already corrects for an
+			    inherent 1-column offset between normal-flow content and the
+			    absolutely-positioned Static block above it; leftMargin adds the
+			    same left-align shift as the static items and the input box. */}
 			{liveQueuedComponents.length > 0 && (
-				<Box marginLeft={-1} flexDirection="column">
+				<Box marginLeft={leftMargin - 1} flexDirection="column">
 					{liveQueuedComponents.map((component, index) => (
 						<RenderErrorBoundary key={componentKey(component, `live-${index}`)}>
 							{component}

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -5,7 +5,7 @@ import {commandRegistry} from '@/commands';
 import {DevelopmentModeIndicator} from '@/components/development-mode-indicator';
 import TextInput from '@/components/text-input';
 import {useInputState} from '@/hooks/useInputState';
-import {useResponsiveTerminal} from '@/hooks/useTerminalWidth';
+import {usePromptWidth, useResponsiveTerminal} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
 import {useUIStateContext} from '@/hooks/useUIState';
 import type {
@@ -41,9 +41,6 @@ import {getVisualLineSegments} from '@/utils/text-wrapping';
 import type {ActiveEditorState} from '@/vscode/vscode-server';
 
 const MAX_COMMAND_COMPLETION_ROWS = 10;
-
-// Prompt box width floor: keeps narrow terminals legible.
-const PROMPT_WIDTH_MIN = 40;
 
 interface ChatProps {
 	onSubmit?: (
@@ -114,8 +111,9 @@ export default function UserInput({
 	const {isNarrow, actualWidth, truncate} = useResponsiveTerminal();
 	// Prompt spans the full terminal width at every size (minus a 4-col
 	// margin so the rounded border never wraps and shatters), floored at 40
-	// cols for legibility on tiny terminals.
-	const promptWidth = Math.max(PROMPT_WIDTH_MIN, actualWidth - 4);
+	// cols for legibility on tiny terminals. Shared with the chat transcript
+	// (usePromptWidth) so both track the same left edge as the terminal resizes.
+	const {promptWidth} = usePromptWidth();
 	// Must match the wrapWidth passed to TextInput below — both sides use it to
 	// decide whether Up/Down means line navigation or history.
 	const inputWrapWidth = promptWidth - 4;

--- a/source/hooks/useTerminalWidth.tsx
+++ b/source/hooks/useTerminalWidth.tsx
@@ -146,3 +146,28 @@ export const useResponsiveTerminal = () => {
 		truncatePath,
 	};
 };
+
+// Prompt box width floor: keeps narrow terminals legible.
+const PROMPT_WIDTH_MIN = 40;
+// Horizontal budget the input box's rounded border + centering eats into
+// actualWidth (2 cols of margin on each side).
+const PROMPT_WIDTH_BUDGET = 4;
+
+/**
+ * Single source of truth for the input box's width and the left margin that
+ * centers it — shared with anything else that needs to visually track the
+ * input box's left border (e.g. the chat transcript, the status indicator)
+ * as the terminal resizes.
+ */
+export const usePromptWidth = () => {
+	const {actualWidth} = useResponsiveTerminal();
+	const promptWidth = Math.max(
+		PROMPT_WIDTH_MIN,
+		actualWidth - PROMPT_WIDTH_BUDGET,
+	);
+	// Mirrors the centering `alignItems="center"` performs when the input box
+	// (width=promptWidth) sits inside a width=actualWidth container.
+	const promptMargin = Math.max(0, Math.floor((actualWidth - promptWidth) / 2));
+
+	return {actualWidth, promptWidth, promptMargin};
+};

--- a/source/types/components.ts
+++ b/source/types/components.ts
@@ -34,6 +34,13 @@ export interface ChatQueueProps {
 	 * to print into. Only a bounded tail of components is rendered.
 	 */
 	disableStatic?: boolean;
+	/**
+	 * Left indent applied to every rendered item, so callers can line the
+	 * transcript up with some other left edge (e.g. the main chat's input
+	 * box). Defaults to 0 — callers with no such reference (e.g. the subagent
+	 * detail view) get the original flush-left layout.
+	 */
+	leftMargin?: number;
 }
 
 export type Completion = {name: string; isCustom: boolean};


### PR DESCRIPTION
Closes #1112. Extracts the input box's margin math into a `usePromptWidth()` hook and threads it into ChatHistory/ChatQueue so the transcript tracks the input box on resize (margin applied per-item inside `<Static>`). Targets `feature/new-ui`. build + typecheck + alignment tests green.