### PR TITLE
fix(acp): resolve race condition in prompt handling

### DIFF
--- a/.changeset/bug-1038-race.md
+++ b/.changeset/bug-1038-race.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix a race condition corrupting the UI state on rapid concurrent prompts.

--- a/source/acp/acp-agent.spec.ts
+++ b/source/acp/acp-agent.spec.ts
@@ -457,6 +457,29 @@ test('AcpAgent.prompt - throws on unknown session', async t => {
 	);
 });
 
+test('AcpAgent.prompt - rejects overlapping prompts before async boundaries', async t => {
+	const {agent} = createAgent();
+	const created = await agent.newSession({cwd: '/tmp'});
+
+	const p1 = agent.prompt({
+		sessionId: created.sessionId,
+		prompt: [{type: 'text', text: 'first'}],
+	});
+
+	// Fire a concurrent prompt immediately before p1 yields or completes
+	await t.throwsAsync(
+		agent.prompt({
+			sessionId: created.sessionId,
+			prompt: [{type: 'text', text: 'second'}],
+		}),
+		{message: `Prompt already in progress for session: ${created.sessionId}`},
+	);
+
+	// Let p1 finish
+	agent.cancel({sessionId: created.sessionId});
+	const result = await p1;
+	t.is(result.stopReason, 'cancelled');
+});
 
 test('AcpAgent.prompt - propagates API errors cleanly', async t => {
 	const {agent} = createAgent();

--- a/source/acp/acp-agent.ts
+++ b/source/acp/acp-agent.ts
@@ -191,178 +191,176 @@ export class AcpAgent implements Agent {
 		}
 
 		session.beginTurn();
+		try {
+			const {text: userText, images} = await acpContentToUserMessage(
+				params.prompt,
+				{
+					conn: this.conn,
+					sessionId: params.sessionId,
+					canReadTextFile: this.clientCapabilities?.fs?.readTextFile ?? false,
+				},
+			);
+			logger.info(
+				`ACP prompt: session=${params.sessionId} text=${userText.slice(0, 100)} images=${images.length}`,
+			);
 
-		const {text: userText, images} = await acpContentToUserMessage(
-			params.prompt,
-			{
-				conn: this.conn,
-				sessionId: params.sessionId,
-				canReadTextFile: this.clientCapabilities?.fs?.readTextFile ?? false,
-			},
-		);
-		logger.info(
-			`ACP prompt: session=${params.sessionId} text=${userText.slice(0, 100)} images=${images.length}`,
-		);
+			// Prepend active workspace context (e.g. the file focused in VS Code) so
+			// the model always knows what the user is looking at.
+			let contextualUserText = userText;
 
-		// Prepend active workspace context (e.g. the file focused in VS Code) so
-		// the model always knows what the user is looking at.
-		let contextualUserText = userText;
+			// Slash command interception
+			const trimmedUserText = userText.trim();
+			if (trimmedUserText.startsWith('/')) {
+				const commandName = trimmedUserText.split(/\s+/)[0].substring(1);
 
-		// Slash command interception
-		const trimmedUserText = userText.trim();
-		if (trimmedUserText.startsWith('/')) {
-			const commandName = trimmedUserText.split(/\s+/)[0].substring(1);
+				// If the 'command name' contains a slash, it's likely a file path (e.g. /home/user/file.ts)
+				// not a slash command. Skip command interception.
+				if (!commandName.includes('/')) {
+					const command =
+						this.initContext.customCommandLoader?.getCommand(commandName);
 
-			// If the 'command name' contains a slash, it's likely a file path (e.g. /home/user/file.ts)
-			// not a slash command. Skip command interception.
-			if (!commandName.includes('/')) {
-				const command =
-					this.initContext.customCommandLoader?.getCommand(commandName);
+					if (command) {
+						// Custom user-defined command — expand its instructions into the prompt
+						const commandInstruction = `### ${command.fullName}\n\n${command.content}`;
+						contextualUserText = `${contextualUserText}\n\n## Included Command Instructions\n\n${commandInstruction}\n\nPlease follow these instructions for the user's request above.`;
+					} else {
+						// Check for built-in commands that have special ACP handling
+						const sendBuiltinReply = (msg: string) => {
+							session.messages = [
+								...session.messages,
+								{
+									role: 'user',
+									content: contextualUserText,
+									displayOnly: true,
+								},
+								{role: 'assistant', content: msg, displayOnly: true},
+							];
+							this.conn.sessionUpdate({
+								sessionId: params.sessionId,
+								update: {
+									sessionUpdate: 'agent_message_chunk',
+									content: {type: 'text', text: msg},
+								},
+							});
+							return {stopReason: 'end_turn' as const};
+						};
 
-				if (command) {
-					// Custom user-defined command — expand its instructions into the prompt
-					const commandInstruction = `### ${command.fullName}\n\n${command.content}`;
-					contextualUserText = `${contextualUserText}\n\n## Included Command Instructions\n\n${commandInstruction}\n\nPlease follow these instructions for the user's request above.`;
-				} else {
-					// Check for built-in commands that have special ACP handling
-					const sendBuiltinReply = (msg: string) => {
-						session.messages = [
-							...session.messages,
-							{
-								role: 'user',
-								content: contextualUserText,
-								displayOnly: true,
-							},
-							{role: 'assistant', content: msg, displayOnly: true},
-						];
-						this.conn.sessionUpdate({
-							sessionId: params.sessionId,
-							update: {
-								sessionUpdate: 'agent_message_chunk',
-								content: {type: 'text', text: msg},
-							},
-						});
-						return {stopReason: 'end_turn' as const};
-					};
+						if (commandName === 'clear') {
+							// Clear the conversation history and action timeline
+							session.messages = [];
+							await session.timeline.clear();
+							const msg = 'Conversation cleared.';
+							this.conn.sessionUpdate({
+								sessionId: params.sessionId,
+								update: {
+									sessionUpdate: 'agent_message_chunk',
+									content: {type: 'text', text: msg},
+								},
+							});
+							return {stopReason: 'end_turn'};
+						}
 
-					if (commandName === 'clear') {
-						// Clear the conversation history and action timeline
-						session.messages = [];
-						await session.timeline.clear();
-						const msg = 'Conversation cleared.';
-						this.conn.sessionUpdate({
-							sessionId: params.sessionId,
-							update: {
-								sessionUpdate: 'agent_message_chunk',
-								content: {type: 'text', text: msg},
-							},
-						});
-						return {stopReason: 'end_turn'};
+						if (commandName === 'help') {
+							const customCmds =
+								this.initContext.customCommandLoader?.getAllCommands() ?? [];
+							const customList =
+								customCmds.length > 0
+									? customCmds
+											.map(
+												c =>
+													`- \`/${c.fullName}\` — ${c.metadata.description || 'custom command'}`,
+											)
+											.join('\n')
+									: '';
+							const msg = [
+								'**Available slash commands in VS Code GUI:**',
+								'',
+								'- `/clear` — Clear the current conversation',
+								'- `/copy` — Copy the last assistant response',
+								'- `/copy code` — Copy the last code block from the last response',
+								'- `/help` — Show this help message',
+								'',
+								'**Not available in VS Code GUI** (CLI-only):',
+								'- `/init`, `/theme`, `/context-max`, `/compact`, `/usage`, and other interactive commands',
+								'',
+								customList ? `**Your custom commands:**\n${customList}` : '',
+							]
+								.filter(Boolean)
+								.join('\n');
+							return sendBuiltinReply(msg);
+						}
+
+						// `/copy` is normally intercepted by the webview before it
+						// reaches us, but `/help` advertises it, so a client without
+						// that interception must not get "unrecognized command".
+						if (commandName === 'copy') {
+							const msg =
+								'`/copy` is handled by the chat view. Type it in the Nanocoder chat input (or press Ctrl+Alt+Shift+C / Cmd+Alt+Shift+C for the last code block).';
+							return sendBuiltinReply(msg);
+						}
+
+						if (['model', 'provider'].includes(commandName)) {
+							const msg = `Use the ${commandName} selector in the chat header to switch ${commandName}s.`;
+							return sendBuiltinReply(msg);
+						}
+
+						if (commandName === 'settings') {
+							const msg =
+								'Use the Settings tab in the Nanocoder sidebar (the gear icon in the view title bar, or `Nanocoder: Settings` in the Command Palette).';
+							return sendBuiltinReply(msg);
+						}
+
+						if (
+							['init', 'theme', 'compact', 'context-max', 'usage'].includes(
+								commandName,
+							)
+						) {
+							const msg = `The \`/${commandName}\` command is only available in the interactive CLI (\`nanocoder\` in a terminal). It is not supported in the VS Code GUI.`;
+							return sendBuiltinReply(msg);
+						}
+
+						// Truly unrecognized command
+						const errorMsg = `Unrecognized slash command: \`/${commandName}\`. Type \`/help\` to see available commands.`;
+						return sendBuiltinReply(errorMsg);
 					}
-
-					if (commandName === 'help') {
-						const customCmds =
-							this.initContext.customCommandLoader?.getAllCommands() ?? [];
-						const customList =
-							customCmds.length > 0
-								? customCmds
-										.map(
-											c =>
-												`- \`/${c.fullName}\` — ${c.metadata.description || 'custom command'}`,
-										)
-										.join('\n')
-								: '';
-						const msg = [
-							'**Available slash commands in VS Code GUI:**',
-							'',
-							'- `/clear` — Clear the current conversation',
-							'- `/copy` — Copy the last assistant response',
-							'- `/copy code` — Copy the last code block from the last response',
-							'- `/help` — Show this help message',
-							'',
-							'**Not available in VS Code GUI** (CLI-only):',
-							'- `/init`, `/theme`, `/context-max`, `/compact`, `/usage`, and other interactive commands',
-							'',
-							customList ? `**Your custom commands:**\n${customList}` : '',
-						]
-							.filter(Boolean)
-							.join('\n');
-						return sendBuiltinReply(msg);
-					}
-
-					// `/copy` is normally intercepted by the webview before it
-					// reaches us, but `/help` advertises it, so a client without
-					// that interception must not get "unrecognized command".
-					if (commandName === 'copy') {
-						const msg =
-							'`/copy` is handled by the chat view. Type it in the Nanocoder chat input (or press Ctrl+Alt+Shift+C / Cmd+Alt+Shift+C for the last code block).';
-						return sendBuiltinReply(msg);
-					}
-
-					if (['model', 'provider'].includes(commandName)) {
-						const msg = `Use the ${commandName} selector in the chat header to switch ${commandName}s.`;
-						return sendBuiltinReply(msg);
-					}
-
-					if (commandName === 'settings') {
-						const msg =
-							'Use the Settings tab in the Nanocoder sidebar (the gear icon in the view title bar, or `Nanocoder: Settings` in the Command Palette).';
-						return sendBuiltinReply(msg);
-					}
-
-					if (
-						['init', 'theme', 'compact', 'context-max', 'usage'].includes(
-							commandName,
-						)
-					) {
-						const msg = `The \`/${commandName}\` command is only available in the interactive CLI (\`nanocoder\` in a terminal). It is not supported in the VS Code GUI.`;
-						return sendBuiltinReply(msg);
-					}
-
-					// Truly unrecognized command
-					const errorMsg = `Unrecognized slash command: \`/${commandName}\`. Type \`/help\` to see available commands.`;
-					return sendBuiltinReply(errorMsg);
 				}
 			}
-		}
 
-		if (session.activeFile) {
-			contextualUserText = `[Active file: ${session.activeFile}]\n\n${contextualUserText}`;
-		}
-
-		session.messages = [
-			...session.messages,
-			{
-				role: 'user',
-				content: contextualUserText,
-				...(images.length > 0 ? {images} : {}),
-			},
-		];
-
-		if (session.baseSystemMessage) {
-			const projectContext = await appendRelevantProjectContextWithCount(
-				session.baseSystemMessage.content,
-				userText,
-				session.getMemoryFinder(),
-				getProjectContextPreferences(),
-			);
-			session.systemMessage = {
-				role: 'system',
-				content: projectContext.systemPrompt,
-			};
-			setLastBuiltPrompt(projectContext.systemPrompt);
-			if (projectContext.memoryCount > 0) {
-				logger.info(
-					`ACP recall: session=${params.sessionId} count=${projectContext.memoryCount}`,
-				);
+			if (session.activeFile) {
+				contextualUserText = `[Active file: ${session.activeFile}]\n\n${contextualUserText}`;
 			}
-		}
 
-		const config = getAppConfig();
-		const nonInteractiveAlwaysAllow = config.alwaysAllow ?? [];
+			session.messages = [
+				...session.messages,
+				{
+					role: 'user',
+					content: contextualUserText,
+					...(images.length > 0 ? {images} : {}),
+				},
+			];
 
-		session.turnActive = true;
-		try {
+			if (session.baseSystemMessage) {
+				const projectContext = await appendRelevantProjectContextWithCount(
+					session.baseSystemMessage.content,
+					userText,
+					session.getMemoryFinder(),
+					getProjectContextPreferences(),
+				);
+				session.systemMessage = {
+					role: 'system',
+					content: projectContext.systemPrompt,
+				};
+				setLastBuiltPrompt(projectContext.systemPrompt);
+				if (projectContext.memoryCount > 0) {
+					logger.info(
+						`ACP recall: session=${params.sessionId} count=${projectContext.memoryCount}`,
+					);
+				}
+			}
+
+			const config = getAppConfig();
+			const nonInteractiveAlwaysAllow = config.alwaysAllow ?? [];
+
 			return await runAcpConversation({
 				session,
 				client: this.initContext.client,

--- a/source/acp/acp-session.spec.ts
+++ b/source/acp/acp-session.spec.ts
@@ -138,6 +138,17 @@ test('AcpSession - beginTurn creates fresh abort controller', t => {
 	t.false(session.abortController.signal.aborted);
 });
 
+test('AcpSession - beginTurn sets turnActive to true', t => {
+	const session = new AcpSession({
+		sessionId: 'test-id',
+		cwd: '/tmp',
+		conn: createMockConn(),
+	});
+	t.false(session.turnActive);
+	session.beginTurn();
+	t.true(session.turnActive);
+});
+
 test('AcpSession - cancel after beginTurn aborts the turn controller', t => {
 	const session = new AcpSession({
 		sessionId: 'test-id',

--- a/source/acp/acp-session.ts
+++ b/source/acp/acp-session.ts
@@ -49,5 +49,6 @@ export class AcpSession {
 
 	beginTurn(): void {
 		this.abortController = new AbortController();
+		this.turnActive = true;
 	}
 }


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause: The \`turnActive\` state was set asynchronously after ACP prompt content conversion, opening a window where concurrent prompts could both pass the lock check and overwrite the \`AbortController\`.
Fix: Moved \`this.turnActive = true\` directly into \`AcpSession.beginTurn()\` to acquire the turn lock synchronously. Expanded the \`try...finally\` block in \`AcpAgent.prompt()\` to correctly wrap \`beginTurn()\` and subsequent setup steps so that early returns and setup errors correctly clean up the lock state. Added tests covering overlapping prompts.
Validation: Ran \`pnpm run build\`, \`pnpm test:format\`, \`pnpm test:lint\`, \`pnpm test:types\`, \`pnpm test:knip\`. Ran targeted test \`pnpm test:ava source/acp/acp-session.spec.ts source/acp/acp-agent.spec.ts source/acp/acp-conversation.spec.ts\` explicitly due to container time limit limits for test:all suite. All checks pass and regressions tests confirm synchronous failure for rapid overlapping requests before async yielding.

Fixes https://github.com/Nano-Collective/nanocoder/issues/1038

Fixes #1038
