### PR TITLE
feat(mcp): add resources and prompts support

### DIFF
--- a/.changeset/mcp-resources-and-prompts.md
+++ b/.changeset/mcp-resources-and-prompts.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added MCP resources and prompts support, closing the gap between the MCP client and `docs/battlemap.md`'s claim of parity with Claude Code. `MCPClient` now discovers a connected server's resources and prompts alongside its tools (best-effort — a server that doesn't declare either capability just contributes none, same as before). Resources are usable the same way local files already are: type `@` to fuzzy-search filenames and connected servers' resources together, and select one to inline its content. Prompts are usable the same way custom commands already are: type `/mcp:<server>:<prompt>` to fetch the prompt fresh from its server and send it as the next turn, with positional arguments filled in against the prompt's declared parameter order. Refs #1162.

--- a/docs/battlemap.md
+++ b/docs/battlemap.md
@@ -261,7 +261,7 @@ Everywhere else, Nanocoder is at parity or ahead.
 ## Where Nanocoder is at parity
 
 - **Multi-provider support.** Matched by Aider, OpenCode, Crush, Pi, OMP.
-- **MCP client support.** Matched by Claude Code, Codex, Gemini, OpenCode, Crush, OMP.
+- **MCP client support**, including resources surfaced as `@`-mentions and prompts surfaced as slash commands, not just tools. Matched by Claude Code, Codex, Gemini, OpenCode, Crush, OMP.
 - **OSS license.** Matched by Codex, Gemini, Aider, OpenCode, Crush, Pi, OMP.
 - **Plain / non-TTY mode for CI.** Matched by every tool in this survey.
 - **Native tool calling.** Matched by every tool except Aider.

--- a/docs/configuration/mcp-configuration.md
+++ b/docs/configuration/mcp-configuration.md
@@ -255,6 +255,15 @@ Two consequences worth calling out:
   `"enabled": false`, or don't configure that server in a project whose skills
   run under the daemon.
 
+## Resources and Prompts
+
+A server can also declare MCP resources and prompts, alongside tools:
+
+- **Resources** join the local file list under the `@` mention trigger — type `@` and fuzzy-search filenames and connected servers' resources together. Selecting one reads it from the server and inlines its content the same way a file mention does — including the same size guard: a resource over the inline line limit is truncated to a head preview plus a `read_file(...)` hint instead of being dumped in full, so a single `@`-mention can't flood the conversation.
+- **Prompts** are invoked as `/mcp:<server>:<prompt>`, shown alongside custom commands in the `/` completion menu. Unlike a custom command's static template, the prompt is fetched fresh from the server on every call — arguments are filled in positionally, in the order the server declares them, and the result is sent as the next chat turn.
+
+Both are gated on the server's declared capabilities: a server that doesn't declare `resources` or `prompts` in its `initialize` response is never sent a `resources/list` or `prompts/list` request, and just contributes none — same as a server with no tools.
+
 ## Environment Variables
 
 Use environment variable references to keep credentials out of config files:

--- a/docs/configuration/mcp-configuration.md
+++ b/docs/configuration/mcp-configuration.md
@@ -259,7 +259,7 @@ Two consequences worth calling out:
 
 A server can also declare MCP resources and prompts, alongside tools:
 
-- **Resources** join the local file list under the `@` mention trigger — type `@` and fuzzy-search filenames and connected servers' resources together. Selecting one reads it from the server and inlines its content the same way a file mention does — including the same size guard: a resource over the inline line limit is truncated to a head preview plus a `read_file(...)` hint instead of being dumped in full, so a single `@`-mention can't flood the conversation.
+- **Resources** join the local file list under the `@` mention trigger — type `@` and fuzzy-search filenames and connected servers' resources together. Selecting one reads it from the server and inlines its content the same way a file mention does — including the same size guard: a resource over the inline line limit is truncated to a head preview instead of being dumped in full, so a single `@`-mention can't flood the conversation.
 - **Prompts** are invoked as `/mcp:<server>:<prompt>`, shown alongside custom commands in the `/` completion menu. Unlike a custom command's static template, the prompt is fetched fresh from the server on every call — arguments are filled in positionally, in the order the server declares them, and the result is sent as the next chat turn.
 
 Both are gated on the server's declared capabilities: a server that doesn't declare `resources` or `prompts` in its `initialize` response is never sent a `resources/list` or `prompts/list` request, and just contributes none — same as a server with no tools.

--- a/source/app/utils/app-util.ts
+++ b/source/app/utils/app-util.ts
@@ -31,6 +31,7 @@ import {
 	handleSkillsCreate,
 	handleToolCreate,
 } from './handlers/create-handler';
+import {handleMCPPromptCommand} from './handlers/mcp-prompt-handler';
 import {handleRetryCommand} from './handlers/retry-handler';
 import {handleResumeCommand} from './handlers/session-handler';
 
@@ -674,6 +675,16 @@ async function handleSlashCommand(
 	const commandName = message.slice(1).split(/\s+/)[0];
 
 	if (await handleCustomCommand(message, commandName, options)) {
+		return;
+	}
+
+	if (
+		await handleMCPPromptCommand(
+			commandName,
+			parseCustomCommandArgs(message.slice(commandName.length + 2)),
+			options,
+		)
+	) {
 		return;
 	}
 

--- a/source/app/utils/app-util.ts
+++ b/source/app/utils/app-util.ts
@@ -678,6 +678,15 @@ async function handleSlashCommand(
 		return;
 	}
 
+	// #1162 (phase 2) proposed routing MCP prompts through
+	// source/commands/lazy-registry.ts, the same way built-in commands are
+	// dispatched. That registry is a static array of compile-time-known
+	// commands, each with a dynamic-import() thunk - a shape that doesn't fit
+	// prompts, whose entire set only exists at runtime and changes as MCP
+	// servers connect/disconnect, and whose "load" is an RPC (getPrompt) to a
+	// live server, not a module import. Intercepting here instead mirrors how
+	// handleCustomCommand (checked just above) already dispatches the other
+	// runtime-discovered command source - project `.nanocoder/commands/` files.
 	if (
 		await handleMCPPromptCommand(
 			commandName,

--- a/source/app/utils/handlers/mcp-prompt-handler.spec.ts
+++ b/source/app/utils/handlers/mcp-prompt-handler.spec.ts
@@ -1,0 +1,217 @@
+import test from 'ava';
+import {setToolManagerGetter} from '@/message-handler';
+import type {MessageSubmissionOptions} from '@/types';
+import {handleMCPPromptCommand} from './mcp-prompt-handler.js';
+
+console.log('\nmcp-prompt-handler.spec.ts');
+
+test.afterEach(() => {
+	setToolManagerGetter(() => null);
+});
+
+function mockToolManager(mcpClient: unknown) {
+	return {getMCPClient: () => mcpClient} as any;
+}
+
+function mockMCPClient(opts: {
+	prompts: Array<{
+		name: string;
+		serverName: string;
+		arguments?: Array<{name: string; required?: boolean}>;
+	}>;
+	getPrompt?: (
+		serverName: string,
+		name: string,
+		args?: Record<string, string>,
+	) => Promise<{
+		description?: string;
+		messages: Array<{
+			role: string;
+			content: {type: string; text?: string; mimeType?: string};
+		}>;
+	}>;
+}) {
+	return {
+		getAllPrompts: () => opts.prompts,
+		getPrompt: opts.getPrompt,
+	} as any;
+}
+
+function createOptions(overrides: Partial<MessageSubmissionOptions> = {}) {
+	return {
+		onAddToChatQueue: () => {},
+		onCommandComplete: () => {},
+		onHandleChatMessage: async () => {},
+		...overrides,
+	} as MessageSubmissionOptions;
+}
+
+test('returns false when no MCP client is connected', async t => {
+	setToolManagerGetter(() => null);
+
+	const handled = await handleMCPPromptCommand(
+		'mcp:server:greet',
+		[],
+		createOptions(),
+	);
+
+	t.false(handled);
+});
+
+test('returns false when the command name matches no connected prompt', async t => {
+	setToolManagerGetter(() =>
+		mockToolManager(mockMCPClient({prompts: [{name: 'greet', serverName: 'a'}]})),
+	);
+
+	const handled = await handleMCPPromptCommand(
+		'mcp:a:not-a-prompt',
+		[],
+		createOptions(),
+	);
+
+	t.false(handled);
+});
+
+test('sends the resolved prompt text as the next chat message', async t => {
+	let sentPrompt: string | undefined;
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [{name: 'greet', serverName: 'docs', arguments: []}],
+				getPrompt: async () => ({
+					messages: [{role: 'user', content: {type: 'text', text: 'hello there'}}],
+				}),
+			}),
+		),
+	);
+
+	const handled = await handleMCPPromptCommand(
+		'mcp:docs:greet',
+		[],
+		createOptions({
+			onHandleChatMessage: async prompt => {
+				sentPrompt = prompt;
+			},
+		}),
+	);
+
+	t.true(handled);
+	t.is(sentPrompt, 'hello there');
+});
+
+test('maps positional args onto the prompt arguments in declared order (not all onto the first)', async t => {
+	let receivedArgs: Record<string, string> | undefined;
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [
+					{
+						name: 'review',
+						serverName: 'gh',
+						arguments: [
+							{name: 'repo', required: true},
+							{name: 'pr', required: true},
+						],
+					},
+				],
+				getPrompt: async (_server, _name, args) => {
+					receivedArgs = args;
+					return {messages: [{role: 'user', content: {type: 'text', text: 'ok'}}]};
+				},
+			}),
+		),
+	);
+
+	await handleMCPPromptCommand(
+		'mcp:gh:review',
+		['nanocoder', '42'],
+		createOptions(),
+	);
+
+	t.deepEqual(receivedArgs, {repo: 'nanocoder', pr: '42'});
+});
+
+test('reports missing required arguments without calling the server', async t => {
+	let called = false;
+	let queuedMessage = '';
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [
+					{
+						name: 'review',
+						serverName: 'gh',
+						arguments: [{name: 'repo', required: true}],
+					},
+				],
+				getPrompt: async () => {
+					called = true;
+					return {messages: []};
+				},
+			}),
+		),
+	);
+
+	const handled = await handleMCPPromptCommand(
+		'mcp:gh:review',
+		[],
+		createOptions({
+			onAddToChatQueue: node => {
+				queuedMessage = String((node as {props?: {message?: string}})?.props?.message ?? '');
+			},
+		}),
+	);
+
+	t.true(handled);
+	t.false(called);
+	t.regex(queuedMessage, /Missing required argument.*repo/);
+});
+
+test('routes to the prompt bound server, not just the first server with a matching name', async t => {
+	let calledServer: string | undefined;
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [
+					{name: 'summarize', serverName: 'server-a', arguments: []},
+					{name: 'summarize', serverName: 'server-b', arguments: []},
+				],
+				getPrompt: async serverName => {
+					calledServer = serverName;
+					return {messages: [{role: 'user', content: {type: 'text', text: 'ok'}}]};
+				},
+			}),
+		),
+	);
+
+	await handleMCPPromptCommand('mcp:server-b:summarize', [], createOptions());
+
+	t.is(calledServer, 'server-b');
+});
+
+test('reports a server error instead of throwing', async t => {
+	let queuedMessage = '';
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [{name: 'greet', serverName: 'docs', arguments: []}],
+				getPrompt: async () => {
+					throw new Error('server unreachable');
+				},
+			}),
+		),
+	);
+
+	const handled = await handleMCPPromptCommand(
+		'mcp:docs:greet',
+		[],
+		createOptions({
+			onAddToChatQueue: node => {
+				queuedMessage = String((node as {props?: {message?: string}})?.props?.message ?? '');
+			},
+		}),
+	);
+
+	t.true(handled);
+	t.regex(queuedMessage, /server unreachable/);
+});

--- a/source/app/utils/handlers/mcp-prompt-handler.spec.ts
+++ b/source/app/utils/handlers/mcp-prompt-handler.spec.ts
@@ -42,6 +42,8 @@ function createOptions(overrides: Partial<MessageSubmissionOptions> = {}) {
 		onAddToChatQueue: () => {},
 		onCommandComplete: () => {},
 		onHandleChatMessage: async () => {},
+		messages: [],
+		setMessages: () => {},
 		...overrides,
 	} as MessageSubmissionOptions;
 }
@@ -131,6 +133,70 @@ test('maps positional args onto the prompt arguments in declared order (not all 
 	t.deepEqual(receivedArgs, {repo: 'nanocoder', pr: '42'});
 });
 
+test('warns and ignores extra positional args beyond what the prompt declares', async t => {
+	let receivedArgs: Record<string, string> | undefined;
+	let warning = '';
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [
+					{
+						name: 'review',
+						serverName: 'gh',
+						arguments: [{name: 'repo', required: true}],
+					},
+				],
+				getPrompt: async (_server, _name, args) => {
+					receivedArgs = args;
+					return {messages: [{role: 'user', content: {type: 'text', text: 'ok'}}]};
+				},
+			}),
+		),
+	);
+
+	await handleMCPPromptCommand(
+		'mcp:gh:review',
+		['nanocoder', 'extra1', 'extra2'],
+		createOptions({
+			onAddToChatQueue: node => {
+				warning = String((node as {props?: {message?: string}})?.props?.message ?? '');
+			},
+		}),
+	);
+
+	t.deepEqual(receivedArgs, {repo: 'nanocoder'});
+	t.regex(warning, /takes 1 argument.*ignoring extra.*extra1, extra2/);
+});
+
+test('warns when args are given to a prompt that declares none', async t => {
+	let called = false;
+	let warning = '';
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [{name: 'greet', serverName: 'docs', arguments: []}],
+				getPrompt: async () => {
+					called = true;
+					return {messages: [{role: 'user', content: {type: 'text', text: 'hi'}}]};
+				},
+			}),
+		),
+	);
+
+	await handleMCPPromptCommand(
+		'mcp:docs:greet',
+		['unexpected'],
+		createOptions({
+			onAddToChatQueue: node => {
+				warning = String((node as {props?: {message?: string}})?.props?.message ?? '');
+			},
+		}),
+	);
+
+	t.true(called);
+	t.regex(warning, /takes no arguments.*ignoring.*unexpected/);
+});
+
 test('reports missing required arguments without calling the server', async t => {
 	let called = false;
 	let queuedMessage = '';
@@ -214,4 +280,132 @@ test('reports a server error instead of throwing', async t => {
 
 	t.true(handled);
 	t.regex(queuedMessage, /server unreachable/);
+});
+
+// ============================================================================
+// Regression (reviewer feedback on #1172): multi-message prompts must keep
+// their per-message roles instead of being flattened into one user turn.
+// ============================================================================
+
+test('a multi-message prompt ending on a user turn splices earlier turns into history and only submits the last', async t => {
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [{name: 'few-shot', serverName: 'docs', arguments: []}],
+				getPrompt: async () => ({
+					messages: [
+						{role: 'user', content: {type: 'text', text: 'example input'}},
+						{role: 'assistant', content: {type: 'text', text: 'example output'}},
+						{role: 'user', content: {type: 'text', text: 'real question'}},
+					],
+				}),
+			}),
+		),
+	);
+
+	let sentMessage: string | undefined;
+	let sentHistory: Array<{role: string; content: string}> | undefined;
+	let setMessagesCalled = false;
+
+	const handled = await handleMCPPromptCommand(
+		'mcp:docs:few-shot',
+		[],
+		createOptions({
+			setMessages: () => {
+				setMessagesCalled = true;
+			},
+			onHandleChatMessage: async (message, _displayValue, _images, history) => {
+				sentMessage = message;
+				sentHistory = history as Array<{role: string; content: string}>;
+			},
+		}),
+	);
+
+	t.true(handled);
+	// Only the final user turn is submitted as the "next chat message" ...
+	t.is(sentMessage, 'real question');
+	// ... and the earlier turns arrive as separate, role-preserving messages,
+	// not joined into one blob.
+	t.deepEqual(sentHistory, [
+		{role: 'user', content: 'example input'},
+		{role: 'assistant', content: 'example output'},
+	]);
+	t.false(
+		setMessagesCalled,
+		'the user-turn path submits through onHandleChatMessage, not a direct setMessages splice',
+	);
+});
+
+test('a single-message prompt is submitted with no history messages', async t => {
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [{name: 'greet', serverName: 'docs', arguments: []}],
+				getPrompt: async () => ({
+					messages: [{role: 'user', content: {type: 'text', text: 'hello there'}}],
+				}),
+			}),
+		),
+	);
+
+	let sentHistory: unknown;
+	await handleMCPPromptCommand(
+		'mcp:docs:greet',
+		[],
+		createOptions({
+			onHandleChatMessage: async (_message, _displayValue, _images, history) => {
+				sentHistory = history;
+			},
+		}),
+	);
+
+	t.is(sentHistory, undefined);
+});
+
+test('a prompt that does not end on a user turn is appended as history instead of a fabricated chat message', async t => {
+	setToolManagerGetter(() =>
+		mockToolManager(
+			mockMCPClient({
+				prompts: [{name: 'seed', serverName: 'docs', arguments: []}],
+				getPrompt: async () => ({
+					messages: [
+						{role: 'user', content: {type: 'text', text: 'set the scene'}},
+						{role: 'assistant', content: {type: 'text', text: 'scripted reply'}},
+					],
+				}),
+			}),
+		),
+	);
+
+	let onHandleChatMessageCalled = false;
+	let newMessages: Array<{role: string; content: string}> | undefined;
+	let completed = false;
+
+	const handled = await handleMCPPromptCommand(
+		'mcp:docs:seed',
+		[],
+		createOptions({
+			messages: [],
+			setMessages: msgs => {
+				newMessages = msgs as Array<{role: string; content: string}>;
+			},
+			onHandleChatMessage: async () => {
+				onHandleChatMessageCalled = true;
+			},
+			onCommandComplete: () => {
+				completed = true;
+			},
+		}),
+	);
+
+	t.true(handled);
+	t.false(
+		onHandleChatMessageCalled,
+		'there is no next user turn to submit, so no chat round-trip is triggered',
+	);
+	t.deepEqual(newMessages, [
+		{role: 'user', content: 'set the scene'},
+		{role: 'assistant', content: 'scripted reply'},
+	]);
+	t.true(completed);
 });

--- a/source/app/utils/handlers/mcp-prompt-handler.ts
+++ b/source/app/utils/handlers/mcp-prompt-handler.ts
@@ -1,0 +1,99 @@
+import {DELAY_COMMAND_COMPLETE_MS} from '@/constants';
+import {getToolManager} from '@/message-handler';
+import type {MessageSubmissionOptions} from '@/types/index';
+import {errorMsg} from '@/utils/message-factory';
+
+/**
+ * Dispatches `/mcp:<server>:<prompt>` — an MCP prompt invoked as a slash
+ * command. Unlike a custom command's static template, an MCP prompt is
+ * filled in by the server itself: this fetches it fresh on every call and
+ * feeds the result to the model as the next chat turn, the same way a
+ * custom command's rendered body does.
+ *
+ * Returns true if `commandName` matched a connected server's prompt (handled
+ * either way, success or reported error).
+ */
+export async function handleMCPPromptCommand(
+	commandName: string,
+	args: string[],
+	options: MessageSubmissionOptions,
+): Promise<boolean> {
+	const {onAddToChatQueue, onCommandComplete, onHandleChatMessage} = options;
+
+	const toolManager = getToolManager();
+	const mcpClient = toolManager?.getMCPClient();
+	if (!mcpClient) return false;
+
+	const prompt = mcpClient
+		.getAllPrompts()
+		.find(p => `mcp:${p.serverName}:${p.name}` === commandName);
+	if (!prompt) return false;
+
+	const promptArgs: Record<string, string> = {};
+	const missing: string[] = [];
+	(prompt.arguments ?? []).forEach((arg, index) => {
+		const value = args[index];
+		if (value !== undefined && value !== '') {
+			promptArgs[arg.name] = value;
+		} else if (arg.required) {
+			missing.push(arg.name);
+		}
+	});
+
+	if (missing.length > 0) {
+		onAddToChatQueue(
+			errorMsg(
+				`Missing required argument${missing.length === 1 ? '' : 's'} for /${commandName}: ${missing.join(', ')}`,
+				'mcp-prompt-error',
+			),
+		);
+		setTimeout(() => onCommandComplete?.(), DELAY_COMMAND_COMPLETE_MS);
+		return true;
+	}
+
+	try {
+		const result = await mcpClient.getPrompt(
+			prompt.serverName,
+			prompt.name,
+			promptArgs,
+		);
+		const promptText = result.messages
+			.map(m => contentToText(m.content))
+			.filter(Boolean)
+			.join('\n\n');
+
+		if (promptText.trim()) {
+			await onHandleChatMessage(promptText);
+		} else {
+			onAddToChatQueue(
+				errorMsg(
+					`MCP prompt "/${commandName}" returned no text content.`,
+					'mcp-prompt-error',
+				),
+			);
+			setTimeout(() => onCommandComplete?.(), DELAY_COMMAND_COMPLETE_MS);
+		}
+	} catch (error) {
+		onAddToChatQueue(
+			errorMsg(
+				`Failed to load MCP prompt "/${commandName}": ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+				'mcp-prompt-error',
+			),
+		);
+		setTimeout(() => onCommandComplete?.(), DELAY_COMMAND_COMPLETE_MS);
+	}
+
+	return true;
+}
+
+/** Text content passes through; non-text blocks get a short, honest note. */
+function contentToText(content: {
+	type: 'text' | 'image' | 'resource';
+	text?: string;
+	mimeType?: string;
+}): string {
+	if (content.type === 'text') return content.text ?? '';
+	return `[${content.type} content: ${content.mimeType ?? 'unknown type'}, not inlined]`;
+}

--- a/source/app/utils/handlers/mcp-prompt-handler.ts
+++ b/source/app/utils/handlers/mcp-prompt-handler.ts
@@ -1,7 +1,8 @@
 import {DELAY_COMMAND_COMPLETE_MS} from '@/constants';
 import {getToolManager} from '@/message-handler';
+import type {Message} from '@/types/core';
 import type {MessageSubmissionOptions} from '@/types/index';
-import {errorMsg} from '@/utils/message-factory';
+import {errorMsg, warningMsg} from '@/utils/message-factory';
 
 /**
  * Dispatches `/mcp:<server>:<prompt>` — an MCP prompt invoked as a slash
@@ -18,7 +19,13 @@ export async function handleMCPPromptCommand(
 	args: string[],
 	options: MessageSubmissionOptions,
 ): Promise<boolean> {
-	const {onAddToChatQueue, onCommandComplete, onHandleChatMessage} = options;
+	const {
+		onAddToChatQueue,
+		onCommandComplete,
+		onHandleChatMessage,
+		messages,
+		setMessages,
+	} = options;
 
 	const toolManager = getToolManager();
 	const mcpClient = toolManager?.getMCPClient();
@@ -29,9 +36,10 @@ export async function handleMCPPromptCommand(
 		.find(p => `mcp:${p.serverName}:${p.name}` === commandName);
 	if (!prompt) return false;
 
+	const declaredArgs = prompt.arguments ?? [];
 	const promptArgs: Record<string, string> = {};
 	const missing: string[] = [];
-	(prompt.arguments ?? []).forEach((arg, index) => {
+	declaredArgs.forEach((arg, index) => {
 		const value = args[index];
 		if (value !== undefined && value !== '') {
 			promptArgs[arg.name] = value;
@@ -51,20 +59,36 @@ export async function handleMCPPromptCommand(
 		return true;
 	}
 
+	// Args are filled in positionally, in the order the server declares them
+	// (see docs/configuration/mcp-configuration.md). Anything beyond that -
+	// including every arg typed when the prompt declares none at all - has
+	// nowhere to go and would otherwise vanish with no indication why.
+	if (args.length > declaredArgs.length) {
+		const extra = args.slice(declaredArgs.length);
+		onAddToChatQueue(
+			warningMsg(
+				declaredArgs.length === 0
+					? `/${commandName} takes no arguments; ignoring: ${extra.join(', ')}`
+					: `/${commandName} takes ${declaredArgs.length} argument${declaredArgs.length === 1 ? '' : 's'}; ignoring extra: ${extra.join(', ')}`,
+				'mcp-prompt-warning',
+			),
+		);
+	}
+
 	try {
 		const result = await mcpClient.getPrompt(
 			prompt.serverName,
 			prompt.name,
 			promptArgs,
 		);
-		const promptText = result.messages
-			.map(m => contentToText(m.content))
-			.filter(Boolean)
-			.join('\n\n');
+		// Keep each message's own role instead of joining every message's text
+		// into one blob - a few-shot prompt's assistant turns are structure the
+		// model relies on, not just extra text to prepend.
+		const textEntries = result.messages
+			.map(m => ({role: m.role, text: contentToText(m.content)}))
+			.filter(m => m.text.trim().length > 0);
 
-		if (promptText.trim()) {
-			await onHandleChatMessage(promptText);
-		} else {
+		if (textEntries.length === 0) {
 			onAddToChatQueue(
 				errorMsg(
 					`MCP prompt "/${commandName}" returned no text content.`,
@@ -72,6 +96,34 @@ export async function handleMCPPromptCommand(
 				),
 			);
 			setTimeout(() => onCommandComplete?.(), DELAY_COMMAND_COMPLETE_MS);
+			return true;
+		}
+
+		const last = textEntries[textEntries.length - 1];
+		const priorMessages: Message[] = textEntries
+			.slice(0, -1)
+			.map(m => ({role: m.role, content: m.text}));
+
+		if (last.role === 'user') {
+			// The common shape: any earlier turns (e.g. few-shot examples) are
+			// spliced into history as-is, and only the final user turn triggers
+			// the actual chat round-trip.
+			await onHandleChatMessage(
+				last.text,
+				undefined,
+				undefined,
+				priorMessages.length > 0 ? priorMessages : undefined,
+			);
+		} else {
+			// The prompt doesn't end on a user turn - e.g. it seeds a scripted
+			// assistant reply with nothing left to respond to. There is no
+			// "next chat message" to submit, so append every turn as inert
+			// history instead of fabricating a user message out of it.
+			setMessages([
+				...messages,
+				...textEntries.map(m => ({role: m.role, content: m.text}) as Message),
+			]);
+			onCommandComplete?.();
 		}
 	} catch (error) {
 		onAddToChatQueue(

--- a/source/commands/doctor.spec.tsx
+++ b/source/commands/doctor.spec.tsx
@@ -165,6 +165,33 @@ test('Doctor reports LSP MCP and daemon details', async t => {
 	t.regex(output, /uptime 1h/);
 });
 
+test('Doctor reports MCP resource and prompt counts', async t => {
+	const report = await collectDoctorReport(
+		createDependencies({
+			getToolManager: () =>
+				({
+					getConnectedServers: () => ['docs-server'],
+					getServerTools: () => [
+						{name: 'search_docs', description: 'Search docs'},
+					],
+					getServerInfo: () => ({
+						name: 'docs-server',
+						transport: 'stdio',
+						connected: true,
+						resourceCount: 2,
+						promptCount: 5,
+					}),
+				}) as never,
+		}),
+	);
+
+	const {lastFrame} = renderWithTheme(<Doctor report={report} />);
+	const output = lastFrame()!;
+
+	t.regex(output, /2 resources/);
+	t.regex(output, /5 prompts/);
+});
+
 test('Doctor handles no LSP MCP or daemon data', async t => {
 	const report = await collectDoctorReport(
 		createDependencies({

--- a/source/commands/doctor.tsx
+++ b/source/commands/doctor.tsx
@@ -43,6 +43,8 @@ export interface DoctorMcpServer {
 	name: string;
 	transport: string;
 	toolCount: number;
+	resourceCount: number;
+	promptCount: number;
 	url?: string;
 }
 
@@ -199,6 +201,8 @@ function collectMcp(toolManager: ToolManager | null): DoctorMcpServer[] {
 			name: serverName,
 			transport: String(serverInfo?.transport ?? 'stdio'),
 			toolCount: serverTools.length,
+			resourceCount: serverInfo?.resourceCount ?? 0,
+			promptCount: serverInfo?.promptCount ?? 0,
 			url: serverInfo?.url,
 		};
 	});
@@ -381,6 +385,12 @@ export function Doctor({report}: {report: DoctorReport}) {
 					<Text key={server.name} color={colors.text}>
 						• {server.name}: {server.transport} • {server.toolCount} tool
 						{server.toolCount === 1 ? '' : 's'}
+						{server.resourceCount > 0
+							? ` • ${server.resourceCount} resource${server.resourceCount === 1 ? '' : 's'}`
+							: ''}
+						{server.promptCount > 0
+							? ` • ${server.promptCount} prompt${server.promptCount === 1 ? '' : 's'}`
+							: ''}
 						{server.url ? ` • ${server.url}` : ''}
 					</Text>
 				))

--- a/source/commands/mcp-command.spec.tsx
+++ b/source/commands/mcp-command.spec.tsx
@@ -225,6 +225,65 @@ test('MCP command: shows configuration examples', t => {
 	t.regex(output!, /"url":/);
 });
 
+test('MCP command: displays resource and prompt counts and names', t => {
+	const mockToolManager = {
+		getConnectedServers: () => ['docs-server'],
+		getServerTools: () => [{name: 'search', description: 'Search docs'}],
+		getServerInfo: () => ({
+			name: 'docs-server',
+			transport: 'stdio',
+			toolCount: 1,
+			resourceCount: 2,
+			promptCount: 1,
+			connected: true,
+		}),
+		getMCPClient: () => ({
+			getServerResources: () => [
+				{uri: 'file:///a.md', name: 'api-docs', serverName: 'docs-server'},
+				{uri: 'file:///b.md', name: 'changelog', serverName: 'docs-server'},
+			],
+			getServerPrompts: () => [
+				{name: 'summarize', serverName: 'docs-server'},
+			],
+		}),
+	} as unknown as ToolManager;
+
+	const {lastFrame} = renderWithTheme(<MCP toolManager={mockToolManager} />);
+
+	const output = lastFrame();
+	t.truthy(output);
+	t.regex(output!, /2 resources/);
+	t.regex(output!, /1 prompt\b/);
+	t.regex(output!, /Resources:/);
+	t.regex(output!, /api-docs/);
+	t.regex(output!, /changelog/);
+	t.regex(output!, /Prompts:/);
+	t.regex(output!, /\/mcp:docs-server:summarize/);
+});
+
+test('MCP command: omits resource and prompt lines when a server has none (no getMCPClient on the mock)', t => {
+	const mockToolManager = {
+		getConnectedServers: () => ['plain-server'],
+		getServerTools: () => [{name: 'tool', description: 'A tool'}],
+		getServerInfo: () => ({
+			name: 'plain-server',
+			transport: 'stdio',
+			toolCount: 1,
+			connected: true,
+		}),
+		// Deliberately no getMCPClient, matching a caller/mock that predates
+		// resources/prompts support - must not throw.
+	} as unknown as ToolManager;
+
+	t.notThrows(() => {
+		const {lastFrame} = renderWithTheme(<MCP toolManager={mockToolManager} />);
+		const output = lastFrame();
+		t.truthy(output);
+		t.notRegex(output!, /Resources:/);
+		t.notRegex(output!, /Prompts:/);
+	});
+});
+
 test('MCP command: uses transport type getTransportIcon function correctly', t => {
 	// Test the helper function indirectly through component rendering
 	const testCases = [

--- a/source/commands/mcp.tsx
+++ b/source/commands/mcp.tsx
@@ -89,6 +89,10 @@ export function MCP({toolManager}: MCPProps) {
 
 					{connectedServers.map((serverName, index) => {
 						const serverTools = toolManager?.getServerTools(serverName) || [];
+						const mcpClient = toolManager?.getMCPClient?.();
+						const serverResources =
+							mcpClient?.getServerResources(serverName) || [];
+						const serverPrompts = mcpClient?.getServerPrompts(serverName) || [];
 						const serverInfo = toolManager?.getServerInfo(serverName);
 						const transportIcon = getTransportIcon(
 							serverInfo?.transport || 'stdio',
@@ -105,6 +109,10 @@ export function MCP({toolManager}: MCPProps) {
 										</Text>{' '}
 										• {serverTools.length} tool
 										{serverTools.length !== 1 ? 's' : ''}
+										{serverResources.length > 0 &&
+											`, ${serverResources.length} resource${serverResources.length !== 1 ? 's' : ''}`}
+										{serverPrompts.length > 0 &&
+											`, ${serverPrompts.length} prompt${serverPrompts.length !== 1 ? 's' : ''}`}
 									</Text>
 
 									{serverInfo?.url && (
@@ -131,6 +139,19 @@ export function MCP({toolManager}: MCPProps) {
 											Tools:{' '}
 											{serverTools
 												.map((t: {name: string}) => t.name)
+												.join(', ')}
+										</Text>
+									)}
+									{serverResources.length > 0 && (
+										<Text color={colors.tool}>
+											Resources: {serverResources.map(r => r.name).join(', ')}
+										</Text>
+									)}
+									{serverPrompts.length > 0 && (
+										<Text color={colors.tool}>
+											Prompts:{' '}
+											{serverPrompts
+												.map(p => `/mcp:${serverName}:${p.name}`)
 												.join(', ')}
 										</Text>
 									)}

--- a/source/components/user-input-completion.spec.tsx
+++ b/source/components/user-input-completion.spec.tsx
@@ -5,7 +5,9 @@ import stripAnsi from 'strip-ansi';
 import {themes} from '../config/themes';
 import {ThemeContext} from '../hooks/useTheme';
 import {UIStateProvider} from '../hooks/useUIState';
+import {setToolManagerGetter} from '../message-handler';
 import {promptHistory} from '../prompt-history';
+import type {ToolManager} from '../tools/tool-manager';
 import UserInput from './user-input';
 
 console.log('\nuser-input-completion.spec.tsx');
@@ -104,6 +106,61 @@ test('a command recalled from history does not auto-open the menu until typed', 
 		stripAnsi(lastFrame() ?? ''),
 		/zzalpha/,
 		'typing into the recalled command surfaces suggestions again',
+	);
+
+	unmount();
+});
+
+// Regression (reviewer feedback on #1172): an MCP resource shares the file
+// `@`-mention completion list, and the list's displayPath ("name (server)",
+// for on-screen disambiguation only) was being passed as the resourceName
+// argument instead of the bare resource name. That stamped the server
+// annotation twice: once from displayPath, once from the assembled prompt
+// header ("=== MCP Resource: x (from server) ==="). Selecting the resource
+// must produce a plain `[@<name>]` chip.
+test('selecting an MCP resource mention does not double-stamp the server name', async t => {
+	const fakeResource = {
+		uri: 'file:///docs/api.md',
+		name: 'api-docs',
+		serverName: 'docs-server',
+	};
+	const fakeMCPClient = {
+		getAllResources: () => [fakeResource],
+		readResource: async () => [
+			{uri: fakeResource.uri, mimeType: 'text/markdown', text: 'hello'},
+		],
+	};
+	setToolManagerGetter(
+		() =>
+			({
+				getMCPClient: () => fakeMCPClient,
+			}) as unknown as ToolManager,
+	);
+	t.teardown(() => setToolManagerGetter(() => null));
+
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput forceFocus={true} />
+		</TestWrapper>,
+	);
+
+	stdin.write('@api-docs');
+	await waitForFrame(lastFrame, /api-docs \(docs-server\)/); // completion list shows the disambiguated form
+	// The per-keystroke autocomplete effect has no in-flight cancellation, so a
+	// stale fetch for an earlier partial mention (e.g. "api-do") can still
+	// resolve after the final one and briefly overwrite the completion list.
+	// Give those stragglers time to settle before selecting, matching this
+	// file's existing pattern for other timing-sensitive interactions.
+	await wait(300);
+	stdin.write(TAB);
+	await waitForFrame(lastFrame, /\[@api-docs\]/);
+
+	const frame = stripAnsi(lastFrame() ?? '');
+	t.regex(frame, /\[@api-docs\]/);
+	t.notRegex(
+		frame,
+		/\[@api-docs \(docs-server\)\]/,
+		'the placeholder chip must not carry the server name a second time',
 	);
 
 	unmount();

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -12,6 +12,7 @@ import type {
 	QueuedUserMessage,
 	UserMessageQueueDraft,
 } from '@/hooks/useUserMessageQueue';
+import {getToolManager} from '@/message-handler';
 import {promptHistory} from '@/prompt-history';
 import type {TuneConfig} from '@/types/config';
 import type {
@@ -36,13 +37,67 @@ import {
 	getFileCompletions,
 } from '@/utils/file-autocomplete';
 import {handleFileMention} from '@/utils/file-mention-handler';
+import {fuzzyScoreFilePath} from '@/utils/fuzzy-matching';
 import {assemblePrompt} from '@/utils/prompt-processor';
+import {handleResourceMention} from '@/utils/resource-mention-handler';
 import {isSelectionMode, toggleSelectionMode} from '@/utils/terminal-mouse';
 import {pasteEvents} from '@/utils/terminal-paste';
 import {getVisualLineSegments} from '@/utils/text-wrapping';
 import type {ActiveEditorState} from '@/vscode/vscode-server';
 
 const MAX_COMMAND_COMPLETION_ROWS = 10;
+
+// An MCP resource shares the file-mention `@` trigger and completion list,
+// distinguished from a filesystem path by this prefix so `handleFileSelection`
+// knows which resolver to call. `resource.uri` can itself contain colons
+// (e.g. `file:///…`), so the prefix only wraps the leading `serverName` and
+// is split off with a bounded split rather than a plain `:` join/parse.
+const MCP_RESOURCE_PATH_PREFIX = 'mcp-resource:';
+
+function encodeMCPResourcePath(serverName: string, uri: string): string {
+	return `${MCP_RESOURCE_PATH_PREFIX}${serverName}:${uri}`;
+}
+
+function decodeMCPResourcePath(
+	path: string,
+): {serverName: string; uri: string} | null {
+	if (!path.startsWith(MCP_RESOURCE_PATH_PREFIX)) return null;
+	const rest = path.slice(MCP_RESOURCE_PATH_PREFIX.length);
+	const separatorIndex = rest.indexOf(':');
+	if (separatorIndex === -1) return null;
+	return {
+		serverName: rest.slice(0, separatorIndex),
+		uri: rest.slice(separatorIndex + 1),
+	};
+}
+
+/**
+ * MCP resources from every connected server, scored against the partial
+ * `@mention` the same way local files are, and merged into the same
+ * completion list. Mirrors `getFileCompletions`'s shape and score-based
+ * filtering so the two sources sort together without special-casing.
+ */
+async function getMCPResourceCompletions(partialPath: string): Promise<
+	Array<{
+		path: string;
+		displayPath: string;
+		score: number;
+		isDirectory: boolean;
+	}>
+> {
+	const mcpClient = getToolManager()?.getMCPClient();
+	if (!mcpClient) return [];
+
+	return mcpClient
+		.getAllResources()
+		.map(resource => ({
+			path: encodeMCPResourcePath(resource.serverName, resource.uri),
+			displayPath: `${resource.name} (${resource.serverName})`,
+			score: fuzzyScoreFilePath(resource.name, partialPath),
+			isDirectory: false,
+		}))
+		.filter(c => c.score > 0);
+}
 
 interface ChatProps {
 	onSubmit?: (
@@ -132,7 +187,7 @@ export default function UserInput({
 	// File autocomplete state
 	const [isFileAutocompleteMode, setIsFileAutocompleteMode] = useState(false);
 	const [fileCompletions, setFileCompletions] = useState<
-		Array<{path: string; score: number}>
+		Array<{path: string; displayPath: string; score: number}>
 	>([]);
 	const [selectedFileIndex, setSelectedFileIndex] = useState(0);
 	const [selectedQueuedIndex, setSelectedQueuedIndex] = useState(-1);
@@ -296,8 +351,15 @@ export default function UserInput({
 			if (mention) {
 				setIsFileAutocompleteMode(true);
 				const cwd = process.cwd();
-				const completions = await getFileCompletions(mention.mention, cwd);
-				setFileCompletions(completions);
+				const [completions, resourceCompletions] = await Promise.all([
+					getFileCompletions(mention.mention, cwd),
+					getMCPResourceCompletions(mention.mention),
+				]);
+				setFileCompletions(
+					[...completions, ...resourceCompletions]
+						.sort((a, b) => b.score - a.score)
+						.slice(0, 20),
+				);
 				setSelectedFileIndex(0); // Reset selection when completions change
 			} else {
 				setIsFileAutocompleteMode(false);
@@ -326,7 +388,10 @@ export default function UserInput({
 		const commandPrefix = input.slice(1).split(' ')[0];
 
 		const builtInCompletions = commandRegistry.getCompletions(commandPrefix);
-		const customCompletions = customCommands
+		const mcpPromptNames = (
+			getToolManager()?.getMCPClient()?.getAllPrompts() ?? []
+		).map(p => `mcp:${p.serverName}:${p.name}`);
+		const customCompletions = [...customCommands, ...mcpPromptNames]
 			.filter(cmd => {
 				// Include all when no prefix, otherwise filter by prefix
 				return (
@@ -402,13 +467,28 @@ export default function UserInput({
 		// Extract the original mention text (the @... part we're replacing)
 		const mentionText = input.substring(mention.startIndex, mention.endIndex);
 
-		// Handle the file mention to create placeholder
-		const result = await handleFileMention(
-			selectedPath,
-			currentState.displayValue,
-			currentState.placeholderContent,
-			mentionText,
-		);
+		// Handle the mention to create a placeholder. An MCP resource and a
+		// filesystem file share this completion list and are resolved by
+		// different readers, distinguished by the encoded path's prefix.
+		const decoded = decodeMCPResourcePath(selectedPath);
+		const mcpClient = decoded ? getToolManager()?.getMCPClient() : undefined;
+		const result =
+			decoded && mcpClient
+				? await handleResourceMention(
+						mcpClient,
+						decoded.serverName,
+						decoded.uri,
+						fileCompletions[selectedFileIndex]?.displayPath ?? decoded.uri,
+						currentState.displayValue,
+						currentState.placeholderContent,
+						mentionText,
+					)
+				: await handleFileMention(
+						selectedPath,
+						currentState.displayValue,
+						currentState.placeholderContent,
+						mentionText,
+					);
 
 		if (result) {
 			setInputState(result);
@@ -1118,7 +1198,9 @@ export default function UserInput({
 								bold={index === selectedFileIndex}
 							>
 								{index === selectedFileIndex ? '▸ ' : '  '}
-								{file.path}
+								{decodeMCPResourcePath(file.path)
+									? file.displayPath
+									: file.path}
 							</Text>
 						))}
 					</Box>

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -81,6 +81,7 @@ async function getMCPResourceCompletions(partialPath: string): Promise<
 	Array<{
 		path: string;
 		displayPath: string;
+		resourceName: string;
 		score: number;
 		isDirectory: boolean;
 	}>
@@ -92,7 +93,12 @@ async function getMCPResourceCompletions(partialPath: string): Promise<
 		.getAllResources()
 		.map(resource => ({
 			path: encodeMCPResourcePath(resource.serverName, resource.uri),
+			// displayPath is for the completion list UI only — it must never be
+			// used as the resourceName passed to handleResourceMention, or the
+			// "(serverName)" suffix it carries gets stamped a second time by the
+			// assembled prompt header (see prompt-processor.ts's RESOURCE case).
 			displayPath: `${resource.name} (${resource.serverName})`,
+			resourceName: resource.name,
 			score: fuzzyScoreFilePath(resource.name, partialPath),
 			isDirectory: false,
 		}))
@@ -187,7 +193,12 @@ export default function UserInput({
 	// File autocomplete state
 	const [isFileAutocompleteMode, setIsFileAutocompleteMode] = useState(false);
 	const [fileCompletions, setFileCompletions] = useState<
-		Array<{path: string; displayPath: string; score: number}>
+		Array<{
+			path: string;
+			displayPath: string;
+			resourceName?: string;
+			score: number;
+		}>
 	>([]);
 	const [selectedFileIndex, setSelectedFileIndex] = useState(0);
 	const [selectedQueuedIndex, setSelectedQueuedIndex] = useState(-1);
@@ -478,7 +489,7 @@ export default function UserInput({
 						mcpClient,
 						decoded.serverName,
 						decoded.uri,
-						fileCompletions[selectedFileIndex]?.displayPath ?? decoded.uri,
+						fileCompletions[selectedFileIndex]?.resourceName ?? decoded.uri,
 						currentState.displayValue,
 						currentState.placeholderContent,
 						mentionText,

--- a/source/hooks/chat-handler/types.ts
+++ b/source/hooks/chat-handler/types.ts
@@ -70,6 +70,7 @@ export interface ChatHandlerReturn {
 		message: string,
 		displayValue?: string,
 		images?: ImageAttachment[],
+		historyMessages?: Message[],
 	) => Promise<void>;
 	processAssistantResponse: (
 		systemMessage: Message,

--- a/source/hooks/chat-handler/useChatHandler.spec.tsx
+++ b/source/hooks/chat-handler/useChatHandler.spec.tsx
@@ -638,6 +638,58 @@ test('useChatHandler - allocates a session before starting a turn', async t => {
 	t.is(ensureCalls, 1);
 });
 
+// Regression (reviewer feedback on #1172): a caller (the MCP prompt handler)
+// can supply prior-turn messages to splice into history ahead of the new user
+// message, preserving their roles instead of flattening a multi-message
+// prompt into one user turn.
+test('useChatHandler - handleChatMessage splices historyMessages ahead of the new user message', async t => {
+	let hookResult: ChatHandlerReturn | null = null;
+	// The conversation loop calls setMessages again once the (mocked) assistant
+	// reply comes back, so only the FIRST call reflects what this fix actually
+	// changed: how the new user message and its preceding history get merged
+	// into the existing conversation before the round-trip starts.
+	let firstMessages: Message[] | null = null;
+	const customCommandLoader = {
+		findRelevantCommands: () => [],
+	} as unknown as NonNullable<UseChatHandlerProps['customCommandLoader']>;
+
+	render(
+		<TestHookComponent
+			{...createMockProps({
+				client: createMockClient(),
+				toolManager: createMockToolManager(),
+				customCommandLoader,
+				setMessages: msgs => {
+					firstMessages ??= msgs;
+				},
+			})}
+			onResult={result => {
+				hookResult = result;
+			}}
+		/>,
+	);
+
+	await waitForCondition(() => hookResult !== null);
+	await hookResult!.handleChatMessage(
+		'real question',
+		undefined,
+		undefined,
+		[
+			{role: 'user', content: 'example input'},
+			{role: 'assistant', content: 'example output'},
+		],
+	);
+
+	t.deepEqual(
+		firstMessages?.map(m => ({role: m.role, content: m.content})),
+		[
+			{role: 'user', content: 'example input'},
+			{role: 'assistant', content: 'example output'},
+			{role: 'user', content: 'real question'},
+		],
+	);
+});
+
 // The signal must be scoped to plan mode — a normal-mode turn completing must
 // NOT surface the plan review bar (this is the fix for the mode-inference race).
 test('useChatHandler - does NOT fire onPlanTurnComplete for a normal-mode turn', async t => {

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -342,6 +342,7 @@ export function useChatHandler({
 		message: string,
 		displayValue?: string,
 		images?: ImageAttachment[],
+		historyMessages?: Message[],
 	) => {
 		if (!client || !toolManager) return;
 		const sessionId = ensureCurrentSessionId?.();
@@ -376,8 +377,15 @@ export function useChatHandler({
 			/>,
 		);
 
-		// Add user message to conversation history (single addition)
+		// Add user message to conversation history (single addition). Any
+		// caller-supplied historyMessages (e.g. the preceding turns of a
+		// multi-message MCP prompt) are spliced in first, preserving their
+		// original roles, so a few-shot prompt keeps its turn structure
+		// instead of being flattened into this one user message.
 		const builder = new MessageBuilder(messages);
+		for (const historyMessage of historyMessages ?? []) {
+			builder.addMessage(historyMessage);
+		}
 		builder.addUserMessage(message, images);
 		const updatedMessages = builder.build();
 		setMessages(updatedMessages);

--- a/source/mcp/mcp-client.spec.ts
+++ b/source/mcp/mcp-client.spec.ts
@@ -1280,6 +1280,9 @@ test('MCPClient.connectToServer: registers the server once tool discovery succee
 				],
 			};
 		},
+		getServerCapabilities() {
+			return undefined;
+		},
 		async close() {},
 	};
 
@@ -1337,6 +1340,9 @@ test('MCPClient.connectToServer: carries annotations.readOnlyHint onto discovere
 					},
 				],
 			};
+		},
+		getServerCapabilities() {
+			return undefined;
 		},
 		async close() {},
 	};
@@ -1423,6 +1429,9 @@ test('MCPClient.getToolMapping: is cached and invalidated on connect/disconnect'
 				],
 			};
 		},
+		getServerCapabilities() {
+			return undefined;
+		},
 		async close() {},
 	};
 
@@ -1454,6 +1463,9 @@ test('MCPClient.getToolMapping: a mapping taken before connect is not left stale
 				],
 			};
 		},
+		getServerCapabilities() {
+			return undefined;
+		},
 		async close() {},
 	};
 
@@ -1473,4 +1485,390 @@ test('MCPClient.getToolMapping: a mapping taken before connect is not left stale
 		afterConnect.has('late_tool'),
 		'tools discovered after the first call must still be mapped',
 	);
+});
+
+// ============================================================================
+// Tests for MCP Resources Support
+// ============================================================================
+
+test('MCPClient.getAllResources: returns empty array when no servers connected', t => {
+	const client = new MCPClient();
+	const resources = client.getAllResources();
+
+	t.true(Array.isArray(resources));
+	t.is(resources.length, 0);
+});
+
+test('MCPClient.getAllResources: returns resources from connected servers', t => {
+	const client = new MCPClient();
+
+	// Simulate connected server with resources
+	(client as any).serverResources.set('test-server', [
+		{
+			uri: 'file:///test/resource1.txt',
+			name: 'resource1',
+			description: 'Test resource 1',
+			mimeType: 'text/plain',
+			serverName: 'test-server',
+		},
+		{
+			uri: 'file:///test/resource2.json',
+			name: 'resource2',
+			description: 'Test resource 2',
+			mimeType: 'application/json',
+			serverName: 'test-server',
+		},
+	]);
+
+	const resources = client.getAllResources();
+
+	t.is(resources.length, 2);
+	t.is(resources[0].name, 'resource1');
+	t.is(resources[0].uri, 'file:///test/resource1.txt');
+	t.is(resources[1].name, 'resource2');
+});
+
+test('MCPClient.getServerResources: returns empty array for non-existent server', t => {
+	const client = new MCPClient();
+	const resources = client.getServerResources('non-existent');
+
+	t.true(Array.isArray(resources));
+	t.is(resources.length, 0);
+});
+
+test('MCPClient.getServerResources: returns resources for specific server', t => {
+	const client = new MCPClient();
+
+	const testResources = [
+		{
+			uri: 'file:///test/resource.txt',
+			name: 'resource',
+			description: 'Test resource',
+			mimeType: 'text/plain',
+			serverName: 'test-server',
+		},
+	];
+
+	(client as any).serverResources.set('test-server', testResources);
+
+	const resources = client.getServerResources('test-server');
+
+	t.is(resources.length, 1);
+	t.deepEqual(resources, testResources);
+});
+
+test('MCPClient.readResource: throws error when server is not connected', async t => {
+	const client = new MCPClient();
+
+	await t.throwsAsync(
+		async () => await client.readResource('non-existent', 'file:///x'),
+		{message: /No MCP client connected for server/},
+	);
+});
+
+test('MCPClient.readResource: discriminates text vs. blob content (neither carries a type field)', async t => {
+	const injected = {
+		async connect() {},
+		async listTools() {
+			return {tools: []};
+		},
+		getServerCapabilities() {
+			return {resources: {}};
+		},
+		async listResources() {
+			return {
+				resources: [
+					{uri: 'file:///a.txt', name: 'a', mimeType: 'text/plain'},
+				],
+			};
+		},
+		async readResource({uri}: {uri: string}) {
+			return {
+				contents: [
+					{uri: 'file:///a.txt', mimeType: 'text/plain', text: 'hello'},
+					{uri: 'file:///b.png', mimeType: 'image/png', blob: 'YmFzZTY0'},
+				],
+			};
+		},
+		async close() {},
+	};
+
+	const client = new SeamMCPClient(injected);
+	await client.connectToServer(httpServer);
+
+	const contents = await client.readResource('seam-server', 'file:///a.txt');
+
+	t.is(contents.length, 2);
+	t.is(contents[0].text, 'hello');
+	t.is(contents[0].blob, undefined);
+	t.is(contents[1].blob, 'YmFzZTY0');
+	t.is(contents[1].text, undefined);
+});
+
+test('MCPClient.connectToServer: does not call listResources when the server does not declare the resources capability', async t => {
+	let listResourcesCalled = false;
+	const injected = {
+		async connect() {},
+		async listTools() {
+			return {tools: []};
+		},
+		getServerCapabilities() {
+			return {prompts: {}};
+		},
+		async listResources() {
+			listResourcesCalled = true;
+			return {resources: []};
+		},
+		async close() {},
+	};
+
+	const client = new SeamMCPClient(injected);
+	await client.connectToServer(httpServer);
+
+	t.false(
+		listResourcesCalled,
+		'listResources must not be called when capabilities.resources is absent',
+	);
+	t.is(client.getServerResources('seam-server').length, 0);
+});
+
+test('MCPClient.getServerInfo: includes resource count', t => {
+	const client = new MCPClient();
+
+	const testConfig = {
+		name: 'test-server',
+		transport: 'stdio' as const,
+		command: 'node',
+		args: ['server.js'],
+	};
+
+	const mockClient = {};
+
+	(client as any).clients.set('test-server', mockClient);
+	(client as any).serverConfigs.set('test-server', testConfig);
+	(client as any).serverTools.set('test-server', []);
+	(client as any).serverResources.set('test-server', [
+		{
+			uri: 'file:///resource1.txt',
+			name: 'resource1',
+			serverName: 'test-server',
+		},
+		{
+			uri: 'file:///resource2.txt',
+			name: 'resource2',
+			serverName: 'test-server',
+		},
+	]);
+	(client as any).serverPrompts.set('test-server', []);
+
+	const serverInfo = client.getServerInfo('test-server');
+
+	t.truthy(serverInfo);
+	t.is(serverInfo?.resourceCount, 2);
+});
+
+// ============================================================================
+// Tests for MCP Prompts Support
+// ============================================================================
+
+test('MCPClient.getAllPrompts: returns empty array when no servers connected', t => {
+	const client = new MCPClient();
+	const prompts = client.getAllPrompts();
+
+	t.true(Array.isArray(prompts));
+	t.is(prompts.length, 0);
+});
+
+test('MCPClient.getAllPrompts: returns prompts from connected servers', t => {
+	const client = new MCPClient();
+
+	// Simulate connected server with prompts
+	(client as any).serverPrompts.set('test-server', [
+		{
+			name: 'prompt1',
+			description: 'Test prompt 1',
+			arguments: [
+				{name: 'query', description: 'Query parameter', required: true},
+			],
+			serverName: 'test-server',
+		},
+		{
+			name: 'prompt2',
+			description: 'Test prompt 2',
+			serverName: 'test-server',
+		},
+	]);
+
+	const prompts = client.getAllPrompts();
+
+	t.is(prompts.length, 2);
+	t.is(prompts[0].name, 'prompt1');
+	t.is(prompts[0].description, 'Test prompt 1');
+	t.is(prompts[1].name, 'prompt2');
+});
+
+test('MCPClient.getServerPrompts: returns empty array for non-existent server', t => {
+	const client = new MCPClient();
+	const prompts = client.getServerPrompts('non-existent');
+
+	t.true(Array.isArray(prompts));
+	t.is(prompts.length, 0);
+});
+
+test('MCPClient.getServerPrompts: returns prompts for specific server', t => {
+	const client = new MCPClient();
+
+	const testPrompts = [
+		{
+			name: 'test-prompt',
+			description: 'Test prompt',
+			arguments: [],
+			serverName: 'test-server',
+		},
+	];
+
+	(client as any).serverPrompts.set('test-server', testPrompts);
+
+	const prompts = client.getServerPrompts('test-server');
+
+	t.is(prompts.length, 1);
+	t.deepEqual(prompts, testPrompts);
+});
+
+test('MCPClient.getPrompt: throws error when server is not connected', async t => {
+	const client = new MCPClient();
+
+	await t.throwsAsync(
+		async () => await client.getPrompt('non-existent', 'prompt', {}),
+		{message: /No MCP client connected for server/},
+	);
+});
+
+test('MCPClient.getPrompt: fetches and normalizes a prompt from its own server', async t => {
+	const injected = {
+		async connect() {},
+		async listTools() {
+			return {tools: []};
+		},
+		getServerCapabilities() {
+			return {prompts: {}};
+		},
+		async listPrompts() {
+			return {
+				prompts: [
+					{
+						name: 'greet',
+						description: 'Greets someone',
+						arguments: [{name: 'who', required: true}],
+					},
+				],
+			};
+		},
+		async getPrompt({
+			name,
+			arguments: args,
+		}: {
+			name: string;
+			arguments?: Record<string, string>;
+		}) {
+			return {
+				description: 'A greeting',
+				messages: [
+					{role: 'user', content: {type: 'text', text: `hi ${args?.who}`}},
+				],
+			};
+		},
+		async close() {},
+	};
+
+	const client = new SeamMCPClient(injected);
+	await client.connectToServer(httpServer);
+
+	const result = await client.getPrompt('seam-server', 'greet', {
+		who: 'world',
+	});
+
+	t.is(result.description, 'A greeting');
+	t.is(result.messages.length, 1);
+	t.is(result.messages[0].content.text, 'hi world');
+});
+
+test('MCPClient.connectToServer: does not call listPrompts when the server does not declare the prompts capability', async t => {
+	let listPromptsCalled = false;
+	const injected = {
+		async connect() {},
+		async listTools() {
+			return {tools: []};
+		},
+		getServerCapabilities() {
+			return {resources: {}};
+		},
+		async listPrompts() {
+			listPromptsCalled = true;
+			return {prompts: []};
+		},
+		async close() {},
+	};
+
+	const client = new SeamMCPClient(injected);
+	await client.connectToServer(httpServer);
+
+	t.false(
+		listPromptsCalled,
+		'listPrompts must not be called when capabilities.prompts is absent',
+	);
+	t.is(client.getServerPrompts('seam-server').length, 0);
+});
+
+test('MCPClient.getServerInfo: includes prompt count', t => {
+	const client = new MCPClient();
+
+	const testConfig = {
+		name: 'test-server',
+		transport: 'stdio' as const,
+		command: 'node',
+		args: ['server.js'],
+	};
+
+	const mockClient = {};
+
+	(client as any).clients.set('test-server', mockClient);
+	(client as any).serverConfigs.set('test-server', testConfig);
+	(client as any).serverTools.set('test-server', []);
+	(client as any).serverResources.set('test-server', []);
+	(client as any).serverPrompts.set('test-server', [
+		{name: 'prompt1', serverName: 'test-server'},
+		{name: 'prompt2', serverName: 'test-server'},
+		{name: 'prompt3', serverName: 'test-server'},
+	]);
+
+	const serverInfo = client.getServerInfo('test-server');
+
+	t.truthy(serverInfo);
+	t.is(serverInfo?.promptCount, 3);
+});
+
+// ============================================================================
+// Tests for disconnect with resources and prompts
+// ============================================================================
+
+test('MCPClient.disconnect: clears resources and prompts', async t => {
+	const client = new MCPClient();
+
+	// Add some mock state including resources and prompts
+	(client as any).clients.set('mock', {});
+	(client as any).transports.set('mock', {});
+	(client as any).serverTools.set('mock', []);
+	(client as any).serverResources.set('mock', [{uri: 'test', name: 'test', serverName: 'mock'}]);
+	(client as any).serverPrompts.set('mock', [{name: 'test', serverName: 'mock'}]);
+	(client as any).serverConfigs.set('mock', {});
+	(client as any).isConnected = true;
+
+	await client.disconnect();
+
+	// State should be cleared
+	t.is(client.getServerResources('mock').length, 0);
+	t.is(client.getServerPrompts('mock').length, 0);
+	t.is(client.getAllResources().length, 0);
+	t.is(client.getAllPrompts().length, 0);
 });

--- a/source/mcp/mcp-client.ts
+++ b/source/mcp/mcp-client.ts
@@ -214,15 +214,21 @@ export class MCPClient {
 					} catch (error) {
 						// Server declared the capability but the call still failed -
 						// this is a genuine error, not an unsupported-feature guess.
-						this.logger.warn('MCP resources/list failed despite declared capability', {
-							serverName: normalizedServer.name,
-							error: formatError(error),
-						});
+						this.logger.warn(
+							'MCP resources/list failed despite declared capability',
+							{
+								serverName: normalizedServer.name,
+								error: formatError(error),
+							},
+						);
 					}
 				} else {
-					this.logger.debug('MCP server does not declare resources capability', {
-						serverName: normalizedServer.name,
-					});
+					this.logger.debug(
+						'MCP server does not declare resources capability',
+						{
+							serverName: normalizedServer.name,
+						},
+					);
 				}
 
 				// List available prompts from this server
@@ -247,10 +253,13 @@ export class MCPClient {
 					} catch (error) {
 						// Server declared the capability but the call still failed -
 						// this is a genuine error, not an unsupported-feature guess.
-						this.logger.warn('MCP prompts/list failed despite declared capability', {
-							serverName: normalizedServer.name,
-							error: formatError(error),
-						});
+						this.logger.warn(
+							'MCP prompts/list failed despite declared capability',
+							{
+								serverName: normalizedServer.name,
+								error: formatError(error),
+							},
+						);
 					}
 				} else {
 					this.logger.debug('MCP server does not declare prompts capability', {

--- a/source/mcp/mcp-client.ts
+++ b/source/mcp/mcp-client.ts
@@ -14,6 +14,10 @@ import {dynamicTool} from 'ai';
 import type {
 	AISDKCoreTool,
 	MCPInitResult,
+	MCPPrompt,
+	MCPPromptResult,
+	MCPResource,
+	MCPResourceContent,
 	MCPServer,
 	MCPTool,
 	MCPToolInputSchema,
@@ -50,6 +54,8 @@ export class MCPClient {
 		string,
 		{serverName: string; originalName: string; readOnly: boolean}
 	> | null = null;
+	private serverResources: Map<string, MCPResource[]> = new Map();
+	private serverPrompts: Map<string, MCPPrompt[]> = new Map();
 	private serverConfigs: Map<string, MCPServer> = new Map();
 	private isConnected: boolean = false;
 	private logger = getLogger();
@@ -182,19 +188,93 @@ export class MCPClient {
 					readOnly: tool.annotations?.readOnlyHint === true,
 				}));
 
-				// Store client, transport, config, and tools together only after
-				// connection and tool discovery have both succeeded.
+				// Discovery is gated on the server's declared capabilities (available
+				// on the Client only after connect() completes the handshake) rather
+				// than attempted unconditionally, so a server that never advertises
+				// resources/prompts doesn't pay for a doomed round trip on every
+				// connect.
+				const capabilities = client.getServerCapabilities();
+
+				// List available resources from this server
+				let resources: MCPResource[] = [];
+				if (capabilities?.resources) {
+					try {
+						const resourcesResult = await client.listResources();
+						resources = resourcesResult.resources.map(resource => ({
+							uri: resource.uri,
+							name: resource.name,
+							description: resource.description || undefined,
+							mimeType: resource.mimeType || undefined,
+							serverName: normalizedServer.name,
+						}));
+						this.logger.debug('MCP resources discovered', {
+							serverName: normalizedServer.name,
+							resourceCount: resources.length,
+						});
+					} catch (error) {
+						// Server declared the capability but the call still failed -
+						// this is a genuine error, not an unsupported-feature guess.
+						this.logger.warn('MCP resources/list failed despite declared capability', {
+							serverName: normalizedServer.name,
+							error: formatError(error),
+						});
+					}
+				} else {
+					this.logger.debug('MCP server does not declare resources capability', {
+						serverName: normalizedServer.name,
+					});
+				}
+
+				// List available prompts from this server
+				let prompts: MCPPrompt[] = [];
+				if (capabilities?.prompts) {
+					try {
+						const promptsResult = await client.listPrompts();
+						prompts = promptsResult.prompts.map(prompt => ({
+							name: prompt.name,
+							description: prompt.description || undefined,
+							arguments: prompt.arguments?.map(arg => ({
+								name: arg.name,
+								description: arg.description || undefined,
+								required: arg.required || false,
+							})),
+							serverName: normalizedServer.name,
+						}));
+						this.logger.debug('MCP prompts discovered', {
+							serverName: normalizedServer.name,
+							promptCount: prompts.length,
+						});
+					} catch (error) {
+						// Server declared the capability but the call still failed -
+						// this is a genuine error, not an unsupported-feature guess.
+						this.logger.warn('MCP prompts/list failed despite declared capability', {
+							serverName: normalizedServer.name,
+							error: formatError(error),
+						});
+					}
+				} else {
+					this.logger.debug('MCP server does not declare prompts capability', {
+						serverName: normalizedServer.name,
+					});
+				}
+
+				// Store client, transport, config, tools, resources, and prompts together only after
+				// connection and discovery have both succeeded.
 				this.clients.set(normalizedServer.name, client);
 				this.transports.set(normalizedServer.name, transport);
 				this.serverConfigs.set(normalizedServer.name, normalizedServer);
 				this.serverTools.set(normalizedServer.name, tools);
 				this.toolMappingCache = null;
+				this.serverResources.set(normalizedServer.name, resources);
+				this.serverPrompts.set(normalizedServer.name, prompts);
 
 				const finalMetrics = endMetrics(metrics);
 
 				this.logger.info('MCP server connection completed', {
 					serverName: normalizedServer.name,
 					toolCount: tools.length,
+					resourceCount: resources.length,
+					promptCount: prompts.length,
 					duration: `${finalMetrics.duration.toFixed(2)}ms`,
 					memoryDelta: formatMemoryUsage(
 						finalMetrics.memoryUsage || getSafeMemory(),
@@ -257,16 +337,23 @@ export class MCPClient {
 
 					await this.connectToServer(normalizedServer);
 					const tools = this.serverTools.get(normalizedServer.name) || [];
+					const resources =
+						this.serverResources.get(normalizedServer.name) || [];
+					const prompts = this.serverPrompts.get(normalizedServer.name) || [];
 					const result: MCPInitResult = {
 						serverName: normalizedServer.name,
 						success: true,
 						toolCount: tools.length,
+						resourceCount: resources.length,
+						promptCount: prompts.length,
 					};
 					results.push(result);
 
 					this.logger.debug('MCP server connection successful in batch', {
 						serverName: normalizedServer.name,
 						toolCount: tools.length,
+						resourceCount: resources.length,
+						promptCount: prompts.length,
 						correlationId,
 					});
 
@@ -666,6 +753,298 @@ export class MCPClient {
 		}, correlationId);
 	}
 
+	/**
+	 * Gets server information including transport type and URL for remote servers
+	 */
+	getServerInfo(serverName: string):
+		| {
+				name: string;
+				transport: string;
+				url?: string;
+				toolCount: number;
+				resourceCount: number;
+				promptCount: number;
+				connected: boolean;
+				description?: string;
+				tags?: string[];
+				autoApprovedCommands?: string[];
+		  }
+		| undefined {
+		const client = this.clients.get(serverName);
+		const serverConfig = this.serverConfigs.get(serverName);
+		const tools = this.serverTools.get(serverName) || [];
+		const resources = this.serverResources.get(serverName) || [];
+		const prompts = this.serverPrompts.get(serverName) || [];
+
+		if (!client || !serverConfig) {
+			return undefined;
+		}
+
+		return {
+			name: serverName,
+			transport: serverConfig.transport,
+			url: serverConfig.url,
+			toolCount: tools.length,
+			resourceCount: resources.length,
+			promptCount: prompts.length,
+			connected: true,
+			description: serverConfig.description,
+			tags: serverConfig.tags,
+			autoApprovedCommands: serverConfig.alwaysAllow,
+		};
+	}
+
+	/**
+	 * Get all MCP resources from all connected servers
+	 */
+	getAllResources(): MCPResource[] {
+		const resources: MCPResource[] = [];
+
+		this.logger.debug('Building all resources registry from MCP servers', {
+			serverCount: this.serverResources.size,
+			totalResourcesAvailable: Array.from(this.serverResources.values()).reduce(
+				(sum, resources) => sum + resources.length,
+				0,
+			),
+		});
+
+		for (const [
+			serverName,
+			serverResources,
+		] of this.serverResources.entries()) {
+			this.logger.debug('Processing resources from MCP server', {
+				serverName,
+				resourceCount: serverResources.length,
+			});
+
+			resources.push(...serverResources);
+		}
+
+		return resources;
+	}
+
+	/**
+	 * Get resources from a specific server
+	 */
+	getServerResources(serverName: string): MCPResource[] {
+		return this.serverResources.get(serverName) || [];
+	}
+
+	/**
+	 * Read content from an MCP resource
+	 */
+	/**
+	 * Read a resource's content from a specific server. `serverName` is
+	 * required (rather than searching every connected server by URI) so two
+	 * servers can never be confused when they happen to expose the same URI.
+	 *
+	 * Returns every content block the server sent: a resource read can
+	 * legitimately return more than one (`ReadResourceResult.contents` is an
+	 * array), so truncating to the first would silently drop data.
+	 */
+	async readResource(
+		serverName: string,
+		uri: string,
+	): Promise<MCPResourceContent[]> {
+		const correlationId = generateCorrelationId();
+		const metrics = startMetrics();
+
+		return await withNewCorrelationContext(async () => {
+			this.logger.info('Reading MCP resource', {
+				uri,
+				serverName,
+				correlationId,
+			});
+
+			const client = this.clients.get(serverName);
+			if (!client) {
+				throw new Error(`No MCP client connected for server: ${serverName}`);
+			}
+
+			try {
+				const result = await client.readResource({uri});
+
+				// Text vs. blob content is NOT distinguished by a `type` field in
+				// the MCP schema — TextResourceContents carries a `text` property,
+				// BlobResourceContents carries a `blob` property, and neither
+				// declares the other. Discriminate on which key is present.
+				const contents: MCPResourceContent[] = (result.contents ?? []).map(
+					c => {
+						const block = c as {
+							uri: string;
+							mimeType?: string;
+							text?: string;
+							blob?: string;
+						};
+						return {
+							uri: block.uri,
+							mimeType: block.mimeType,
+							text: 'text' in block ? block.text : undefined,
+							blob: 'blob' in block ? block.blob : undefined,
+						};
+					},
+				);
+
+				const finalMetrics = endMetrics(metrics);
+				this.logger.info('MCP resource read completed', {
+					uri,
+					serverName,
+					contentCount: contents.length,
+					duration: `${finalMetrics.duration.toFixed(2)}ms`,
+					correlationId,
+				});
+
+				return contents;
+			} catch (error) {
+				const errorMessage = formatError(error);
+				const errorName = error instanceof Error ? error.name : 'Unknown';
+
+				const finalMetrics = endMetrics(metrics);
+
+				this.logger.error('MCP resource read failed', {
+					uri,
+					serverName,
+					error: errorMessage,
+					errorName,
+					duration: `${finalMetrics.duration.toFixed(2)}ms`,
+					correlationId,
+				});
+
+				throw new Error(`MCP resource read failed: ${errorMessage}`);
+			}
+		}, correlationId);
+	}
+
+	/**
+	 * Get all MCP prompts from all connected servers
+	 */
+	getAllPrompts(): MCPPrompt[] {
+		const prompts: MCPPrompt[] = [];
+
+		this.logger.debug('Building all prompts registry from MCP servers', {
+			serverCount: this.serverPrompts.size,
+			totalPromptsAvailable: Array.from(this.serverPrompts.values()).reduce(
+				(sum, prompts) => sum + prompts.length,
+				0,
+			),
+		});
+
+		for (const [serverName, serverPrompts] of this.serverPrompts.entries()) {
+			this.logger.debug('Processing prompts from MCP server', {
+				serverName,
+				promptCount: serverPrompts.length,
+			});
+
+			prompts.push(...serverPrompts);
+		}
+
+		return prompts;
+	}
+
+	/**
+	 * Get prompts from a specific server
+	 */
+	getServerPrompts(serverName: string): MCPPrompt[] {
+		return this.serverPrompts.get(serverName) || [];
+	}
+
+	/**
+	 * Get a prompt from an MCP server
+	 */
+	/**
+	 * Fetch a prompt from a specific server. `serverName` is required (rather
+	 * than searching every connected server by name) so two servers can never
+	 * be confused when they happen to expose a same-named prompt.
+	 */
+	async getPrompt(
+		serverName: string,
+		name: string,
+		args?: Record<string, string>,
+	): Promise<MCPPromptResult> {
+		const correlationId = generateCorrelationId();
+		const metrics = startMetrics();
+
+		return await withNewCorrelationContext(async () => {
+			this.logger.info('Getting MCP prompt', {
+				name,
+				serverName,
+				hasArgs: !!args,
+				argCount: args ? Object.keys(args).length : 0,
+				correlationId,
+			});
+
+			const client = this.clients.get(serverName);
+			if (!client) {
+				throw new Error(`No MCP client connected for server: ${serverName}`);
+			}
+
+			try {
+				const result = await client.getPrompt({name, arguments: args});
+
+				this.logger.debug('MCP prompt retrieved successfully', {
+					name,
+					serverName,
+					hasDescription: !!result.description,
+					messageCount: result.messages?.length || 0,
+					correlationId,
+				});
+
+				const finalMetrics = endMetrics(metrics);
+				this.logger.info('MCP prompt retrieval completed', {
+					name,
+					serverName,
+					messageCount: result.messages?.length || 0,
+					duration: `${finalMetrics.duration.toFixed(2)}ms`,
+					correlationId,
+				});
+
+				return {
+					description: result.description,
+					messages: result.messages.map(
+						(msg: {
+							role: string;
+							content:
+								| {
+										type: string;
+										text?: string;
+										data?: string;
+										mimeType?: string;
+								  }
+								| string;
+						}) => ({
+							role: msg.role as 'user' | 'assistant',
+							content:
+								typeof msg.content === 'string'
+									? {type: 'text' as const, text: msg.content}
+									: {
+											type: msg.content.type as 'text' | 'image' | 'resource',
+											text: msg.content.text,
+											data: msg.content.data,
+											mimeType: msg.content.mimeType,
+										},
+						}),
+					),
+				};
+			} catch (error) {
+				const errorMessage = formatError(error);
+				const errorName = error instanceof Error ? error.name : 'Unknown';
+
+				const finalMetrics = endMetrics(metrics);
+
+				this.logger.error('MCP prompt retrieval failed', {
+					name,
+					serverName,
+					error: errorMessage,
+					errorName,
+					duration: `${finalMetrics.duration.toFixed(2)}ms`,
+					correlationId,
+				});
+
+				throw new Error(`MCP prompt retrieval failed: ${errorMessage}`);
+			}
+		}, correlationId);
+	}
+
 	async disconnect(): Promise<void> {
 		const correlationId = generateCorrelationId();
 		const serverNames = Array.from(this.clients.keys());
@@ -712,6 +1091,8 @@ export class MCPClient {
 			this.transports.clear();
 			this.serverTools.clear();
 			this.toolMappingCache = null;
+			this.serverResources.clear();
+			this.serverPrompts.clear();
 			this.serverConfigs.clear();
 			this.isConnected = false;
 
@@ -734,40 +1115,5 @@ export class MCPClient {
 
 	getServerTools(serverName: string): MCPTool[] {
 		return this.serverTools.get(serverName) || [];
-	}
-
-	/**
-	 * Gets server information including transport type and URL for remote servers
-	 */
-	getServerInfo(serverName: string):
-		| {
-				name: string;
-				transport: string;
-				url?: string;
-				toolCount: number;
-				connected: boolean;
-				description?: string;
-				tags?: string[];
-				autoApprovedCommands?: string[];
-		  }
-		| undefined {
-		const client = this.clients.get(serverName);
-		const serverConfig = this.serverConfigs.get(serverName);
-		const tools = this.serverTools.get(serverName) || [];
-
-		if (!client || !serverConfig) {
-			return undefined;
-		}
-
-		return {
-			name: serverName,
-			transport: serverConfig.transport,
-			url: serverConfig.url,
-			toolCount: tools.length,
-			connected: true,
-			description: serverConfig.description,
-			tags: serverConfig.tags,
-			autoApprovedCommands: serverConfig.alwaysAllow,
-		};
 	}
 }

--- a/source/types/app.ts
+++ b/source/types/app.ts
@@ -40,6 +40,7 @@ export interface MessageSubmissionOptions {
 		message: string,
 		displayValue?: string,
 		images?: ImageAttachment[],
+		historyMessages?: Message[],
 	) => Promise<void>;
 	onSwitchModel?: (provider: string, model: string) => Promise<boolean>;
 	onAddToChatQueue: (component: React.ReactNode) => void;

--- a/source/types/hooks.ts
+++ b/source/types/hooks.ts
@@ -4,6 +4,7 @@ import type {ImageAttachment} from '@/types/core';
 export enum PlaceholderType {
 	PASTE = 'paste',
 	FILE = 'file',
+	RESOURCE = 'resource',
 	// Future types can be added here:
 	// TEMPLATE = 'template',
 	// ENV_VAR = 'env_var',
@@ -37,10 +38,20 @@ interface FilePlaceholderContent extends BasePlaceholderContent {
 	checksum?: string; // For detecting file changes
 }
 
+interface ResourcePlaceholderContent extends BasePlaceholderContent {
+	type: PlaceholderType.RESOURCE;
+	uri: string; // MCP resource URI
+	content: string; // Resource contents at time of inclusion
+	mimeType?: string; // Resource MIME type
+	serverName: string; // MCP server that provided the resource
+	resourceName: string; // Human-readable resource name
+}
+
 // Union type for all placeholder content types - fully type-safe
 export type PlaceholderContent =
 	| PastePlaceholderContent
-	| FilePlaceholderContent;
+	| FilePlaceholderContent
+	| ResourcePlaceholderContent;
 
 // Core data structure for placeholder handling system
 export interface InputState {

--- a/source/types/mcp.ts
+++ b/source/types/mcp.ts
@@ -21,9 +21,52 @@ export interface MCPTool {
 	readOnly?: boolean;
 }
 
+export interface MCPResource {
+	uri: string;
+	name: string;
+	description?: string;
+	mimeType?: string;
+	serverName: string;
+}
+
+export interface MCPResourceContent {
+	uri: string;
+	mimeType?: string;
+	text?: string;
+	blob?: string;
+}
+
+export interface MCPPrompt {
+	name: string;
+	description?: string;
+	arguments?: Array<{
+		name: string;
+		description?: string;
+		required?: boolean;
+	}>;
+	serverName: string;
+}
+
+export interface MCPPromptMessage {
+	role: 'user' | 'assistant';
+	content: {
+		type: 'text' | 'image' | 'resource';
+		text?: string;
+		data?: string;
+		mimeType?: string;
+	};
+}
+
+export interface MCPPromptResult {
+	description?: string;
+	messages: MCPPromptMessage[];
+}
+
 export interface MCPInitResult {
 	serverName: string;
 	success: boolean;
 	toolCount?: number;
+	resourceCount?: number;
+	promptCount?: number;
 	error?: string;
 }

--- a/source/utils/placeholders.ts
+++ b/source/utils/placeholders.ts
@@ -6,6 +6,7 @@ const ORDINAL = /^\d+$/;
 const ID_PREFIX: Record<PlaceholderType, string> = {
 	[PlaceholderType.PASTE]: 'paste',
 	[PlaceholderType.FILE]: 'file',
+	[PlaceholderType.RESOURCE]: 'resource',
 };
 
 const PASTE_MARKER = `${ID_PREFIX[PlaceholderType.PASTE]}_`;

--- a/source/utils/prompt-processor.spec.ts
+++ b/source/utils/prompt-processor.spec.ts
@@ -246,3 +246,83 @@ test('assemblePrompt - expands a legacy paste that has no displayText', t => {
 
 	t.is(assemblePrompt(inputState), 'look legacy body ok');
 });
+
+test('assemblePrompt - replaces placeholder with MCP resource content', t => {
+	const inputState: InputState = {
+		displayValue: 'Check this [@api-docs]',
+		placeholderContent: {
+			resource_1: {
+				type: PlaceholderType.RESOURCE,
+				displayText: '[@api-docs]',
+				uri: 'mcp://server/docs/api',
+				content: 'API documentation content',
+				mimeType: 'text/markdown',
+				serverName: 'docs-server',
+				resourceName: 'api-docs',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	t.true(result.includes('=== MCP Resource: api-docs (from docs-server) ==='));
+	t.true(result.includes('Content-Type: text/markdown'));
+	t.true(result.includes('API documentation content'));
+});
+
+test('assemblePrompt - handles MCP resource without mimeType', t => {
+	const inputState: InputState = {
+		displayValue: 'Review [@config]',
+		placeholderContent: {
+			resource_1: {
+				type: PlaceholderType.RESOURCE,
+				displayText: '[@config]',
+				uri: 'mcp://server/config',
+				content: 'Configuration data',
+				serverName: 'config-server',
+				resourceName: 'config',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	t.true(result.includes('=== MCP Resource: config (from config-server) ==='));
+	t.false(result.includes('Content-Type'));
+	t.true(result.includes('Configuration data'));
+});
+
+test('assemblePrompt - handles mixed file, paste, and resource placeholders', t => {
+	const inputState: InputState = {
+		displayValue: 'Compare [@file.ts] with [Paste #1: 5 chars] and [@resource]',
+		placeholderContent: {
+			file_1: {
+				type: PlaceholderType.FILE,
+				content: 'file content',
+				filePath: 'file.ts',
+				displayText: '[@file.ts]',
+			},
+			paste_1: {
+				type: PlaceholderType.PASTE,
+				content: 'Hello',
+				displayText: '[Paste #1: 5 chars]',
+			},
+			resource_1: {
+				type: PlaceholderType.RESOURCE,
+				displayText: '[@resource]',
+				uri: 'mcp://server/resource',
+				content: 'resource content',
+				serverName: 'test-server',
+				resourceName: 'resource',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	t.true(result.includes('=== File: file.ts ==='));
+	t.true(result.includes('file content'));
+	t.true(result.includes('Hello'));
+	t.true(result.includes('=== MCP Resource: resource (from test-server) ==='));
+	t.true(result.includes('resource content'));
+});

--- a/source/utils/prompt-processor.spec.ts
+++ b/source/utils/prompt-processor.spec.ts
@@ -292,6 +292,73 @@ test('assemblePrompt - handles MCP resource without mimeType', t => {
 	t.true(result.includes('Configuration data'));
 });
 
+test('assemblePrompt - inlines an MCP resource at the line threshold in full', t => {
+	const content = Array.from(
+		{length: FILE_MENTION_INLINE_MAX_LINES},
+		(_, i) => `line ${i + 1}`,
+	).join('\n');
+	const inputState: InputState = {
+		displayValue: '[@small-resource]',
+		placeholderContent: {
+			resource_1: {
+				type: PlaceholderType.RESOURCE,
+				displayText: '[@small-resource]',
+				uri: 'mcp://server/small-resource',
+				content,
+				serverName: 'docs-server',
+				resourceName: 'small-resource',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	t.true(
+		result.includes('=== MCP Resource: small-resource (from docs-server) ==='),
+	);
+	t.true(result.includes(content), 'full content is inlined');
+	t.false(result.includes('truncated'), 'no truncation for small resources');
+});
+
+test('assemblePrompt - previews a large MCP resource instead of flooding the conversation', t => {
+	const totalLines = FILE_MENTION_INLINE_MAX_LINES + 100;
+	const lines = Array.from({length: totalLines}, (_, i) => `line ${i + 1}`);
+	const content = lines.join('\n');
+	const inputState: InputState = {
+		displayValue: '[@big-resource]',
+		placeholderContent: {
+			resource_1: {
+				type: PlaceholderType.RESOURCE,
+				displayText: '[@big-resource]',
+				uri: 'mcp://server/big-resource',
+				content,
+				serverName: 'docs-server',
+				resourceName: 'big-resource',
+			},
+		},
+	};
+
+	const result = assemblePrompt(inputState);
+
+	// Header advertises the truncation and total line count, same as the FILE case.
+	t.true(
+		result.includes(
+			`=== MCP Resource: big-resource (from docs-server, ${totalLines} lines, showing first ${FILE_MENTION_PREVIEW_LINES}) ===`,
+		),
+	);
+	// Only the preview lines are present; lines past the preview are dropped
+	t.true(result.includes(`line ${FILE_MENTION_PREVIEW_LINES}`));
+	t.false(
+		result.includes(`line ${FILE_MENTION_PREVIEW_LINES + 1}\n`),
+		'lines beyond the preview window are not inlined',
+	);
+	t.true(
+		result.includes(
+			`${totalLines - FILE_MENTION_PREVIEW_LINES} more lines truncated - mcp://server/big-resource is too large to inline in full`,
+		),
+	);
+});
+
 test('assemblePrompt - handles mixed file, paste, and resource placeholders', t => {
 	const inputState: InputState = {
 		displayValue: 'Compare [@file.ts] with [Paste #1: 5 chars] and [@resource]',

--- a/source/utils/prompt-processor.ts
+++ b/source/utils/prompt-processor.ts
@@ -92,6 +92,17 @@ export function assemblePrompt(inputState: InputState): string {
 				}
 				break;
 			}
+			case PlaceholderType.RESOURCE: {
+				// Format MCP resource content with header for LLM context
+				const resourceName = placeholderContent.resourceName;
+				const header = `=== MCP Resource: ${resourceName} (from ${placeholderContent.serverName}) ===`;
+				const footer = '='.repeat(header.length);
+				const contentWithType = placeholderContent.mimeType
+					? `Content-Type: ${placeholderContent.mimeType}\n\n${placeholderContent.content}`
+					: placeholderContent.content;
+				replacementContent = `${header}\n${contentWithType}\n${footer}`;
+				break;
+			}
 			default: {
 				placeholderContent satisfies never;
 				replacementContent = '';

--- a/source/utils/prompt-processor.ts
+++ b/source/utils/prompt-processor.ts
@@ -93,14 +93,35 @@ export function assemblePrompt(inputState: InputState): string {
 				break;
 			}
 			case PlaceholderType.RESOURCE: {
-				// Format MCP resource content with header for LLM context
+				// Format MCP resource content with header for LLM context. Same
+				// guard as the FILE case above: a resource can be arbitrarily
+				// large and, unlike a file, there is no read_file()-style tool
+				// the model can call to page through the rest of it, so a large
+				// resource is truncated to a head preview rather than inlined
+				// whole - a single @-mention still can't flood the conversation.
 				const resourceName = placeholderContent.resourceName;
-				const header = `=== MCP Resource: ${resourceName} (from ${placeholderContent.serverName}) ===`;
-				const footer = '='.repeat(header.length);
-				const contentWithType = placeholderContent.mimeType
-					? `Content-Type: ${placeholderContent.mimeType}\n\n${placeholderContent.content}`
-					: placeholderContent.content;
-				replacementContent = `${header}\n${contentWithType}\n${footer}`;
+				const lines = placeholderContent.content.split('\n');
+				const totalLines = lines.length;
+
+				if (totalLines > FILE_MENTION_INLINE_MAX_LINES) {
+					const previewBody = lines
+						.slice(0, FILE_MENTION_PREVIEW_LINES)
+						.join('\n');
+					const remaining = totalLines - FILE_MENTION_PREVIEW_LINES;
+					const header = `=== MCP Resource: ${resourceName} (from ${placeholderContent.serverName}, ${totalLines} lines, showing first ${FILE_MENTION_PREVIEW_LINES}) ===`;
+					const footer = `=== ${remaining} more lines truncated - ${placeholderContent.uri} is too large to inline in full ===`;
+					const previewWithType = placeholderContent.mimeType
+						? `Content-Type: ${placeholderContent.mimeType}\n\n${previewBody}`
+						: previewBody;
+					replacementContent = `${header}\n${previewWithType}\n${footer}`;
+				} else {
+					const header = `=== MCP Resource: ${resourceName} (from ${placeholderContent.serverName}) ===`;
+					const footer = '='.repeat(header.length);
+					const contentWithType = placeholderContent.mimeType
+						? `Content-Type: ${placeholderContent.mimeType}\n\n${placeholderContent.content}`
+						: placeholderContent.content;
+					replacementContent = `${header}\n${contentWithType}\n${footer}`;
+				}
 				break;
 			}
 			default: {

--- a/source/utils/resource-mention-handler.spec.ts
+++ b/source/utils/resource-mention-handler.spec.ts
@@ -1,0 +1,171 @@
+import test from 'ava';
+import type {MCPClient} from '../mcp/mcp-client.js';
+import {PlaceholderType} from '../types/hooks.js';
+import {handleResourceMention} from './resource-mention-handler.js';
+
+console.log('\nresource-mention-handler.spec.ts');
+
+// Mock MCP Client — only `readResource` is exercised, matching the real
+// contract: `(serverName, uri) => Promise<MCPResourceContent[]>`.
+class MockMCPClient {
+	constructor(
+		private readonly reader: (
+			serverName: string,
+			uri: string,
+		) => Promise<Array<{uri: string; mimeType?: string; text?: string; blob?: string}>>,
+	) {}
+
+	async readResource(serverName: string, uri: string) {
+		return this.reader(serverName, uri);
+	}
+}
+
+function clientReturning(
+	blocks: Array<{uri: string; mimeType?: string; text?: string; blob?: string}>,
+): MCPClient {
+	return new MockMCPClient(async () => blocks) as unknown as MCPClient;
+}
+
+test('handleResourceMention: creates a placeholder from a text resource', async t => {
+	const mockClient = clientReturning([
+		{uri: 'file:///test/resource.txt', mimeType: 'text/plain', text: 'hello'},
+	]);
+
+	const result = await handleResourceMention(
+		mockClient,
+		'test-server',
+		'file:///test/resource.txt',
+		'resource.txt',
+		'Check this @resource.txt',
+		{},
+		'@resource.txt',
+	);
+
+	t.truthy(result);
+	t.is(result!.displayValue, 'Check this [@resource.txt]');
+
+	const placeholders = Object.values(result!.placeholderContent);
+	t.is(placeholders.length, 1);
+	t.is(placeholders[0].type, PlaceholderType.RESOURCE);
+
+	if (placeholders[0].type === PlaceholderType.RESOURCE) {
+		t.is(placeholders[0].uri, 'file:///test/resource.txt');
+		t.is(placeholders[0].resourceName, 'resource.txt');
+		t.is(placeholders[0].serverName, 'test-server');
+		t.is(placeholders[0].content, 'hello');
+		t.is(placeholders[0].mimeType, 'text/plain');
+	}
+});
+
+test('handleResourceMention: returns null when the server returns no content blocks', async t => {
+	const mockClient = clientReturning([]);
+
+	const result = await handleResourceMention(
+		mockClient,
+		'test-server',
+		'file:///empty',
+		'empty',
+		'Check this @empty',
+		{},
+		'@empty',
+	);
+
+	t.is(result, null);
+});
+
+test('handleResourceMention: handles resource read errors gracefully', async t => {
+	const mockClient = new MockMCPClient(async () => {
+		throw new Error('Read failed');
+	}) as unknown as MCPClient;
+
+	const result = await handleResourceMention(
+		mockClient,
+		'test-server',
+		'file:///test/resource.txt',
+		'resource.txt',
+		'Check this @resource.txt',
+		{},
+		'@resource.txt',
+	);
+
+	t.is(result, null);
+});
+
+test('handleResourceMention: preserves existing placeholders', async t => {
+	const mockClient = clientReturning([
+		{uri: 'file:///test/resource.txt', mimeType: 'text/plain', text: 'hi'},
+	]);
+
+	const existingPlaceholder = {
+		paste_1: {
+			type: PlaceholderType.PASTE,
+			displayText: '[Paste #1]',
+			content: 'existing content',
+			originalSize: 16,
+		},
+	};
+
+	const result = await handleResourceMention(
+		mockClient,
+		'test-server',
+		'file:///test/resource.txt',
+		'resource.txt',
+		'Text [Paste #1] and @resource.txt',
+		existingPlaceholder,
+		'@resource.txt',
+	);
+
+	t.truthy(result);
+
+	const placeholders = Object.values(result!.placeholderContent);
+	t.is(placeholders.length, 2);
+	t.truthy(result!.placeholderContent.paste_1);
+});
+
+test('handleResourceMention: a binary block becomes a placeholder note, not raw base64', async t => {
+	const mockClient = clientReturning([
+		{uri: 'file:///image.png', mimeType: 'image/png', blob: 'aGVsbG8='},
+	]);
+
+	const result = await handleResourceMention(
+		mockClient,
+		'test-server',
+		'file:///image.png',
+		'image.png',
+		'Check @image.png',
+		{},
+		'@image.png',
+	);
+
+	t.truthy(result);
+	const placeholders = Object.values(result!.placeholderContent);
+	t.is(placeholders.length, 1);
+
+	if (placeholders[0].type === PlaceholderType.RESOURCE) {
+		t.false(placeholders[0].content.includes('aGVsbG8='));
+		t.regex(placeholders[0].content, /binary resource.*image\/png/);
+	}
+});
+
+test('handleResourceMention: joins multiple content blocks with a blank line', async t => {
+	const mockClient = clientReturning([
+		{uri: 'file:///multi', mimeType: 'text/plain', text: 'first'},
+		{uri: 'file:///multi', mimeType: 'text/plain', text: 'second'},
+	]);
+
+	const result = await handleResourceMention(
+		mockClient,
+		'test-server',
+		'file:///multi',
+		'multi',
+		'Check @multi',
+		{},
+		'@multi',
+	);
+
+	t.truthy(result);
+	const placeholders = Object.values(result!.placeholderContent);
+	if (placeholders[0].type === PlaceholderType.RESOURCE) {
+		t.is(placeholders[0].content, 'first\n\nsecond');
+	}
+});

--- a/source/utils/resource-mention-handler.spec.ts
+++ b/source/utils/resource-mention-handler.spec.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import type {MCPClient} from '../mcp/mcp-client.js';
 import {PlaceholderType} from '../types/hooks.js';
+import {setGlobalMessageQueue} from './message-queue.js';
 import {handleResourceMention} from './resource-mention-handler.js';
 
 console.log('\nresource-mention-handler.spec.ts');
@@ -89,6 +90,36 @@ test('handleResourceMention: handles resource read errors gracefully', async t =
 	);
 
 	t.is(result, null);
+});
+
+// Regression (reviewer feedback on #1172): a remote read failure (server
+// error, timeout, unknown URI) must be visible to the user, unlike a missing
+// local file, which the user can already see for themselves in their
+// filesystem.
+test('handleResourceMention: surfaces a read failure to the chat queue instead of failing silently', async t => {
+	const queued: unknown[] = [];
+	setGlobalMessageQueue(component => queued.push(component));
+	t.teardown(() => setGlobalMessageQueue(() => {}));
+
+	const mockClient = new MockMCPClient(async () => {
+		throw new Error('Connection timed out');
+	}) as unknown as MCPClient;
+
+	const result = await handleResourceMention(
+		mockClient,
+		'test-server',
+		'file:///test/resource.txt',
+		'resource.txt',
+		'Check this @resource.txt',
+		{},
+		'@resource.txt',
+	);
+
+	t.is(result, null);
+	t.is(queued.length, 1, 'the failure must reach the chat queue');
+	const rendered = JSON.stringify(queued[0]);
+	t.true(rendered.includes('resource.txt'));
+	t.true(rendered.includes('Connection timed out'));
 });
 
 test('handleResourceMention: preserves existing placeholders', async t => {

--- a/source/utils/resource-mention-handler.ts
+++ b/source/utils/resource-mention-handler.ts
@@ -1,0 +1,86 @@
+import type {MCPClient} from '../mcp/mcp-client.js';
+import {
+	InputState,
+	PlaceholderContent,
+	PlaceholderType,
+} from '../types/hooks.js';
+import {allocatePlaceholderId} from './placeholders.js';
+
+/**
+ * Handle @resource mention by creating a placeholder. Called when a resource
+ * is selected from autocomplete.
+ *
+ * `serverName` is required (rather than looked up by URI alone) because two
+ * connected servers can expose a resource at the same URI — the completion
+ * that triggers this already knows which server it came from, so that
+ * identity must not get lost here.
+ *
+ * Returns null if the resource can't be read (silent failure, matching
+ * `handleFileMention`'s behavior for a missing file).
+ */
+export async function handleResourceMention(
+	mcpClient: MCPClient,
+	serverName: string,
+	resourceUri: string,
+	resourceName: string,
+	currentDisplayValue: string,
+	currentPlaceholderContent: Record<string, PlaceholderContent>,
+	mentionText: string, // The original "@resource:uri" text to replace
+): Promise<InputState | null> {
+	try {
+		const blocks = await mcpClient.readResource(serverName, resourceUri);
+		if (blocks.length === 0) {
+			return null;
+		}
+
+		// Concatenate text blocks. A binary block (base64 `blob`) isn't useful
+		// to an LLM as text, so it gets a short placeholder note instead of
+		// its raw base64 dumped into the prompt.
+		const content = blocks
+			.map(block =>
+				block.text !== undefined
+					? block.text
+					: `[binary resource: ${block.mimeType ?? 'unknown type'}, not inlined]`,
+			)
+			.join('\n\n');
+		const mimeType = blocks[0]?.mimeType;
+
+		const {id: resourceId} = allocatePlaceholderId(
+			currentPlaceholderContent,
+			PlaceholderType.RESOURCE,
+		);
+
+		// Create compact placeholder for display
+		const placeholder = `[@${resourceName}]`;
+
+		// Create resource placeholder content
+		const placeholderContent: PlaceholderContent = {
+			type: PlaceholderType.RESOURCE,
+			displayText: placeholder,
+			uri: resourceUri,
+			content,
+			mimeType,
+			serverName,
+			resourceName,
+		};
+
+		const newPlaceholderContent = {
+			...currentPlaceholderContent,
+			[resourceId]: placeholderContent,
+		};
+
+		// Replace the @mention text with placeholder in display
+		const newDisplayValue = currentDisplayValue.replace(
+			mentionText,
+			placeholder,
+		);
+
+		return {
+			displayValue: newDisplayValue,
+			placeholderContent: newPlaceholderContent,
+		};
+	} catch (_error) {
+		// If resource read fails, return null (silently skip per spec)
+		return null;
+	}
+}

--- a/source/utils/resource-mention-handler.ts
+++ b/source/utils/resource-mention-handler.ts
@@ -4,6 +4,7 @@ import {
 	PlaceholderContent,
 	PlaceholderType,
 } from '../types/hooks.js';
+import {logError} from './message-queue.js';
 import {allocatePlaceholderId} from './placeholders.js';
 
 /**
@@ -15,8 +16,11 @@ import {allocatePlaceholderId} from './placeholders.js';
  * that triggers this already knows which server it came from, so that
  * identity must not get lost here.
  *
- * Returns null if the resource can't be read (silent failure, matching
- * `handleFileMention`'s behavior for a missing file).
+ * Returns null if the resource can't be read. An empty result is silent,
+ * matching `handleFileMention`'s behavior for a missing file, but a thrown
+ * read error is surfaced via `logError` first — a remote failure (server
+ * error, timeout, unknown URI) isn't something the user can independently
+ * notice the way a missing local file is.
  */
 export async function handleResourceMention(
 	mcpClient: MCPClient,
@@ -79,8 +83,17 @@ export async function handleResourceMention(
 			displayValue: newDisplayValue,
 			placeholderContent: newPlaceholderContent,
 		};
-	} catch (_error) {
-		// If resource read fails, return null (silently skip per spec)
+	} catch (error) {
+		// Unlike a missing local file, a failed remote read (server error,
+		// timeout, unknown URI) is not something the user can see for
+		// themselves, so it must not disappear silently the way
+		// handleFileMention's missing-file case does - surface it and still
+		// decline to create a placeholder.
+		logError(
+			`Failed to read MCP resource "${resourceName}" from "${serverName}": ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
 		return null;
 	}
 }


### PR DESCRIPTION
Closes #1162.

## Description

Adds MCP resources and prompts support to `MCPClient`, and wires both into the interactive UI: resources join the existing `@`-mention/file-completion system, prompts dispatch as `/mcp:<server>:<prompt>` slash commands that feed the model the same way a custom command does. Phases 1 and 2 of #1162; sampling/elicitation/roots (phase 3) are explicitly out of scope for this PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
