### PR TITLE
fix(checkpoint): refuse to snapshot files from outside the workspace

### DIFF
--- a/.changeset/fix-capture-outside-workspace.md
+++ b/.changeset/fix-capture-outside-workspace.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Refuse to snapshot a file from outside the workspace. Snapshot keys are the file's path relative to the workspace, so a file above it was keyed `../name` and would have been written outside the checkpoint's own files directory. `captureFiles` now drops those paths and reports them through `skipped`, so an incomplete checkpoint still says so at restore time. The same containment rule already guarded restore and delete and is now shared by all three.

--- a/source/services/file-snapshot.spec.ts
+++ b/source/services/file-snapshot.spec.ts
@@ -881,3 +881,49 @@ test.serial(
 		}
 	},
 );
+
+test.serial(
+	'captureFiles refuses a path outside the workspace and reports it as skipped',
+	async t => {
+		const tempDir = await createTempDir();
+		// A sibling of the workspace. Keys are path.relative(workspaceRoot, file),
+		// so this is keyed `../name` and would escape a checkpoint's files
+		// directory once joined onto it.
+		const outsideFile = path.join(tempDir, '..', `escaped-${Date.now()}.txt`);
+		try {
+			await fs.writeFile(outsideFile, 'secret', 'utf-8');
+			const service = new FileSnapshotService(tempDir);
+
+			const {snapshots, skipped} = await service.captureFiles([outsideFile]);
+
+			t.is(snapshots.size, 0, 'the file must not be captured');
+			t.is(skipped.length, 1, 'the drop must be reported, not silent');
+			t.true(skipped[0]!.path.startsWith('..'));
+			t.is(skipped[0]!.reason, 'Outside the workspace');
+		} finally {
+			await fs.rm(outsideFile, {force: true});
+			await cleanupTempDir(tempDir);
+		}
+	},
+);
+
+test.serial(
+	'captureFiles still captures a file inside the workspace',
+	async t => {
+		const tempDir = await createTempDir();
+		try {
+			const insideFile = path.join(tempDir, 'src', 'kept.txt');
+			await fs.mkdir(path.dirname(insideFile), {recursive: true});
+			await fs.writeFile(insideFile, 'kept', 'utf-8');
+			const service = new FileSnapshotService(tempDir);
+
+			const {snapshots, skipped} = await service.captureFiles([insideFile]);
+
+			t.deepEqual([...snapshots.keys()], ['src/kept.txt']);
+			t.is(snapshots.get('src/kept.txt')?.toString(), 'kept');
+			t.is(skipped.length, 0);
+		} finally {
+			await cleanupTempDir(tempDir);
+		}
+	},
+);

--- a/source/services/file-snapshot.ts
+++ b/source/services/file-snapshot.ts
@@ -47,6 +47,20 @@ export class FileSnapshotService {
 	 * did not put back. A file that is simply gone is not one of them - see
 	 * {@link isMissingFile} - so `skipped` means "existed but would not read".
 	 */
+	/**
+	 * Is `absolutePath` inside the workspace?
+	 *
+	 * Snapshot keys are `path.relative(workspaceRoot, file)`, so anything
+	 * outside the workspace is keyed `../..` and would escape the checkpoint's
+	 * files directory when joined onto it. The same rule guards capture,
+	 * restore and delete, which is why it lives here rather than at each of
+	 * the three call sites.
+	 */
+	private isInsideWorkspace(absolutePath: string): boolean {
+		const relative = path.relative(this.workspaceRoot, absolutePath);
+		return !relative.startsWith('..') && !path.isAbsolute(relative);
+	}
+
 	async captureFiles(filePaths: string[]): Promise<CaptureResult> {
 		const snapshots = new Map<string, Buffer>();
 		const skipped: SkippedFile[] = [];
@@ -57,6 +71,17 @@ export class FileSnapshotService {
 			const absolutePath = path.resolve(this.workspaceRoot, filePath); // nosemgrep
 			const relativePath = path.relative(this.workspaceRoot, absolutePath);
 			const normalizedPath = relativePath.split(path.sep).join('/');
+
+			if (!this.isInsideWorkspace(absolutePath)) {
+				skipped.push({
+					path: normalizedPath,
+					reason: 'Outside the workspace',
+				});
+				logWarning('Refusing to capture a file outside the workspace', true, {
+					context: {filePath},
+				});
+				continue;
+			}
 
 			try {
 				const content = await fs.readFile(absolutePath);
@@ -92,8 +117,7 @@ export class FileSnapshotService {
 				// Snapshot keys are read back from user-writable metadata on disk
 				// (checkpoint / timeline index files), so a corrupted or tampered
 				// index must not be able to write outside the workspace.
-				const relative = path.relative(this.workspaceRoot, absolutePath);
-				if (relative.startsWith('..') || path.isAbsolute(relative)) {
+				if (!this.isInsideWorkspace(absolutePath)) {
 					throw new Error(
 						`Refusing to restore path outside workspace: ${relativePath}`,
 					);
@@ -244,8 +268,7 @@ export class FileSnapshotService {
 	 */
 	async deleteFile(relativePath: string): Promise<void> {
 		const absolutePath = path.resolve(this.workspaceRoot, relativePath); // nosemgrep
-		const relative = path.relative(this.workspaceRoot, absolutePath);
-		if (relative.startsWith('..') || path.isAbsolute(relative)) {
+		if (!this.isInsideWorkspace(absolutePath)) {
 			throw new Error(
 				`Refusing to delete path outside workspace: ${relativePath}`,
 			);


### PR DESCRIPTION
Closes #1148.

## Reachability, stated up front

This is defense-in-depth, not a live bug. No production caller passes `modifiedFiles`, and the git-derived list (`git diff --name-only HEAD` run with `cwd: workspaceRoot`) cannot produce a `..` path. It is reachable only through the optional parameter. An earlier version of this description implied otherwise, which was wrong.

## The gap

Snapshot keys are the file's path relative to the workspace:

```ts
const relativePath = path.relative(this.workspaceRoot, absolutePath);
const normalizedPath = relativePath.split(path.sep).join('/');
```

`captureFiles` never required the file to be inside the workspace, so a file above it is keyed `../name`. Joined onto a checkpoint's `files` directory, that writes outside the checkpoint.

`file-snapshot.ts` already refused this on the way back out, in `restoreFiles` and `deleteFile`. Only the capture side was open.

## The change

The rule now has one home, `isInsideWorkspace`, and three callers instead of two open-coded copies:

- **capture** drops the path and reports it through `skipped`, so it reaches the `skippedFiles` metadata and an incomplete checkpoint still says so at restore time.
- **restore** and **delete** keep their existing throw, unchanged in behaviour.

Capture reports rather than throws because it is best-effort, which is how the cap and unreadable-file cases already behave.

## Test plan

Two tests in `file-snapshot.spec.ts`. Confirmed the first fails without the guard:

```
captureFiles refuses a path outside the workspace and reports it as skipped
  the file must not be captured
  Difference (- actual, + expected):
  - 1
  + 0
```

That `1` is the outside-workspace file being captured. With the guard, `file-snapshot.spec.ts` passes 39 and `checkpoint-manager.spec.ts` passes 33, which covers the restore and delete paths the shared rule now serves. `tsc --noEmit` and `biome check` are clean.

Three `cli-integration` tests fail in the full suite. They fail identically on `upstream/main` with this branch's changes stashed, re-checked against the current base.

## Not included

`timeline-manager.ts` reads `entry.filesChanged` off the on-disk index and joins it onto `filesDir` without revalidating, which is the same argument. Left as a follow-up as suggested rather than widening this PR.