### PR TITLE
fix: quote parameters correctly for cmd.exe custom tools

### DIFF
--- a/.changeset/custom-tool-windows-cmd-quoting.md
+++ b/.changeset/custom-tool-windows-cmd-quoting.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix custom tool templating to quote parameters correctly under cmd.exe

--- a/source/custom-tools/handler.ts
+++ b/source/custom-tools/handler.ts
@@ -19,10 +19,10 @@ export function buildHandler(
 	projectRoot: string,
 ): ToolHandler {
 	return async (args: Record<string, unknown>): Promise<string> => {
-		const rendered = renderBody(body, args ?? {});
+		const shell = pickShell(metadata.shell);
+		const rendered = renderBody(body, args ?? {}, shell);
 		const cwd = resolveCwd(metadata.cwd, projectRoot);
 		const env = mergeEnv(metadata.env);
-		const shell = pickShell(metadata.shell);
 		return runScript(rendered, {
 			cwd,
 			env,
@@ -195,7 +195,7 @@ export function shellArgs(shell: string, script: string): string[] {
 	return isWindowsCmd(shell) ? ['/d', '/s', '/c', script] : ['-c', script];
 }
 
-function isWindowsCmd(shell: string): boolean {
+export function isWindowsCmd(shell: string): boolean {
 	const name = shell.replaceAll('\\', '/').split('/').pop() ?? '';
 	return /^cmd(\.exe)?$/i.test(name);
 }

--- a/source/custom-tools/template.spec.ts
+++ b/source/custom-tools/template.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {renderBody, renderValue, shellQuote} from './template';
+import {renderBody, renderValue, shellQuote, cmdQuote} from './template';
 
 console.log('\ncustom-tools/template.spec.ts');
 
@@ -34,6 +34,17 @@ test('renderValue handles arrays', t => {
 test('renderValue handles numbers and booleans', t => {
 	t.is(renderValue(42), `'42'`);
 	t.is(renderValue(true), `'true'`);
+});
+
+test('cmdQuote escapes %, &, |, <, >, ^', t => {
+	t.is(cmdQuote('%PATH%'), '"^%PATH^%"');
+	t.is(cmdQuote('a & b | c < d > e ^ f'), '"a ^& b ^| c ^< d ^> e ^^ f"');
+});
+
+test('renderValue uses cmdQuote for cmd.exe', t => {
+	t.is(renderValue(['a', 'b & c'], 'cmd.exe'), '"a" "b ^& c"');
+	t.is(renderValue(42, 'cmd.exe'), '"42"');
+	t.is(renderValue('hello', 'cmd'), '"hello"');
 });
 
 test('renderBody substitutes parameters with shell-quoted values', t => {
@@ -103,4 +114,9 @@ test('renderBody positive and inverted sections on the same var', t => {
 	const tpl = `{{# json }}A {{ id }}{{/ json }}{{^ json }}B {{ id }}{{/ json }}`;
 	t.is(renderBody(tpl, {id: '1', json: true}), "A '1'");
 	t.is(renderBody(tpl, {id: '1', json: false}), "B '1'");
+});
+
+test('renderBody uses cmd quoting when shell is cmd.exe', t => {
+	const out = renderBody('echo {{ msg }}', {msg: "hello & world"}, 'cmd.exe');
+	t.is(out, 'echo "hello ^& world"');
 });

--- a/source/custom-tools/template.ts
+++ b/source/custom-tools/template.ts
@@ -19,6 +19,7 @@
  * same quotes are not quoting, so this is not an injection barrier.
  */
 
+import {isWindowsCmd} from '@/custom-tools/handler';
 import {expandSections} from '@/utils/template-sections';
 
 /**
@@ -35,14 +36,28 @@ export function shellQuote(value: string): string {
 }
 
 /**
+ * Wrap a string in cmd.exe-safe double quotes.
+ *
+ * Escapes %, &, |, <, >, and ^ by prefixing them with ^.
+ */
+export function cmdQuote(value: string): string {
+	const escaped = value.replace(/[%&|<>^]/g, '^$&');
+	return `"${escaped}"`;
+}
+
+/**
  * Render an argument value as a shell-safe token (or token list, for arrays).
  */
-export function renderValue(value: unknown): string {
+export function renderValue(value: unknown, shell?: string): string {
 	if (value === null || value === undefined) return '';
+
+	const quote = shell && isWindowsCmd(shell) ? cmdQuote : shellQuote;
+
 	if (Array.isArray(value)) {
-		return value.map(v => shellQuote(stringify(v))).join(' ');
+		return value.map(v => quote(stringify(v))).join(' ');
 	}
-	return shellQuote(stringify(value));
+
+	return quote(stringify(value));
 }
 
 function stringify(value: unknown): string {
@@ -75,20 +90,22 @@ function isTruthyArg(value: unknown): boolean {
 export function renderBody(
 	body: string,
 	args: Record<string, unknown>,
+	shell?: string,
 ): string {
 	const afterSections = expandSections(body, name => isTruthyArg(args[name]));
-	return expandSubstitutions(afterSections, args);
+	return expandSubstitutions(afterSections, args, shell);
 }
 
 function expandSubstitutions(
 	body: string,
 	args: Record<string, unknown>,
+	shell?: string,
 ): string {
 	return body.replace(
 		/\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g,
 		(_match, name: string) => {
 			if (!(name in args)) return '';
-			return renderValue(args[name]);
+			return renderValue(args[name], shell);
 		},
 	);
 }


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause: The custom tool template engine universally applied POSIX single-quote escaping for all arguments (`renderValue` -> `shellQuote`). On Windows `cmd.exe`, this resulted in strings wrapped in literal `'` marks, breaking file paths and failing to prevent shell injection vectors from characters like `&` and `%VAR%`.

Fix: Extracted `isWindowsCmd` from `handler.ts` and introduced a `cmdQuote` function in `template.ts` that escapes metacharacters `%`, `&`, `|`, `<`, `>`, and `^` by prefixing them with `^` and wrapping the argument in double quotes. The template renderer now takes the shell as an optional parameter and uses `cmdQuote` if it detects a Windows `cmd` shell.

Validation:
```
pnpm run build
pnpm test:format
pnpm test:lint
pnpm test:types
pnpm test:knip
pnpm test:ava source/custom-tools/*.spec.ts
```
(Note: Only custom-tools tests were run via `ava` due to container environment timeouts)

Fixes https://github.com/Nano-Collective/nanocoder/issues/1084

Fixes #1084
