### PR TITLE
fix(vscode): remove copy button and improve spacing for user messages

### DIFF
--- a/.changeset/odd-fans-glow.md
+++ b/.changeset/odd-fans-glow.md
@@ -1,0 +1,6 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Added improved spacing and removed the copy button from user messages in the VS Code chat panel.
+  

--- a/.changeset/odd-fans-glow.md
+++ b/.changeset/odd-fans-glow.md
@@ -3,4 +3,3 @@
 ---
 
 Added improved spacing and removed the copy button from user messages in the VS Code chat panel.
-  

--- a/plugins/vscode/media/chat-panel.js
+++ b/plugins/vscode/media/chat-panel.js
@@ -681,7 +681,7 @@
 
 	function createMessageFooter(getText, role, sentAt) {
 		const footer = document.createElement('div');
-		footer.className = 'message-footer flex h-5 items-center gap-1.5 mt-1 text-xs text-vscode-fg opacity-60 ' +
+		footer.className = 'message-footer flex h-5 items-center gap-1.5 mt-2 text-xs text-vscode-fg opacity-60 ' +
 			(role === 'user' ? 'self-end' : 'self-start');
 
 		const btn = document.createElement('button');
@@ -721,7 +721,7 @@
 
 		if (role === 'user') {
 			footer.appendChild(timeEl);
-			footer.appendChild(btn);
+			
 		} else {
 			footer.appendChild(btn);
 			footer.appendChild(timeEl);

--- a/plugins/vscode/media/chat-panel.js
+++ b/plugins/vscode/media/chat-panel.js
@@ -684,6 +684,15 @@
 		footer.className = 'message-footer flex h-5 items-center gap-1.5 mt-2 text-xs text-vscode-fg opacity-60 ' +
 			(role === 'user' ? 'self-end' : 'self-start');
 
+		const timeEl = document.createElement('span');
+		timeEl.className = 'leading-none';
+		timeEl.textContent = sentAt.toLocaleTimeString([], {hour: 'numeric', minute: '2-digit'});
+
+		if (role === 'user') {
+			footer.appendChild(timeEl);
+			return footer;
+		}
+
 		const btn = document.createElement('button');
 		btn.type = 'button';
 		btn.className = 'flex items-center justify-center bg-transparent border-none cursor-pointer text-vscode-fg opacity-60 hover:opacity-100 p-1 rounded hover:bg-vscode-toolbarHover [&_svg]:mr-0 mb-1';
@@ -714,19 +723,8 @@
 				}, 1500);
 			});
 		});
-
-		const timeEl = document.createElement('span');
-		timeEl.className = 'leading-none';
-		timeEl.textContent = sentAt.toLocaleTimeString([], {hour: 'numeric', minute: '2-digit'});
-
-		if (role === 'user') {
-			footer.appendChild(timeEl);
-			
-		} else {
-			footer.appendChild(btn);
-			footer.appendChild(timeEl);
-		}
-
+		footer.appendChild(btn);
+		footer.appendChild(timeEl);
 		return footer;
 	}
 


### PR DESCRIPTION
## Description

Closes #1093 

Fixes the cramped and visually awkward layout of user messages in the VS Code chat panel, especially for short prompts such as `hi`.

This implements the proposed changes from the issue:
- Removes the copy button from user messages while keeping it available for assistant messages.
- Increases the spacing between the user message bubble and its timestamp.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

This is a small VS Code UI improvement with no user-facing API or behavior changes.

## Changes

- Removed the copy button from user messages since users generally don't need to copy their own prompts.
- Increased the spacing between the user message bubble and its timestamp from `mt-1` to `mt-2`.
- Kept the copy button for assistant messages.

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [x] Verified the VS Code chat panel UI locally.
- [x] Verified that user messages no longer display the copy button.
- [x] Verified that assistant messages still display the copy button.
- [x] Verified the increased spacing below user messages, including short prompts.
- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
