### PR TITLE
feat(vscode): add setting to toggle token/cost counter visibility

### DIFF
--- a/.changeset/cool-snails-jump.md
+++ b/.changeset/cool-snails-jump.md
@@ -1,0 +1,5 @@
+---
+"nanocoder-vscode": minor
+---
+
+Add setting to toggle Token/Cost counter visibility

--- a/plugins/vscode/media/chat-panel.js
+++ b/plugins/vscode/media/chat-panel.js
@@ -1905,8 +1905,8 @@
 
 	// Render a small grayed-out usage line (e.g. "Tokens: 4.2k | ~$0.01")
 	// under the finished response. Cost is omitted when unknown (local models).
-	function appendUsageIndicator(usage, cost) {
-		if (!usage) return;
+	function appendUsageIndicator(usage, cost, showTokenUsage) {
+		if (!usage || !showTokenUsage) return;
 		const total = Number.isFinite(usage.totalTokens)
 			? usage.totalTokens
 			: (Number.isFinite(usage.inputTokens) ? usage.inputTokens : 0) +
@@ -2280,7 +2280,7 @@
 			handlePlanUpdate(update);
 		} else if (update.sessionUpdate === 'prompt_response' || update.sessionUpdate === 'done') {
 			// Show token usage (and estimated cost) for the finished turn
-			appendUsageIndicator(update.usage, update.cost);
+			appendUsageIndicator(update.usage, update.cost, update.showTokenUsage);
 			// Turn is complete — restore the send button
 			setProcessing(false, update.outcome || 'completed');
 		}

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -164,6 +164,11 @@
 					"default": false,
 					"description": "Automatically start Nanocoder CLI if not running"
 				},
+				"nanocoder.showTokenUsage": {
+					"type": "boolean",
+					"default": false,
+					"description": "Show token usage and estimated cost in the chat panel"
+				},
 				"nanocoder.showDiffPreview": {
 					"type": "boolean",
 					"default": true,

--- a/plugins/vscode/src/chat-webview-provider.ts
+++ b/plugins/vscode/src/chat-webview-provider.ts
@@ -243,6 +243,7 @@ export class ChatWebviewProvider
 				: response
 					? 'completed'
 					: 'failed');
+		const showTokenUsage = vscode.workspace.getConfiguration('nanocoder').get<boolean>('showTokenUsage', false);
 		this.postMessage({
 			type: 'acpUpdate',
 			update: {
@@ -250,6 +251,7 @@ export class ChatWebviewProvider
 				outcome,
 				usage: response?.usage,
 				cost: (response?._meta as Record<string, any> | undefined)?.['nanocoder/usage']?.cost,
+				showTokenUsage,
 			},
 		});
 	}


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause: The token and cost counter is shown unconditionally, which creates visual noise for some users.
Fix: Added a VS Code setting `nanocoder.showTokenUsage` (defaulting to false) and plumbed it into the webview payload so that the UI only renders the counter when enabled. Created a changeset.
Validation: Ran `pnpm run build`, `pnpm test:format`, `pnpm test:lint`, `pnpm test:types`, `pnpm test:knip`, and targeted tests `pnpm test:ava plugins/vscode/src/`. All passed. Validated changeset logic with `node scripts/validate-changesets.js`.
Fixes https://github.com/Nano-Collective/nanocoder/issues/1096

Fixes #1096
