### PR TITLE
fix(schedule): render */N minute as "every N minutes"

### DIFF
--- a/.changeset/fix-cron-every-n-minutes.md
+++ b/.changeset/fix-cron-every-n-minutes.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix `formatCronHuman` leaking raw cron syntax for `*/N` minute expressions. `*/5 * * * *` rendered verbatim as "every hour at minute */5"; it now renders as "every 5 minutes". Thanks to @MsfPablo. Closes #1132.

--- a/source/schedule/cron.spec.ts
+++ b/source/schedule/cron.spec.ts
@@ -69,6 +69,14 @@ test('formatCronHuman formats hourly pattern', t => {
 	t.is(formatCronHuman('0 * * * *'), 'every hour at minute 0');
 });
 
+test('formatCronHuman formats every-N-minutes without leaking cron syntax', t => {
+	// Regression for #1132: "*/N" in the minute field used to render verbatim
+	// as "every hour at minute */5".
+	t.is(formatCronHuman('*/5 * * * *'), 'every 5 minutes');
+	t.is(formatCronHuman('*/15 * * * *'), 'every 15 minutes');
+	t.is(formatCronHuman('*/1 * * * *'), 'every 1 minutes');
+});
+
 test('formatCronHuman formats daily pattern', t => {
 	t.is(formatCronHuman('0 9 * * *'), 'daily at 9:00');
 	t.is(formatCronHuman('30 14 * * *'), 'daily at 14:30');

--- a/source/schedule/cron.ts
+++ b/source/schedule/cron.ts
@@ -46,6 +46,21 @@ export function formatCronHuman(expression: string): string {
 		return 'every minute';
 	}
 
+	// Every N minutes: minute is "*/N", all other fields wildcard. Rendered
+	// explicitly so the cron syntax does not leak into the human label (#1132).
+	if (
+		minute?.startsWith('*/') &&
+		hour === '*' &&
+		dayOfMonth === '*' &&
+		month === '*' &&
+		dayOfWeek === '*'
+	) {
+		const step = minute.slice(2);
+		if (/^[1-9]\d*$/.test(step)) {
+			return `every ${step} minutes`;
+		}
+	}
+
 	if (
 		minute !== '*' &&
 		hour === '*' &&


### PR DESCRIPTION
## Summary

`formatCronHuman` leaked raw cron syntax for `*/N` minute expressions. `*/5 * * * *` matched the hourly branch (any non-`*` minute with every other field wildcard) and rendered verbatim as `every hour at minute */5`.

Added an explicit every-N-minutes branch so `*/5 * * * *` renders as `every 5 minutes`, and `*/15 * * * *` as `every 15 minutes`.

Closes #1132.

## Test plan

- [x] New regression `formatCronHuman formats every-N-minutes without leaking cron syntax` (fails without the fix, passes with it)
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] changeset added (`patch`)
