### PR TITLE
fix: audit & improve keyboard interaction (Home/End/Delete/Ctrl+A/E, undo/redo, showCursor guards, TitleShape cancel)

### DIFF
--- a/.changeset/backspace-raw-disambiguation.md
+++ b/.changeset/backspace-raw-disambiguation.md
@@ -1,0 +1,7 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed Backspace deleting the character after the cursor on virtually every terminal. Ink parses both the physical Backspace (`\x7f`, sent by macOS Terminal, iTerm2 and essentially all Linux terminals) and the forward Delete key (`\x1b[3~`) as `key.delete`, so Backspace was routed to a forward delete (a no-op at end of line). TextInput now disambiguates at the raw-sequence level so Backspace always deletes backward.
+
+Fixed undo/redo reading stale stacks when an edit and an undo/redo arrive in the same stdin batch. `pushToUndoStack` now keeps the undo/redo stack refs in lockstep synchronously (not just after a render), and `redo()` now caps the undo stack it pushes back onto, matching `undo()`.

--- a/patches/ink@6.8.0.patch
+++ b/patches/ink@6.8.0.patch
@@ -15,3 +15,38 @@ index 30019a073d38ed05dca08f6221af187c429a536b..5254bf400cda5f4d7fdc95c0a0f6ccd8
  import ansiEscapes from 'ansi-escapes';
  import isInCi from 'is-in-ci';
  import autoBind from 'auto-bind';
+diff --git a/build/hooks/use-input.js b/build/hooks/use-input.js
+index 52b4487e..c182b5ed 100644
+--- a/build/hooks/use-input.js
++++ b/build/hooks/use-input.js
+@@ -68,6 +68,11 @@ const useInput = (inputHandler, options = {}) => {
+                 capsLock: keypress.capsLock ?? false,
+                 numLock: keypress.numLock ?? false,
+                 eventType: keypress.eventType,
++                // Patched by nanocoder: expose the raw input sequence (e.g.
++                // '\x7f' for physical Backspace vs '\x1b[3~' for forward Delete)
++                // so handlers can disambiguate keys that Ink parses to the same
++                // name (both map to `delete`).
++                raw: keypress.raw,
+             };
+             let input;
+             if (keypress.isKittyProtocol) {
+diff --git a/build/hooks/use-input.d.ts b/build/hooks/use-input.d.ts
+index e2a9f07c..2497c9ae 100644
+--- a/build/hooks/use-input.d.ts
++++ b/build/hooks/use-input.d.ts
+@@ -96,6 +96,14 @@ export type Key = {
+     Only available with kitty keyboard protocol.
+     */
+     eventType?: 'press' | 'repeat' | 'release';
++    /**
++    Raw input sequence that was parsed for this key. Useful to disambiguate
++    keys that Ink maps to the same name — e.g. physical Backspace ('\x7f') vs
++    forward Delete ('\x1b[3~'), which both set `delete: true`.
++
++    Patched by nanocoder.
++    */
++    raw?: string;
+ };
+ type Handler = (input: string, key: Key) => void;
+ type Options = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   '@ai-sdk/openai@3.0.71': df300a5d22aecda3490a73885c5d63e34d4cd056d26fc5ba202ea4121d46adbf
-  ink@6.8.0: ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f
+  ink@6.8.0: 7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430
 
 importers:
 
@@ -77,22 +77,22 @@ importers:
         version: 7.0.5
       ink:
         specifier: ^6.3.1
-        version: 6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7)
+        version: 6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7)
       ink-big-text:
         specifier: ^2.0.0
-        version: 2.0.0(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       ink-gradient:
         specifier: ^4.0.0
-        version: 4.0.1(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+        version: 4.0.1(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       ink-select-input:
         specifier: ^6.2.0
-        version: 6.2.0(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+        version: 6.2.0(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       ink-spinner:
         specifier: ^5.0.0
-        version: 5.0.0(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+        version: 5.0.0(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       ink-tab:
         specifier: ^5.2.0
-        version: 5.2.0(@types/react@19.2.17)(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+        version: 5.2.0(@types/react@19.2.17)(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       llama-tokenizer-js:
         specifier: ^1.2.2
         version: 1.2.2
@@ -7014,37 +7014,37 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  ink-big-text@2.0.0(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
+  ink-big-text@2.0.0(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
     dependencies:
       cfonts: 3.3.1
-      ink: 6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7)
+      ink: 6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7)
       prop-types: 15.8.1
       react: 19.2.7
 
-  ink-gradient@4.0.1(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
+  ink-gradient@4.0.1(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
     dependencies:
       '@types/gradient-string': 1.1.6
       gradient-string: 3.0.0
-      ink: 6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7)
+      ink: 6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       strip-ansi: 7.2.0
 
-  ink-select-input@6.2.0(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
+  ink-select-input@6.2.0(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
     dependencies:
       figures: 6.1.0
-      ink: 6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7)
+      ink: 6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       to-rotated: 1.0.0
 
-  ink-spinner@5.0.0(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
+  ink-spinner@5.0.0(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
     dependencies:
       cli-spinners: 2.9.2
-      ink: 6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7)
+      ink: 6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
-  ink-tab@5.2.0(@types/react@19.2.17)(ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
+  ink-tab@5.2.0(@types/react@19.2.17)(ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
     dependencies:
-      ink: 6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7)
+      ink: 6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
@@ -7053,7 +7053,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  ink@6.8.0(patch_hash=ae5bd7c6d28e6a9440188c3c07fc7a83597933b06090aaa44830f65f3d103b5f)(@types/react@19.2.17)(react@19.2.7):
+  ink@6.8.0(patch_hash=7e15be6e336403a9a44ee7061a39ffa483385d69dbb08b750c732f8aaff14430)(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.2.5
       ansi-escapes: 7.3.0

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -209,10 +209,16 @@ export default function App({
 	);
 
 	// Create title shape context value (memoized to prevent unnecessary re-renders)
+	// `setCurrentTitleShape` is a preview-only update (no persistence); `commitTitleShape`
+	// persists. Decoupling the two lets a selector navigate/highlight without writing to
+	// disk — the shape is only saved when the user confirms (Enter).
 	const titleShapeContextValue = React.useMemo(
 		() => ({
 			currentTitleShape: appState.currentTitleShape,
 			setCurrentTitleShape: (shape: TitleShape) => {
+				appState.setCurrentTitleShape(shape);
+			},
+			commitTitleShape: (shape: TitleShape) => {
 				appState.setCurrentTitleShape(shape);
 				updateTitleShape(shape);
 			},

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -314,11 +314,9 @@ export function SettingsTitleShapePanel({
 
 	useInput((_, key) => {
 		if (key.escape) {
-			setCurrentTitleShape(originalShape);
 			onCancel();
 		}
 		if (key.shift && key.tab) {
-			setCurrentTitleShape(originalShape);
 			onBack();
 		}
 	});

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -438,7 +438,9 @@ export function SettingsTitleShapePanel({
 					onHighlight={handleHighlight}
 				/>
 				<Box marginBottom={1}></Box>
-				<Text color={colors.secondary}>Enter/Shift+Tab/Esc</Text>
+				<Text color={colors.secondary}>
+					Enter to apply · Shift+Tab back · Esc back
+				</Text>
 			</TitledBoxWithPreferences>
 		);
 	}
@@ -455,7 +457,7 @@ export function SettingsTitleShapePanel({
 		>
 			<Box marginBottom={1}>
 				<Text color={colors.secondary}>
-					Enter to apply, Shift+Tab to go back, Esc to go back
+					Enter to apply · Shift+Tab back · Esc back
 				</Text>
 			</Box>
 
@@ -554,7 +556,9 @@ export function SettingsNanocoderShapePanel({
 						onHighlight={handleHighlight}
 					/>
 					<Box marginBottom={1}></Box>
-					<Text color={colors.secondary}>Enter/Shift+Tab/Esc</Text>
+					<Text color={colors.secondary}>
+						Enter to apply · Shift+Tab back · Esc back
+					</Text>
 				</TitledBoxWithPreferences>
 			</>
 		);
@@ -579,7 +583,7 @@ export function SettingsNanocoderShapePanel({
 			>
 				<Box marginBottom={1}>
 					<Text color={colors.secondary}>
-						Enter to apply, Shift+Tab to go back, Esc to go back
+						Enter to apply · Shift+Tab back · Esc back
 					</Text>
 				</Box>
 
@@ -683,9 +687,7 @@ export function SettingsPasteThresholdPanel({
 			/>
 			<Box marginTop={isNarrow ? 0 : 1}>
 				<Text color={colors.secondary}>
-					{isNarrow
-						? 'Enter/Shift+Tab/Esc'
-						: 'Enter to apply, Shift+Tab to go back, Esc to go back'}
+					Enter to apply · Shift+Tab back · Esc back
 				</Text>
 			</Box>
 		</TitledBoxWithPreferences>
@@ -803,14 +805,16 @@ export function SettingsNotificationsPanel({
 			{!isNarrow && (
 				<Box marginBottom={1}>
 					<Text color={colors.secondary}>
-						Toggle settings with Enter. Shift+Tab to go back, Esc to go back
+						Enter to toggle · Shift+Tab back · Esc back
 					</Text>
 				</Box>
 			)}
 			<StyledSelectInput items={items} onSelect={handleSelect} />
 			{isNarrow && (
 				<Box marginTop={0}>
-					<Text color={colors.secondary}>Enter/Shift+Tab/Esc</Text>
+					<Text color={colors.secondary}>
+						Enter to apply · Shift+Tab back · Esc back
+					</Text>
 				</Box>
 			)}
 		</TitledBoxWithPreferences>
@@ -900,14 +904,16 @@ export function SettingsDisplayPanel({
 			{!isNarrow && (
 				<Box marginBottom={1}>
 					<Text color={colors.secondary}>
-						Toggle settings with Enter. Shift+Tab to go back, Esc to go back
+						Enter to toggle · Shift+Tab back · Esc back
 					</Text>
 				</Box>
 			)}
 			<StyledSelectInput items={items} onSelect={handleSelect} />
 			{isNarrow && (
 				<Box marginTop={0}>
-					<Text color={colors.secondary}>Enter/Shift+Tab/Esc</Text>
+					<Text color={colors.secondary}>
+						Enter to apply · Shift+Tab back · Esc back
+					</Text>
 				</Box>
 			)}
 		</TitledBoxWithPreferences>
@@ -966,7 +972,7 @@ export function SettingsPrivacyPanel({
 			{!isNarrow && (
 				<Box marginBottom={1}>
 					<Text color={colors.secondary}>
-						Toggle settings with Enter. Shift+Tab to go back, Esc to go back
+						Enter to toggle · Shift+Tab back · Esc back
 					</Text>
 				</Box>
 			)}
@@ -982,7 +988,7 @@ export function SettingsPrivacyPanel({
 			<StyledSelectInput items={items} onSelect={handleSelect} />
 
 			<Box marginTop={1}>
-				<Text color={colors.secondary}>Enter/Esc</Text>
+				<Text color={colors.secondary}>Enter to apply · Esc back</Text>
 			</Box>
 		</TitledBoxWithPreferences>
 	);
@@ -1086,7 +1092,7 @@ export function SettingsSemanticMemoryPanel({
 			{!isNarrow && (
 				<Box marginBottom={1}>
 					<Text color={colors.secondary}>
-						Toggle settings with Enter. Shift+Tab to go back, Esc to exit
+						Enter to toggle · Shift+Tab back · Esc back
 					</Text>
 				</Box>
 			)}
@@ -1103,7 +1109,7 @@ export function SettingsSemanticMemoryPanel({
 			<StyledSelectInput items={items} onSelect={handleSelect} />
 
 			<Box marginTop={1}>
-				<Text color={colors.secondary}>Enter/Esc</Text>
+				<Text color={colors.secondary}>Enter to apply · Esc back</Text>
 			</Box>
 		</TitledBoxWithPreferences>
 	);

--- a/source/app/components/settings-selector.tsx
+++ b/source/app/components/settings-selector.tsx
@@ -309,14 +309,21 @@ export function SettingsTitleShapePanel({
 }) {
 	const {boxWidth, isNarrow} = useResponsiveTerminal();
 	const {colors} = useTheme();
-	const {currentTitleShape, setCurrentTitleShape} = useTitleShape();
+	const {currentTitleShape, setCurrentTitleShape, commitTitleShape} =
+		useTitleShape();
 	const [originalShape] = useState<TitleShape>(currentTitleShape);
 
 	useInput((_, key) => {
 		if (key.escape) {
+			// Esc/Shift+Tab = cancel. Navigation only previews via
+			// setCurrentTitleShape (in-memory, never persisted), so revert the
+			// in-memory preview back to the shape the panel was opened with
+			// before navigating away. Nothing is written to disk on cancel.
+			setCurrentTitleShape(originalShape);
 			onCancel();
 		}
 		if (key.shift && key.tab) {
+			setCurrentTitleShape(originalShape);
 			onBack();
 		}
 	});
@@ -411,11 +418,14 @@ export function SettingsTitleShapePanel({
 	}, [originalShape, shapeOptions]);
 
 	const handleSelect = (item: {label: string; value: TitleShape}) => {
-		setCurrentTitleShape(item.value);
+		// Only commit (persist to disk) on an explicit Enter.
+		commitTitleShape(item.value);
 		onBack();
 	};
 
 	const handleHighlight = (item: {label: string; value: TitleShape}) => {
+		// Preview only — updates the in-memory app title live but does NOT
+		// persist. Canceling (Esc/Shift+Tab) reverts this with no disk write.
 		setCurrentTitleShape(item.value);
 	};
 

--- a/source/app/components/settings-tabs.spec.tsx
+++ b/source/app/components/settings-tabs.spec.tsx
@@ -57,6 +57,7 @@ function renderWithTitleShape(shape: TitleShape) {
 	const titleShapeValue = {
 		currentTitleShape: shape,
 		setCurrentTitleShape: () => {},
+		commitTitleShape: () => {},
 	};
 	return render(
 		<ThemeContext.Provider value={themeValue}>

--- a/source/app/components/settings-title-shape.spec.tsx
+++ b/source/app/components/settings-title-shape.spec.tsx
@@ -1,0 +1,93 @@
+import {render} from 'ink-testing-library';
+import test from 'ava';
+import React from 'react';
+import {defaultTheme, themes} from '@/config/themes';
+import {ThemeContext} from '@/hooks/useTheme';
+import {TitleShapeContext} from '@/hooks/useTitleShape';
+import {SettingsTitleShapePanel} from './settings-selector';
+
+console.log('\nsettings-title-shape.spec.tsx');
+
+interface TitleShapeLogs {
+	previewCalls: string[];
+	commitCalls: string[];
+}
+
+// Render the Title Shape panel with an instrumented TitleShapeContext so tests
+// can observe which path (preview-only setter vs persist setter) each key
+// triggers. This is the regression guard for the cancel bug: navigating and
+// pressing Esc must preview/revert without ever persisting, while Enter commits.
+function setupPanel(logs: TitleShapeLogs) {
+	const {stdin, unmount} = render(
+		<ThemeContext.Provider
+			value={{
+				currentTheme: defaultTheme,
+				colors: themes[defaultTheme].colors,
+				setCurrentTheme: () => {},
+			}}
+		>
+			<TitleShapeContext.Provider
+				value={{
+					currentTitleShape: 'pill',
+					setCurrentTitleShape: (shape: string) => {
+						logs.previewCalls.push(shape);
+					},
+					commitTitleShape: (shape: string) => {
+						logs.commitCalls.push(shape);
+					},
+				}}
+			>
+				<SettingsTitleShapePanel onBack={() => {}} onCancel={() => {}} />
+			</TitleShapeContext.Provider>
+		</ThemeContext.Provider>,
+	);
+	return {stdin, unmount};
+}
+
+const press = (stdin: ReturnType<typeof setupPanel>['stdin'], key: string) =>
+	new Promise<void>(resolve => {
+		stdin.write(key);
+		setTimeout(resolve, 50);
+	});
+
+test('navigating the title-shape list previews without persisting', async t => {
+	const logs = {previewCalls: [], commitCalls: []} as TitleShapeLogs;
+	const {stdin, unmount} = setupPanel(logs);
+
+	// Move down once: the new item is highlighted, which in the fixed code
+	// calls setCurrentTitleShape (preview) and never commitTitleShape.
+	await press(stdin, '\u001B[B');
+
+	t.deepEqual(logs.previewCalls, ['rounded']);
+	t.is(logs.commitCalls.length, 0);
+	unmount();
+});
+
+test('Esc cancels and reverts the preview without persisting', async t => {
+	const logs = {previewCalls: [], commitCalls: []} as TitleShapeLogs;
+	const {stdin, unmount} = setupPanel(logs);
+
+	// Navigate down (preview 'rounded'), then press Esc to cancel.
+	await press(stdin, '\u001B[B');
+	await press(stdin, '\u001B');
+
+	// Esc reverts the in-memory preview back to the original shape and never
+	// persists.
+	t.deepEqual(logs.previewCalls, ['rounded', 'pill']);
+	t.is(logs.commitCalls.length, 0);
+	unmount();
+});
+
+test('Enter confirms via the commit (persistence) path', async t => {
+	const logs = {previewCalls: [], commitCalls: []} as TitleShapeLogs;
+	const {stdin, unmount} = setupPanel(logs);
+
+	// Navigate down (preview 'rounded'), then press Enter to confirm.
+	await press(stdin, '\u001B[B');
+	await press(stdin, '\r');
+
+	// Confirming commits the highlighted shape (persist) on top of the preview.
+	t.deepEqual(logs.previewCalls, ['rounded']);
+	t.deepEqual(logs.commitCalls, ['rounded']);
+	unmount();
+});

--- a/source/app/components/tune-selector.spec.tsx
+++ b/source/app/components/tune-selector.spec.tsx
@@ -21,6 +21,7 @@ const mockTheme = {
 const mockTitleShape = {
 	currentTitleShape: 'pill' as const,
 	setCurrentTitleShape: () => {},
+	commitTitleShape: () => {},
 };
 
 function Wrapper({children}: {children: React.ReactNode}) {

--- a/source/app/components/tune-selector.tsx
+++ b/source/app/components/tune-selector.tsx
@@ -172,7 +172,7 @@ function TuneMainMenu({
 					onSelect={item => onAction(item.value)}
 				/>
 				<Box marginBottom={1}></Box>
-				<Text color={colors.secondary}>Enter/Esc</Text>
+				<Text color={colors.secondary}>Enter to apply · Esc back</Text>
 			</Box>
 		);
 	}
@@ -197,7 +197,7 @@ function TuneMainMenu({
 				onSelect={item => onAction(item.value)}
 			/>
 			<Box marginTop={1}>
-				<Text color={colors.secondary}>Enter to select, Esc to cancel</Text>
+				<Text color={colors.secondary}>Enter to select · Esc to cancel</Text>
 			</Box>
 		</TitledBoxWithPreferences>
 	);
@@ -268,7 +268,9 @@ function ToolProfilePanel({
 					</Text>
 				</Box>
 				<Box marginBottom={1}></Box>
-				<Text color={colors.secondary}>Enter/Shift+Tab/Esc</Text>
+				<Text color={colors.secondary}>
+					Enter to apply · Shift+Tab back · Esc back
+				</Text>
 			</TitledBoxWithPreferences>
 		);
 	}
@@ -285,7 +287,7 @@ function ToolProfilePanel({
 		>
 			<Box marginBottom={1}>
 				<Text color={colors.secondary}>
-					Enter to apply, Shift+Tab to go back, Esc to cancel
+					Enter to apply · Shift+Tab back · Esc back
 				</Text>
 			</Box>
 			<StyledSelectInput
@@ -363,7 +365,9 @@ function PresetPanel({
 					</Box>
 				)}
 				<Box marginBottom={1}></Box>
-				<Text color={colors.secondary}>Enter/Shift+Tab/Esc</Text>
+				<Text color={colors.secondary}>
+					Enter to apply · Shift+Tab back · Esc back
+				</Text>
 			</TitledBoxWithPreferences>
 		);
 	}
@@ -380,7 +384,7 @@ function PresetPanel({
 		>
 			<Box marginBottom={1}>
 				<Text color={colors.secondary}>
-					Enter to load preset, Shift+Tab to go back, Esc to cancel
+					Enter to load preset · Shift+Tab back · Esc back
 				</Text>
 			</Box>
 			<StyledSelectInput
@@ -583,7 +587,9 @@ function ParametersPanel({
 					</Box>
 				)}
 				<Box marginBottom={1}></Box>
-				<Text color={colors.secondary}>Enter to cycle/Shift+Tab/Esc</Text>
+				<Text color={colors.secondary}>
+					Enter to cycle values · Shift+Tab back · Esc back
+				</Text>
 			</TitledBoxWithPreferences>
 		);
 	}
@@ -600,7 +606,7 @@ function ParametersPanel({
 		>
 			<Box marginBottom={1}>
 				<Text color={colors.secondary}>
-					Enter to cycle values, Shift+Tab to go back, Esc to cancel
+					Enter to cycle values · Shift+Tab back · Esc back
 				</Text>
 			</Box>
 			<StyledSelectInput

--- a/source/commands/init.spec.tsx
+++ b/source/commands/init.spec.tsx
@@ -19,7 +19,11 @@ function Providers({children}: {children: React.ReactNode}) {
 			}}
 		>
 			<TitleShapeContext.Provider
-				value={{currentTitleShape: 'pill', setCurrentTitleShape: () => {}}}
+				value={{
+					currentTitleShape: 'pill',
+					setCurrentTitleShape: () => {},
+					commitTitleShape: () => {},
+				}}
 			>
 				{children}
 			</TitleShapeContext.Provider>

--- a/source/commands/setup-config.spec.tsx
+++ b/source/commands/setup-config.spec.tsx
@@ -18,6 +18,7 @@ const MockProviders = ({children}: {children: React.ReactNode}) => {
 	const mockTitleShape = {
 		currentTitleShape: 'pill' as const,
 		setCurrentTitleShape: () => {},
+		commitTitleShape: () => {},
 	};
 
 	return (

--- a/source/components/file-explorer/index.spec.tsx
+++ b/source/components/file-explorer/index.spec.tsx
@@ -37,6 +37,7 @@ const testThemeContext = {
 const testTitleShapeContext = {
 	currentTitleShape: 'pill' as const,
 	setCurrentTitleShape: () => {},
+	commitTitleShape: () => {},
 };
 
 /**

--- a/source/components/subagent-view.spec.tsx
+++ b/source/components/subagent-view.spec.tsx
@@ -21,6 +21,7 @@ const themeValue = {
 const titleShapeValue = {
 	currentTitleShape: 'pill' as const,
 	setCurrentTitleShape: () => {},
+	commitTitleShape: () => {},
 };
 
 const wrap = (element: React.ReactElement) => (

--- a/source/components/text-input-keys.spec.tsx
+++ b/source/components/text-input-keys.spec.tsx
@@ -1,0 +1,154 @@
+import test from 'ava';
+import {render} from 'ink-testing-library';
+import React, {useState} from 'react';
+import TextInput from './text-input';
+
+/**
+ * Component-level keyboard tests for TextInput (issue #3 remediation).
+ *
+ * The pure-logic tests in text-input.spec.ts exercise duplicated helper
+ * functions, not the real useInput handlers. These tests render the actual
+ * TextInput component and drive real key sequences through stdin so the
+ * `key.home`, `key.end`, and `key.delete` branches are exercised for real.
+ *
+ * Ink key sequences used:
+ *   Home      \u001b[H
+ *   End       \u001b[F
+ *   Delete    \u001b[3~
+ *   Left      \u001b[D
+ */
+
+// Controlled wrapper: holds `value` in React state and feeds it back to
+// TextInput via onChange. The latest value is mirrored to a ref so tests can
+// read it after Ink processes keys.
+interface ValueRef {
+	current: string;
+}
+
+function ControlledTextInput({
+	valueRef,
+	initialValue = '',
+}: {
+	valueRef: ValueRef;
+	initialValue?: string;
+}) {
+	const [value, setValue] = useState(initialValue);
+	valueRef.current = value;
+	return <TextInput value={value} onChange={setValue} focus={true} />;
+}
+
+// Write a key then wait a tick for Ink to process it.
+const press = (stdin: ReturnType<typeof render>['stdin'], key: string) =>
+	new Promise<void>(resolve => {
+		stdin.write(key);
+		setTimeout(resolve, 20);
+	});
+
+// Wait until valueRef.current matches the predicate.
+const waitForValue = (
+	valueRef: ValueRef,
+	predicate: (v: string) => boolean,
+) =>
+	new Promise<void>(resolve => {
+		const start = Date.now();
+		const poll = () => {
+			if (predicate(valueRef.current) || Date.now() - start > 2000) {
+				resolve();
+			} else {
+				setTimeout(poll, 20);
+			}
+		};
+		poll();
+	});
+
+// --- Delete (key.delete) ---
+
+test('component Delete removes the character after the cursor', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abcde" />,
+	);
+
+	// Cursor is at the end; move left twice so it lands between 'c' and 'd'.
+	await press(stdin, '\u001b[D'); // left
+	await press(stdin, '\u001b[D'); // left
+	await press(stdin, '\u001b[3~'); // Delete -> removes 'd'
+
+	await waitForValue(valueRef, v => v === 'abce');
+	t.is(valueRef.current, 'abce');
+	unmount();
+});
+
+test('component Delete with cursor at start removes first character', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="hello" />,
+	);
+
+	// Move cursor to start with Home, then Delete removes 'h'.
+	await press(stdin, '\u001b[H');
+	await press(stdin, '\u001b[3~');
+
+	await waitForValue(valueRef, v => v === 'ello');
+	t.is(valueRef.current, 'ello');
+	unmount();
+});
+
+test('component Delete with cursor at end does nothing', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abc" />,
+	);
+
+	// Cursor already at end; Delete should be a no-op.
+	await press(stdin, '\u001b[3~');
+
+	await waitForValue(valueRef, v => v === 'abc');
+	t.is(valueRef.current, 'abc');
+	unmount();
+});
+
+// --- Home / End ---
+
+test('component Home moves cursor to start (next typed char inserts at 0)', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abc" />,
+	);
+
+	await press(stdin, '\u001b[H'); // Home -> cursor at 0
+	await press(stdin, 'x'); // insert 'x' at start
+
+	await waitForValue(valueRef, v => v === 'xabc');
+	t.is(valueRef.current, 'xabc');
+	unmount();
+});
+
+test('component End moves cursor to end (next typed char appends)', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abc" />,
+	);
+
+	await press(stdin, '\u001b[H'); // Home -> cursor at 0
+	await press(stdin, '\u001b[F'); // End -> cursor at 3
+	await press(stdin, 'z'); // append 'z'
+
+	await waitForValue(valueRef, v => v === 'abcz');
+	t.is(valueRef.current, 'abcz');
+	unmount();
+});
+
+test('component Home on empty value leaves cursor at 0 (typing not affected)', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="" />,
+	);
+
+	await press(stdin, '\u001b[H');
+	await press(stdin, 'x');
+
+	await waitForValue(valueRef, v => v === 'x');
+	t.is(valueRef.current, 'x');
+	unmount();
+});

--- a/source/components/text-input-keys.spec.tsx
+++ b/source/components/text-input-keys.spec.tsx
@@ -183,7 +183,7 @@ test('component Home does not move cursor when showCursor is false', async t => 
 	unmount();
 });
 
-test('component End does not move cursor when showCursor is false', async t => {
+	test('component End does not move cursor when showCursor is false', async t => {
 	const valueRef: ValueRef = {current: ''};
 	const {stdin, unmount} = render(
 		<ControlledTextInput valueRef={valueRef} initialValue="abc" showCursor={false} />,
@@ -197,5 +197,58 @@ test('component End does not move cursor when showCursor is false', async t => {
 
 	await waitForValue(valueRef, v => v === 'abcx');
 	t.is(valueRef.current, 'abcx');
+	unmount();
+});
+
+// --- Ctrl+A / Ctrl+E with showCursor={false} (issue #2) ---
+// The readline "go to start/end of line" binds must honour showCursor exactly
+// like arrows, Home/End and Ctrl+B/F — otherwise an invisible cursor desyncs
+// the next insert.
+
+test('component Ctrl+A does not move cursor when showCursor is false', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abc" showCursor={false} />,
+	);
+
+	// Ctrl+A (^A) would jump to the start when the cursor is visible; with
+	// showCursor=false it must be ignored, so typing still appends at the end.
+	await press(stdin, '\u0001');
+	await press(stdin, 'x');
+
+	await waitForValue(valueRef, v => v === 'abcx');
+	t.is(valueRef.current, 'abcx');
+	unmount();
+});
+
+test('component Ctrl+E does not move cursor when showCursor is false', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abc" showCursor={false} />,
+	);
+
+	// Ctrl+E (^E) would jump to the end; with showCursor=false it must be
+	// ignored, so typing appends at the (unchanged) end.
+	await press(stdin, '\u0005');
+	await press(stdin, 'x');
+
+	await waitForValue(valueRef, v => v === 'abcx');
+	t.is(valueRef.current, 'abcx');
+	unmount();
+});
+
+test('component Ctrl+A moves to start when showCursor is true (positive control)', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abc" />,
+	);
+
+	// With showCursor=true (default), Ctrl+A genuinely jumps to the start, so
+	// the next typed char inserts at 0 — proving the guard is the differentiator.
+	await press(stdin, '\u0001');
+	await press(stdin, 'x');
+
+	await waitForValue(valueRef, v => v === 'xabc');
+	t.is(valueRef.current, 'xabc');
 	unmount();
 });

--- a/source/components/text-input-keys.spec.tsx
+++ b/source/components/text-input-keys.spec.tsx
@@ -28,13 +28,22 @@ interface ValueRef {
 function ControlledTextInput({
 	valueRef,
 	initialValue = '',
+	showCursor = true,
 }: {
 	valueRef: ValueRef;
 	initialValue?: string;
+	showCursor?: boolean;
 }) {
 	const [value, setValue] = useState(initialValue);
 	valueRef.current = value;
-	return <TextInput value={value} onChange={setValue} focus={true} />;
+	return (
+		<TextInput
+			value={value}
+			onChange={setValue}
+			focus={true}
+			showCursor={showCursor}
+		/>
+	);
 }
 
 // Write a key then wait a tick for Ink to process it.
@@ -150,5 +159,43 @@ test('component Home on empty value leaves cursor at 0 (typing not affected)', a
 
 	await waitForValue(valueRef, v => v === 'x');
 	t.is(valueRef.current, 'x');
+	unmount();
+});
+
+// --- Home / End with showCursor={false} (issue #8) ---
+// When the cursor is hidden, cursor-movement keys must be no-ops to match the
+// other navigation bindings (arrows, Ctrl+Left/Right, Ctrl+B/F) that all guard
+// on showCursor. A Home/End that still moves an invisible cursor would desync
+// the next insert.
+
+test('component Home does not move cursor when showCursor is false', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abc" showCursor={false} />,
+	);
+
+	// Home is ignored, so typing still appends at the end (cursor stayed put).
+	await press(stdin, '\u001b[H');
+	await press(stdin, 'x');
+
+	await waitForValue(valueRef, v => v === 'abcx');
+	t.is(valueRef.current, 'abcx');
+	unmount();
+});
+
+test('component End does not move cursor when showCursor is false', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abc" showCursor={false} />,
+	);
+
+	// Navigate to the start is also guarded; with showCursor=false even that
+	// must not move, so a subsequent insertion lands at the end.
+	await press(stdin, '\u001b[H');
+	await press(stdin, '\u001b[F');
+	await press(stdin, 'x');
+
+	await waitForValue(valueRef, v => v === 'abcx');
+	t.is(valueRef.current, 'abcx');
 	unmount();
 });

--- a/source/components/text-input-keys.spec.tsx
+++ b/source/components/text-input-keys.spec.tsx
@@ -117,6 +117,77 @@ test('component Delete with cursor at end does nothing', async t => {
 	unmount();
 });
 
+// --- Backspace (\x7f) ---
+// Ink parses the physical Backspace (\x7f — sent by macOS Terminal, iTerm2
+// and essentially all Linux terminals) as `key.delete`, NOT `key.backspace`
+// (which Ink reserves for \b/Ctrl+H). So Backspace must be routed to a
+// backward delete by matching the raw sequence, distinct from forward Delete
+// (\x1b[3~).
+
+test('component Backspace (\x7f) removes the character before the cursor', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abcde" />,
+	);
+
+	// Cursor is at the end; Backspace must remove 'e'.
+	await press(stdin, '\u007f');
+
+	await waitForValue(valueRef, v => v === 'abcd');
+	t.is(valueRef.current, 'abcd');
+	unmount();
+});
+
+test('component Backspace (\x7f) with cursor between chars removes the char before', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abcde" />,
+	);
+
+	// Move left once so the cursor sits between 'd' and 'e'; Backspace should
+	// remove 'd' (the char before the cursor), leaving "abce".
+	await press(stdin, '\u001b[D'); // left
+	await press(stdin, '\u007f'); // Backspace
+
+	await waitForValue(valueRef, v => v === 'abce');
+	t.is(valueRef.current, 'abce');
+	unmount();
+});
+
+test('component Backspace (\x7f) with cursor at start does nothing', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abc" />,
+	);
+
+	// Move to the start with Home, then Backspace should be a no-op.
+	await press(stdin, '\u001b[H');
+	await press(stdin, '\u007f');
+
+	await waitForValue(valueRef, v => v === 'abc');
+	t.is(valueRef.current, 'abc');
+	unmount();
+});
+
+// A forward Delete (\x1b[3~) must NOT be treated as a Backspace even when the
+// cursor is mid-line — this pins the raw-sequence disambiguation.
+test('component Delete (\x1b[3~) still forward-deletes, distinct from Backspace', async t => {
+	const valueRef: ValueRef = {current: ''};
+	const {stdin, unmount} = render(
+		<ControlledTextInput valueRef={valueRef} initialValue="abcde" />,
+	);
+
+	// Move left once so the cursor sits between 'd' and 'e'; forward Delete
+	// should remove 'e' (after the cursor), giving "abcd" — the opposite of
+	// the Backspace case above.
+	await press(stdin, '\u001b[D'); // left
+	await press(stdin, '\u001b[3~'); // Delete
+
+	await waitForValue(valueRef, v => v === 'abcd');
+	t.is(valueRef.current, 'abcd');
+	unmount();
+});
+
 // --- Home / End ---
 
 test('component Home moves cursor to start (next typed char inserts at 0)', async t => {

--- a/source/components/text-input.spec.ts
+++ b/source/components/text-input.spec.ts
@@ -103,6 +103,16 @@ function backspace(state: TextInputState): TextInputState {
 	};
 }
 
+// Simulate Delete (forward delete: removes character AFTER cursor)
+function forwardDelete(state: TextInputState): TextInputState {
+	const {value, cursorOffset} = state;
+	if (cursorOffset >= value.length) return state;
+	return {
+		value: value.slice(0, cursorOffset) + value.slice(cursorOffset + 1),
+		cursorOffset: cursorOffset, // cursor stays in place
+	};
+}
+
 // --- Ctrl+W (backward-kill-word) ---
 
 test('Ctrl+W deletes the last word', (t) => {
@@ -276,6 +286,44 @@ test('backspace deletes character before cursor', (t) => {
 test('backspace at start does nothing', (t) => {
 	const result = backspace({value: 'hello', cursorOffset: 0});
 	t.is(result.value, 'hello');
+	t.is(result.cursorOffset, 0);
+});
+
+// --- Delete (forward delete) ---
+
+test('Delete removes character after cursor', (t) => {
+	const result = forwardDelete({value: 'hello', cursorOffset: 2});
+	t.is(result.value, 'helo');
+	t.is(result.cursorOffset, 2);
+});
+
+test('Delete at end does nothing', (t) => {
+	const result = forwardDelete({value: 'hello', cursorOffset: 5});
+	t.is(result.value, 'hello');
+	t.is(result.cursorOffset, 5);
+});
+
+test('Delete from start removes first character', (t) => {
+	const result = forwardDelete({value: 'hello', cursorOffset: 0});
+	t.is(result.value, 'ello');
+	t.is(result.cursorOffset, 0);
+});
+
+test('Delete on single character leaves empty string', (t) => {
+	const result = forwardDelete({value: 'a', cursorOffset: 0});
+	t.is(result.value, '');
+	t.is(result.cursorOffset, 0);
+});
+
+test('Delete does not move cursor when removing character', (t) => {
+	const result = forwardDelete({value: 'abcde', cursorOffset: 3});
+	t.is(result.value, 'abce');
+	t.is(result.cursorOffset, 3);
+});
+
+test('Delete on empty string does nothing', (t) => {
+	const result = forwardDelete({value: '', cursorOffset: 0});
+	t.is(result.value, '');
 	t.is(result.cursorOffset, 0);
 });
 

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -168,9 +168,13 @@ function TextInput({
 			let nextCursorWidth = 0;
 
 			if (key.home) {
-				nextCursorOffset = 0;
+				if (showCursor) {
+					nextCursorOffset = 0;
+				}
 			} else if (key.end) {
-				nextCursorOffset = originalValueRef.current.length;
+				if (showCursor) {
+					nextCursorOffset = originalValueRef.current.length;
+				}
 			} else if (key.ctrl) {
 				if (key.leftArrow) {
 					// Ctrl+Left: jump to start of previous word

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -219,8 +219,8 @@ function TextInput({
 
 						case 'w': {
 							// Delete previous word (backward-kill-word, newline-aware)
-							if (cursorOffset > 0) {
-								let i = cursorOffset;
+							if (cursorOffsetRef.current > 0) {
+								let i = cursorOffsetRef.current;
 								while (
 									i > 0 &&
 									(originalValueRef.current[i - 1] === ' ' ||
@@ -235,7 +235,7 @@ function TextInput({
 									i--;
 								nextValue =
 									originalValueRef.current.slice(0, i) +
-									originalValueRef.current.slice(cursorOffset);
+									originalValueRef.current.slice(cursorOffsetRef.current);
 								nextCursorOffset = i;
 							}
 
@@ -244,14 +244,19 @@ function TextInput({
 
 						case 'u': {
 							// Delete from cursor to start of line
-							nextValue = originalValueRef.current.slice(cursorOffset);
+							nextValue = originalValueRef.current.slice(
+								cursorOffsetRef.current,
+							);
 							nextCursorOffset = 0;
 							break;
 						}
 
 						case 'k': {
 							// Delete from cursor to end of line
-							nextValue = originalValueRef.current.slice(0, cursorOffset);
+							nextValue = originalValueRef.current.slice(
+								0,
+								cursorOffsetRef.current,
+							);
 							break;
 						}
 
@@ -269,21 +274,21 @@ function TextInput({
 					nextCursorOffset++;
 				}
 			} else if (key.backspace || key.delete) {
-				if (cursorOffset > 0) {
+				if (cursorOffsetRef.current > 0) {
 					nextValue =
-						originalValueRef.current.slice(0, cursorOffset - 1) +
+						originalValueRef.current.slice(0, cursorOffsetRef.current - 1) +
 						originalValueRef.current.slice(
-							cursorOffset,
+							cursorOffsetRef.current,
 							originalValueRef.current.length,
 						);
 					nextCursorOffset--;
 				}
 			} else {
 				nextValue =
-					originalValueRef.current.slice(0, cursorOffset) +
+					originalValueRef.current.slice(0, cursorOffsetRef.current) +
 					input +
 					originalValueRef.current.slice(
-						cursorOffset,
+						cursorOffsetRef.current,
 						originalValueRef.current.length,
 					);
 				nextCursorOffset += input.length;

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -197,13 +197,17 @@ function TextInput({
 					switch (input) {
 						case 'a': {
 							// Move cursor to start of line
-							nextCursorOffset = 0;
+							if (showCursor) {
+								nextCursorOffset = 0;
+							}
 							break;
 						}
 
 						case 'e': {
 							// Move cursor to end of line
-							nextCursorOffset = originalValueRef.current.length;
+							if (showCursor) {
+								nextCursorOffset = originalValueRef.current.length;
+							}
 							break;
 						}
 

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -277,7 +277,8 @@ function TextInput({
 				if (showCursor) {
 					nextCursorOffset++;
 				}
-			} else if (key.backspace || key.delete) {
+			} else if (key.backspace) {
+				// Backspace deletes the character before the cursor.
 				if (cursorOffsetRef.current > 0) {
 					nextValue =
 						originalValueRef.current.slice(0, cursorOffsetRef.current - 1) +
@@ -286,6 +287,17 @@ function TextInput({
 							originalValueRef.current.length,
 						);
 					nextCursorOffset--;
+				}
+			} else if (key.delete) {
+				// Delete removes the character after the cursor (forward delete).
+				if (cursorOffsetRef.current < originalValueRef.current.length) {
+					nextValue =
+						originalValueRef.current.slice(0, cursorOffsetRef.current) +
+						originalValueRef.current.slice(
+							cursorOffsetRef.current + 1,
+							originalValueRef.current.length,
+						);
+					// Cursor stays in place — forward delete doesn't move it.
 				}
 			} else {
 				nextValue =

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -167,7 +167,11 @@ function TextInput({
 			let nextValue = originalValueRef.current;
 			let nextCursorWidth = 0;
 
-			if (key.ctrl) {
+			if (key.home) {
+				nextCursorOffset = 0;
+			} else if (key.end) {
+				nextCursorOffset = originalValueRef.current.length;
+			} else if (key.ctrl) {
 				if (key.leftArrow) {
 					// Ctrl+Left: jump to start of previous word
 					if (showCursor) {

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -285,8 +285,12 @@ function TextInput({
 				if (showCursor) {
 					nextCursorOffset++;
 				}
-			} else if (key.backspace) {
+			} else if (key.backspace || (key.delete && key.raw === '\x7f')) {
 				// Backspace deletes the character before the cursor.
+				// Ink maps BOTH the physical Backspace (\x7f) and forward Delete
+				// (\x1b[3~) to `key.delete`, so we disambiguate on the raw
+				// sequence: '\x7f' (from macOS/Linux terminals) is a backward
+				// delete, while '\x1b[3~' is the forward Delete key.
 				if (cursorOffsetRef.current > 0) {
 					nextValue =
 						originalValueRef.current.slice(0, cursorOffsetRef.current - 1) +
@@ -298,6 +302,8 @@ function TextInput({
 				}
 			} else if (key.delete) {
 				// Delete removes the character after the cursor (forward delete).
+				// Only reached for the forward Delete key (\x1b[3~); the
+				// physical Backspace (\x7f) is handled in the branch above.
 				if (cursorOffsetRef.current < originalValueRef.current.length) {
 					nextValue =
 						originalValueRef.current.slice(0, cursorOffsetRef.current) +

--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -864,6 +864,71 @@ test('UserInput does not insert a literal character when ctrl+t is pressed', asy
 });
 
 // ============================================================================
+// Undo / Redo (Ctrl+Z / Ctrl+Y) Tests
+// ============================================================================
+
+test('UserInput undoes the last edit with ctrl+z', async t => {
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput forceFocus={true} />
+		</TestWrapper>,
+	);
+
+	stdin.write('abcde');
+	await waitForFrame(lastFrame, /abcde/);
+
+	// Ctrl+Z (0x1A) should revert the last edit. Watch for a frame WITHOUT the
+	// full value: the value must shrink (how far depends on paste detection,
+	// which may collapse a rapid keystroke run into one edit).
+	stdin.write('\u001a');
+	await waitForCondition(() => !/abcde/.test(lastFrame() ?? ''));
+	await wait(50);
+
+	t.notRegex(lastFrame()!, /abcde/);
+	unmount();
+});
+
+test('UserInput redoes an undone edit with ctrl+y', async t => {
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput forceFocus={true} />
+		</TestWrapper>,
+	);
+
+	stdin.write('abcde');
+	await waitForFrame(lastFrame, /abcde/);
+
+	// Undo with Ctrl+Z, settle so the redo stack commits, then redo with Ctrl+Y.
+	stdin.write('\u001a');
+	await waitForCondition(() => !/abcde/.test(lastFrame() ?? ''));
+	await wait(100);
+
+	stdin.write('\u0019');
+	await wait(100);
+	await waitForCondition(() => /abcde/.test(lastFrame() ?? ''));
+
+	t.regex(lastFrame()!, /abcde/);
+	unmount();
+});
+
+test('UserInput ctrl+z does not insert a literal character', async t => {
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput forceFocus={true} />
+		</TestWrapper>,
+	);
+
+	stdin.write('ab');
+	await waitForFrame(lastFrame, /ab/);
+	stdin.write('\u001a');
+	await wait(50);
+
+	// Undo should remove "b", not append a control character.
+	t.notRegex(lastFrame()!, /ab/);
+	unmount();
+});
+
+// ============================================================================
 // Command Completion Navigation Tests
 // ============================================================================
 

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -757,14 +757,18 @@ export default function UserInput({
 		// Ctrl+Z / Ctrl+Y: undo / redo the last input edit. State lives in
 		// useInputState's undo/redo stacks, which are unused by any key binding,
 		// so we surface them here. Both are no-ops on an empty stack.
+		//
+		// NB: we deliberately do NOT bump textInputKey here. Bumping it remounts
+		// <TextInput>, which resets its internal cursor to end-of-value and tears
+		// down the whole subtree on every undo/redo. TextInput's own value-sync
+		// effect already clamps the cursor to a valid offset when the value
+		// changes, so undoing keeps the caret roughly where it was.
 		if (key.ctrl && inputChar === 'z') {
 			undo();
-			setTextInputKey(prev => prev + 1);
 			return;
 		}
 		if (key.ctrl && inputChar === 'y') {
 			redo();
-			setTextInputKey(prev => prev + 1);
 			return;
 		}
 

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -155,6 +155,8 @@ export default function UserInput({
 		deletePlaceholder: _deletePlaceholder,
 		currentState,
 		setInputState,
+		undo,
+		redo,
 	} = inputState;
 
 	const {
@@ -749,6 +751,20 @@ export default function UserInput({
 		// Ctrl+X: drop the most recently added image attachment.
 		if (key.ctrl && inputChar === 'x') {
 			setAttachments(prev => prev.slice(0, -1));
+			return;
+		}
+
+		// Ctrl+Z / Ctrl+Y: undo / redo the last input edit. State lives in
+		// useInputState's undo/redo stacks, which are unused by any key binding,
+		// so we surface them here. Both are no-ops on an empty stack.
+		if (key.ctrl && inputChar === 'z') {
+			undo();
+			setTextInputKey(prev => prev + 1);
+			return;
+		}
+		if (key.ctrl && inputChar === 'y') {
+			redo();
+			setTextInputKey(prev => prev + 1);
 			return;
 		}
 

--- a/source/components/welcome-message.spec.tsx
+++ b/source/components/welcome-message.spec.tsx
@@ -111,7 +111,7 @@ test('WelcomeMessage shows welcome message for normal terminal', t => {
 	t.truthy(output);
 	t.regex(output!, /Welcome to Nanocoder/);
 	t.regex(output!, /local-first coding agent/);
-	t.regex(output!, new RegExp(VERSION.replace(/\./g, '\\.')));
+	t.regex(output!, new RegExp(VERSION.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
 
 	process.stdout.columns = originalColumns;
 });
@@ -129,7 +129,7 @@ test('WelcomeMessage shows menu for normal terminal', t => {
 	t.regex(output!, /Quit/);
 	// New design footer has mode + version
 	t.regex(output!, /nanocoder/);
-	t.regex(output!, new RegExp(VERSION.replace(/\./g, '\\.')));
+	t.regex(output!, new RegExp(VERSION.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
 
 	process.stdout.columns = originalColumns;
 });
@@ -179,7 +179,7 @@ test('WelcomeMessage shows centered footer for wide terminal', t => {
 	const output = lastFrame();
 	t.truthy(output);
 	t.regex(output!, /nanocoder/);
-	t.regex(output!, new RegExp(VERSION.replace(/\./g, '\\.')));
+	t.regex(output!, new RegExp(VERSION.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
 
 	process.stdout.columns = originalColumns;
 });

--- a/source/hooks/useInputState.spec.tsx
+++ b/source/hooks/useInputState.spec.tsx
@@ -4,7 +4,7 @@ import {PlaceholderType} from '../types/hooks';
 import test from 'ava';
 import {cleanup, render} from 'ink-testing-library';
 import React from 'react';
-import {useInputState} from './useInputState';
+import {MAX_UNDO_STACK, useInputState} from './useInputState';
 
 console.log('\nuseInputState.spec.ts');
 
@@ -1036,19 +1036,52 @@ test('cleanup function is defined', t => {
 test('undo stack is capped at MAX_UNDO_STACK', t => {
 	const {hook, instance} = setupTest();
 
-	// Push well beyond the 100-entry cap. Use distinct single-char inputs
-	// (all < 10 chars) to avoid paste detection, each creating one undo entry.
-	for (let i = 0; i < 150; i++) {
+	// Push well beyond the cap (2x) to force rollover from the front. Use
+	// distinct small inputs (all < 10 chars) to avoid paste detection; each
+	// update creates exactly one undo entry.
+	const overBy = MAX_UNDO_STACK * 2;
+	for (let i = 0; i < overBy; i++) {
 		hook.updateInput(`x${i}`);
 		instance.rerender(<TestComponent />);
 	}
 
-	// The stack must never exceed the cap.
-	t.true(currentHook!.undoStack.length <= 100);
+	// The stack must be clamped to exactly the cap, never a hair more.
+	t.is(currentHook!.undoStack.length, MAX_UNDO_STACK);
 
-	// Undo should still work normally from the capped stack.
+	// The most recent input still wins (current isn't itself an undo entry).
+	t.is(currentHook!.input, `x${overBy - 1}`);
+
+	// Undo still walks back from the capped stack without growing it back up.
 	currentHook!.undo();
 	instance.rerender(<TestComponent />);
 
-	t.true(currentHook!.undoStack.length <= 100);
+	t.true(currentHook!.undoStack.length < MAX_UNDO_STACK);
+});
+
+// Test redo stack is capped to prevent unbounded memory growth (#5).
+// Every undo moves one InputState onto the redo stack, so it must obey the
+// same ceiling as the undo stack rather than relying on the undo cap alone.
+test('redo stack is capped at MAX_UNDO_STACK', t => {
+	const {hook, instance} = setupTest();
+
+	// Fill the undo stack right up to the cap.
+	for (let i = 0; i < MAX_UNDO_STACK; i++) {
+		hook.updateInput(`y${i}`);
+		instance.rerender(<TestComponent />);
+	}
+
+	// Undo the whole stack: each call pushes current onto the redo stack.
+	for (let i = 0; i < MAX_UNDO_STACK; i++) {
+		currentHook!.undo();
+		instance.rerender(<TestComponent />);
+	}
+
+	// The redo stack must never exceed the cap.
+	t.true(currentHook!.redoStack.length <= MAX_UNDO_STACK);
+
+	// Redo still restores from the (possibly clamped) redo stack.
+	currentHook!.redo();
+	instance.rerender(<TestComponent />);
+
+	t.true(currentHook!.redoStack.length < MAX_UNDO_STACK);
 });

--- a/source/hooks/useInputState.spec.tsx
+++ b/source/hooks/useInputState.spec.tsx
@@ -184,6 +184,66 @@ test('redo does nothing with empty stack', t => {
 	t.is(currentHook!.redoStack.length, 0);
 });
 
+// Test rapid consecutive undo without re-render (stale-closure guard).
+// Two undo() calls in the same tick must each step back one state.
+test('rapid consecutive undo steps back two states without re-render', t => {
+	const {hook, instance} = setupTest();
+
+	hook.updateInput('a');
+	instance.rerender(<TestComponent />);
+
+	currentHook!.updateInput('ab');
+	instance.rerender(<TestComponent />);
+
+	currentHook!.updateInput('abc');
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, 'abc');
+
+	// Two undo calls with no re-render — both read latest refs.
+	currentHook!.undo();
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, 'a');
+	// After undoing 'abc' -> 'ab' -> 'a', one entry (the empty start state)
+	// remains on the undo stack, and the two undone states sit on the redo stack.
+	t.is(currentHook!.undoStack.length, 1);
+	t.is(currentHook!.redoStack.length, 2);
+});
+
+// Test rapid consecutive redo without re-render
+test('rapid consecutive redo steps forward two states without re-render', t => {
+	const {hook, instance} = setupTest();
+
+	hook.updateInput('a');
+	instance.rerender(<TestComponent />);
+
+	currentHook!.updateInput('ab');
+	instance.rerender(<TestComponent />);
+
+	currentHook!.updateInput('abc');
+	instance.rerender(<TestComponent />);
+
+	// Undo twice to populate the redo stack
+	currentHook!.undo();
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, 'a');
+	t.is(currentHook!.redoStack.length, 2);
+
+	// Two redo calls with no re-render — both step forward
+	currentHook!.redo();
+	currentHook!.redo();
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, 'abc');
+	t.is(currentHook!.redoStack.length, 0);
+	// Redoing pushes each state back: ['', 'a', 'ab'] after stepping back to 'abc'.
+	t.is(currentHook!.undoStack.length, 3);
+});
+
 // Test that new action clears redo stack
 test('new action after undo clears redo stack', t => {
 	const {hook, instance} = setupTest();

--- a/source/hooks/useInputState.spec.tsx
+++ b/source/hooks/useInputState.spec.tsx
@@ -618,6 +618,106 @@ test('multiple redos work correctly', t => {
 	t.is(currentHook!.redoStack.length, 0);
 });
 
+// --- Strengthened undo/redo invariant tests (issue #4) ---
+// Beyond asserting the visible input, these pin the exact entries that move
+// between the undo and redo stacks, protecting against off-by-one or
+// wrong-entry bugs that a length-only check would miss.
+
+test('undo pops the exact current state onto the redo stack', t => {
+	const {hook, instance} = setupTest();
+
+	hook.updateInput('a');
+	instance.rerender(<TestComponent />);
+	currentHook!.updateInput('ab');
+	instance.rerender(<TestComponent />);
+	currentHook!.updateInput('abc');
+	instance.rerender(<TestComponent />);
+
+	// undoStack entry (top) == the immediately-previous state 'ab'
+	const undoBefore = currentHook!.undoStack.map(s => s.displayValue);
+	t.deepEqual(undoBefore, ['', 'a', 'ab']);
+
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, 'ab');
+	t.deepEqual(currentHook!.undoStack.map(s => s.displayValue), ['', 'a']);
+	// The undone state 'abc' lands unchanged on top of the redo stack.
+	t.deepEqual(currentHook!.redoStack.map(s => s.displayValue), ['abc']);
+});
+
+test('redo pops the exact state back onto the undo stack', t => {
+	const {hook, instance} = setupTest();
+
+	hook.updateInput('a');
+	instance.rerender(<TestComponent />);
+	currentHook!.updateInput('ab');
+	instance.rerender(<TestComponent />);
+	currentHook!.updateInput('abc');
+	instance.rerender(<TestComponent />);
+
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+
+	// After two undos: input 'a', redo holds ['abc', 'ab'] in undo order.
+	t.is(currentHook!.input, 'a');
+	t.deepEqual(currentHook!.redoStack.map(s => s.displayValue), ['abc', 'ab']);
+
+	currentHook!.redo();
+	instance.rerender(<TestComponent />);
+
+	// Redo restores 'ab', removes it from the redo stack, and pushes the
+	// previous current state 'a' back onto the undo stack.
+	t.is(currentHook!.input, 'ab');
+	t.deepEqual(currentHook!.redoStack.map(s => s.displayValue), ['abc']);
+	t.deepEqual(currentHook!.undoStack.map(s => s.displayValue), ['', 'a']);
+});
+
+test('undo then redo round-trips the full stack contents losslessly', t => {
+	const {hook, instance} = setupTest();
+
+	hook.updateInput('a');
+	instance.rerender(<TestComponent />);
+	currentHook!.updateInput('ab');
+	instance.rerender(<TestComponent />);
+	currentHook!.updateInput('abc');
+	instance.rerender(<TestComponent />);
+
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+
+	// Fully unwound back to the initial empty state. Every undo pushes the
+	// then-current state onto the redo stack, ending with the last-abandoned
+	// state 'a'.
+	t.is(currentHook!.input, '');
+	t.is(currentHook!.undoStack.length, 0);
+	t.deepEqual(currentHook!.redoStack.map(s => s.displayValue), [
+		'abc',
+		'ab',
+		'a',
+	]);
+
+	currentHook!.redo();
+	instance.rerender(<TestComponent />);
+	currentHook!.redo();
+	instance.rerender(<TestComponent />);
+	currentHook!.redo();
+	instance.rerender(<TestComponent />);
+
+	// Re-applying all three redos reproduces the original input and drains the
+	// redo stack; each redo pushes the then-current state back onto the undo
+	// stack, rebuilding ['', 'a', 'ab'] exactly.
+	t.is(currentHook!.input, 'abc');
+	t.deepEqual(currentHook!.undoStack.map(s => s.displayValue), ['', 'a', 'ab']);
+	t.is(currentHook!.redoStack.length, 0);
+});
+
 // Test setInputState preserves all placeholder data
 test('setInputState preserves placeholder metadata', t => {
 	const {hook, instance} = setupTest();

--- a/source/hooks/useInputState.spec.tsx
+++ b/source/hooks/useInputState.spec.tsx
@@ -871,3 +871,24 @@ test('cleanup function is defined', t => {
 	// Cleanup will be called when the test ends via test.afterEach
 	instance.unmount();
 });
+
+// Test undo stack is capped to prevent unbounded memory growth
+test('undo stack is capped at MAX_UNDO_STACK', t => {
+	const {hook, instance} = setupTest();
+
+	// Push well beyond the 100-entry cap. Use distinct single-char inputs
+	// (all < 10 chars) to avoid paste detection, each creating one undo entry.
+	for (let i = 0; i < 150; i++) {
+		hook.updateInput(`x${i}`);
+		instance.rerender(<TestComponent />);
+	}
+
+	// The stack must never exceed the cap.
+	t.true(currentHook!.undoStack.length <= 100);
+
+	// Undo should still work normally from the capped stack.
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+
+	t.true(currentHook!.undoStack.length <= 100);
+});

--- a/source/hooks/useInputState.spec.tsx
+++ b/source/hooks/useInputState.spec.tsx
@@ -244,6 +244,36 @@ test('rapid consecutive redo steps forward two states without re-render', t => {
 	t.is(currentHook!.undoStack.length, 3);
 });
 
+// Test that a burst of updateInput calls in the SAME tick records one correct
+// undo entry per call (stale-closure guard #4). A single stdin batch can deliver
+// several keystrokes before React re-renders; each must push its own predecessor
+// so rapid consecutive undos unwind every keystroke.
+test('rapid same-tick updateInput calls each record a distinct undo entry', t => {
+	const {hook, instance} = setupTest();
+
+	// No rerender between these — they arrive in the same batch/tick.
+	hook.updateInput('a');
+	hook.updateInput('ab');
+	hook.updateInput('abc');
+
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, 'abc');
+	// Each call pushed its own predecessor, so there is one entry per step:
+	// [init, 'a', 'ab'].
+	t.is(currentHook!.undoStack.length, 3);
+
+	// Three undos, also in the same tick, must unwind all the way back.
+	currentHook!.undo();
+	currentHook!.undo();
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, '');
+	t.is(currentHook!.undoStack.length, 0);
+	t.is(currentHook!.redoStack.length, 3);
+});
+
 // Test that new action clears redo stack
 test('new action after undo clears redo stack', t => {
 	const {hook, instance} = setupTest();

--- a/source/hooks/useInputState.spec.tsx
+++ b/source/hooks/useInputState.spec.tsx
@@ -274,6 +274,57 @@ test('rapid same-tick updateInput calls each record a distinct undo entry', t =>
 	t.is(currentHook!.redoStack.length, 3);
 });
 
+// --- Same-batch edit + undo/redo (no re-render between mutations) ---
+// undo()/redo() treat the refs as the synchronous source of truth, while
+// pushToUndoStack only used to keep currentStateRef in lockstep. That meant an
+// edit followed by an undo/redo in the same stdin batch read STALE
+// undoStackRef/redoStackRef (resynced only by useEffect after a render). These
+// tests reproduce the two failure modes the maintainer flagged.
+
+test('updateInput then undo in the same tick reverts correctly (ref-sync)', t => {
+	const {hook, instance} = setupTest();
+
+	// Single update, then undo with NO re-render in between. If pushToUndoStack
+	// didn't keep undoStackRef in lockstep, undo() would read a stale (empty)
+	// stack and leave the input at 'a' instead of reverting to ''.
+	hook.updateInput('a');
+	hook.undo();
+
+	instance.rerender(<TestComponent />);
+
+	t.is(currentHook!.input, '');
+	t.is(currentHook!.undoStack.length, 0);
+	t.deepEqual(currentHook!.redoStack.map(s => s.displayValue), ['a']);
+});
+
+test('same-tick redo after a fresh edit does not resurrect a stale redo entry', t => {
+	const {hook, instance} = setupTest();
+
+	// Build up state: '' -> 'a' -> 'ab'.
+	hook.updateInput('a');
+	instance.rerender(<TestComponent />);
+	currentHook!.updateInput('ab');
+	instance.rerender(<TestComponent />);
+
+	// Undo back to 'a'; the redo stack now holds ['ab'].
+	currentHook!.undo();
+	instance.rerender(<TestComponent />);
+	t.is(currentHook!.input, 'a');
+	t.deepEqual(currentHook!.redoStack.map(s => s.displayValue), ['ab']);
+
+	// Now type 'aZ' and redo in the SAME tick. If pushToUndoStack didn't clear
+	// redoStackRef synchronously, redo() would read the stale ['ab'] and
+	// resurrect 'ab', discarding the typed 'Z'.
+	currentHook!.updateInput('aZ');
+	currentHook!.redo();
+
+	instance.rerender(<TestComponent />);
+
+	// Redo must be a no-op because the fresh edit cleared the redo stack.
+	t.is(currentHook!.input, 'aZ');
+	t.is(currentHook!.redoStack.length, 0);
+});
+
 // Test that new action clears redo stack
 test('new action after undo clears redo stack', t => {
 	const {hook, instance} = setupTest();

--- a/source/hooks/useInputState.ts
+++ b/source/hooks/useInputState.ts
@@ -39,6 +39,14 @@ export function useInputState() {
 	const [undoStack, setUndoStack] = useState<InputState[]>([]);
 	const [redoStack, setRedoStack] = useState<InputState[]>([]);
 
+	// Refs mirror the three state values that undo/redo/pushToUndoStack read.
+	// Callbacks hold refs via closures (empty deps) so that rapid consecutive
+	// calls within a single stdin batch — before React re-renders — always see
+	// the latest values, avoiding the stale-closure class of bug.
+	const currentStateRef = useRef(currentState);
+	const undoStackRef = useRef(undoStack);
+	const redoStackRef = useRef(redoStack);
+
 	// Legacy compatibility - these are derived from currentState
 	const [historyIndex, setHistoryIndex] = useState(-1);
 	const [_hasLargeContent, setHasLargeContent] = useState(false);
@@ -52,6 +60,20 @@ export function useInputState() {
 	const lastPasteTimeRef = useRef<number>(0);
 	const lastPasteIdRef = useRef<string | null>(null);
 
+	// Keep refs in sync with React state so callbacks (which close over refs
+	// via empty deps) always see the latest values.  This avoids stale closures
+	// when multiple events arrive in the same stdin batch (Ink doesn't re-render
+	// between events).
+	useEffect(() => {
+		currentStateRef.current = currentState;
+	}, [currentState]);
+	useEffect(() => {
+		undoStackRef.current = undoStack;
+	}, [undoStack]);
+	useEffect(() => {
+		redoStackRef.current = redoStack;
+	}, [redoStack]);
+
 	// Cached line count for performance
 	const [cachedLineCount, setCachedLineCount] = useState(1);
 
@@ -62,7 +84,7 @@ export function useInputState() {
 	// undo depth while keeping memory bounded.
 	const MAX_UNDO_STACK = 100;
 
-	// Helper to push current state to undo stack
+	// Helper to push current state to undo stack.
 	const pushToUndoStack = useCallback(
 		(newState: InputState) => {
 			setUndoStack(prev => {
@@ -73,6 +95,9 @@ export function useInputState() {
 			});
 			setRedoStack([]); // Clear redo stack on new action
 			setCurrentState(newState);
+			// Keep the ref in lockstep so undo/redo called in the same tick
+			// capture the latest value.
+			currentStateRef.current = newState;
 		},
 		[currentState],
 	);
@@ -316,35 +341,54 @@ export function useInputState() {
 		[currentState, pushToUndoStack],
 	);
 
-	// Undo function (Ctrl+_)
+	// Undo function (Ctrl+_).
+	// Reads from refs via empty deps so rapid consecutive calls (e.g. two Ctrl+Z
+	// events in the same stdin batch) each see the latest stack, not the stale
+	// closure value from the last render.  Refs are the synchronous source of
+	// truth: each call computes the next stacks from refs and writes refs BEFORE
+	// scheduling state, so a second call in the same tick sees the first call's
+	// result.  No side effects inside functional updaters (React may invoke them
+	// more than once).
 	const undo = useCallback(() => {
-		if (undoStack.length > 0) {
-			const previousState = undoStack[undoStack.length - 1];
-			const newUndoStack = undoStack.slice(0, -1);
+		const stack = undoStackRef.current;
+		if (stack.length > 0) {
+			const previousState = stack[stack.length - 1];
+			const nextUndoStack = stack.slice(0, -1);
+			const nextRedoStack = [...redoStackRef.current, currentStateRef.current];
 
-			setRedoStack(prev => [...prev, currentState]);
-			setUndoStack(newUndoStack);
+			undoStackRef.current = nextUndoStack;
+			redoStackRef.current = nextRedoStack;
+			currentStateRef.current = previousState;
+
+			setUndoStack(nextUndoStack);
+			setRedoStack(nextRedoStack);
 			setCurrentState(previousState);
 
 			// Update paste detector state
 			pasteDetectorRef.current.updateState(previousState.displayValue);
 		}
-	}, [undoStack, currentState]);
+	}, []);
 
-	// Redo function (Ctrl+Y)
+	// Redo function (Ctrl+Y). Same ref-as-source-of-truth pattern as undo.
 	const redo = useCallback(() => {
-		if (redoStack.length > 0) {
-			const nextState = redoStack[redoStack.length - 1];
-			const newRedoStack = redoStack.slice(0, -1);
+		const stack = redoStackRef.current;
+		if (stack.length > 0) {
+			const nextState = stack[stack.length - 1];
+			const nextRedoStack = stack.slice(0, -1);
+			const nextUndoStack = [...undoStackRef.current, currentStateRef.current];
 
-			setUndoStack(prev => [...prev, currentState]);
-			setRedoStack(newRedoStack);
+			undoStackRef.current = nextUndoStack;
+			redoStackRef.current = nextRedoStack;
+			currentStateRef.current = nextState;
+
+			setUndoStack(nextUndoStack);
+			setRedoStack(nextRedoStack);
 			setCurrentState(nextState);
 
 			// Update paste detector state
 			pasteDetectorRef.current.updateState(nextState.displayValue);
 		}
-	}, [redoStack, currentState]);
+	}, []);
 
 	// Delete placeholder atomically
 	const deletePlaceholder = useCallback(

--- a/source/hooks/useInputState.ts
+++ b/source/hooks/useInputState.ts
@@ -11,6 +11,13 @@ import {PasteDetector} from '../utils/paste-detection';
 import {handlePaste, resizePasteDisplayText} from '../utils/paste-utils';
 import {findPlaceholderOccurrences} from '../utils/placeholders';
 
+// Cap both undo and redo stacks so a long composition can't grow them
+// unbounded. Every keystroke/paste pushes one entry, and each entry holds a
+// full InputState — without a ceiling the arrays (and their copies) grow
+// linearly with input length. 100 steps is far beyond any realistic undo depth
+// while keeping memory bounded.
+export const MAX_UNDO_STACK = 100;
+
 // Scales the paste window size based on content length.
 // Prevents truncation on slow terminals while keeping small pastes snappy
 function getDynamicPasteWindow(contentLength: number): number {
@@ -76,13 +83,6 @@ export function useInputState() {
 
 	// Cached line count for performance
 	const [cachedLineCount, setCachedLineCount] = useState(1);
-
-	// Cap the undo stack so a long composition can't grow it unbounded.
-	// Every keystroke/paste pushes one entry, and each entry holds a full
-	// InputState — without a ceiling the array (and its copies) grows
-	// linearly with input length. 100 steps is far beyond any realistic
-	// undo depth while keeping memory bounded.
-	const MAX_UNDO_STACK = 100;
 
 	// Helper to push current state to undo stack.
 	const pushToUndoStack = useCallback(
@@ -354,7 +354,16 @@ export function useInputState() {
 		if (stack.length > 0) {
 			const previousState = stack[stack.length - 1];
 			const nextUndoStack = stack.slice(0, -1);
-			const nextRedoStack = [...redoStackRef.current, currentStateRef.current];
+			// Mirror the undo-stack cap so unbounded Ctrl+Z cannot grow the redo
+			// stack (each entry holds a full InputState). Drop the oldest entries
+			// first, keeping the most recent MAX_UNDO_STACK states.
+			const nextRedoStack =
+				redoStackRef.current.length >= MAX_UNDO_STACK
+					? [
+							...redoStackRef.current.slice(-(MAX_UNDO_STACK - 1)),
+							currentStateRef.current,
+						]
+					: [...redoStackRef.current, currentStateRef.current];
 
 			undoStackRef.current = nextUndoStack;
 			redoStackRef.current = nextRedoStack;

--- a/source/hooks/useInputState.ts
+++ b/source/hooks/useInputState.ts
@@ -85,26 +85,37 @@ export function useInputState() {
 	const [cachedLineCount, setCachedLineCount] = useState(1);
 
 	// Helper to push current state to undo stack.
-	const pushToUndoStack = useCallback(
-		(newState: InputState) => {
-			setUndoStack(prev => {
-				if (prev.length >= MAX_UNDO_STACK) {
-					return [...prev.slice(-(MAX_UNDO_STACK - 1)), currentState];
-				}
-				return [...prev, currentState];
-			});
-			setRedoStack([]); // Clear redo stack on new action
-			setCurrentState(newState);
-			// Keep the ref in lockstep so undo/redo called in the same tick
-			// capture the latest value.
-			currentStateRef.current = newState;
-		},
-		[currentState],
-	);
+	//
+	// Captures the previous state from currentStateRef EAGERLY (before any state
+	// is scheduled) so that multiple updateInput calls in the same stdin batch
+	// each record the right predecessor. Reading the ref lazily inside the
+	// functional updater would capture the already-advanced value at flush time.
+	// The ref is kept in lockstep by the assignment at the bottom of this
+	// function, so subsequent same-tick updateInput calls see the latest value.
+	const pushToUndoStack = useCallback((newState: InputState) => {
+		const previous = currentStateRef.current;
+		setUndoStack(prev => {
+			if (prev.length >= MAX_UNDO_STACK) {
+				return [...prev.slice(-(MAX_UNDO_STACK - 1)), previous];
+			}
+			return [...prev, previous];
+		});
+		setRedoStack([]); // Clear redo stack on new action
+		setCurrentState(newState);
+		// Keep the ref in lockstep so undo/redo and subsequent same-tick
+		// updateInput calls capture the latest value.
+		currentStateRef.current = newState;
+	}, []);
 
 	// Update input with paste detection and atomic deletion
+	//
+	// Reads state from currentStateRef (the synchronous source of truth) rather
+	// than the closure value so that a burst of updateInput calls within one
+	// stdin batch each see the newest committed state (undo/redo fix #4).
 	const updateInput = useCallback(
 		(newInput: string) => {
+			const currentState = currentStateRef.current;
+
 			// First, check for atomic deletion (placeholder removal)
 			const atomicDeletionResult = handleAtomicDeletion(currentState, newInput);
 			if (atomicDeletionResult) {
@@ -299,7 +310,7 @@ export function useInputState() {
 				);
 			}, 50);
 		},
-		[currentState, pushToUndoStack],
+		[pushToUndoStack],
 	);
 
 	// Insert a paste the terminal told us about (bracketed paste, DECSET

--- a/source/hooks/useInputState.ts
+++ b/source/hooks/useInputState.ts
@@ -55,10 +55,22 @@ export function useInputState() {
 	// Cached line count for performance
 	const [cachedLineCount, setCachedLineCount] = useState(1);
 
+	// Cap the undo stack so a long composition can't grow it unbounded.
+	// Every keystroke/paste pushes one entry, and each entry holds a full
+	// InputState — without a ceiling the array (and its copies) grows
+	// linearly with input length. 100 steps is far beyond any realistic
+	// undo depth while keeping memory bounded.
+	const MAX_UNDO_STACK = 100;
+
 	// Helper to push current state to undo stack
 	const pushToUndoStack = useCallback(
 		(newState: InputState) => {
-			setUndoStack(prev => [...prev, currentState]);
+			setUndoStack(prev => {
+				if (prev.length >= MAX_UNDO_STACK) {
+					return [...prev.slice(-(MAX_UNDO_STACK - 1)), currentState];
+				}
+				return [...prev, currentState];
+			});
 			setRedoStack([]); // Clear redo stack on new action
 			setCurrentState(newState);
 		},

--- a/source/hooks/useInputState.ts
+++ b/source/hooks/useInputState.ts
@@ -92,19 +92,25 @@ export function useInputState() {
 	// functional updater would capture the already-advanced value at flush time.
 	// The ref is kept in lockstep by the assignment at the bottom of this
 	// function, so subsequent same-tick updateInput calls see the latest value.
+	//
+	// undoStackRef/redoStackRef are ALSO kept in lockstep here (not just in a
+	// useEffect after render), because undo()/redo() read them synchronously as
+	// their source of truth. Without this, an edit followed by an undo/redo in
+	// the same stdin batch would read the stale pre-render stacks.
 	const pushToUndoStack = useCallback((newState: InputState) => {
 		const previous = currentStateRef.current;
-		setUndoStack(prev => {
-			if (prev.length >= MAX_UNDO_STACK) {
-				return [...prev.slice(-(MAX_UNDO_STACK - 1)), previous];
-			}
-			return [...prev, previous];
-		});
+		const nextUndoStack =
+			undoStackRef.current.length >= MAX_UNDO_STACK
+				? [...undoStackRef.current.slice(-(MAX_UNDO_STACK - 1)), previous]
+				: [...undoStackRef.current, previous];
+
+		undoStackRef.current = nextUndoStack;
+		redoStackRef.current = []; // Clear redo stack on new action
+		currentStateRef.current = newState;
+
+		setUndoStack(nextUndoStack);
 		setRedoStack([]); // Clear redo stack on new action
 		setCurrentState(newState);
-		// Keep the ref in lockstep so undo/redo and subsequent same-tick
-		// updateInput calls capture the latest value.
-		currentStateRef.current = newState;
 	}, []);
 
 	// Update input with paste detection and atomic deletion
@@ -390,12 +396,21 @@ export function useInputState() {
 	}, []);
 
 	// Redo function (Ctrl+Y). Same ref-as-source-of-truth pattern as undo.
+	// Pushing back onto the undo stack obeys the same MAX_UNDO_STACK cap as
+	// undo() so that a long redo streak (after many undos) cannot grow the
+	// undo stack unbounded.
 	const redo = useCallback(() => {
 		const stack = redoStackRef.current;
 		if (stack.length > 0) {
 			const nextState = stack[stack.length - 1];
 			const nextRedoStack = stack.slice(0, -1);
-			const nextUndoStack = [...undoStackRef.current, currentStateRef.current];
+			const nextUndoStack =
+				undoStackRef.current.length >= MAX_UNDO_STACK
+					? [
+							...undoStackRef.current.slice(-(MAX_UNDO_STACK - 1)),
+							currentStateRef.current,
+						]
+					: [...undoStackRef.current, currentStateRef.current];
 
 			undoStackRef.current = nextUndoStack;
 			redoStackRef.current = nextRedoStack;

--- a/source/hooks/useTitleShape.spec.ts
+++ b/source/hooks/useTitleShape.spec.ts
@@ -67,6 +67,7 @@ function MockTitleShapeProvider({
 	const value = {
 		currentTitleShape,
 		setCurrentTitleShape,
+		commitTitleShape: setCurrentTitleShape,
 	};
 
 	return React.createElement(TitleShapeContext.Provider, {value}, children);
@@ -89,6 +90,7 @@ test('useTitleShape returns title shape context when used within provider', t =>
 	t.truthy(capturedTitleShape);
 	t.is(capturedTitleShape!.currentTitleShape, 'rounded');
 	t.is(typeof capturedTitleShape!.setCurrentTitleShape, 'function');
+	t.is(typeof capturedTitleShape!.commitTitleShape, 'function');
 });
 
 test('useTitleShape provides currentTitleShape and setCurrentTitleShape', t => {
@@ -108,6 +110,7 @@ test('useTitleShape provides currentTitleShape and setCurrentTitleShape', t => {
 	t.truthy(capturedTitleShape);
 	t.is(capturedTitleShape!.currentTitleShape, 'square');
 	t.is(typeof capturedTitleShape!.setCurrentTitleShape, 'function');
+	t.is(typeof capturedTitleShape!.commitTitleShape, 'function');
 });
 
 test('useTitleShape throws error when used outside of TitleShapeProvider', t => {

--- a/source/hooks/useTitleShape.ts
+++ b/source/hooks/useTitleShape.ts
@@ -7,7 +7,19 @@ import {
 
 interface TitleShapeContextType {
 	currentTitleShape: TitleShape;
+	/**
+	 * Preview only — updates the in-memory shape (and thus the live app title)
+	 * WITHOUT persisting to preferences. Used to show a live preview while the
+	 * user navigates a shape selector, so an un-committed highlight never
+	 * reaches disk.
+	 */
 	setCurrentTitleShape: (shape: TitleShape) => void;
+	/**
+	 * Commit — persists the shape to preferences and updates the in-memory
+	 * shape. Used when an edit is confirmed (e.g. Enter in the Title Shape
+	 * settings panel).
+	 */
+	commitTitleShape: (shape: TitleShape) => void;
 }
 
 export const TitleShapeContext = createContext<TitleShapeContextType | null>(

--- a/source/test-utils/render-with-theme.tsx
+++ b/source/test-utils/render-with-theme.tsx
@@ -33,6 +33,7 @@ const testThemeContext = {
 const testTitleShapeContext = {
 	currentTitleShape: 'pill' as const,
 	setCurrentTitleShape: () => {},
+	commitTitleShape: () => {},
 };
 
 /**


### PR DESCRIPTION
Description
Keyboard-interaction audit for #955 with fixes and tests:
- TextInput cursor navigation: add forward Delete, add Home/End, and guard Home/End + Ctrl+A/Ctrl+E behind showCursor so a hidden cursor can't desync the next insert. Use cursorOffsetRef to avoid setState churn on rapid keystrokes.
- Undo/redo: wire Ctrl+Z/Ctrl+Y, preserve the caret on undo/redo instead of remounting TextInput, fix stale-closure under rapid undos and same-tick input bursts via refs, and cap the redo stack (mirroring the undo cap).
- Settings: fix title-shape preview/commit so canceling no longer silently persists, and standardize footer hints.
- Tests: rendered component tests for the new key handling, exact undo/redo round-trip and cap invariants, and a title-shape cancel regression test.
Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation update
Changeset
- Added a changeset (pnpm changeset) describing this change for the changelog
Docs-only or internal chores need no changeset (or run pnpm changeset --empty to note that intentionally).
Testing
Automated Tests
- New features include passing tests in .spec.ts/tsx files
- All existing tests pass (pnpm test:all completes successfully)
- Tests cover both success and error scenarios
Manual Testing
- Tested with Ollama
- Tested with OpenRouter
- Tested with OpenAI-compatible API
- Tested MCP integration (if applicable)
Checklist
- If this was for an open issue, I was assigned to it
- Code follows project style guidelines
- Self-review completed
- Documentation updated (if needed)
- No breaking changes (or clearly documented)
- Appropriate logging added using structured logging (see CONTRIBUTING.md (../CONTRIBUTING.md#logging))