### PR TITLE
feat(config): add `nanocoder config` to show resolved settings and th…

### DIFF
--- a/.changeset/effective-config-command.md
+++ b/.changeset/effective-config-command.md
@@ -1,0 +1,19 @@
+---
+'@nanocollective/nanocoder': minor
+---
+
+Add `nanocoder config` to see your settings and which file each one came from.
+
+Settings come from four places: built-in defaults, your global config folder, the project folder you're in, and `NANOCODER_*` environment variables. When a setting didn't do what you expected, finding out which file set it meant opening all four by hand.
+
+Three commands:
+
+- `nanocoder config list` — every setting, its value, and the file it came from
+- `nanocoder config show <key>` — one setting in detail: its default, and any values it beat
+- `nanocoder config diff` — only what your files change, plus values that are set but unused
+
+All three take `--json`.
+
+**The part worth knowing.** Settings are grouped into blocks, like `autoCompact`. Nanocoder takes the *whole* block from the first file that mentions it — it does not mix fields from two files. So if your global config sets `threshold` and `notifyUser`, and your project config sets only `threshold`, your `notifyUser` is thrown away and the built-in default is used instead. Nothing told you that before. `config diff` now lists it under "Ignored values".
+
+Two smaller things. Values are shown the way the app really uses them — write `threshold: 200` and you'll see `95`, because it's capped at 95. And API keys show as `<redacted>`, so you can paste the output into a bug report.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -46,6 +46,45 @@ Nanocoder looks for configuration in the following order (first found wins):
 
 > **Tip:** Use `/setup-config` to list all available configuration files and open any of them in your `$EDITOR`.
 
+## Inspecting the Effective Configuration
+
+When a setting is not behaving the way you expect, the hard question is not
+what the value is but which file set it. `nanocoder config` answers both
+without booting the interactive app.
+
+```bash
+nanocoder config list                                   # every resolved key and its layer
+nanocoder config show nanocoder.autoCompact.threshold   # one key, in detail
+nanocoder config show autoCompact                       # a whole block
+nanocoder config diff                                   # only what your files change
+nanocoder config diff --json                            # machine-readable output
+```
+
+`config list` prints the layers in play — built-in defaults, the global config
+directory, the project directory, and `NANOCODER_*` environment variables —
+along with whether each file is present, missing, or unreadable. A `*` beside a
+key means a lower-precedence layer also sets it.
+
+`config show <key>` adds the built-in default, the values that lost, and a line
+explaining the rule that decided the winner. The key can be given in full
+(`nanocoder.autoCompact.threshold`), without the `nanocoder.` prefix
+(`autoCompact.threshold`), or as a block name to print every field under it.
+
+`config diff` is the debugging view: everything your config files change
+relative to the defaults, followed by every value that is set somewhere but is
+not in effect, with the reason it lost.
+
+> **Note:** Most settings are resolved **block by block**, not key by key. The
+> highest-precedence file that defines a block — say `nanocoder.autoCompact` —
+> supplies the whole block, and the fields it omits fall back to built-in
+> defaults rather than to a lower-precedence file. A project file setting one
+> field therefore discards the global file's other fields for that block.
+> `config diff` lists exactly those discarded values.
+
+API keys and other credentials are replaced with `<redacted>` in every output
+format. An unsubstituted `${VAR}` reference is shown verbatim, since naming the
+variable is the point of the output and the reference is not itself a secret.
+
 ## Environment Variables
 
 Keep API keys out of version control using environment variables. Variables are loaded from shell environment (`.bashrc`, `.zshrc`) or `.env` file in your working directory.
@@ -455,3 +494,5 @@ Checkpoints deliberately skip `.nanocoderignore`. A file you hid from listings i
 - [Preferences](preferences.md) - User preferences and application data
 - [Logging](logging.md) - Structured logging with Pino
 - [Lifecycle Hooks](../features/hooks.md) - Shell commands run at fixed points in the agent loop
+
+See also [Inspecting the Effective Configuration](#inspecting-the-effective-configuration) for debugging which layer supplied a value.

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -72,6 +72,19 @@ if (args[0] === 'daemon') {
 	process.exit(result.exitCode);
 }
 
+// Handle `nanocoder config <sub>` — fast path. Resolving the effective
+// config only needs the config module graph, not Ink or the tool registry.
+if (args[0] === 'config') {
+	const {runConfigCli} = await import('@/config/config-cli');
+	const result = runConfigCli(args[1], args.slice(2));
+	if (result.exitCode === 0) {
+		console.log(result.output);
+	} else {
+		console.error(result.output);
+	}
+	process.exit(result.exitCode);
+}
+
 // Handle `nanocoder init` without booting the interactive app. The shared
 // initializer is also used by /init, so both entry points keep identical file
 // generation and overwrite behavior.
@@ -136,6 +149,8 @@ Commands:
   copilot login [provider-name]   Log in to GitHub Copilot (device flow). Saves credentials for the "GitHub Copilot" provider.
   daemon <subcommand>             Manage the per-project skill daemon.
                                   Subcommands: start, stop, status, logs, install, uninstall.
+  config <subcommand>             Inspect the resolved configuration and where each value came from.
+                                  Subcommands: list, show [key], diff. Add --json for machine output.
 
 Options:
   -v, --version       Show version number

--- a/source/config/config-cli.ts
+++ b/source/config/config-cli.ts
@@ -1,0 +1,350 @@
+/**
+ * CLI surface for `nanocoder config <show|diff|list>`.
+ *
+ * Follows the same shape as `daemon/cli.ts`: each handler returns an
+ * `{exitCode, output}` pair and the wiring in `cli.tsx` decides which stream
+ * to print it on. Rendering is plain text with no ANSI colour so the output
+ * pipes into a file or a bug report unchanged.
+ */
+
+import {basename} from 'node:path';
+import {
+	type EffectiveConfig,
+	type EffectiveConfigEntry,
+	findEntries,
+	resolveEffectiveConfig,
+	selectOverrides,
+} from '@/config/effective-config';
+
+export interface ConfigCliResult {
+	exitCode: 0 | 1;
+	output: string;
+}
+
+export type ConfigCliCommand = 'show' | 'diff' | 'list';
+
+const CONFIG_CLI_COMMANDS: readonly ConfigCliCommand[] = [
+	'show',
+	'diff',
+	'list',
+];
+
+const CONFIG_CLI_USAGE = `Usage: nanocoder config <command> [key] [--json]
+
+Commands:
+  list                 Show every resolved setting and the layer it came from
+  show [key]           Show one setting (or a whole block) in detail.
+                       With no key, identical to "list".
+  diff                 Show only what your config files change, plus the
+                       values they shadow
+
+Options:
+  --json               Emit machine-readable JSON instead of a table
+
+Examples:
+  nanocoder config list
+  nanocoder config show nanocoder.autoCompact.threshold
+  nanocoder config show autoCompact
+  nanocoder config diff --json`;
+
+const MAX_VALUE_WIDTH = 60;
+
+/** Render a resolved value as a single line, truncated for table use. */
+function formatValue(value: unknown, maxWidth = MAX_VALUE_WIDTH): string {
+	if (value === undefined) return '(unset)';
+	const text = typeof value === 'string' ? value : JSON.stringify(value);
+	if (text === undefined) return '(unset)';
+	const oneLine = text.replace(/\s+/g, ' ');
+	return oneLine.length > maxWidth
+		? `${oneLine.slice(0, maxWidth - 1)}…`
+		: oneLine;
+}
+
+/** Short label for the SOURCE column; full paths live in the layer header. */
+function shortOrigin(origin: string): string {
+	return origin.includes('/') || origin.includes('\\')
+		? basename(origin)
+		: origin;
+}
+
+function pad(text: string, width: number): string {
+	return text.length >= width ? text : text + ' '.repeat(width - text.length);
+}
+
+function renderTable(rows: string[][], headers: string[]): string[] {
+	const widths = headers.map((header, index) =>
+		Math.max(header.length, ...rows.map(row => (row[index] ?? '').length)),
+	);
+	const line = (cells: string[]) =>
+		cells
+			.map((cell, index) =>
+				index === cells.length - 1 ? cell : pad(cell, widths[index] as number),
+			)
+			.join('  ')
+			.trimEnd();
+	return [line(headers), ...rows.map(line)];
+}
+
+function renderLayerHeader(config: EffectiveConfig): string[] {
+	const lines = [
+		'Effective configuration',
+		`  working directory  ${config.cwd}`,
+		`  config directory   ${config.configDir}`,
+		'',
+		'Layers (lowest precedence first)',
+	];
+
+	const rows = config.layers.map(layer => {
+		const status = layer.error
+			? `unreadable: ${layer.error}`
+			: layer.skipped
+				? `skipped: ${layer.skipped}`
+				: layer.exists
+					? 'present'
+					: 'missing';
+		return [`  ${layer.layer}`, layer.origin, status];
+	});
+	rows.push([
+		'  env',
+		'NANOCODER_* environment variables',
+		'highest precedence',
+	]);
+	lines.push(...renderTable(rows, ['  LAYER', 'SOURCE', 'STATUS']));
+	return lines;
+}
+
+function renderEntryRows(entries: EffectiveConfigEntry[]): string[][] {
+	return entries.map(entry => [
+		entry.shadowed.length > 0 ? `${entry.key} *` : entry.key,
+		formatValue(entry.value),
+		entry.layer,
+		shortOrigin(entry.origin),
+	]);
+}
+
+function renderList(config: EffectiveConfig): string {
+	const lines = [...renderLayerHeader(config), ''];
+
+	if (config.entries.length === 0) {
+		lines.push('No settings resolved. Every value is a built-in default.');
+		return lines.join('\n');
+	}
+
+	lines.push(
+		...renderTable(renderEntryRows(config.entries), [
+			'KEY',
+			'VALUE',
+			'LAYER',
+			'SOURCE',
+		]),
+	);
+
+	if (config.entries.some(entry => entry.shadowed.length > 0)) {
+		lines.push(
+			'',
+			'* also set in a lower-precedence layer. Run "nanocoder config show <key>" for details.',
+		);
+	}
+	return lines.join('\n');
+}
+
+/**
+ * Explain, in one sentence, why the losing layers lost. The block rule is the
+ * one worth spelling out: a project file that sets a single field of a block
+ * discards the global file's whole block, not just that field.
+ */
+function resolutionNote(entry: EffectiveConfigEntry): string {
+	switch (entry.rule) {
+		case 'block':
+			return `How this is decided: "${entry.block}" is taken as a whole block from one file — the project file first, then the global one. Anything that file leaves out uses the built-in default. It is not filled in from the other file.`;
+		case 'closest-file':
+			return 'How this is decided: preferences come from one file only — the project file if it exists, otherwise the global one. The other file is ignored completely.';
+		case 'merge-by-name':
+			return 'How this is decided: these are matched up by name. An environment variable wins, then the project file, then the global one. Only an entry with the same name gets replaced.';
+		case 'env':
+			return `How this is decided: the ${entry.origin} environment variable beats every config file for this setting.`;
+	}
+}
+
+function renderDetail(
+	entry: EffectiveConfigEntry,
+	includeNote: boolean,
+): string[] {
+	const lines = [
+		entry.key,
+		`  value    ${formatValue(entry.value, 200)}`,
+		`  layer    ${entry.layer}`,
+		`  source   ${entry.origin}`,
+	];
+	if (entry.hasDefault) {
+		lines.push(`  default  ${formatValue(entry.defaultValue, 200)}`);
+	}
+	if (entry.redacted) {
+		lines.push('  note     credential values are redacted');
+	}
+
+	if (entry.shadowed.length > 0) {
+		lines.push('', '  Ignored values (set, but not in effect):');
+		lines.push(
+			...renderTable(
+				entry.shadowed.map(shadow => [
+					`    ${shadow.layer}`,
+					shadow.origin,
+					formatValue(shadow.value),
+				]),
+				['    LAYER', 'SOURCE', 'VALUE'],
+			),
+		);
+	}
+
+	if (includeNote) lines.push('', `  ${resolutionNote(entry)}`);
+	return lines;
+}
+
+function renderShow(config: EffectiveConfig, key: string): ConfigCliResult {
+	const matches = findEntries(config, key);
+	if (matches.length === 0) {
+		return {
+			exitCode: 1,
+			output: `No configuration key matching "${key}".\nRun "nanocoder config list" to see every resolved key.`,
+		};
+	}
+
+	const notes = new Set(matches.map(resolutionNote));
+	const shared = notes.size === 1 ? [...notes][0] : undefined;
+	const blocks = matches.map(entry =>
+		renderDetail(entry, shared === undefined).join('\n'),
+	);
+	const output = blocks.join('\n\n');
+	return {
+		exitCode: 0,
+		output: shared === undefined ? output : `${output}\n\n${shared}`,
+	};
+}
+
+/** Why a shadowed value is not in effect, phrased per resolution rule. */
+function shadowReason(entry: EffectiveConfigEntry): string {
+	if (entry.rule === 'block' && entry.block) {
+		const winner =
+			entry.blockOrigin === undefined
+				? 'a higher-priority file'
+				: `${shortOrigin(entry.blockOrigin)} (${entry.blockLayer})`;
+		return entry.layer === 'default'
+			? `${winner} sets the "${entry.block}" block but not this field, so the default is used`
+			: `${winner} sets the whole "${entry.block}" block`;
+	}
+	if (entry.rule === 'closest-file') {
+		return `${shortOrigin(entry.origin)} (${entry.layer}) is the file being used`;
+	}
+	return `replaced by the one in ${shortOrigin(entry.origin)} (${entry.layer})`;
+}
+
+function renderDiff(config: EffectiveConfig): string {
+	const overrides = selectOverrides(config);
+	const lines = [...renderLayerHeader(config), ''];
+
+	const inEffect = overrides.filter(entry => entry.layer !== 'default');
+	if (inEffect.length === 0) {
+		lines.push(
+			'Overrides in effect: none. Every setting is a built-in default.',
+		);
+	} else {
+		lines.push('Overrides in effect');
+		lines.push(
+			...renderTable(
+				inEffect.map(entry => [
+					`  ${entry.key}`,
+					formatValue(entry.value),
+					entry.layer,
+					shortOrigin(entry.origin),
+					entry.hasDefault ? formatValue(entry.defaultValue, 24) : '',
+				]),
+				['  KEY', 'VALUE', 'LAYER', 'SOURCE', 'DEFAULT'],
+			),
+		);
+	}
+
+	const shadowRows = overrides.flatMap(entry =>
+		entry.shadowed.map(shadow => [
+			`  ${entry.key}`,
+			formatValue(shadow.value),
+			shadow.layer,
+			shortOrigin(shadow.origin),
+			shadowReason(entry),
+		]),
+	);
+
+	lines.push('');
+	if (shadowRows.length === 0) {
+		lines.push('Ignored values: none. No layer is shadowing another.');
+	} else {
+		lines.push('Ignored values (set, but not in effect)');
+		lines.push(
+			...renderTable(shadowRows, [
+				'  KEY',
+				'VALUE',
+				'LAYER',
+				'SOURCE',
+				'REASON',
+			]),
+		);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Run a `nanocoder config` subcommand. `args` are the arguments after the
+ * subcommand name.
+ */
+export function runConfigCli(
+	command: string | undefined,
+	args: readonly string[] = [],
+	options?: {cwd?: string; configDir?: string},
+): ConfigCliResult {
+	if (command === undefined || command === '--help' || command === '-h') {
+		return {exitCode: 0, output: CONFIG_CLI_USAGE};
+	}
+
+	if (!(CONFIG_CLI_COMMANDS as readonly string[]).includes(command)) {
+		return {
+			exitCode: 1,
+			output: `Unknown config command "${command}".\n\n${CONFIG_CLI_USAGE}`,
+		};
+	}
+
+	const json = args.includes('--json');
+	const positional = args.filter(arg => !arg.startsWith('-'));
+	const config = resolveEffectiveConfig(options);
+
+	if (command === 'diff') {
+		if (json) {
+			return {
+				exitCode: 0,
+				output: JSON.stringify(
+					{...config, entries: selectOverrides(config)},
+					null,
+					2,
+				),
+			};
+		}
+		return {exitCode: 0, output: renderDiff(config)};
+	}
+
+	const key = command === 'show' ? positional[0] : undefined;
+	if (key !== undefined) {
+		const matches = findEntries(config, key);
+		if (json) {
+			return {
+				exitCode: matches.length === 0 ? 1 : 0,
+				output: JSON.stringify({...config, entries: matches}, null, 2),
+			};
+		}
+		return renderShow(config, key);
+	}
+
+	if (json) {
+		return {exitCode: 0, output: JSON.stringify(config, null, 2)};
+	}
+	return {exitCode: 0, output: renderList(config)};
+}

--- a/source/config/effective-config.spec.ts
+++ b/source/config/effective-config.spec.ts
@@ -1,0 +1,384 @@
+import {mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import {runConfigCli} from './config-cli';
+import {
+	type EffectiveConfig,
+	findEntries,
+	redactValue,
+	resolveEffectiveConfig,
+	selectOverrides,
+} from './effective-config';
+import {clearAppConfig} from './index';
+import {resetPreferencesCache} from './preferences';
+
+console.log(`\neffective-config.spec.ts`);
+
+interface Fixture {
+	/** JSON written to `<project>/agents.config.json`. */
+	projectAgents?: unknown;
+	/** JSON written to `<configDir>/agents.config.json`. */
+	globalAgents?: unknown;
+	projectPreferences?: unknown;
+	globalPreferences?: unknown;
+	/** Environment variables set for the duration of the callback. */
+	env?: Record<string, string | undefined>;
+}
+
+let fixtureCounter = 0;
+
+/**
+ * Run `body` against a throwaway project directory and config directory, with
+ * the module-level caches in `config/index.ts` and `config/preferences.ts`
+ * cleared on the way in and out. Tests are serial, so mutating `process.cwd()`
+ * and `process.env` here is safe.
+ */
+function withFixture<T>(
+	fixture: Fixture,
+	body: (paths: {project: string; configDir: string}) => T,
+): T {
+	const root = join(tmpdir(), `nanocoder-effective-${Date.now()}-${fixtureCounter++}`);
+	const project = join(root, 'project');
+	const configDir = join(root, 'config');
+	mkdirSync(project, {recursive: true});
+	mkdirSync(configDir, {recursive: true});
+
+	const write = (path: string, value: unknown) => {
+		if (value !== undefined) writeFileSync(path, JSON.stringify(value), 'utf-8');
+	};
+	write(join(project, 'agents.config.json'), fixture.projectAgents);
+	write(join(configDir, 'agents.config.json'), fixture.globalAgents);
+	write(join(project, 'nanocoder-preferences.json'), fixture.projectPreferences);
+	write(join(configDir, 'nanocoder-preferences.json'), fixture.globalPreferences);
+
+	const originalCwd = process.cwd();
+	const originalEnv = {...process.env};
+	process.chdir(project);
+	process.env.NANOCODER_CONFIG_DIR = configDir;
+	for (const [key, value] of Object.entries(fixture.env ?? {})) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	clearAppConfig();
+	resetPreferencesCache();
+
+	try {
+		return body({project, configDir});
+	} finally {
+		process.chdir(originalCwd);
+		for (const key of Object.keys(process.env)) {
+			if (!(key in originalEnv)) delete process.env[key];
+		}
+		Object.assign(process.env, originalEnv);
+		clearAppConfig();
+		resetPreferencesCache();
+		rmSync(root, {recursive: true, force: true});
+	}
+}
+
+function entry(config: EffectiveConfig, key: string) {
+	return config.entries.find(candidate => candidate.key === key);
+}
+
+test('unset keys resolve to the built-in default layer', t => {
+	withFixture({}, () => {
+		const config = resolveEffectiveConfig();
+		const threshold = entry(config, 'nanocoder.autoCompact.threshold');
+
+		t.is(threshold?.value, 60);
+		t.is(threshold?.layer, 'default');
+		t.is(threshold?.origin, 'built-in');
+		t.true(threshold?.hasDefault);
+		t.deepEqual(threshold?.shadowed, []);
+	});
+});
+
+test('a project value wins and records the global value it shadows', t => {
+	withFixture(
+		{
+			projectAgents: {nanocoder: {autoCompact: {threshold: 80}}},
+			globalAgents: {nanocoder: {autoCompact: {threshold: 70}}},
+		},
+		paths => {
+			const config = resolveEffectiveConfig();
+			const threshold = entry(config, 'nanocoder.autoCompact.threshold');
+
+			t.is(threshold?.value, 80);
+			t.is(threshold?.layer, 'project');
+			t.is(threshold?.origin, join(paths.project, 'agents.config.json'));
+			t.deepEqual(threshold?.shadowed, [
+				{
+					layer: 'global',
+					origin: join(paths.configDir, 'agents.config.json'),
+					value: 70,
+					redacted: false,
+				},
+			]);
+		},
+	);
+});
+
+test('block precedence discards the whole losing block, not just the shared field', t => {
+	// The project file sets one field of `autoCompact`. The loader takes the
+	// entire block from that file, so the global file's `notifyUser: false` is
+	// ignored and the built-in default runs instead. Surfacing exactly this is
+	// the point of the command.
+	withFixture(
+		{
+			projectAgents: {nanocoder: {autoCompact: {threshold: 80}}},
+			globalAgents: {nanocoder: {autoCompact: {notifyUser: false}}},
+		},
+		paths => {
+			const config = resolveEffectiveConfig();
+			const notify = entry(config, 'nanocoder.autoCompact.notifyUser');
+
+			t.is(notify?.value, true, 'built-in default, not the global file value');
+			t.is(notify?.layer, 'default');
+			t.is(notify?.block, 'nanocoder.autoCompact');
+			t.deepEqual(notify?.shadowed, [
+				{
+					layer: 'global',
+					origin: join(paths.configDir, 'agents.config.json'),
+					value: false,
+					redacted: false,
+				},
+			]);
+		},
+	);
+});
+
+test('a field that exists only in a losing layer is still reported', t => {
+	// `modeProviders` has no built-in defaults, so nothing backfills a field
+	// the winning file omits. The global file's `normal` entry vanishes
+	// entirely when the project file claims the block — the discarded value
+	// has to appear as shadowed or the command hides the very thing it exists
+	// to surface.
+	withFixture(
+		{
+			projectAgents: {
+				nanocoder: {
+					providers: [{name: 'p', models: ['m']}],
+					modeProviders: {plan: {provider: 'p', model: 'm'}},
+				},
+			},
+			globalAgents: {
+				nanocoder: {modeProviders: {normal: {provider: 'p', model: 'm'}}},
+			},
+		},
+		paths => {
+			const config = resolveEffectiveConfig();
+			const normal = entry(config, 'nanocoder.modeProviders.normal.provider');
+
+			t.truthy(normal, 'the discarded field still gets a row');
+			t.is(normal?.value, undefined, 'it is not in effect');
+			t.deepEqual(normal?.shadowed, [
+				{
+					layer: 'global',
+					origin: join(paths.configDir, 'agents.config.json'),
+					value: 'p',
+					redacted: false,
+				},
+			]);
+
+			t.is(
+				entry(config, 'nanocoder.modeProviders.plan.provider')?.layer,
+				'project',
+			);
+		},
+	);
+});
+
+test('the effective value is the clamped one the app will actually use', t => {
+	withFixture(
+		{projectAgents: {nanocoder: {autoCompact: {threshold: 200}}}},
+		() => {
+			const config = resolveEffectiveConfig();
+			const threshold = entry(config, 'nanocoder.autoCompact.threshold');
+
+			t.is(threshold?.value, 95, 'clamped to the 50-95 range');
+			t.is(threshold?.layer, 'project');
+		},
+	);
+});
+
+test('an environment variable outranks the config file', t => {
+	withFixture(
+		{
+			projectAgents: {nanocoder: {headless: {maxTurns: 42}}},
+			env: {NANOCODER_MAX_TURNS: '7'},
+		},
+		paths => {
+			const config = resolveEffectiveConfig();
+			const maxTurns = entry(config, 'nanocoder.headless.maxTurns');
+
+			t.is(maxTurns?.value, 7);
+			t.is(maxTurns?.layer, 'env');
+			t.is(maxTurns?.origin, 'NANOCODER_MAX_TURNS');
+			t.deepEqual(maxTurns?.shadowed, [
+				{
+					layer: 'project',
+					origin: join(paths.project, 'agents.config.json'),
+					value: 42,
+					redacted: false,
+				},
+			]);
+		},
+	);
+});
+
+test('NANOCODER_CONFIG_DIR marks the project preferences file as skipped', t => {
+	withFixture(
+		{
+			globalPreferences: {selectedTheme: 'dark'},
+			projectPreferences: {selectedTheme: 'light'},
+		},
+		paths => {
+			const config = resolveEffectiveConfig();
+			const theme = entry(config, 'preferences.selectedTheme');
+
+			t.is(theme?.value, 'dark', 'the config directory wins when it is explicit');
+			t.is(theme?.layer, 'global');
+			t.deepEqual(theme?.shadowed, [
+				{
+					layer: 'project',
+					origin: join(paths.project, 'nanocoder-preferences.json'),
+					value: 'light',
+					redacted: false,
+				},
+			]);
+
+			const skipped = config.layers.find(layer => layer.skipped !== undefined);
+			t.is(skipped?.origin, join(paths.project, 'nanocoder-preferences.json'));
+		},
+	);
+});
+
+test('provider credentials are redacted in both effective and shadowed values', t => {
+	withFixture(
+		{
+			projectAgents: {
+				nanocoder: {
+					providers: [
+						{name: 'shared', models: ['m'], apiKey: 'sk-project-secret'},
+						{name: 'unresolved', models: ['m'], apiKey: '${NANOCODER_NOT_SET}'},
+					],
+				},
+			},
+			globalAgents: {
+				nanocoder: {
+					providers: [{name: 'shared', models: ['m'], apiKey: '${SOME_KEY}'}],
+				},
+			},
+			env: {NANOCODER_NOT_SET: undefined},
+		},
+		() => {
+			const config = resolveEffectiveConfig();
+			const shared = entry(config, 'nanocoder.providers.shared');
+
+			t.true(shared?.redacted);
+			t.is((shared?.value as {apiKey: string}).apiKey, '<redacted>');
+			t.is(
+				(shared?.shadowed[0]?.value as {apiKey: string}).apiKey,
+				'${SOME_KEY}',
+				'a raw env reference names the variable to check, so it is safe to show',
+			);
+
+			// An unset reference substitutes to an empty string. Showing that
+			// verbatim is the whole diagnosis: the variable is not exported.
+			const unresolved = entry(config, 'nanocoder.providers.unresolved');
+			t.is((unresolved?.value as {apiKey: string}).apiKey, '');
+			t.false(unresolved?.redacted);
+		},
+	);
+});
+
+test('redactValue leaves non-secret values untouched', t => {
+	t.deepEqual(redactValue({baseUrl: 'http://x', models: ['a']}), {
+		value: {baseUrl: 'http://x', models: ['a']},
+		redacted: false,
+	});
+	t.deepEqual(redactValue('hunter2', 'password'), {
+		value: '<redacted>',
+		redacted: true,
+	});
+});
+
+test('selectOverrides returns only what the config files change', t => {
+	withFixture(
+		{
+			projectAgents: {nanocoder: {retries: {maxEmptyTurns: 9}}},
+			globalAgents: {nanocoder: {retries: {maxEmptyTurns: 4}}},
+		},
+		() => {
+			const config = resolveEffectiveConfig();
+			const overrides = selectOverrides(config);
+			const keys = overrides.map(override => override.key);
+
+			t.true(keys.includes('nanocoder.retries.maxEmptyTurns'));
+			t.false(
+				keys.includes('nanocoder.autoCompact.threshold'),
+				'untouched defaults stay out of the diff',
+			);
+		},
+	);
+});
+
+test('findEntries accepts exact keys, blocks, and the bare suffix', t => {
+	withFixture({projectAgents: {nanocoder: {autoCompact: {threshold: 80}}}}, () => {
+		const config = resolveEffectiveConfig();
+
+		t.is(findEntries(config, 'nanocoder.autoCompact.threshold').length, 1);
+		t.is(findEntries(config, 'autoCompact.threshold').length, 1);
+		t.is(findEntries(config, 'nanocoder.autoCompact').length, 5);
+		t.is(findEntries(config, 'autoCompact').length, 5);
+		t.is(findEntries(config, 'no-such-key').length, 0);
+	});
+});
+
+test('runConfigCli renders list, show, and diff', t => {
+	withFixture({projectAgents: {nanocoder: {autoCompact: {threshold: 80}}}}, () => {
+		const list = runConfigCli('list');
+		t.is(list.exitCode, 0);
+		t.regex(list.output, /nanocoder\.autoCompact\.threshold\s+80\s+project/);
+
+		const show = runConfigCli('show', ['nanocoder.autoCompact.threshold']);
+		t.is(show.exitCode, 0);
+		t.regex(show.output, /value\s+80/);
+		t.regex(show.output, /default\s+60/);
+
+		const diff = runConfigCli('diff');
+		t.is(diff.exitCode, 0);
+		t.regex(diff.output, /Overrides in effect/);
+	});
+});
+
+test('runConfigCli reports an unknown key and a bad subcommand', t => {
+	withFixture({}, () => {
+		const unknownKey = runConfigCli('show', ['nope.nope']);
+		t.is(unknownKey.exitCode, 1);
+		t.regex(unknownKey.output, /No configuration key matching "nope\.nope"/);
+
+		const badCommand = runConfigCli('explode');
+		t.is(badCommand.exitCode, 1);
+		t.regex(badCommand.output, /Unknown config command "explode"/);
+
+		const help = runConfigCli('--help');
+		t.is(help.exitCode, 0);
+		t.regex(help.output, /Usage: nanocoder config/);
+	});
+});
+
+test('runConfigCli --json emits parseable output', t => {
+	withFixture({projectAgents: {nanocoder: {autoCompact: {threshold: 80}}}}, () => {
+		const result = runConfigCli('diff', ['--json']);
+		t.is(result.exitCode, 0);
+
+		const parsed = JSON.parse(result.output) as EffectiveConfig;
+		const threshold = parsed.entries.find(
+			candidate => candidate.key === 'nanocoder.autoCompact.threshold',
+		);
+		t.is(threshold?.value, 80);
+		t.is(threshold?.layer, 'project');
+	});
+});

--- a/source/config/effective-config.spec.ts
+++ b/source/config/effective-config.spec.ts
@@ -27,6 +27,10 @@ interface Fixture {
 	globalAgents?: unknown;
 	projectPreferences?: unknown;
 	globalPreferences?: unknown;
+	/** JSON written to `<project>/.mcp.json`. */
+	projectMcp?: unknown;
+	/** JSON written to `<configDir>/.mcp.json`. */
+	globalMcp?: unknown;
 	/** Environment variables set for the duration of the callback. */
 	env?: Record<string, string | undefined>;
 }
@@ -56,6 +60,8 @@ function withFixture<T>(
 	write(join(configDir, 'agents.config.json'), fixture.globalAgents);
 	write(join(project, 'nanocoder-preferences.json'), fixture.projectPreferences);
 	write(join(configDir, 'nanocoder-preferences.json'), fixture.globalPreferences);
+	write(join(project, '.mcp.json'), fixture.projectMcp);
+	write(join(configDir, '.mcp.json'), fixture.globalMcp);
 
 	const originalCwd = process.cwd();
 	const originalEnv = {...process.env};
@@ -417,6 +423,128 @@ test('mutating the resolved config does not rewrite the built-in defaults', t =>
 			'the reported default still matches the real built-in',
 		);
 	});
+});
+
+test('an MCP server set in two files reports the one that lost', t => {
+	withFixture(
+		{
+			projectMcp: {mcpServers: {docs: {command: 'project-server'}}},
+			globalMcp: {mcpServers: {docs: {command: 'global-server'}}},
+		},
+		paths => {
+			const config = resolveEffectiveConfig();
+			const docs = entry(config, 'mcpServers.docs');
+
+			t.is(docs?.layer, 'project');
+			t.is(docs?.origin, join(paths.project, '.mcp.json'));
+			t.is(docs?.shadowed.length, 1, 'the global definition is reported');
+			t.is(docs?.shadowed[0]?.layer, 'global');
+			t.is(docs?.shadowed[0]?.origin, join(paths.configDir, '.mcp.json'));
+			t.like(docs?.shadowed[0]?.value, {command: 'global-server'});
+		},
+	);
+});
+
+test('MCP servers from NANOCODER_MCPSERVERS_FILE name that variable as the origin', t => {
+	const serverFile = join(tmpdir(), `nanocoder-mcp-${Date.now()}.json`);
+	writeFileSync(
+		serverFile,
+		JSON.stringify({mcpServers: {docs: {command: 'from-file'}}}),
+		'utf-8',
+	);
+
+	try {
+		withFixture(
+			{
+				projectMcp: {mcpServers: {docs: {command: 'from-project'}}},
+				env: {
+					NANOCODER_MCPSERVERS: undefined,
+					NANOCODER_MCPSERVERS_FILE: serverFile,
+				},
+			},
+			paths => {
+				const docs = entry(resolveEffectiveConfig(), 'mcpServers.docs');
+
+				t.is(docs?.layer, 'env');
+				t.is(
+					docs?.origin,
+					'NANOCODER_MCPSERVERS_FILE',
+					'the variable actually in use, not the inline one',
+				);
+				t.is(docs?.shadowed[0]?.origin, join(paths.project, '.mcp.json'));
+			},
+		);
+	} finally {
+		rmSync(serverFile, {force: true});
+	}
+});
+
+test('MCP server credentials are redacted', t => {
+	withFixture(
+		{
+			projectMcp: {
+				mcpServers: {
+					github: {
+						command: 'gh-mcp',
+						// `\btoken\b` never matched GITHUB_TOKEN — no word boundary
+						// after the underscore — so this used to print in full.
+						env: {GITHUB_TOKEN: 'ghp_realsecret', LOG_LEVEL: 'debug'},
+						headers: {Authorization: 'Bearer realsecret'},
+					},
+				},
+			},
+		},
+		() => {
+			const github = entry(resolveEffectiveConfig(), 'mcpServers.github');
+			const value = github?.value as {
+				env: Record<string, string>;
+				headers: Record<string, string>;
+				command: string;
+			};
+
+			t.true(github?.redacted);
+			t.is(value.env.GITHUB_TOKEN, '<redacted>');
+			t.is(value.headers.Authorization, '<redacted>');
+			t.is(value.env.LOG_LEVEL, 'debug', 'non-secrets stay readable');
+			t.is(value.command, 'gh-mcp');
+		},
+	);
+});
+
+test('runConfigCli --json covers list and show as well as diff', t => {
+	withFixture(
+		{
+			projectAgents: {nanocoder: {autoCompact: {threshold: 80}}},
+			projectMcp: {mcpServers: {docs: {command: 'x'}}},
+		},
+		() => {
+			const list = runConfigCli('list', ['--json']);
+			t.is(list.exitCode, 0);
+			const listed = JSON.parse(list.output) as EffectiveConfig;
+			t.true(listed.entries.length > 1);
+			t.truthy(listed.layers.length, 'layer metadata travels with the JSON');
+			t.truthy(
+				listed.entries.find(e => e.key === 'nanocoder.autoCompact.enabled'),
+				'list --json includes untouched defaults, unlike diff',
+			);
+
+			const show = runConfigCli('show', [
+				'nanocoder.autoCompact.threshold',
+				'--json',
+			]);
+			t.is(show.exitCode, 0);
+			const shown = JSON.parse(show.output) as EffectiveConfig;
+			t.is(shown.entries.length, 1, 'show --json is scoped to the match');
+			t.is(shown.entries[0]?.value, 80);
+			t.is(shown.entries[0]?.layer, 'project');
+
+			// A miss must be a non-zero exit even in JSON mode, so scripts can
+            // branch on it rather than parsing for an empty array.
+			const missing = runConfigCli('show', ['nope.nope', '--json']);
+			t.is(missing.exitCode, 1);
+			t.deepEqual((JSON.parse(missing.output) as EffectiveConfig).entries, []);
+		},
+	);
 });
 
 test('runConfigCli renders list, show, and diff', t => {

--- a/source/config/effective-config.spec.ts
+++ b/source/config/effective-config.spec.ts
@@ -336,6 +336,49 @@ test('findEntries accepts exact keys, blocks, and the bare suffix', t => {
 	});
 });
 
+test('config keys named after Object.prototype members are not resolved', t => {
+	// Every key here comes from user-written JSON, so reads must stay on own
+	// properties. The sharpest case is a provider named `constructor`: reading
+	// it off a plain accumulator object returns Object's own constructor for
+	// *any* layer, which used to invent a shadowing layer that does not exist.
+	withFixture(
+		{
+			projectAgents: {
+				nanocoder: {
+					autoCompact: {threshold: 80, toString: 'hijacked'},
+					providers: [
+						{name: 'constructor', models: ['m']},
+						{name: '__proto__', models: ['m']},
+					],
+				},
+			},
+			globalAgents: {nanocoder: {providers: [{name: 'real', models: ['m']}]}},
+		},
+		() => {
+			const config = resolveEffectiveConfig();
+
+			for (const name of ['constructor', '__proto__']) {
+				const provider = entry(config, `nanocoder.providers.${name}`);
+				t.is(provider?.layer, 'project', `${name} resolves from the file`);
+				t.deepEqual(
+					provider?.shadowed,
+					[],
+					`${name} must not report a layer that never declared it`,
+				);
+			}
+
+			// An inherited member is never mistaken for a real setting or for a
+			// built-in default.
+			t.is(findEntries(config, 'nanocoder.autoCompact.toString').length, 0);
+			t.is(findEntries(config, 'nanocoder.autoCompact.valueOf').length, 0);
+
+			// Real fields alongside the hostile ones still resolve normally.
+			t.is(entry(config, 'nanocoder.autoCompact.threshold')?.value, 80);
+			t.is(entry(config, 'nanocoder.autoCompact.enabled')?.value, true);
+		},
+	);
+});
+
 test('runConfigCli renders list, show, and diff', t => {
 	withFixture({projectAgents: {nanocoder: {autoCompact: {threshold: 80}}}}, () => {
 		const list = runConfigCli('list');

--- a/source/config/effective-config.spec.ts
+++ b/source/config/effective-config.spec.ts
@@ -1,4 +1,4 @@
-import {mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
@@ -10,7 +10,12 @@ import {
 	resolveEffectiveConfig,
 	selectOverrides,
 } from './effective-config';
-import {clearAppConfig} from './index';
+import {
+	clearAppConfig,
+	DEFAULT_SESSION_CONFIG,
+	getAppConfig,
+	reloadAppConfig,
+} from './index';
 import {resetPreferencesCache} from './preferences';
 
 console.log(`\neffective-config.spec.ts`);
@@ -377,6 +382,41 @@ test('config keys named after Object.prototype members are not resolved', t => {
 			t.is(entry(config, 'nanocoder.autoCompact.enabled')?.value, true);
 		},
 	);
+});
+
+test('the layer report matches disk after the loaders create a default file', t => {
+	withFixture({}, paths => {
+		const preferencesPath = join(paths.configDir, 'nanocoder-preferences.json');
+		const config = resolveEffectiveConfig();
+		const row = config.layers.find(layer => layer.origin === preferencesPath);
+
+		t.is(
+			row?.exists,
+			existsSync(preferencesPath),
+			'reported status must match what is actually on disk',
+		);
+	});
+});
+
+test('mutating the resolved config does not rewrite the built-in defaults', t => {
+	withFixture({}, () => {
+		const before = DEFAULT_SESSION_CONFIG.maxMessages;
+
+		const sessions = getAppConfig().sessions;
+		t.not(sessions, DEFAULT_SESSION_CONFIG, 'must not hand out the constant');
+		if (sessions) sessions.maxMessages = 3;
+
+		t.is(DEFAULT_SESSION_CONFIG.maxMessages, before, 'constant is unchanged');
+
+		reloadAppConfig();
+		t.is(getAppConfig().sessions?.maxMessages, before, 'reload is unpoisoned');
+		t.is(
+			entry(resolveEffectiveConfig(), 'nanocoder.sessions.maxMessages')
+				?.defaultValue,
+			before,
+			'the reported default still matches the real built-in',
+		);
+	});
 });
 
 test('runConfigCli renders list, show, and diff', t => {

--- a/source/config/effective-config.spec.ts
+++ b/source/config/effective-config.spec.ts
@@ -1,4 +1,10 @@
-import {existsSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
@@ -35,6 +41,18 @@ interface Fixture {
 	env?: Record<string, string | undefined>;
 }
 
+/**
+ * The temp directory with symlinks resolved.
+ *
+ * On macOS `os.tmpdir()` reports `/var/folders/...`, but `/var` is a symlink to
+ * `/private/var`, so once a fixture calls `process.chdir()` the resolver sees
+ * `/private/var/folders/...` and every path assertion in this file compares two
+ * spellings of the same directory. Linux CI never sees it because `/tmp` is a
+ * real directory there. Resolving once, up front, keeps both sides identical on
+ * either platform.
+ */
+const TMP_ROOT = realpathSync(tmpdir());
+
 let fixtureCounter = 0;
 
 /**
@@ -47,7 +65,10 @@ function withFixture<T>(
 	fixture: Fixture,
 	body: (paths: {project: string; configDir: string}) => T,
 ): T {
-	const root = join(tmpdir(), `nanocoder-effective-${Date.now()}-${fixtureCounter++}`);
+	const root = join(
+		TMP_ROOT,
+		`nanocoder-effective-${Date.now()}-${fixtureCounter++}`,
+	);
 	const project = join(root, 'project');
 	const configDir = join(root, 'config');
 	mkdirSync(project, {recursive: true});
@@ -446,7 +467,7 @@ test('an MCP server set in two files reports the one that lost', t => {
 });
 
 test('MCP servers from NANOCODER_MCPSERVERS_FILE name that variable as the origin', t => {
-	const serverFile = join(tmpdir(), `nanocoder-mcp-${Date.now()}.json`);
+	const serverFile = join(TMP_ROOT, `nanocoder-mcp-${Date.now()}.json`);
 	writeFileSync(
 		serverFile,
 		JSON.stringify({mcpServers: {docs: {command: 'from-file'}}}),

--- a/source/config/effective-config.ts
+++ b/source/config/effective-config.ts
@@ -1,0 +1,789 @@
+/**
+ * Effective-configuration resolver.
+ *
+ * Nanocoder reads settings from several places, and when a setting misbehaves
+ * the hard question is not "what is the value?" but "which file put it
+ * there?". This module answers both: for every known key it reports the value
+ * actually in effect plus the layer it came from, and it keeps the values that
+ * lower-precedence layers wanted but did not get.
+ *
+ * Two properties of the real loader are reproduced faithfully here, because
+ * both routinely surprise people:
+ *
+ * 1. **Block-level precedence, not per-key merge.** `loadHierarchicalConfig`
+ *    in `config/index.ts` takes the *first* file that contains a block (e.g.
+ *    `nanocoder.autoCompact`) and ignores that block in every lower file. A
+ *    project file setting one field of a block does not inherit the other
+ *    fields from the global file — it inherits them from the built-in
+ *    defaults. Entries carry `block` so a formatter can say so.
+ * 2. **Preferences use closest-file precedence.** `loadPreferences` reads a
+ *    single file chosen by `getClosestConfigFile`, so a project
+ *    `nanocoder-preferences.json` shadows the global one wholesale, and
+ *    `NANOCODER_CONFIG_DIR` suppresses the project lookup entirely.
+ *
+ * Effective values are taken from the live loaders (`getAppConfig`,
+ * `loadPreferences`, `loadAllMCPConfigs`) rather than recomputed, so clamped
+ * and validated values — a `threshold: 200` that becomes `95` — show up as
+ * what the app will really use. Origins are computed by scanning the raw
+ * files, which is the only way to see what a losing layer asked for.
+ */
+
+import {existsSync, readFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {
+	DEFAULT_AUTO_COMPACT_CONFIG,
+	DEFAULT_HEADLESS_CONFIG,
+	DEFAULT_RETRY_LIMITS,
+	DEFAULT_SESSION_CONFIG,
+	getAppConfig,
+	getDefaultPasteConfig,
+	loadDefaultMode,
+} from '@/config/index';
+import {loadAllMCPConfigs} from '@/config/mcp-config-loader';
+import {getConfigPath} from '@/config/paths';
+import {loadPreferences} from '@/config/preferences';
+
+/**
+ * Where a value came from, in ascending precedence. `default` is a built-in
+ * constant, `global` the user-level config directory, `project` the working
+ * directory, `env` a `NANOCODER_*` environment variable.
+ */
+export type ConfigLayerId = 'default' | 'global' | 'project' | 'env';
+
+/** Ascending precedence. Index into this to compare two layers. */
+const LAYER_PRECEDENCE: readonly ConfigLayerId[] = [
+	'default',
+	'global',
+	'project',
+	'env',
+];
+
+export type ConfigFileName =
+	| 'agents.config.json'
+	| 'nanocoder-preferences.json';
+
+/** One value found for a key, whether or not it is the one in effect. */
+export interface ConfigValueAt {
+	layer: ConfigLayerId;
+	/** Absolute file path, environment variable name, or `built-in`. */
+	origin: string;
+	value: unknown;
+	/** True when `value` was replaced with a placeholder because it is secret. */
+	redacted?: boolean;
+}
+
+export interface EffectiveConfigEntry extends ConfigValueAt {
+	/** Dotted key, e.g. `nanocoder.autoCompact.threshold`. */
+	key: string;
+	/** The built-in default, when this key has one. */
+	defaultValue?: unknown;
+	hasDefault: boolean;
+	/**
+	 * Values set in a lower-precedence layer that are not in effect, highest
+	 * precedence first.
+	 */
+	shadowed: ConfigValueAt[];
+	/**
+	 * Dotted path of the block that decided the winning layer, when the key was
+	 * resolved by block-level precedence. Present even when the winning layer is
+	 * `default`, so a formatter can explain a shadowed sibling.
+	 */
+	block?: string;
+	/**
+	 * The file that claimed the block, when one did. Needed because a field the
+	 * winning file omits resolves to `default`/`built-in`, which loses track of
+	 * *which* file caused the fallback — the one thing the reader needs to know.
+	 */
+	blockOrigin?: string;
+	blockLayer?: ConfigLayerId;
+	/** How this key is resolved, for the explanation line in `config show`. */
+	rule: 'block' | 'closest-file' | 'merge-by-name' | 'env';
+}
+
+/** A file (or the pseudo-file `built-in`) that participates in resolution. */
+export interface ConfigLayerInfo {
+	layer: ConfigLayerId;
+	origin: string;
+	exists: boolean;
+	/** Set when the file exists but could not be parsed. */
+	error?: string;
+	/** Set when the file exists but is skipped, with the reason why. */
+	skipped?: string;
+}
+
+export interface EffectiveConfig {
+	cwd: string;
+	configDir: string;
+	layers: ConfigLayerInfo[];
+	entries: EffectiveConfigEntry[];
+}
+
+const REDACTED = '<redacted>';
+
+/**
+ * Keys whose values are credentials. Matched against the last segment of a
+ * dotted key and against object keys nested inside a value.
+ */
+const SECRET_KEY_PATTERN =
+	/(api[-_]?key|access[-_]?token|refresh[-_]?token|\btoken\b|secret|password|passwd|authorization|credential)/i;
+
+/**
+ * An `$VAR` / `${VAR}` / `${VAR:-default}` reference is what the user wrote in
+ * the file, not the credential itself, so showing it is both safe and the
+ * whole point — it tells them which environment variable to check.
+ */
+function isEnvReference(value: unknown): boolean {
+	return typeof value === 'string' && /^\$\{?[A-Za-z_]/.test(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Replace credential values with a placeholder, recursively. Returns the
+ * value unchanged (and `redacted: false`) when nothing was secret.
+ */
+export function redactValue(
+	value: unknown,
+	keyHint = '',
+): {value: unknown; redacted: boolean} {
+	if (SECRET_KEY_PATTERN.test(keyHint) && !isEnvReference(value)) {
+		if (value === undefined || value === null || value === '') {
+			return {value, redacted: false};
+		}
+		return {value: REDACTED, redacted: true};
+	}
+
+	if (Array.isArray(value)) {
+		let redacted = false;
+		const mapped = value.map(item => {
+			const result = redactValue(item, keyHint);
+			redacted ||= result.redacted;
+			return result.value;
+		});
+		return {value: redacted ? mapped : value, redacted};
+	}
+
+	if (isPlainObject(value)) {
+		let redacted = false;
+		const mapped: Record<string, unknown> = {};
+		for (const [key, item] of Object.entries(value)) {
+			const result = redactValue(item, key);
+			redacted ||= result.redacted;
+			mapped[key] = result.value;
+		}
+		return {value: redacted ? mapped : value, redacted};
+	}
+
+	return {value, redacted: false};
+}
+
+interface RawLayer {
+	layer: ConfigLayerId;
+	file: ConfigFileName;
+	path: string;
+	exists: boolean;
+	data: Record<string, unknown> | null;
+	error?: string;
+}
+
+function readRawFile(
+	layer: ConfigLayerId,
+	file: ConfigFileName,
+	path: string,
+): RawLayer {
+	if (!existsSync(path)) {
+		return {layer, file, path, exists: false, data: null};
+	}
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+		return {
+			layer,
+			file,
+			path,
+			exists: true,
+			data: isPlainObject(parsed) ? parsed : null,
+			error: isPlainObject(parsed)
+				? undefined
+				: 'top-level value is not a JSON object',
+		};
+	} catch (error) {
+		return {
+			layer,
+			file,
+			path,
+			exists: true,
+			data: null,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+/**
+ * The raw file layers, ascending in precedence (global, then project) for each
+ * of the two config files.
+ */
+function readRawLayers(cwd: string, configDir: string): RawLayer[] {
+	const files: ConfigFileName[] = [
+		'agents.config.json',
+		'nanocoder-preferences.json',
+	];
+	return files.flatMap(file => [
+		readRawFile('global', file, join(configDir, file)),
+		readRawFile('project', file, join(cwd, file)),
+	]);
+}
+
+function getAt(
+	data: Record<string, unknown> | null,
+	path: readonly string[],
+): unknown {
+	let current: unknown = data;
+	for (const segment of path) {
+		if (!isPlainObject(current)) return undefined;
+		current = current[segment];
+	}
+	return current;
+}
+
+function hasAt(
+	data: Record<string, unknown> | null,
+	path: readonly string[],
+): boolean {
+	if (path.length === 0) return data !== null;
+	const parent = getAt(data, path.slice(0, -1));
+	const last = path[path.length - 1] as string;
+	return isPlainObject(parent) && parent[last] !== undefined;
+}
+
+/**
+ * Flatten a resolved value into dotted leaves. Arrays and primitives are
+ * leaves; plain objects recurse. `maxDepth` stops a pathological nested blob
+ * (a `nanocoderTools` config, say) from producing thousands of rows.
+ */
+function flattenLeaves(
+	value: unknown,
+	prefix: string[],
+	maxDepth: number,
+): Array<{path: string[]; value: unknown}> {
+	if (
+		!isPlainObject(value) ||
+		maxDepth <= 0 ||
+		Object.keys(value).length === 0
+	) {
+		return [{path: prefix, value}];
+	}
+	return Object.entries(value).flatMap(([key, item]) =>
+		flattenLeaves(item, [...prefix, key], maxDepth - 1),
+	);
+}
+
+/**
+ * A block is the unit of override in `loadHierarchicalConfig`: the first file
+ * that contains `path` wins the whole thing.
+ */
+interface BlockSpec {
+	/** Location of the block inside the raw JSON file. */
+	path: string[];
+	file: ConfigFileName;
+	/** The resolved value, from the live loader. */
+	effective: unknown;
+	/** Built-in defaults for the leaves inside the block, when it has any. */
+	defaults?: Record<string, unknown>;
+	/** Treat the block as one value instead of flattening it into leaves. */
+	leaf?: boolean;
+	/** Environment variable that can override a leaf inside this block. */
+	env?: {variable: string; leaf: string};
+	/** How deep to flatten. Defaults to 2 (block field, plus one nesting). */
+	depth?: number;
+}
+
+function blockSpecs(): BlockSpec[] {
+	const config = getAppConfig();
+	const agents: ConfigFileName = 'agents.config.json';
+	const preferences: ConfigFileName = 'nanocoder-preferences.json';
+
+	return [
+		{
+			path: ['nanocoder', 'autoCompact'],
+			file: agents,
+			effective: config.autoCompact,
+			defaults: DEFAULT_AUTO_COMPACT_CONFIG as unknown as Record<
+				string,
+				unknown
+			>,
+		},
+		{
+			path: ['nanocoder', 'sessions'],
+			file: preferences,
+			effective: config.sessions,
+			defaults: DEFAULT_SESSION_CONFIG as unknown as Record<string, unknown>,
+		},
+		{
+			path: ['nanocoder', 'headless'],
+			file: agents,
+			effective: config.headless,
+			defaults: DEFAULT_HEADLESS_CONFIG as unknown as Record<string, unknown>,
+			env: {variable: 'NANOCODER_MAX_TURNS', leaf: 'maxTurns'},
+		},
+		{
+			path: ['nanocoder', 'retries'],
+			file: agents,
+			effective: config.retries,
+			defaults: DEFAULT_RETRY_LIMITS as unknown as Record<string, unknown>,
+		},
+		{
+			path: ['nanocoder', 'paste'],
+			file: preferences,
+			effective: config.paste,
+			defaults: getDefaultPasteConfig() as unknown as Record<string, unknown>,
+		},
+		{
+			path: ['nanocoder', 'defaultMode'],
+			file: agents,
+			effective: loadDefaultMode(),
+			leaf: true,
+		},
+		{
+			path: ['nanocoder', 'alwaysAllow'],
+			file: agents,
+			effective: config.alwaysAllow,
+			leaf: true,
+		},
+		{
+			path: ['nanocoder', 'disabledTools'],
+			file: agents,
+			effective: config.disabledTools,
+			leaf: true,
+		},
+		{
+			path: ['nanocoder', 'systemPrompt'],
+			file: agents,
+			effective: config.systemPrompt,
+		},
+		{
+			path: ['nanocoder', 'modeProviders'],
+			file: agents,
+			effective: config.modeProviders,
+			depth: 2,
+		},
+		{
+			path: ['nanocoder', 'tune'],
+			file: agents,
+			effective: config.tune,
+		},
+		{
+			path: ['nanocoder', 'nanocoderTools'],
+			file: agents,
+			effective: config.nanocoderTools,
+			depth: 3,
+		},
+	];
+}
+
+/** Highest-precedence raw layer that contains the block, if any. */
+function winningLayer(
+	spec: BlockSpec,
+	layers: RawLayer[],
+): RawLayer | undefined {
+	const candidates = layers.filter(l => l.file === spec.file);
+	for (let i = candidates.length - 1; i >= 0; i--) {
+		const layer = candidates[i] as RawLayer;
+		if (hasAt(layer.data, spec.path)) return layer;
+	}
+	return undefined;
+}
+
+function resolveBlockEntries(
+	spec: BlockSpec,
+	layers: RawLayer[],
+): EffectiveConfigEntry[] {
+	const blockKey = spec.path.join('.');
+	const winner = winningLayer(spec, layers);
+	const candidates = layers.filter(l => l.file === spec.file);
+	const losers = candidates
+		.filter(l => hasAt(l.data, spec.path) && l !== winner)
+		.reverse();
+
+	const envRaw = spec.env ? process.env[spec.env.variable] : undefined;
+	const envActive =
+		spec.env !== undefined && envRaw !== undefined && envRaw.trim() !== '';
+
+	// The leaf set is the union of the resolved value's fields and the fields
+	// every raw layer declares. A field that exists *only* in a losing layer
+	// still needs a row — it is precisely the value the winning file silently
+	// discarded, and reporting it is the point of the command. Building the
+	// list from the resolved value alone hid those for blocks with no built-in
+	// defaults, where nothing backfills the missing field.
+	const leafPaths = new Map<string, string[]>();
+	const collect = (value: unknown) => {
+		for (const leaf of flattenLeaves(value, [], spec.depth ?? 1)) {
+			leafPaths.set(leaf.path.join('\u0000'), leaf.path);
+		}
+	};
+	collect(spec.effective);
+	for (const layer of candidates) {
+		if (hasAt(layer.data, spec.path)) collect(getAt(layer.data, spec.path));
+	}
+
+	const leaves = spec.leaf
+		? [{path: [] as string[], value: spec.effective}]
+		: [...leafPaths.values()].map(path => ({
+				path,
+				value: getAt(
+					isPlainObject(spec.effective) ? spec.effective : null,
+					path,
+				),
+			}));
+
+	return leaves.map(leaf => {
+		const key = [...spec.path, ...leaf.path].join('.');
+		const keyHint = leaf.path[leaf.path.length - 1] ?? blockKey;
+		const hasDefault =
+			spec.defaults !== undefined &&
+			leaf.path.length === 1 &&
+			leaf.path[0] !== undefined &&
+			leaf.path[0] in spec.defaults;
+		const defaultValue = hasDefault
+			? spec.defaults?.[leaf.path[0] as string]
+			: undefined;
+
+		const shadowed: ConfigValueAt[] = [];
+		const pushRaw = (layer: RawLayer) => {
+			const raw = getAt(layer.data, [...spec.path, ...leaf.path]);
+			if (raw === undefined) return;
+			const {value, redacted} = redactValue(raw, keyHint);
+			shadowed.push({
+				layer: layer.layer,
+				origin: layer.path,
+				value,
+				redacted,
+			});
+		};
+
+		// Env wins outright; the winning file (if any) becomes shadowed too.
+		const winnerSuppliesLeaf =
+			winner !== undefined &&
+			getAt(winner.data, [...spec.path, ...leaf.path]) !== undefined;
+
+		if (envActive && spec.env?.leaf === leaf.path[0]) {
+			if (winner) pushRaw(winner);
+			for (const loser of losers) pushRaw(loser);
+			const {value, redacted} = redactValue(leaf.value, keyHint);
+			return {
+				key,
+				value,
+				redacted,
+				layer: 'env' as const,
+				origin: spec.env.variable,
+				hasDefault,
+				defaultValue,
+				shadowed,
+				block: blockKey,
+				blockOrigin: winner?.path,
+				blockLayer: winner?.layer,
+				rule: 'env' as const,
+			};
+		}
+
+		// When the winner claimed the block but left this field out, the
+		// built-in default is what runs, and every losing file's copy of the
+		// field is ignored — captured as shadowed either way.
+		for (const loser of losers) pushRaw(loser);
+
+		const {value, redacted} = redactValue(leaf.value, keyHint);
+		return {
+			key,
+			value,
+			redacted,
+			layer: winnerSuppliesLeaf
+				? ((winner as RawLayer).layer as ConfigLayerId)
+				: ('default' as const),
+			origin: winnerSuppliesLeaf ? (winner as RawLayer).path : 'built-in',
+			hasDefault,
+			defaultValue,
+			shadowed,
+			block: blockKey,
+			blockOrigin: winner?.path,
+			blockLayer: winner?.layer,
+			rule: 'block' as const,
+		};
+	});
+}
+
+/**
+ * Preferences resolution differs from every other block: `loadPreferences`
+ * reads exactly one file, picked by `getClosestConfigFile`. So the project
+ * file shadows the global one in full, and `NANOCODER_CONFIG_DIR` skips the
+ * project lookup altogether.
+ */
+function resolvePreferencesEntries(layers: RawLayer[]): EffectiveConfigEntry[] {
+	const candidates = layers.filter(
+		l => l.file === 'nanocoder-preferences.json',
+	);
+	const project = candidates.find(l => l.layer === 'project');
+	const global = candidates.find(l => l.layer === 'global');
+	const explicitConfigDir = Boolean(process.env.NANOCODER_CONFIG_DIR);
+
+	const winner =
+		!explicitConfigDir && project?.exists ? project : (global ?? null);
+	const loser = winner === project ? global : project;
+
+	const effective = loadPreferences();
+	const keys = Object.keys(effective).filter(key => key !== 'nanocoder');
+
+	return keys.sort().map(key => {
+		const {value, redacted} = redactValue(
+			(effective as Record<string, unknown>)[key],
+			key,
+		);
+		const shadowed: ConfigValueAt[] = [];
+		const loserRaw = loser?.exists ? getAt(loser.data, [key]) : undefined;
+		if (loser && loserRaw !== undefined) {
+			const redactedLoser = redactValue(loserRaw, key);
+			shadowed.push({
+				layer: loser.layer,
+				origin: loser.path,
+				value: redactedLoser.value,
+				redacted: redactedLoser.redacted,
+			});
+		}
+		return {
+			key: `preferences.${key}`,
+			value,
+			redacted,
+			layer: (winner?.layer ?? 'default') as ConfigLayerId,
+			origin: winner?.path ?? 'built-in',
+			hasDefault: false,
+			shadowed,
+			rule: 'closest-file' as const,
+		};
+	});
+}
+
+/**
+ * Providers and MCP servers merge by name across layers rather than replacing
+ * one another, so each named entry gets its own row and its own winner.
+ */
+function resolveProviderEntries(layers: RawLayer[]): EffectiveConfigEntry[] {
+	const rawProviders = (layer: RawLayer): Record<string, unknown> => {
+		const nested = getAt(layer.data, ['nanocoder', 'providers']);
+		const top = getAt(layer.data, ['providers']);
+		const list = Array.isArray(nested) ? nested : Array.isArray(top) ? top : [];
+		const byName: Record<string, unknown> = {};
+		for (const provider of list) {
+			if (isPlainObject(provider) && typeof provider.name === 'string') {
+				byName[provider.name] = provider;
+			}
+		}
+		return byName;
+	};
+
+	const fileLayers = layers.filter(l => l.file === 'agents.config.json');
+	const envNames = readEnvProviderNames();
+
+	return (getAppConfig().providers ?? []).map(provider => {
+		const name = provider.name;
+		const found = fileLayers
+			.filter(layer => rawProviders(layer)[name] !== undefined)
+			.reverse();
+		const {value, redacted} = redactValue(provider, name);
+
+		// An env-provided provider outranks every file, so a same-named file
+		// entry is shadowed rather than winning.
+		const fromEnv = envNames.has(name);
+		const winner = fromEnv ? undefined : found[0];
+		const shadowedLayers = fromEnv ? found : found.slice(1);
+
+		const shadowed: ConfigValueAt[] = shadowedLayers.map(layer => {
+			const raw = redactValue(rawProviders(layer)[name], name);
+			return {
+				layer: layer.layer,
+				origin: layer.path,
+				value: raw.value,
+				redacted: raw.redacted,
+			};
+		});
+
+		return {
+			key: `nanocoder.providers.${name}`,
+			value,
+			redacted,
+			layer: (fromEnv ? 'env' : (winner?.layer ?? 'default')) as ConfigLayerId,
+			origin: fromEnv
+				? process.env.NANOCODER_PROVIDERS
+					? 'NANOCODER_PROVIDERS'
+					: 'NANOCODER_PROVIDERS_FILE'
+				: (winner?.path ?? 'built-in'),
+			hasDefault: false,
+			shadowed,
+			rule: 'merge-by-name' as const,
+		};
+	});
+}
+
+/**
+ * Names of providers supplied through `NANOCODER_PROVIDERS` /
+ * `NANOCODER_PROVIDERS_FILE`. Mirrors the shapes `loadEnvProviderConfigs`
+ * accepts; a value that fails to parse simply contributes no names, matching
+ * the loader's own behaviour of falling back to the files.
+ */
+function readEnvProviderNames(): Set<string> {
+	const names = new Set<string>();
+	let rawData = process.env.NANOCODER_PROVIDERS;
+	const file = process.env.NANOCODER_PROVIDERS_FILE;
+	if (!rawData && file && existsSync(file)) {
+		try {
+			rawData = readFileSync(file, 'utf-8');
+		} catch {
+			return names;
+		}
+	}
+	if (!rawData) return names;
+
+	try {
+		const parsed: unknown = JSON.parse(rawData);
+		const list = Array.isArray(parsed)
+			? parsed
+			: (getAt(isPlainObject(parsed) ? parsed : null, [
+					'nanocoder',
+					'providers',
+				]) ?? getAt(isPlainObject(parsed) ? parsed : null, ['providers']));
+		if (!Array.isArray(list)) return names;
+		for (const provider of list) {
+			if (isPlainObject(provider) && typeof provider.name === 'string') {
+				names.add(provider.name);
+			}
+		}
+	} catch {
+		// Unparseable env config: the loader ignores it too.
+	}
+	return names;
+}
+
+function resolveMcpEntries(
+	cwd: string,
+	configDir: string,
+): EffectiveConfigEntry[] {
+	const originFor = (source: string): string => {
+		if (source === 'project') return join(cwd, '.mcp.json');
+		if (source === 'global') return join(configDir, '.mcp.json');
+		return 'NANOCODER_MCPSERVERS';
+	};
+
+	return loadAllMCPConfigs().map(({server, source}) => {
+		const {value, redacted} = redactValue(server, server.name);
+		return {
+			key: `mcpServers.${server.name}`,
+			value,
+			redacted,
+			layer: (source === 'env' ? 'env' : source) as ConfigLayerId,
+			origin: originFor(source),
+			hasDefault: false,
+			shadowed: [],
+			rule: 'merge-by-name' as const,
+		};
+	});
+}
+
+/**
+ * Resolve every known config key to its effective value plus provenance.
+ *
+ * `cwd` and `configDir` default to the live process values; tests pass them
+ * explicitly.
+ */
+export function resolveEffectiveConfig(options?: {
+	cwd?: string;
+	configDir?: string;
+}): EffectiveConfig {
+	const cwd = options?.cwd ?? process.cwd();
+	const configDir = options?.configDir ?? getConfigPath();
+	const rawLayers = readRawLayers(cwd, configDir);
+
+	const entries: EffectiveConfigEntry[] = [
+		...blockSpecs().flatMap(spec => resolveBlockEntries(spec, rawLayers)),
+		...resolvePreferencesEntries(rawLayers),
+		...resolveProviderEntries(rawLayers),
+		...resolveMcpEntries(cwd, configDir),
+	].filter(entry => entry.value !== undefined || entry.shadowed.length > 0);
+
+	const explicitConfigDir = Boolean(process.env.NANOCODER_CONFIG_DIR);
+	const layers: ConfigLayerInfo[] = [
+		{layer: 'default', origin: 'built-in', exists: true},
+		...rawLayers
+			.slice()
+			.sort(
+				(a, b) =>
+					LAYER_PRECEDENCE.indexOf(a.layer) - LAYER_PRECEDENCE.indexOf(b.layer),
+			)
+			.map(layer => ({
+				layer: layer.layer,
+				origin: layer.path,
+				exists: layer.exists,
+				error: layer.error,
+				skipped:
+					explicitConfigDir &&
+					layer.layer === 'project' &&
+					layer.file === 'nanocoder-preferences.json' &&
+					layer.exists
+						? 'NANOCODER_CONFIG_DIR is set, so preferences are read from the config directory only'
+						: undefined,
+			})),
+	];
+
+	return {cwd, configDir, layers, entries};
+}
+
+/**
+ * Entries whose effective value is not the built-in default, plus every entry
+ * that is shadowing a value set in a lower layer. This is what `config diff`
+ * renders: the complete set of places a config file is changing behaviour.
+ */
+export function selectOverrides(
+	config: EffectiveConfig,
+): EffectiveConfigEntry[] {
+	return config.entries.filter(
+		entry => entry.layer !== 'default' || entry.shadowed.length > 0,
+	);
+}
+
+/**
+ * Find entries matching a user-supplied key. Matches an exact dotted key
+ * first, then a dotted prefix (so `nanocoder.autoCompact` returns the whole
+ * block), then the same two with a `nanocoder.` prefix added, then
+ * case-insensitively, and finally as a substring so a bare `threshold` still
+ * finds something.
+ */
+export function findEntries(
+	config: EffectiveConfig,
+	key: string,
+): EffectiveConfigEntry[] {
+	const query = key.trim();
+	if (query === '') return [];
+
+	const candidates = [query, `nanocoder.${query}`, `preferences.${query}`];
+
+	for (const candidate of candidates) {
+		const exact = config.entries.filter(entry => entry.key === candidate);
+		if (exact.length > 0) return exact;
+	}
+	for (const candidate of candidates) {
+		const prefixed = config.entries.filter(entry =>
+			entry.key.startsWith(`${candidate}.`),
+		);
+		if (prefixed.length > 0) return prefixed;
+	}
+
+	const lower = query.toLowerCase();
+	const insensitive = config.entries.filter(
+		entry =>
+			entry.key.toLowerCase() === lower ||
+			entry.key.toLowerCase().startsWith(`${lower}.`),
+	);
+	if (insensitive.length > 0) return insensitive;
+
+	return config.entries.filter(entry =>
+		entry.key.toLowerCase().includes(lower),
+	);
+}

--- a/source/config/effective-config.ts
+++ b/source/config/effective-config.ts
@@ -718,6 +718,9 @@ export function resolveEffectiveConfig(options?: {
 }): EffectiveConfig {
 	const cwd = options?.cwd ?? process.cwd();
 	const configDir = options?.configDir ?? getConfigPath();
+	getAppConfig();
+	loadPreferences();
+
 	const rawLayers = readRawLayers(cwd, configDir);
 
 	const entries: EffectiveConfigEntry[] = [

--- a/source/config/effective-config.ts
+++ b/source/config/effective-config.ts
@@ -127,6 +127,30 @@ const REDACTED = '<redacted>';
 const SECRET_KEY_PATTERN =
 	/(api[-_]?key|access[-_]?token|refresh[-_]?token|\btoken\b|secret|password|passwd|authorization|credential)/i;
 
+const SECRET_KEY_SEGMENTS = new Set([
+	'token',
+	'secret',
+	'password',
+	'passwd',
+	'credential',
+	'credentials',
+	'authorization',
+	'auth',
+	'apikey',
+	'accesskey',
+	'privatekey',
+]);
+
+/** Whether a key names a credential. See SECRET_KEY_SEGMENTS. */
+function isSecretKey(key: string): boolean {
+	if (SECRET_KEY_PATTERN.test(key)) return true;
+	return key
+		.replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.some(segment => SECRET_KEY_SEGMENTS.has(segment));
+}
+
 /**
  * An `$VAR` / `${VAR}` / `${VAR:-default}` reference is what the user wrote in
  * the file, not the credential itself, so showing it is both safe and the
@@ -148,7 +172,7 @@ export function redactValue(
 	value: unknown,
 	keyHint = '',
 ): {value: unknown; redacted: boolean} {
-	if (SECRET_KEY_PATTERN.test(keyHint) && !isEnvReference(value)) {
+	if (isSecretKey(keyHint) && !isEnvReference(value)) {
 		if (value === undefined || value === null || value === '') {
 			return {value, redacted: false};
 		}
@@ -186,6 +210,17 @@ interface RawLayer {
 	exists: boolean;
 	data: Record<string, unknown> | null;
 	error?: string;
+}
+
+/** Parse a JSON config file, or null when missing/unreadable/not an object. */
+function parseJsonFile(path: string): Record<string, unknown> | null {
+	if (!existsSync(path)) return null;
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+		return isPlainObject(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
 }
 
 function readRawFile(
@@ -681,26 +716,118 @@ function readEnvProviderNames(): Set<string> {
 	return names;
 }
 
+/**
+ * Server definitions in one `.mcp.json`, keyed by name. Mirrors
+ * `parseMCPServers`, which only accepts the object form.
+ */
+function readMcpServers(
+	data: Record<string, unknown> | null,
+): Map<string, unknown> {
+	const byName = new Map<string, unknown>();
+	const servers = getAt(data, ['mcpServers']);
+	if (!isPlainObject(servers)) return byName;
+	for (const [name, server] of Object.entries(servers)) {
+		byName.set(name, isPlainObject(server) ? {name, ...server} : server);
+	}
+	return byName;
+}
+
+/**
+ * Servers supplied through the environment, plus which variable supplied
+ * them. `NANOCODER_MCPSERVERS` is consulted first and the file variable is the
+ * fallback, exactly as `loadEnvMCPConfigs` does — so reporting the file path
+ * variable only when it is the one actually in use.
+ */
+function readEnvMcpServers(): {servers: Map<string, unknown>; origin: string} {
+	const inline = process.env.NANOCODER_MCPSERVERS;
+	const file = process.env.NANOCODER_MCPSERVERS_FILE;
+	const origin = inline ? 'NANOCODER_MCPSERVERS' : 'NANOCODER_MCPSERVERS_FILE';
+
+	let rawData = inline;
+	if (!rawData && file && existsSync(file)) {
+		try {
+			rawData = readFileSync(file, 'utf-8');
+		} catch {
+			return {servers: new Map(), origin};
+		}
+	}
+	if (!rawData) return {servers: new Map(), origin};
+
+	try {
+		const parsed: unknown = JSON.parse(rawData);
+		if (Array.isArray(parsed)) {
+			const byName = new Map<string, unknown>();
+			for (const server of parsed) {
+				if (isPlainObject(server) && typeof server.name === 'string') {
+					byName.set(server.name, server);
+				}
+			}
+			return {servers: byName, origin};
+		}
+		return {
+			servers: readMcpServers(isPlainObject(parsed) ? parsed : null),
+			origin,
+		};
+	} catch {
+		return {servers: new Map(), origin};
+	}
+}
+
 function resolveMcpEntries(
 	cwd: string,
 	configDir: string,
 ): EffectiveConfigEntry[] {
-	const originFor = (source: string): string => {
-		if (source === 'project') return join(cwd, '.mcp.json');
-		if (source === 'global') return join(configDir, '.mcp.json');
-		return 'NANOCODER_MCPSERVERS';
-	};
+	const env = readEnvMcpServers();
+	// Ascending precedence, matching `mergeMCPConfigs`: env beats project
+	// beats global, and only a server of the same name is displaced.
+	const mcpLayers: Array<{
+		layer: ConfigLayerId;
+		origin: string;
+		servers: Map<string, unknown>;
+	}> = [
+		{
+			layer: 'global',
+			origin: join(configDir, '.mcp.json'),
+			servers: readMcpServers(parseJsonFile(join(configDir, '.mcp.json'))),
+		},
+		{
+			layer: 'project',
+			origin: join(cwd, '.mcp.json'),
+			servers: readMcpServers(parseJsonFile(join(cwd, '.mcp.json'))),
+		},
+		{layer: 'env', origin: env.origin, servers: env.servers},
+	];
 
 	return loadAllMCPConfigs().map(({server, source}) => {
-		const {value, redacted} = redactValue(server, server.name);
+		const name = server.name;
+		const winnerIndex = mcpLayers.findIndex(l => l.layer === source);
+		const winner = mcpLayers[winnerIndex];
+		const {value, redacted} = redactValue(server, name);
+
+		// Everything below the winning layer that names the same server is set
+		// but unused — the same reporting providers already get.
+		const shadowed: ConfigValueAt[] = mcpLayers
+			.slice(0, Math.max(winnerIndex, 0))
+			.filter(layer => layer.servers.has(name))
+			.reverse()
+			.map(layer => {
+				const raw = redactValue(layer.servers.get(name), name);
+				return {
+					layer: layer.layer,
+					origin: layer.origin,
+					value: raw.value,
+					redacted: raw.redacted,
+				};
+			});
+
 		return {
-			key: `mcpServers.${server.name}`,
+			key: `mcpServers.${name}`,
 			value,
 			redacted,
-			layer: (source === 'env' ? 'env' : source) as ConfigLayerId,
-			origin: originFor(source),
+			layer: source as ConfigLayerId,
+			origin: winner?.origin ?? 'built-in',
 			hasDefault: false,
-			shadowed: [],
+			shadowed,
 			rule: 'merge-by-name' as const,
 		};
 	});

--- a/source/config/effective-config.ts
+++ b/source/config/effective-config.ts
@@ -235,18 +235,28 @@ function readRawLayers(cwd: string, configDir: string): RawLayer[] {
 	]);
 }
 
+/**
+ * Read a nested value by path, following **own properties only**.
+ *
+ * Every segment here can originate in a user-written JSON file, so a plain
+ * `current[segment]` would resolve `constructor`, `toString`, `__proto__` and
+ * friends up the prototype chain and report a value that no config file ever
+ * set. `Object.hasOwn` keeps the walk to data the user actually wrote.
+ */
 function getAt(
 	data: Record<string, unknown> | null,
 	path: readonly string[],
 ): unknown {
-	let current: unknown = data;
-	for (const segment of path) {
-		if (!isPlainObject(current)) return undefined;
-		current = current[segment];
-	}
-	return current;
+	return path.reduce<unknown>(
+		(current, segment) =>
+			isPlainObject(current) && Object.hasOwn(current, segment)
+				? current[segment]
+				: undefined,
+		data,
+	);
 }
 
+/** Whether `path` is an own property all the way down. See `getAt`. */
 function hasAt(
 	data: Record<string, unknown> | null,
 	path: readonly string[],
@@ -254,7 +264,11 @@ function hasAt(
 	if (path.length === 0) return data !== null;
 	const parent = getAt(data, path.slice(0, -1));
 	const last = path[path.length - 1] as string;
-	return isPlainObject(parent) && parent[last] !== undefined;
+	return (
+		isPlainObject(parent) &&
+		Object.hasOwn(parent, last) &&
+		parent[last] !== undefined
+	);
 }
 
 /**
@@ -440,11 +454,13 @@ function resolveBlockEntries(
 	return leaves.map(leaf => {
 		const key = [...spec.path, ...leaf.path].join('.');
 		const keyHint = leaf.path[leaf.path.length - 1] ?? blockKey;
+		// `in` would traverse the prototype chain, so a config key named
+		// `toString` would be reported as having a built-in default.
 		const hasDefault =
 			spec.defaults !== undefined &&
 			leaf.path.length === 1 &&
 			leaf.path[0] !== undefined &&
-			leaf.path[0] in spec.defaults;
+			Object.hasOwn(spec.defaults, leaf.path[0]);
 		const defaultValue = hasDefault
 			? spec.defaults?.[leaf.path[0] as string]
 			: undefined;
@@ -567,14 +583,17 @@ function resolvePreferencesEntries(layers: RawLayer[]): EffectiveConfigEntry[] {
  * one another, so each named entry gets its own row and its own winner.
  */
 function resolveProviderEntries(layers: RawLayer[]): EffectiveConfigEntry[] {
-	const rawProviders = (layer: RawLayer): Record<string, unknown> => {
+	// Keyed by a Map, not an object: provider names come from user JSON, and a
+	// provider literally named `__proto__` would otherwise reassign the
+	// accumulator's prototype instead of storing an entry.
+	const rawProviders = (layer: RawLayer): Map<string, unknown> => {
 		const nested = getAt(layer.data, ['nanocoder', 'providers']);
 		const top = getAt(layer.data, ['providers']);
 		const list = Array.isArray(nested) ? nested : Array.isArray(top) ? top : [];
-		const byName: Record<string, unknown> = {};
+		const byName = new Map<string, unknown>();
 		for (const provider of list) {
 			if (isPlainObject(provider) && typeof provider.name === 'string') {
-				byName[provider.name] = provider;
+				byName.set(provider.name, provider);
 			}
 		}
 		return byName;
@@ -586,7 +605,7 @@ function resolveProviderEntries(layers: RawLayer[]): EffectiveConfigEntry[] {
 	return (getAppConfig().providers ?? []).map(provider => {
 		const name = provider.name;
 		const found = fileLayers
-			.filter(layer => rawProviders(layer)[name] !== undefined)
+			.filter(layer => rawProviders(layer).has(name))
 			.reverse();
 		const {value, redacted} = redactValue(provider, name);
 
@@ -597,7 +616,7 @@ function resolveProviderEntries(layers: RawLayer[]): EffectiveConfigEntry[] {
 		const shadowedLayers = fromEnv ? found : found.slice(1);
 
 		const shadowed: ConfigValueAt[] = shadowedLayers.map(layer => {
-			const raw = redactValue(rawProviders(layer)[name], name);
+			const raw = redactValue(rawProviders(layer).get(name), name);
 			return {
 				layer: layer.layer,
 				origin: layer.path,

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -172,6 +172,12 @@ function loadHierarchicalConfig<T>(
  * Built-in auto-compact defaults. Exported so the effective-config resolver
  * (`config/effective-config.ts`) can label a value as coming from the
  * `default` layer without re-declaring the numbers.
+ *
+ * Loaders must return a **copy** of this and of the sibling DEFAULT_* objects,
+ * never the object itself: callers mutate the result of `getAppConfig()` (see
+ * `subagents/subagent-executor.spec.ts`), and handing out the shared constant
+ * lets one such write redefine the built-in default for the whole process —
+ * it even survives `reloadAppConfig()`.
  * @public
  */
 export const DEFAULT_AUTO_COMPACT_CONFIG: AutoCompactConfig = {
@@ -207,7 +213,7 @@ function loadAutoCompactConfig(): AutoCompactConfig {
 				};
 			}
 			return null;
-		}) ?? defaults
+		}) ?? {...defaults}
 	);
 }
 
@@ -308,7 +314,7 @@ function loadSessionConfig(): AppConfig['sessions'] {
 				};
 			}
 			return null;
-		}) ?? defaults
+		}) ?? {...defaults}
 	);
 }
 
@@ -343,10 +349,10 @@ function loadHeadlessConfig(): AppConfig['headless'] {
 				if (typeof value === 'number' && Number.isFinite(value)) {
 					return {maxTurns: Math.max(1, Math.round(value))};
 				}
-				return defaults;
+				return {...defaults};
 			}
 			return null;
-		}) ?? defaults
+		}) ?? {...defaults}
 	);
 }
 
@@ -405,7 +411,7 @@ function loadRetryLimitsConfig(): RetryLimitsConfig {
 				};
 			}
 			return null;
-		}) ?? defaults
+		}) ?? {...defaults}
 	);
 }
 

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -168,15 +168,23 @@ function loadHierarchicalConfig<T>(
 	return tryLoadConfig(join(getConfigPath(), fileName), label, extract); // nosemgrep
 }
 
+/**
+ * Built-in auto-compact defaults. Exported so the effective-config resolver
+ * (`config/effective-config.ts`) can label a value as coming from the
+ * `default` layer without re-declaring the numbers.
+ * @public
+ */
+export const DEFAULT_AUTO_COMPACT_CONFIG: AutoCompactConfig = {
+	enabled: true,
+	threshold: 60,
+	mode: 'conservative',
+	strategy: 'llm',
+	notifyUser: true,
+};
+
 // Load auto-compact configuration and Returns default config if not specified
 function loadAutoCompactConfig(): AutoCompactConfig {
-	const defaults: AutoCompactConfig = {
-		enabled: true,
-		threshold: 60,
-		mode: 'conservative',
-		strategy: 'llm',
-		notifyUser: true,
-	};
+	const defaults = DEFAULT_AUTO_COMPACT_CONFIG;
 
 	return (
 		loadHierarchicalConfig('agents.config.json', 'auto-compact', config => {
@@ -238,16 +246,23 @@ function validateStrategy(strategy: unknown): CompressionStrategy {
 	return 'llm';
 }
 
+/**
+ * Built-in session defaults. See DEFAULT_AUTO_COMPACT_CONFIG for why this is
+ * exported rather than inlined.
+ * @public
+ */
+export const DEFAULT_SESSION_CONFIG: NonNullable<AppConfig['sessions']> = {
+	autoSave: true,
+	saveInterval: 30000, // 30 seconds
+	maxSessions: 100,
+	maxMessages: 1000,
+	retentionDays: 30,
+	directory: '',
+};
+
 // Load session configuration and Returns default config if not specified
 function loadSessionConfig(): AppConfig['sessions'] {
-	const defaults: NonNullable<AppConfig['sessions']> = {
-		autoSave: true,
-		saveInterval: 30000, // 30 seconds
-		maxSessions: 100,
-		maxMessages: 1000,
-		retentionDays: 30,
-		directory: '',
-	};
+	const defaults = DEFAULT_SESSION_CONFIG;
 
 	const normalizeSessionNumber = (
 		value: unknown,
@@ -305,10 +320,12 @@ export const DEFAULT_HEADLESS_MAX_TURNS = 200;
 
 // Load headless conversation limits. Env var wins (handy for CI), then
 // agents.config.json, then the default.
+export const DEFAULT_HEADLESS_CONFIG: NonNullable<AppConfig['headless']> = {
+	maxTurns: DEFAULT_HEADLESS_MAX_TURNS,
+};
+
 function loadHeadlessConfig(): AppConfig['headless'] {
-	const defaults: NonNullable<AppConfig['headless']> = {
-		maxTurns: DEFAULT_HEADLESS_MAX_TURNS,
-	};
+	const defaults = DEFAULT_HEADLESS_CONFIG;
 
 	const envValue = process.env['NANOCODER_MAX_TURNS'];
 	if (envValue !== undefined && envValue.trim() !== '') {
@@ -337,12 +354,14 @@ function loadHeadlessConfig(): AppConfig['headless'] {
 // Defaults mirror the historical hardcoded caps in constants.ts, so behaviour
 // is unchanged unless the user opts in. Distinct from the per-provider
 // `maxRetries` setting, which caps network request retries.
+export const DEFAULT_RETRY_LIMITS: RetryLimitsConfig = {
+	maxRepeatedToolCalls: MAX_REPEATED_TOOL_CALLS,
+	maxEmptyTurns: MAX_EMPTY_TURNS,
+	maxMalformedRetries: MAX_MALFORMED_RETRIES,
+};
+
 function loadRetryLimitsConfig(): RetryLimitsConfig {
-	const defaults: RetryLimitsConfig = {
-		maxRepeatedToolCalls: MAX_REPEATED_TOOL_CALLS,
-		maxEmptyTurns: MAX_EMPTY_TURNS,
-		maxMalformedRetries: MAX_MALFORMED_RETRIES,
-	};
+	const defaults = DEFAULT_RETRY_LIMITS;
 
 	// A fresh tool-call signature already counts as 1 repeat, so a cap below 2
 	// would pause on every single tool call. The nudge/self-correction caps may
@@ -390,11 +409,21 @@ function loadRetryLimitsConfig(): RetryLimitsConfig {
 	);
 }
 
+/**
+ * Built-in paste defaults. A function rather than a const because
+ * `@/utils/paste-utils` imports this module back, and reading
+ * DEFAULT_SINGLE_LINE_PASTE_THRESHOLD at module-evaluation time hits the
+ * temporal dead zone on whichever side of the cycle loads second. Deferring
+ * the read to call time is what the loader below always did.
+ * @public
+ */
+export function getDefaultPasteConfig(): PasteConfig {
+	return {singleLineThreshold: DEFAULT_SINGLE_LINE_PASTE_THRESHOLD};
+}
+
 // Load paste configuration and Returns default config if not specified
 function loadPasteConfig(): PasteConfig {
-	const defaults: PasteConfig = {
-		singleLineThreshold: DEFAULT_SINGLE_LINE_PASTE_THRESHOLD,
-	};
+	const defaults = getDefaultPasteConfig();
 
 	return (
 		loadHierarchicalConfig('nanocoder-preferences.json', 'paste', config => {


### PR DESCRIPTION
## Description

Adds `nanocoder config` so you can see your settings and which file each one came from.

Settings come from four places: built-in defaults, your global config folder, the project folder, and `NANOCODER_*` environment variables. Before this, finding out which one set a value meant opening all four by hand.

Three commands:

- `nanocoder config list` - every setting, its value, and the file it came from
- `nanocoder config show <key>` 0 one setting in detail, with its default and any values it beat
- `nanocoder config diff` - only what your files change, plus values that are set but not used

All three take `--json`.

**Worth knowing:** settings are grouped into blocks like `autoCompact`. Nanocoder takes the *whole* block from the first file that mentions it - it does not mix fields from two files. So if global sets `threshold` and `notifyUser`, and your project file sets only `threshold`, your `notifyUser` is dropped and the built-in default is used. Nothing told you that before. `config diff` now lists it under "Ignored values".

Two smaller things: values show the way the app really uses them (write `threshold: 200`, see `95`, because it's capped), and API keys show as `<redacted>` so output is safe to paste into an issue.

Closes #1006.


https://github.com/user-attachments/assets/5dd05a99-bd84-42c7-b6aa-a7cc93def02e



## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

14 new tests in `source/config/effective-config.spec.ts`. `source/config/` passes 270 tests. `test:types`, `test:lint`, `test:format` and `test:knip` are all clean and the build succeeds. I have not run the full `pnpm test:all` end to end.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Not applicable as this command only reads config files and prints them. It never contacts a provider. Tested by hand against a real global config plus a project config, checking value, layer, source file, shadowed values, and redaction.

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

No logging needed — the command prints to stdout and exits.
