### PR TITLE
fix: give stdout and stderr their own output byte budget

### DIFF
--- a/.changeset/quiet-streams-diverge.md
+++ b/.changeset/quiet-streams-diverge.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed the bash tool silently dropping stdout when stderr was noisy; each stream now gets its own output budget and truncation marker. Closes #1140.

--- a/.changeset/quiet-streams-diverge.md
+++ b/.changeset/quiet-streams-diverge.md
@@ -2,4 +2,4 @@
 "@nanocollective/nanocoder": patch
 ---
 
-Fixed the bash tool silently dropping stdout when stderr was noisy; each stream now gets its own output budget and truncation marker. Closes #1140.
+Fixed the bash tool silently dropping stdout when stderr was noisy; each stream now gets its own output budget and truncation marker. Worst case memory goes from 5MB to 10MB since both streams can now hit the cap at once. Closes #1140.

--- a/source/services/bash-executor.spec.ts
+++ b/source/services/bash-executor.spec.ts
@@ -449,6 +449,55 @@ test('output cap trips and appends the truncation marker exactly once', async t 
 	);
 });
 
+const STDOUT_TRUNCATION_MARKER = '... [Output truncated to prevent memory exhaustion]';
+const STDERR_TRUNCATION_MARKER = '... [Stderr truncated to prevent memory exhaustion]';
+
+test('flooding stderr past the cap does not truncate stdout - each stream has its own independent budget', async t => {
+	const { BASH_MAX_OUTPUT_BYTES } = await import('../constants.js');
+	const executor = createExecutor();
+
+	const { promise } = executor.execute(
+		`python3 -c "import sys; sys.stderr.write('E' * (${BASH_MAX_OUTPUT_BYTES} + 1000)); sys.stderr.flush(); sys.stdout.write('important stdout data')"`,
+	);
+	const result = await promise;
+
+	t.true(
+		result.stderr.includes(STDERR_TRUNCATION_MARKER),
+		'stderr should be marked truncated - it exceeded its own budget',
+	);
+	t.true(
+		result.fullOutput.includes('important stdout data'),
+		'stdout should be fully intact - stderr flooding its own budget must not affect stdout at all',
+	);
+	t.false(
+		result.fullOutput.includes(STDOUT_TRUNCATION_MARKER),
+		'stdout should not be marked truncated - it never exceeded its own independent budget',
+	);
+});
+
+test('flooding stdout past the cap does not truncate stderr - each stream has its own independent budget', async t => {
+	const { BASH_MAX_OUTPUT_BYTES } = await import('../constants.js');
+	const executor = createExecutor();
+
+	const { promise } = executor.execute(
+		`python3 -c "import sys; sys.stdout.write('O' * (${BASH_MAX_OUTPUT_BYTES} + 1000)); sys.stdout.flush(); sys.stderr.write('important stderr data')"`,
+	);
+	const result = await promise;
+
+	t.true(
+		result.fullOutput.includes(STDOUT_TRUNCATION_MARKER),
+		'stdout should be marked truncated - it exceeded its own budget',
+	);
+	t.true(
+		result.stderr.includes('important stderr data'),
+		'stderr should be fully intact - stdout flooding its own budget must not affect stderr at all',
+	);
+	t.false(
+		result.stderr.includes(STDERR_TRUNCATION_MARKER),
+		'stderr should not be marked truncated - it never exceeded its own independent budget',
+	);
+});
+
 test('cancel() on a detached process kills a spawned child (process-group assertion)', async t => {
 	const executor = createExecutor();
 	const { promise, executionId } = executor.execute('node -e "setInterval(() => {}, 1000)" & echo $!');

--- a/source/services/bash-executor.ts
+++ b/source/services/bash-executor.ts
@@ -28,6 +28,24 @@ import {
 
 const isWindows = platform === 'win32';
 
+// Each returned collector has its own budget, so one stream's volume can't affect the other's.
+function makeStreamCollector(append: (text: string) => void, marker: string) {
+	let bytes = 0;
+	let truncated = false;
+	return (data: Buffer) => {
+		if (bytes < BASH_MAX_OUTPUT_BYTES) {
+			const remaining = BASH_MAX_OUTPUT_BYTES - bytes;
+			const limitedChunk = data.subarray(0, remaining);
+			append(limitedChunk.toString());
+			bytes += limitedChunk.length;
+		}
+		if (bytes >= BASH_MAX_OUTPUT_BYTES && !truncated) {
+			truncated = true;
+			append(marker);
+		}
+	};
+}
+
 export interface BashExecutionState {
 	executionId: string;
 	command: string;
@@ -168,23 +186,16 @@ export class BashExecutor extends EventEmitter {
 			}
 		};
 
-		let outputBytes = 0;
-		let outputTruncated = false;
+		const collectStdout = makeStreamCollector(text => {
+			state.fullOutput += text;
+		}, '\n... [Output truncated to prevent memory exhaustion]');
+		const collectStderr = makeStreamCollector(text => {
+			state.stderr += text;
+		}, '\n... [Stderr truncated to prevent memory exhaustion]');
 
 		// Collect output
 		proc.stdout?.on('data', (data: Buffer) => {
-			if (outputBytes < BASH_MAX_OUTPUT_BYTES) {
-				const remaining = BASH_MAX_OUTPUT_BYTES - outputBytes;
-				const limitedChunk = data.subarray(0, remaining);
-				state.fullOutput += limitedChunk.toString();
-				outputBytes += limitedChunk.length;
-
-				if (outputBytes >= BASH_MAX_OUTPUT_BYTES && !outputTruncated) {
-					outputTruncated = true;
-					state.fullOutput +=
-						'\n... [Output truncated to prevent memory exhaustion]';
-				}
-			}
+			collectStdout(data);
 			state.outputPreview = state.fullOutput.slice(-BASH_OUTPUT_PREVIEW_LENGTH);
 			// Emit progress immediately when output is received
 			// This ensures fast commands still show streaming output
@@ -192,18 +203,7 @@ export class BashExecutor extends EventEmitter {
 		});
 
 		proc.stderr?.on('data', (data: Buffer) => {
-			if (outputBytes < BASH_MAX_OUTPUT_BYTES) {
-				const remaining = BASH_MAX_OUTPUT_BYTES - outputBytes;
-				const limitedChunk = data.subarray(0, remaining);
-				state.stderr += limitedChunk.toString();
-				outputBytes += limitedChunk.length;
-
-				if (outputBytes >= BASH_MAX_OUTPUT_BYTES && !outputTruncated) {
-					outputTruncated = true;
-					state.stderr +=
-						'\n... [Stderr truncated to prevent memory exhaustion]';
-				}
-			}
+			collectStderr(data);
 			// Emit progress immediately when stderr is received
 			this.emit('progress', {...state});
 		});


### PR DESCRIPTION
Fixes #1140.

stdout and stderr shared one byte counter and one truncation flag. A noisy stderr could exhaust the shared budget first, silently dropping stdout data after that point with no marker at all - the caller had no way to know anything was cut.

Split into two independent pairs, one per stream. Each stream's truncation now depends only on its own volume, and gets its own marker when it happens.

Ran: test:ava on bash-executor.spec.ts (two new tests, one per direction), test:types, test:lint, test:format, test:changesets.