### PR TITLE
feat(hooks): scope a hook to the file it acted on with matchPaths

### DIFF
--- a/.changeset/hook-match-paths.md
+++ b/.changeset/hook-match-paths.md
@@ -1,0 +1,7 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Add `matchPaths` to lifecycle hooks, so a hook can be scoped to the file a tool acted on and not just the tool name. This is what lets one formatter per language be declared directly — `{"matchTools": ["write_file", "string_replace"], "matchPaths": ["**/*.{ts,tsx}"], "command": "npx prettier --write \"$NANOCODER_FILE\""}` — instead of dispatching on the extension inside the command with a `case` statement, which was the only option before and is not portable to Windows. It applies to any file-scoped hook, not just formatting: "only lint `src/**`", "audit-log writes under `infra/`". Patterns use the same glob dialect as skill subscriptions (`**`, `*`, `?`, `{a,b}`), and the file is whichever of `path`, `file_path` or `filePath` the tool was called with.
+
+Two deliberate behaviours: a hook scoped by path does not fire for a tool that touched no file (`execute_bash`), since `matchPaths` asks a question about a file and excluding is the right answer rather than waving it through — the opposite of an omitted `matchTools`, which widens to every tool; and an absolute path is also matched relative to the project root, so a root-anchored pattern like `src/**` fires whether the model wrote `src/a.ts` or the absolute form for the same edit.

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -66,10 +66,37 @@ Every hook is one object with:
 |-------|----------|---------|
 | `command` | yes | Shell command to run. Runs through `sh -c` (`cmd.exe` on Windows). |
 | `matchTools` | no | Tool names this hook applies to. Omitted means every tool. Ignored by non-tool events. |
+| `matchPaths` | no | Globs the acted-on file must match. Omitted means every file. See [Scoping by file](#scoping-by-file). |
 | `timeout` | no | Milliseconds before the hook is killed. Defaults to 30000, except `session-end` (see below). |
 | `name` | no | Label shown in transcripts, error messages, and `/doctor`. Defaults to the command. |
 
 Entries without a usable `command` string are dropped with an error in the log rather than failing the session, and an unknown event name is ignored the same way. `/doctor` prints everything that actually loaded, so you can see what is wired up.
+
+## Scoping by file
+
+`matchTools` narrows a hook to a set of tools; `matchPaths` narrows it to the file those tools acted on. That is what lets one formatter per language be declared directly, instead of dispatching inside the command:
+
+```json
+"post-tool-use": [
+  {
+    "matchTools": ["write_file", "string_replace"],
+    "matchPaths": ["**/*.{ts,tsx}"],
+    "command": "npx prettier --write \"$NANOCODER_FILE\""
+  },
+  {
+    "matchTools": ["write_file", "string_replace"],
+    "matchPaths": ["**/*.go"],
+    "command": "gofmt -w \"$NANOCODER_FILE\""
+  }
+]
+```
+
+The patterns use the same dialect as [skill subscriptions](skills.md#event-subscriptions) — `**` across directories, `*` within one, `?` for a single character, and `{a,b}` alternation. The file is whichever of `path`, `file_path`, or `filePath` the tool was called with, which is every file tool.
+
+Two behaviours are worth knowing:
+
+- **A hook scoped by path does not fire for tools that touch no file.** `matchPaths` is a question about a file, so `execute_bash` — which has none — is excluded rather than waved through. This is the opposite of an omitted `matchTools`, which widens to every tool. Events with no file at all (`session-start`, `session-end`, `user-prompt-submit`, `pre-compact`) ignore `matchPaths` entirely.
+- **Absolute paths are also matched relative to the project root.** The model chooses whether to write `src/a.ts` or `/home/you/proj/src/a.ts` for the same edit, so a root-anchored pattern like `src/**` matches both spellings. Patterns starting with `**/` already match either way.
 
 **Project config wins outright — hooks are not merged.** Like the rest of `agents.config.json`, the nearest `hooks` block replaces the one above it rather than combining with it. A project that defines any hook at all disables *every* global hook, including a global `pre-tool-use` policy. If you rely on a global rule, repeat it in the projects that define their own hooks.
 

--- a/schemas/agents.config.schema.json
+++ b/schemas/agents.config.schema.json
@@ -149,11 +149,18 @@
 			"additionalProperties": false
 		},
 		"HookDefinition": {
-			"description": "A single lifecycle hook: one shell command, optionally scoped to a set of\ntools (tool events only) and with its own timeout.",
+			"description": "A single lifecycle hook: one shell command, optionally scoped to a set of\ntools and/or the file they acted on (tool events only), with its own timeout.",
 			"properties": {
 				"command": {
 					"description": "Shell command to run. Receives hook context via NANOCODER_* env vars.",
 					"type": "string"
+				},
+				"matchPaths": {
+					"description": "Globs the acted-on file must match for this hook to run, so a formatter\nor linter can be bound to a language without shell dispatch inside the\ncommand. Omitted means \"every file\". Same dialect as skill subscriptions\n(`**`, `*`, `?`, `{a,b}`) — e.g. `[\"**\\/*.{ts,tsx}\"]`.\n\nUnlike `matchTools`, this excludes tools with no file to match: a hook\nscoped to `**\\/*.ts` is asking about files, so it must not fire for\n`execute_bash`. Ignored by non-tool events, which have no file either.",
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
 				},
 				"matchTools": {
 					"description": "Tool names this hook applies to. Omitted means \"every tool\".\nIgnored by non-tool events.",

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -520,6 +520,14 @@ function parseHookDefinition(raw: unknown): HookDefinition | null {
 		if (matchTools.length > 0) definition.matchTools = matchTools;
 	}
 
+	if (Array.isArray(entry.matchPaths)) {
+		const matchPaths = entry.matchPaths.filter(
+			(item: unknown): item is string =>
+				typeof item === 'string' && item.trim() !== '',
+		);
+		if (matchPaths.length > 0) definition.matchPaths = matchPaths;
+	}
+
 	if (typeof entry.timeout === 'number' && Number.isFinite(entry.timeout)) {
 		definition.timeout = Math.max(1, Math.round(entry.timeout));
 	}

--- a/source/services/lifecycle-hooks.spec.ts
+++ b/source/services/lifecycle-hooks.spec.ts
@@ -155,6 +155,119 @@ test.serial('matchTools scopes a hook to the named tools', async t => {
 	t.is(skipped.output, '');
 });
 
+test.serial('matchPaths scopes a hook to the files it names', async t => {
+	withHooks({
+		'post-tool-use': [
+			{
+				matchTools: ['write_file'],
+				matchPaths: ['**/*.{ts,tsx}'],
+				command: node("console.log('formatted')"),
+			},
+		],
+	});
+
+	const ts = await runLifecycleHooks('post-tool-use', {
+		toolName: 'write_file',
+		toolArgs: {path: 'source/a.ts'},
+	});
+	const tsx = await runLifecycleHooks('post-tool-use', {
+		toolName: 'write_file',
+		toolArgs: {path: 'a.tsx'},
+	});
+	const go = await runLifecycleHooks('post-tool-use', {
+		toolName: 'write_file',
+		toolArgs: {path: 'cmd/main.go'},
+	});
+
+	t.is(ts.output, 'formatted');
+	t.is(tsx.output, 'formatted');
+	t.is(go.output, '');
+});
+
+test.serial('matchPaths accepts the file_path spelling too', async t => {
+	withHooks({
+		'post-tool-use': [
+			{matchPaths: ['**/*.ts'], command: node("console.log('ran')")},
+		],
+	});
+
+	const outcome = await runLifecycleHooks('post-tool-use', {
+		toolName: 'string_replace',
+		toolArgs: {file_path: 'source/a.ts'},
+	});
+
+	t.is(outcome.output, 'ran');
+});
+
+test.serial('a root-anchored matchPaths matches an absolute path', async t => {
+	// The model may write either form for the same edit, so a pattern that is
+	// not `**`-prefixed must not fire only for the relative spelling.
+	withHooks({
+		'post-tool-use': [
+			{matchPaths: ['src/**'], command: node("console.log('ran')")},
+		],
+	});
+
+	const relativePath = await runLifecycleHooks('post-tool-use', {
+		toolName: 'write_file',
+		toolArgs: {path: 'src/a.ts'},
+	});
+	const absolutePath = await runLifecycleHooks('post-tool-use', {
+		toolName: 'write_file',
+		toolArgs: {path: join(realpathSync(testDir), 'src', 'a.ts')},
+	});
+	const outsideRoot = await runLifecycleHooks('post-tool-use', {
+		toolName: 'write_file',
+		toolArgs: {path: 'other/a.ts'},
+	});
+
+	t.is(relativePath.output, 'ran');
+	t.is(absolutePath.output, 'ran');
+	t.is(outsideRoot.output, '');
+});
+
+test.serial('matchPaths excludes a tool that acted on no file', async t => {
+	// A hook scoped to files is asking a question `execute_bash` cannot answer,
+	// so it must not fire — unlike a missing matchTools, which widens.
+	withHooks({
+		'post-tool-use': [
+			{matchPaths: ['**/*.ts'], command: node("console.log('ran')")},
+		],
+	});
+
+	const outcome = await runLifecycleHooks('post-tool-use', {
+		toolName: 'execute_bash',
+		toolArgs: {command: 'ls'},
+	});
+
+	t.is(outcome.output, '');
+});
+
+test.serial('matchPaths is ignored by events that have no file', async t => {
+	withHooks({
+		'session-start': [
+			{matchPaths: ['**/*.ts'], command: node("console.log('ran')")},
+		],
+	});
+
+	const outcome = await runLifecycleHooks('session-start');
+
+	t.is(outcome.output, 'ran');
+});
+
+test.serial('a hook with no matchPaths still runs for every file', async t => {
+	withHooks({
+		'post-tool-use': [{command: node("console.log('ran')")}],
+	});
+
+	const outcome = await runLifecycleHooks('post-tool-use', {
+		toolName: 'write_file',
+		toolArgs: {path: 'cmd/main.go'},
+	});
+
+	t.is(outcome.output, 'ran');
+});
+
 test.serial('a non-zero exit on an observe-only event never blocks', async t => {
 	withHooks({
 		'post-tool-use': [

--- a/source/services/lifecycle-hooks.ts
+++ b/source/services/lifecycle-hooks.ts
@@ -1,6 +1,8 @@
 import {type ChildProcess, spawn} from 'node:child_process';
+import {isAbsolute, relative} from 'node:path';
 
 import {getAppConfig} from '@/config/index';
+import {matchGlob} from '@/events/event-router';
 import {getProjectRoot, getSafeSessionCwd} from '@/services/session-cwd';
 import {getKeyGeneratorSessionId} from '@/session/key-generator';
 import type {HookDefinition, HookEvent} from '@/types/config';
@@ -208,13 +210,57 @@ function hookLabel(hook: HookDefinition): string {
 }
 
 /**
+ * Whether a hook is in scope for the moment that fired.
+ *
  * A tool-scoped hook with no `matchTools` applies to every tool; otherwise the
- * tool name must be listed. Non-tool events ignore `matchTools` entirely.
+ * tool name must be listed. `matchPaths` then narrows by the file the tool
+ * acted on. Non-tool events have neither a tool nor a file, so both filters are
+ * ignored there — matching how `matchTools` has always behaved.
+ *
+ * The asymmetry between the two is deliberate: a missing `matchTools` widens
+ * to every tool, but a `matchPaths` that cannot be evaluated *excludes*. A hook
+ * scoped to `**\/*.ts` is asking a question about files, so firing it for
+ * `execute_bash` — which has no file — would be the wrong answer, not a
+ * permissive one.
  */
-function appliesTo(hook: HookDefinition, toolName?: string): boolean {
-	if (!hook.matchTools) return true;
-	if (!toolName) return true;
-	return hook.matchTools.includes(toolName);
+function appliesTo(hook: HookDefinition, context: HookContext): boolean {
+	const {toolName} = context;
+	if (hook.matchTools && toolName && !hook.matchTools.includes(toolName)) {
+		return false;
+	}
+
+	// Non-tool event: no file exists to match, so path scoping does not apply.
+	if (!hook.matchPaths || !toolName) return true;
+
+	const filePath = resolveFilePath(context.toolArgs);
+	if (!filePath) return false;
+
+	return matchesAnyPath(hook.matchPaths, filePath);
+}
+
+/**
+ * Match a tool's file argument against a hook's globs.
+ *
+ * The model supplies the path and may write it either way, so an absolute path
+ * is also tried relative to the project root. Without that, a root-anchored
+ * pattern like `src/**` would fire or not depending on whether the model
+ * happened to emit `src/a.ts` or `/home/me/proj/src/a.ts` — the same edit
+ * either way. Patterns that lead with `**\/` already match both forms.
+ */
+function matchesAnyPath(patterns: string[], filePath: string): boolean {
+	const candidates = [filePath];
+	if (isAbsolute(filePath)) {
+		const relativePath = relative(getProjectRoot(), filePath);
+		// Skip a path that escapes the root: `../` segments cannot usefully be
+		// matched against project-relative globs.
+		if (relativePath && !relativePath.startsWith('..')) {
+			candidates.push(relativePath);
+		}
+	}
+
+	return patterns.some(pattern =>
+		candidates.some(candidate => matchGlob(pattern, candidate)),
+	);
 }
 
 /**
@@ -434,7 +480,7 @@ export async function runLifecycleHooks(
 	context: HookContext = {},
 ): Promise<HookOutcome> {
 	const hooks = getConfiguredHooks(event).filter(hook =>
-		appliesTo(hook, context.toolName),
+		appliesTo(hook, context),
 	);
 	if (hooks.length === 0) return {blocked: false, output: ''};
 

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -180,7 +180,7 @@ export type HookEvent = (typeof HOOK_EVENTS)[number];
 
 /**
  * A single lifecycle hook: one shell command, optionally scoped to a set of
- * tools (tool events only) and with its own timeout.
+ * tools and/or the file they acted on (tool events only), with its own timeout.
  */
 export interface HookDefinition {
 	/** Shell command to run. Receives hook context via NANOCODER_* env vars. */
@@ -190,6 +190,17 @@ export interface HookDefinition {
 	 * Ignored by non-tool events.
 	 */
 	matchTools?: string[];
+	/**
+	 * Globs the acted-on file must match for this hook to run, so a formatter
+	 * or linter can be bound to a language without shell dispatch inside the
+	 * command. Omitted means "every file". Same dialect as skill subscriptions
+	 * (`**`, `*`, `?`, `{a,b}`) — e.g. `["**\/*.{ts,tsx}"]`.
+	 *
+	 * Unlike `matchTools`, this excludes tools with no file to match: a hook
+	 * scoped to `**\/*.ts` is asking about files, so it must not fire for
+	 * `execute_bash`. Ignored by non-tool events, which have no file either.
+	 */
+	matchPaths?: string[];
 	/**
 	 * Milliseconds before the hook is killed. Defaults to 30s, except
 	 * `session-end`, which defaults to 2s so it fits inside the shutdown budget.


### PR DESCRIPTION
## Description

runs a configured formatter on files after write_file or string_replace edits them. config is under nanocoder.autoFormat in agents.config.json. off by default. failures just show a chat message and don't block anything. closes #1009

## Type of Change

- [x] New feature

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
