### PR TITLE
fix(utils): bump BoundedMap access order on overwrite

### DIFF
--- a/.changeset/fix-bounded-map-overwrite-order.md
+++ b/.changeset/fix-bounded-map-overwrite-order.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix `BoundedMap.set` not bumping an existing key's access order on overwrite. A frequently-overwritten key kept its original (oldest) insertion position and could be evicted before newer entries; overwrite now moves the key to most-recent, matching the intended LRU eviction order. Thanks to @MsfPablo. Closes #1143.

--- a/source/utils/bounded-map.spec.ts
+++ b/source/utils/bounded-map.spec.ts
@@ -102,6 +102,26 @@ test('BoundedMap - updating existing key does not trigger eviction', t => {
 	t.is(map.get('b'), 2);
 });
 
+test('BoundedMap - overwrite bumps access order so the key is not evicted', t => {
+	// Regression for #1143: a frequently-overwritten key used to retain its
+	// original (oldest) insertion position and be evicted before newer keys.
+	const map = new BoundedMap<string, number>({maxSize: 2});
+
+	map.set('a', 1);
+	map.set('b', 2);
+
+	// Overwriting 'a' should move it to the most-recent position.
+	map.set('a', 11);
+
+	// Inserting 'c' evicts the oldest remaining key, which is now 'b' — not 'a'.
+	map.set('c', 3);
+
+	t.is(map.size, 2);
+	t.true(map.has('a'));
+	t.false(map.has('b'));
+	t.true(map.has('c'));
+});
+
 test('BoundedMap - TTL causes entries to expire', async t => {
 	const map = new BoundedMap<string, number>({
 		maxSize: 100,

--- a/source/utils/bounded-map.ts
+++ b/source/utils/bounded-map.ts
@@ -49,12 +49,20 @@ export class BoundedMap<K, V> {
 	 * Set a key-value pair, enforcing size limit
 	 */
 	set(key: K, value: V): this {
-		// Remove oldest entry if at capacity
+		// Remove oldest entry if at capacity (skip when overwriting an
+		// existing key — an overwrite must not evict a different entry)
 		if (this.map.size >= this.maxSize && !this.map.has(key)) {
 			const firstKey = this.map.keys().next().value;
 			if (firstKey !== undefined) {
 				this.map.delete(firstKey);
 			}
+		}
+
+		// Bump access order on overwrite: deleting before re-inserting moves
+		// the key to the most-recent position, so a frequently-overwritten key
+		// is not left at the oldest position and prematurely evicted.
+		if (this.map.has(key)) {
+			this.map.delete(key);
 		}
 
 		this.map.set(key, {


### PR DESCRIPTION
## Summary

Fixes #1143.

`BoundedMap.set(key, value)` on an **existing** key updated the value but did not change the key's position in the underlying `Map`'s iteration order. Since eviction picks the oldest key (`this.map.keys().next().value`), a frequently-overwritten key stayed at the oldest position and was evicted before newer entries — the opposite of the intended LRU behavior.

## Change

In `set()`, when the key already exists, delete it before re-inserting so `Map` moves it to the most-recent (last-evicted) position:

```ts
if (this.map.has(key)) {
    this.map.delete(key);
}
```

The existing "skip eviction when overwriting" guard (`!this.map.has(key)`) is unchanged, so overwriting still never evicts a *different* entry — it now also stops evicting the overwritten key itself.

## Test

Adds a regression test (`overwrite bumps access order so the key is not evicted`) that fails on the pre-fix code:

- `maxSize: 2`; insert `a`, `b`; overwrite `a`; insert `c`.
- Pre-fix: `a` is evicted (it kept the oldest position). ✘
- Post-fix: `b` is evicted, `a` survives. ✔

All 22 `bounded-map.spec.ts` tests pass; the new test was verified to fail without the fix.

## Checklist

- [x] Tests added / updated
- [x] Changeset added (`.changeset/fix-bounded-map-overwrite-order.md`)
- [x] `test:ava`, `test:types`, lint, and format clean on the touched files
