### PR TITLE
fix(vscode): move mode selector next to model dropdown and update styling

### DIFF
--- a/.changeset/move-mode-selector.md
+++ b/.changeset/move-mode-selector.md
@@ -1,0 +1,5 @@
+---
+"nanocoder-vscode": patch
+---
+
+Move mode selector next to model dropdown and improve its label/icon

--- a/plugins/vscode/media/chat-panel.html
+++ b/plugins/vscode/media/chat-panel.html
@@ -245,17 +245,14 @@
 						</button>
 						<input type="file" id="image-upload" accept="image/png,image/jpeg,image/webp,image/gif" multiple class="hidden">
 
-						<button id="model-trigger" class="flex items-center gap-1 bg-transparent text-vscode-fg border-none text-[0.85em] outline-none cursor-pointer opacity-70 hover:opacity-100 font-vscode rounded p-1 hover:bg-vscode-toolbarHover flex-1 min-w-0" disabled>
+						<button id="model-trigger" class="flex items-center gap-1 bg-transparent text-vscode-fg border-none text-[0.85em] outline-none cursor-pointer opacity-70 hover:opacity-100 font-vscode rounded p-1 hover:bg-vscode-toolbarHover shrink min-w-0" disabled>
 							<span id="model-trigger-label" class="truncate">Loading models...</span>
 							<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0"><polyline points="6 9 12 15 18 9"></polyline></svg>
 						</button>
 
-						<button id="composer-settings-trigger" class="flex items-center gap-1 bg-transparent text-vscode-fg border-none text-[0.85em] outline-none cursor-pointer opacity-70 hover:opacity-100 font-vscode rounded p-1 hover:bg-vscode-toolbarHover shrink-0 min-w-0" title="Provider and approval mode" aria-label="Composer settings" aria-haspopup="menu" aria-expanded="false" aria-controls="composer-settings">
-							<span id="composer-mode-badge" class="truncate max-w-[40%]"></span>
-							<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0">
-								<circle cx="12" cy="12" r="3"></circle>
-								<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
-							</svg>
+						<button id="composer-settings-trigger" class="flex items-center gap-1 bg-transparent text-vscode-fg border-none text-[0.85em] outline-none cursor-pointer opacity-70 hover:opacity-100 font-vscode rounded p-1 hover:bg-vscode-toolbarHover shrink min-w-0" title="Provider and approval mode" aria-label="Composer settings" aria-haspopup="menu" aria-expanded="false" aria-controls="composer-settings">
+							<span id="composer-mode-badge" class="truncate"></span>
+							<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0"><polyline points="6 9 12 15 18 9"></polyline></svg>
 						</button>
 					</div>
 


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause: The mode selector was positioned on the far right due to the `flex-1` class on the model selector stretching it, and it had a truncated max-width and a gear icon which lacked clarity.
Fix: Removed `flex-1` from the model-trigger button so the mode-trigger (composer-settings-trigger) can immediately follow it. Replaced the mode-trigger gear SVG with a dropdown chevron and removed the `max-w-[40%]` from its label for clearer grouping on the left side of the input.
Validation: Ran `pnpm run build`, `pnpm test:format`, `pnpm test:lint`, `pnpm test:types`, `pnpm test:knip`, and targeted `pnpm test:ava "./plugins/vscode/src/**/*.spec.ts"` successfully.

Fixes https://github.com/Nano-Collective/nanocoder/issues/1095

Fixes #1095
