### PR TITLE
fix(acp): use formatCompactTokenCount for subagent activity card toke…

### DIFF
--- a/.changeset/subagent-token-count-precision.md
+++ b/.changeset/subagent-token-count-precision.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed the subagent activity card in the ACP (VS Code extension) integration truncating token counts to whole thousands (`Math.floor(tokenCount / 1000)`), so 1–999 tokens showed as `0k` and 1500–1999 showed as `1k`. Now uses the existing `formatCompactTokenCount` formatter from `source/usage/format.ts`, matching the precision already used by the per-response usage indicator (e.g. `1.9k tokens` instead of `1k tokens`). Closes #1133.

--- a/source/acp/acp-conversation.ts
+++ b/source/acp/acp-conversation.ts
@@ -41,6 +41,7 @@ import type {
 	ToolCall,
 	ToolResult,
 } from '@/types/core';
+import {formatCompactTokenCount} from '@/usage/format';
 import {buildResponseUsage} from '@/usage/response-usage';
 import {maybeAutoCompact} from '@/utils/auto-compact';
 import {capMessagesForModel} from '@/utils/message-capping';
@@ -621,13 +622,13 @@ async function runTurn(
 					}
 
 					if (best) {
-						const tokens = Math.floor(best.tokenCount / 1000);
+						const tokens = formatCompactTokenCount(best.tokenCount);
 						const lastTool =
 							best.toolHistory.length > 0
 								? best.toolHistory[best.toolHistory.length - 1]
 								: '';
 
-						let title = `${best.subagentName || 'agent'} • ${tokens}k tokens`;
+						let title = `${best.subagentName || 'agent'} • ${tokens} tokens`;
 						if (best.toolCallCount > 0) {
 							title += ` • ${best.toolCallCount} tools${lastTool ? ` (${lastTool})` : ''}`;
 						} else {


### PR DESCRIPTION
Description

Fixes the subagent activity card in the ACP (VS Code extension) integration showing imprecise token counts. It previously computed Math.floor(tokenCount / 1000) and appended k, so 1–999 tokens displayed as 0k and 1500–1999 all displayed as 1k. Now it reuses the existing formatCompactTokenCount formatter from source/usage/format.ts (already used for the per-response usage indicator), so e.g. 1900 tokens correctly shows 1.9k tokens.

Closes #1133.

Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Changeset

- [x] Added a changeset (pnpm changeset) describing this change for the changelog

Testing

Automated Tests

- [ ] New features include passing tests in .spec.ts/tsx files
- [x] All existing tests pass (pnpm test:types, pnpm test:lint,ran locally, both clean)
- [ ] Tests cover both success and error scenarios

No new test added — this is a one-line formatting fix reusing an already-tested formatter (formatCompactTokenCount, covered by existing source/usage/*.spec.ts). Verified the fix's output directly with a throwaway script against the token counts from the issue (500 → 500, 1900 → 1.9k, 12345 → 12.3k, vs. the old 0k/1k/12k).

Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

This path only renders inside the ACP/VS Code extension subagent activity card and isn't reachable through the plain CLI providers above; verified via direct formatter comparison instead of a live ACP session (see Testing notes).

Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed), not needed, no public API/doc surface changed
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see CONTRIBUTING.md (../CONTRIBUTING.md#logging)) — n/a, no new logging needed for this change