### PR TITLE
fix(utils): classify validation errors strictly over network substring heuristics

### DIFF
--- a/.changeset/fix-error-formatter-strict-validation.md
+++ b/.changeset/fix-error-formatter-strict-validation.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix `createErrorInfo` misclassifying validation errors as network errors. A validation message containing the word "connection" (or "fetch") was also flagged `isNetworkError` because the network check used loose `.includes()` substring matching. Validation now takes strict precedence over the network/timeout substring heuristics. Thanks to @MsfPablo. Closes #1136.

--- a/source/utils/error-formatter.spec.ts
+++ b/source/utils/error-formatter.spec.ts
@@ -195,3 +195,22 @@ test('createErrorInfo - recognizes ETIMEDOUT as a network and timeout error', t 
 	t.true(result.isTimeoutError);
 	t.is(result.code, 'ETIMEDOUT');
 });
+
+// Regression for #1136: a validation message containing "connection" must be
+// classified strictly as a validation error, not also as a network error.
+test('createErrorInfo - classifies validation-overlapping messages strictly as validation', t => {
+	const error = new Error('validation failed for connection');
+	const result = createErrorInfo(error);
+
+	t.true(result.isValidationError);
+	t.false(result.isNetworkError);
+	t.false(result.isTimeoutError);
+});
+
+test('createErrorInfo - still classifies a real network error with no validation cue', t => {
+	const error = new Error('failed to fetch: connection refused');
+	const result = createErrorInfo(error);
+
+	t.true(result.isNetworkError);
+	t.false(result.isValidationError);
+});

--- a/source/utils/error-formatter.ts
+++ b/source/utils/error-formatter.ts
@@ -84,6 +84,11 @@ export function createErrorInfo(
 
 	// Determine error type and extract information
 	if (error instanceof Error) {
+		// Classification is strict by precedence: validation beats the looser
+		// network/timeout substring checks. Without this, a validation message
+		// that happens to contain "connection" or "fetch" is also flagged as a
+		// network error (#1136).
+		const validationError = isValidationError(error);
 		const errorInfo: ErrorInfo = {
 			message: error.message,
 			name: error.name,
@@ -91,9 +96,9 @@ export function createErrorInfo(
 			type: 'Error',
 			originalType: error.constructor.name,
 			hasStack: !!error.stack,
-			isNetworkError: isNetworkError(error),
-			isTimeoutError: isTimeoutError(error),
-			isValidationError: isValidationError(error),
+			isNetworkError: !validationError && isNetworkError(error),
+			isTimeoutError: !validationError && isTimeoutError(error),
+			isValidationError: validationError,
 			timestamp,
 			correlationId: effectiveCorrelationId,
 			context,


### PR DESCRIPTION
## Summary

`createErrorInfo` misclassified validation errors as network errors when the message happened to contain a network-sounding substring like `connection` or `fetch` (#1136). The `isNetworkError` / `isTimeoutError` helpers match on loose `.includes()` substrings, so a message such as `"validation failed for connection"` was flagged as **both** a validation and a network error.

Validation now takes strict precedence over the network/timeout substring heuristics: when an error is a validation error, `isNetworkError` and `isTimeoutError` are forced to `false`. Real network errors (identified by error `code` such as `ECONNREFUSED` / `ETIMEDOUT`, or messages without a validation cue) are unaffected.

## Behavior

| message | before | after |
| --- | --- | --- |
| `validation failed for connection` | validation + network | validation only |
| `failed to fetch: connection refused` | network | network |
| `request failed` + `code: ETIMEDOUT` | network + timeout | network + timeout |

## Testing

- Added two regression specs covering the overlapping-message case and a real network error without a validation cue.
- `pnpm run test:types` clean; `error-formatter.spec.ts` 28/28 in isolation; biome clean.
- Existing `createErrorInfo` network/timeout specs continue to pass.

Closes #1136.
