### PR TITLE
feat(daemon): add CI watch mode with automated failure investigation

### DIFF
--- a/.changeset/ci-watch-daemon.md
+++ b/.changeset/ci-watch-daemon.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added background CI-watch: the per-project daemon can now poll GitHub Actions for check-run failures on the current branch (`ciWatch.enabled` in preferences) and automatically run a new read-only `verify-ci-investigator` subagent to diagnose the failure, posting the diagnosis as a PR comment when one exists and firing OS notifications on both detection and completion.

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ coverage
 .nanocoder/tasks.json
 .nanocoder/schedule-runs.json
 .nanocoder/schedules.json
+.nanocoder/ci-watch-state.json
 .generated-prompts/
 .nanocoder/skills
 

--- a/docs/configuration/preferences.md
+++ b/docs/configuration/preferences.md
@@ -84,6 +84,29 @@ Desktop notification preferences are stored under the `nanocoder.notifications` 
 
 You can change these via `/settings` → **Notifications**. See [Desktop Notifications](../features/notifications.md) for full details including platform-specific setup.
 
+### CI Watch Configuration
+
+Background CI-watch preferences are stored under the `nanocoder.ciWatch` namespace. When enabled, the daemon (`nanocoder daemon start`) polls GitHub Actions for failures on the current branch and automatically investigates them:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `nanocoder.ciWatch.enabled` | boolean | `false` | Enable background CI-watch polling. Requires the `gh` CLI to be installed and authenticated. |
+| `nanocoder.ciWatch.pollIntervalMs` | number | `30000` | Base interval between polls, in milliseconds. |
+| `nanocoder.ciWatch.maxPollIntervalMs` | number | `300000` | Backoff ceiling applied when consecutive `gh` calls fail. |
+
+There's no `/settings` wizard for this yet — set it by hand-editing the preferences file:
+
+```json
+{
+  "nanocoder": {
+    "ciWatch": {
+      "enabled": true,
+      "pollIntervalMs": 30000
+    }
+  }
+}
+```
+
 When you restart Nanocoder, it automatically restores your last provider, model, theme, shape, paste threshold, and notification preferences.
 
 ## Manual Management

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -56,7 +56,10 @@ Notification preferences are stored in `nanocoder-preferences.json` under the `n
       "events": {
         "toolConfirmation": true,
         "questionPrompt": true,
-        "generationComplete": false
+        "generationComplete": false,
+        "triggeredRunComplete": true,
+        "ciFailureDetected": true,
+        "ciInvestigationComplete": true
       },
       "customMessages": {
         "toolConfirmation": {
@@ -76,6 +79,11 @@ Notification preferences are stored in `nanocoder-preferences.json` under the `n
 | `events.toolConfirmation` | boolean | `true` | Notify when a tool needs approval |
 | `events.questionPrompt` | boolean | `true` | Notify when the AI asks a question |
 | `events.generationComplete` | boolean | `true` | Notify when a response is ready |
+| `events.triggeredRunComplete` | boolean | `true` | Notify when a daemon-triggered skill run (file-watch, cron, CI watch) finishes |
+| `events.ciFailureDetected` | boolean | `true` | Notify as soon as CI watch detects a failing run, before investigation starts |
+| `events.ciInvestigationComplete` | boolean | `true` | Notify when the automated CI-failure investigation finishes |
 | `customMessages.<event>` | object | — | Override the default title and message for an event |
+
+The last three fire only from the per-project daemon (`nanocoder daemon start`) — see [Scheduler](./scheduler.md) and CI Watch configuration in [Preferences](../configuration/preferences.md#ci-watch-configuration).
 
 Notification titles include the current project directory name, e.g. "Tool Confirmation Required in my-project".

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -140,8 +140,11 @@ subscribe:
     cron: "0 9 * * MON"
 ```
 
-v1 event kinds: `file.changed` (filter: `paths`, `eventKinds`) and
-`schedule.cron` (filter: `cron`).
+v1 event kinds: `file.changed` (filter: `paths`, `eventKinds`),
+`schedule.cron` (filter: `cron`), and `ci.job.failed` (filter: `branches`,
+glob-matched against the failing run's branch; omitted matches every
+branch). `ci.job.failed` only ever fires when the daemon's CI watch is
+active — see [CI Watch Configuration](../configuration/preferences.md#ci-watch-configuration).
 
 ### `confirm: true`
 

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -9,6 +9,7 @@ import {
 } from '@/config/mcp-config-loader';
 import {getConfigPath} from '@/config/paths';
 import {
+	getCiWatchPreference,
 	getNotificationsPreference,
 	loadPreferences,
 } from '@/config/preferences';
@@ -16,6 +17,7 @@ import {defaultTheme, getThemeColors} from '@/config/themes';
 import type {
 	AppConfig,
 	AutoCompactConfig,
+	CiWatchConfig,
 	Colors,
 	CompressionMode,
 	CompressionStrategy,
@@ -491,6 +493,11 @@ function loadNotificationsConfig(): NotificationsConfig | undefined {
 	return getNotificationsPreference();
 }
 
+// Load CI-watch configuration from preferences
+function loadCiWatchConfig(): CiWatchConfig | undefined {
+	return getCiWatchPreference();
+}
+
 export function loadDefaultMode(): CliMode | undefined {
 	return (
 		loadHierarchicalConfig('agents.config.json', 'defaultMode', config => {
@@ -541,6 +548,8 @@ function loadAppConfig(): AppConfig {
 
 	// Load notifications configuration
 	const notifications = loadNotificationsConfig();
+	// Load CI-watch configuration
+	const ciWatch = loadCiWatchConfig();
 
 	// Load mode providers configuration
 	const modeProviders = loadModeProvidersConfig(providers);
@@ -559,6 +568,7 @@ function loadAppConfig(): AppConfig {
 		disabledTools,
 		systemPrompt,
 		notifications,
+		ciWatch,
 		modeProviders,
 		tune,
 	};

--- a/source/config/preferences.ts
+++ b/source/config/preferences.ts
@@ -118,6 +118,18 @@ export function updateNotificationsPreference(
 }
 
 /**
+ * Get the CI-watch config from the preferences file. Set by hand-editing
+ * the preferences file for now — no `/settings` UI wizard yet (that's a
+ * natural follow-up once the feature has seen real-world use).
+ */
+export function getCiWatchPreference():
+	| import('@/types/config').CiWatchConfig
+	| undefined {
+	const preferences = loadPreferences();
+	return preferences.ciWatch;
+}
+
+/**
  * Get the paste threshold from the preferences file.
  */
 export function getPasteThreshold(): number | undefined {

--- a/source/config/preferences.ts
+++ b/source/config/preferences.ts
@@ -1,7 +1,11 @@
 import {readFileSync, writeFileSync} from 'fs';
 import type {TitleShape} from '@/components/ui/styled-title';
 import {getClosestConfigFile} from '@/config/index';
-import type {TuneConfig} from '@/types/config';
+import type {
+	CiWatchConfig,
+	NotificationsConfig,
+	TuneConfig,
+} from '@/types/config';
 import type {UserPreferences} from '@/types/index';
 import type {NanocoderShape, ThemePreset} from '@/types/ui';
 import {logError} from '@/utils/message-queue';
@@ -99,9 +103,7 @@ export function saveTune(config: TuneConfig): void {
 /**
  * Get the notifications config from the preferences file.
  */
-export function getNotificationsPreference():
-	| import('@/types/config').NotificationsConfig
-	| undefined {
+export function getNotificationsPreference(): NotificationsConfig | undefined {
 	const preferences = loadPreferences();
 	return preferences.notifications;
 }
@@ -110,7 +112,7 @@ export function getNotificationsPreference():
  * Save the notifications config to the preferences file.
  */
 export function updateNotificationsPreference(
-	config: import('@/types/config').NotificationsConfig,
+	config: NotificationsConfig,
 ): void {
 	const preferences = loadPreferences();
 	preferences.notifications = config;
@@ -122,9 +124,7 @@ export function updateNotificationsPreference(
  * the preferences file for now — no `/settings` UI wizard yet (that's a
  * natural follow-up once the feature has seen real-world use).
  */
-export function getCiWatchPreference():
-	| import('@/types/config').CiWatchConfig
-	| undefined {
+export function getCiWatchPreference(): CiWatchConfig | undefined {
 	const preferences = loadPreferences();
 	return preferences.ciWatch;
 }

--- a/source/daemon/ci-watch-state.spec.ts
+++ b/source/daemon/ci-watch-state.spec.ts
@@ -1,0 +1,62 @@
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import {
+	getCiWatchStatePath,
+	readCiWatchState,
+	writeCiWatchState,
+} from './ci-watch-state';
+
+console.log('\nci-watch-state.spec.ts');
+
+async function tempProject(): Promise<string> {
+	return mkdtemp(join(tmpdir(), 'ci-watch-state-'));
+}
+
+test('round-trips seenFailedRunIds through write then read', async t => {
+	const root = await tempProject();
+	try {
+		await writeCiWatchState(root, {seenFailedRunIds: [1, 2, 3]});
+		const state = await readCiWatchState(root);
+		t.deepEqual(state, {seenFailedRunIds: [1, 2, 3]});
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test('a missing state file reads as an empty default', async t => {
+	const root = await tempProject();
+	try {
+		const state = await readCiWatchState(root);
+		t.deepEqual(state, {seenFailedRunIds: []});
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test('corrupt JSON reads as an empty default rather than throwing', async t => {
+	const root = await tempProject();
+	try {
+		const path = getCiWatchStatePath(root);
+		await mkdir(join(root, '.nanocoder'), {recursive: true});
+		await writeFile(path, 'not json {{{', 'utf-8');
+		const state = await readCiWatchState(root);
+		t.deepEqual(state, {seenFailedRunIds: []});
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test('a valid JSON file with a non-array seenFailedRunIds reads as an empty default', async t => {
+	const root = await tempProject();
+	try {
+		const path = getCiWatchStatePath(root);
+		await mkdir(join(root, '.nanocoder'), {recursive: true});
+		await writeFile(path, JSON.stringify({seenFailedRunIds: 'nope'}), 'utf-8');
+		const state = await readCiWatchState(root);
+		t.deepEqual(state, {seenFailedRunIds: []});
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});

--- a/source/daemon/ci-watch-state.ts
+++ b/source/daemon/ci-watch-state.ts
@@ -1,0 +1,49 @@
+/**
+ * Persisted CI-watch dedup state. Lets `CiEventSource`'s `seenFailedRunIds`
+ * survive a daemon restart, so a failed run that's already been investigated
+ * and posted doesn't get re-investigated and re-posted the next time the
+ * daemon boots while that run is still the most recent completed one.
+ *
+ * Same atomic-write pattern as `lockfile.ts`: write to a sibling `*.tmp` file
+ * and rename in place. Unlike the lockfile, this file is meant to outlive a
+ * stopped daemon, so there's no removal/liveness helper here.
+ */
+
+import {randomBytes} from 'node:crypto';
+import {existsSync} from 'node:fs';
+import {mkdir, readFile, rename, writeFile} from 'node:fs/promises';
+import {dirname, join} from 'node:path';
+
+export interface CiWatchState {
+	seenFailedRunIds: number[];
+}
+
+export function getCiWatchStatePath(projectRoot: string): string {
+	return join(projectRoot, '.nanocoder', 'ci-watch-state.json');
+}
+
+export async function readCiWatchState(
+	projectRoot: string,
+): Promise<CiWatchState> {
+	const path = getCiWatchStatePath(projectRoot);
+	if (!existsSync(path)) return {seenFailedRunIds: []};
+	try {
+		const raw = await readFile(path, 'utf-8');
+		const parsed = JSON.parse(raw) as CiWatchState;
+		if (!Array.isArray(parsed.seenFailedRunIds)) return {seenFailedRunIds: []};
+		return parsed;
+	} catch {
+		return {seenFailedRunIds: []};
+	}
+}
+
+export async function writeCiWatchState(
+	projectRoot: string,
+	state: CiWatchState,
+): Promise<void> {
+	const path = getCiWatchStatePath(projectRoot);
+	await mkdir(dirname(path), {recursive: true});
+	const tmp = `${path}.${randomBytes(8).toString('hex')}.tmp`;
+	await writeFile(tmp, JSON.stringify(state, null, 2), 'utf-8');
+	await rename(tmp, path);
+}

--- a/source/daemon/daemon.spec.ts
+++ b/source/daemon/daemon.spec.ts
@@ -1,0 +1,151 @@
+import {mkdir, mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import type {Subscription} from '@/events/types';
+import type {SubagentResult, SubagentTask} from '@/subagents/types';
+import {isGhAvailable} from '@/tools/git/utils';
+import {startDaemon} from './daemon';
+import {DaemonIpcClient} from './ipc';
+import {getSocketPath} from './lockfile';
+
+console.log('\ndaemon.spec.ts');
+
+async function tempProject(): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), 'daemon-ci-watch-'));
+	await mkdir(join(root, '.nanocoder'), {recursive: true});
+	return root;
+}
+
+const stubBuildExecutor = () => ({
+	execute: async (_task: SubagentTask): Promise<SubagentResult> => ({
+		subagentName: 'stub',
+		output: 'stub output',
+		success: true,
+		executionTimeMs: 0,
+	}),
+});
+
+// Never let a spec make a real `gh` network call: the fake CI source's
+// start()/stop() are no-ops, so this only exercises daemon.ts's own
+// enable/gh-availability wiring, not CiEventSource's poll loop (that has
+// its own direct coverage in github-checkrun.spec.ts).
+function noopCiEventSourceFactory() {
+	const calls: unknown[] = [];
+	return {
+		factory: (..._args: unknown[]) => {
+			calls.push(_args);
+			return {start: async () => {}, stop: () => {}};
+		},
+		calls,
+	};
+}
+
+// Never let a spec stand up a real, persistent chokidar watcher against the
+// filesystem — that's file-watcher.ts's own concern (covered directly by
+// file-watcher.spec.ts) and leaves handles that can keep the test process
+// from exiting cleanly.
+function noopFileWatcherFactory() {
+	return () => ({start: async () => {}, stop: async () => {}});
+}
+
+async function listSubscriptions(root: string): Promise<Subscription[]> {
+	const client = new DaemonIpcClient(getSocketPath(root));
+	await client.connect();
+	try {
+		return await client.listSubscriptions();
+	} finally {
+		await client.disconnect();
+	}
+}
+
+test.serial('ciWatch omitted registers no builtin ci-investigator subscription', async t => {
+	const root = await tempProject();
+	try {
+		const handle = await startDaemon({
+			projectRoot: root,
+			buildExecutor: stubBuildExecutor,
+			fileWatcherFactory: noopFileWatcherFactory(),
+		});
+		try {
+			const subs = await listSubscriptions(root);
+			t.falsy(subs.find(s => s.id === 'builtin:ci-investigator'));
+		} finally {
+			await handle.stop();
+		}
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test.serial('ciWatch.enabled: false registers no builtin ci-investigator subscription', async t => {
+	const root = await tempProject();
+	try {
+		const handle = await startDaemon({
+			projectRoot: root,
+			buildExecutor: stubBuildExecutor,
+			ciWatch: {enabled: false},
+			fileWatcherFactory: noopFileWatcherFactory(),
+		});
+		try {
+			const subs = await listSubscriptions(root);
+			t.falsy(subs.find(s => s.id === 'builtin:ci-investigator'));
+		} finally {
+			await handle.stop();
+		}
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test.serial(
+	'ciWatch.enabled: true registers the builtin subscription and constructs the source iff gh is available',
+	async t => {
+		const root = await tempProject();
+		const stub = noopCiEventSourceFactory();
+		try {
+			const handle = await startDaemon({
+				projectRoot: root,
+				buildExecutor: stubBuildExecutor,
+				ciWatch: {enabled: true},
+				ciEventSourceFactory: stub.factory,
+				fileWatcherFactory: noopFileWatcherFactory(),
+			});
+			try {
+				const subs = await listSubscriptions(root);
+				const ciSub = subs.find(s => s.id === 'builtin:ci-investigator');
+				if (isGhAvailable()) {
+					t.truthy(ciSub, 'gh is available in this environment, subscription should be registered');
+					t.is(ciSub?.target.kind, 'agent');
+					t.is(ciSub?.target.name, 'verify-ci-investigator');
+					t.is(stub.calls.length, 1);
+				} else {
+					t.falsy(ciSub, 'gh is not available in this environment, subscription should be skipped');
+					t.is(stub.calls.length, 0);
+				}
+			} finally {
+				await handle.stop();
+			}
+		} finally {
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial('startDaemon + stop is clean with ciWatch enabled', async t => {
+	const root = await tempProject();
+	const stub = noopCiEventSourceFactory();
+	try {
+		const handle = await startDaemon({
+			projectRoot: root,
+			buildExecutor: stubBuildExecutor,
+			ciWatch: {enabled: true, pollIntervalMs: 60_000},
+			ciEventSourceFactory: stub.factory,
+			fileWatcherFactory: noopFileWatcherFactory(),
+		});
+		await handle.stop();
+		t.pass();
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});

--- a/source/daemon/daemon.spec.ts
+++ b/source/daemon/daemon.spec.ts
@@ -1,10 +1,11 @@
-import {mkdir, mkdtemp, rm} from 'node:fs/promises';
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
-import type {Subscription} from '@/events/types';
+import type {EventRouter} from '@/events/event-router';
+import type {CiJobFailedPayload, Subscription} from '@/events/types';
+import {resetSkillRegistry} from '@/skills/skill-registry';
 import type {SubagentResult, SubagentTask} from '@/subagents/types';
-import {isGhAvailable} from '@/tools/git/utils';
 import {startDaemon} from './daemon';
 import {DaemonIpcClient} from './ipc';
 import {getSocketPath} from './lockfile';
@@ -26,6 +27,17 @@ const stubBuildExecutor = () => ({
 	}),
 });
 
+function successBuildExecutor(output: string) {
+	return () => ({
+		execute: async (_task: SubagentTask): Promise<SubagentResult> => ({
+			subagentName: 'stub',
+			output,
+			success: true,
+			executionTimeMs: 0,
+		}),
+	});
+}
+
 // Never let a spec make a real `gh` network call: the fake CI source's
 // start()/stop() are no-ops, so this only exercises daemon.ts's own
 // enable/gh-availability wiring, not CiEventSource's poll loop (that has
@@ -36,6 +48,27 @@ function noopCiEventSourceFactory() {
 		factory: (..._args: unknown[]) => {
 			calls.push(_args);
 			return {start: async () => {}, stop: () => {}};
+		},
+		calls,
+	};
+}
+
+// A fake CI source whose start() synchronously emits a `ci.job.failed`
+// event into the router, simulating `CiEventSource` having detected a
+// failure — used to exercise `handleCiInvestigationComplete`/
+// `defaultOnActivity`'s posting logic end to end without any real `gh` call.
+function detectingCiEventSourceFactory(payload: CiJobFailedPayload) {
+	const calls: unknown[] = [];
+	return {
+		factory: (...args: unknown[]) => {
+			calls.push(args);
+			const router = args[0] as EventRouter;
+			return {
+				start: async () => {
+					await router.emit({kind: 'ci.job.failed', payload, at: Date.now()});
+				},
+				stop: () => {},
+			};
 		},
 		calls,
 	};
@@ -58,6 +91,22 @@ async function listSubscriptions(root: string): Promise<Subscription[]> {
 		await client.disconnect();
 	}
 }
+
+/** Flush pending microtasks — needed after triggering a `ci.job.failed`
+ * event, since `defaultOnActivity` posts to the PR fire-and-forget
+ * (`void handleCiInvestigationComplete(...)`), not awaited by the dispatch
+ * chain `startDaemon`'s own `await ciSource?.start()` waits on. */
+async function flush(): Promise<void> {
+	await new Promise(r => setImmediate(r));
+}
+
+const CI_PAYLOAD: CiJobFailedPayload = {
+	runId: 99,
+	workflowName: 'CI',
+	branch: 'feature-x',
+	headSha: 'abc123',
+	url: 'https://github.com/o/r/actions/runs/99',
+};
 
 test.serial('ciWatch omitted registers no builtin ci-investigator subscription', async t => {
 	const root = await tempProject();
@@ -99,7 +148,7 @@ test.serial('ciWatch.enabled: false registers no builtin ci-investigator subscri
 });
 
 test.serial(
-	'ciWatch.enabled: true registers the builtin subscription and constructs the source iff gh is available',
+	'ciWatch.enabled: true + gh available registers the builtin subscription and constructs the source',
 	async t => {
 		const root = await tempProject();
 		const stub = noopCiEventSourceFactory();
@@ -109,20 +158,44 @@ test.serial(
 				buildExecutor: stubBuildExecutor,
 				ciWatch: {enabled: true},
 				ciEventSourceFactory: stub.factory,
+				isGhAvailableFn: () => true,
 				fileWatcherFactory: noopFileWatcherFactory(),
 			});
 			try {
 				const subs = await listSubscriptions(root);
 				const ciSub = subs.find(s => s.id === 'builtin:ci-investigator');
-				if (isGhAvailable()) {
-					t.truthy(ciSub, 'gh is available in this environment, subscription should be registered');
-					t.is(ciSub?.target.kind, 'agent');
-					t.is(ciSub?.target.name, 'verify-ci-investigator');
-					t.is(stub.calls.length, 1);
-				} else {
-					t.falsy(ciSub, 'gh is not available in this environment, subscription should be skipped');
-					t.is(stub.calls.length, 0);
-				}
+				t.truthy(ciSub);
+				t.is(ciSub?.target.kind, 'agent');
+				t.is(ciSub?.target.name, 'verify-ci-investigator');
+				t.is(stub.calls.length, 1);
+			} finally {
+				await handle.stop();
+			}
+		} finally {
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
+	'ciWatch.enabled: true + gh unavailable skips the builtin subscription',
+	async t => {
+		const root = await tempProject();
+		const stub = noopCiEventSourceFactory();
+		try {
+			const handle = await startDaemon({
+				projectRoot: root,
+				buildExecutor: stubBuildExecutor,
+				ciWatch: {enabled: true},
+				ciEventSourceFactory: stub.factory,
+				isGhAvailableFn: () => false,
+				fileWatcherFactory: noopFileWatcherFactory(),
+			});
+			try {
+				const subs = await listSubscriptions(root);
+				const ciSub = subs.find(s => s.id === 'builtin:ci-investigator');
+				t.falsy(ciSub);
+				t.is(stub.calls.length, 0);
 			} finally {
 				await handle.stop();
 			}
@@ -141,6 +214,7 @@ test.serial('startDaemon + stop is clean with ciWatch enabled', async t => {
 			buildExecutor: stubBuildExecutor,
 			ciWatch: {enabled: true, pollIntervalMs: 60_000},
 			ciEventSourceFactory: stub.factory,
+			isGhAvailableFn: () => true,
 			fileWatcherFactory: noopFileWatcherFactory(),
 		});
 		await handle.stop();
@@ -149,3 +223,235 @@ test.serial('startDaemon + stop is clean with ciWatch enabled', async t => {
 		await rm(root, {recursive: true, force: true});
 	}
 });
+
+test.serial('posts the CI investigation to the PR when one exists for the branch', async t => {
+	const root = await tempProject();
+	const ciFactory = detectingCiEventSourceFactory(CI_PAYLOAD);
+	const postCalls: Array<[number, string]> = [];
+	try {
+		const handle = await startDaemon({
+			projectRoot: root,
+			buildExecutor: successBuildExecutor('diagnosis text'),
+			ciWatch: {enabled: true},
+			ciEventSourceFactory: ciFactory.factory,
+			isGhAvailableFn: () => true,
+			fileWatcherFactory: noopFileWatcherFactory(),
+			getPrNumberForBranchFn: async () => 42,
+			postPrCommentFn: async (pr, body) => {
+				postCalls.push([pr, body]);
+			},
+		});
+		try {
+			await flush();
+			t.is(postCalls.length, 1);
+			t.is(postCalls[0]?.[0], 42);
+			t.true(postCalls[0]?.[1].includes('diagnosis text'));
+		} finally {
+			await handle.stop();
+		}
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test.serial("doesn't post when the branch has no open PR", async t => {
+	const root = await tempProject();
+	const ciFactory = detectingCiEventSourceFactory(CI_PAYLOAD);
+	const postCalls: unknown[] = [];
+	try {
+		const handle = await startDaemon({
+			projectRoot: root,
+			buildExecutor: successBuildExecutor('diagnosis text'),
+			ciWatch: {enabled: true},
+			ciEventSourceFactory: ciFactory.factory,
+			isGhAvailableFn: () => true,
+			fileWatcherFactory: noopFileWatcherFactory(),
+			getPrNumberForBranchFn: async () => undefined,
+			postPrCommentFn: async (...args) => {
+				postCalls.push(args);
+			},
+		});
+		try {
+			await flush();
+			t.is(postCalls.length, 0);
+		} finally {
+			await handle.stop();
+		}
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test.serial(
+	"doesn't post a non-builtin skill's output that also subscribes to ci.job.failed",
+	async t => {
+		resetSkillRegistry();
+		const root = await tempProject();
+		await mkdir(join(root, '.nanocoder', 'agents'), {recursive: true});
+		await writeFile(
+			join(root, '.nanocoder', 'agents', 'ci-watcher.md'),
+			`---
+name: ci-watcher
+description: A user-authored skill also watching CI failures.
+subscribe:
+  - kind: ci.job.failed
+---
+Watch CI.`,
+			'utf-8',
+		);
+
+		const ciFactory = detectingCiEventSourceFactory(CI_PAYLOAD);
+		const postCalls: unknown[] = [];
+		try {
+			const handle = await startDaemon({
+				projectRoot: root,
+				buildExecutor: successBuildExecutor('user skill output'),
+				ciWatch: {enabled: true},
+				ciEventSourceFactory: ciFactory.factory,
+				isGhAvailableFn: () => true,
+				fileWatcherFactory: noopFileWatcherFactory(),
+				getPrNumberForBranchFn: async () => 42,
+				postPrCommentFn: async (...args) => {
+					postCalls.push(args);
+				},
+			});
+			try {
+				await flush();
+				// Both the builtin subscription and the user skill's subscription
+				// match the emitted event, but only the builtin one should ever
+				// result in a post.
+				t.is(postCalls.length, 1);
+			} finally {
+				await handle.stop();
+			}
+		} finally {
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial('swallows and logs a postPrComment failure without crashing the daemon', async t => {
+	const root = await tempProject();
+	const ciFactory = detectingCiEventSourceFactory(CI_PAYLOAD);
+	const originalConsoleError = console.error;
+	const errorLines: string[] = [];
+	console.error = (...args: unknown[]) => {
+		errorLines.push(args.map(String).join(' '));
+	};
+	try {
+		const handle = await startDaemon({
+			projectRoot: root,
+			buildExecutor: successBuildExecutor('diagnosis text'),
+			ciWatch: {enabled: true},
+			ciEventSourceFactory: ciFactory.factory,
+			isGhAvailableFn: () => true,
+			fileWatcherFactory: noopFileWatcherFactory(),
+			getPrNumberForBranchFn: async () => 42,
+			postPrCommentFn: async () => {
+				throw new Error('boom');
+			},
+		});
+		try {
+			await flush();
+			await t.notThrowsAsync(async () => {});
+			t.true(
+				errorLines.some(line => line.includes('feature-x') && line.includes('boom')),
+			);
+		} finally {
+			await handle.stop();
+		}
+	} finally {
+		console.error = originalConsoleError;
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test.serial(
+	'warns at boot when a skill subscribes to ci.job.failed but CI watch is off',
+	async t => {
+		resetSkillRegistry();
+		const root = await tempProject();
+		await mkdir(join(root, '.nanocoder', 'agents'), {recursive: true});
+		await writeFile(
+			join(root, '.nanocoder', 'agents', 'ci-watcher.md'),
+			`---
+name: ci-watcher
+description: A user-authored skill watching CI failures.
+subscribe:
+  - kind: ci.job.failed
+---
+Watch CI.`,
+			'utf-8',
+		);
+
+		const originalConsoleWarn = console.warn;
+		const warnLines: string[] = [];
+		console.warn = (...args: unknown[]) => {
+			warnLines.push(args.map(String).join(' '));
+		};
+		try {
+			const handle = await startDaemon({
+				projectRoot: root,
+				buildExecutor: stubBuildExecutor,
+				fileWatcherFactory: noopFileWatcherFactory(),
+			});
+			try {
+				t.true(
+					warnLines.some(
+						line => line.includes('ci.job.failed') && line.includes('ci-watcher'),
+					),
+				);
+			} finally {
+				await handle.stop();
+			}
+		} finally {
+			console.warn = originalConsoleWarn;
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
+	'does not warn when CI watch is enabled and available',
+	async t => {
+		resetSkillRegistry();
+		const root = await tempProject();
+		await mkdir(join(root, '.nanocoder', 'agents'), {recursive: true});
+		await writeFile(
+			join(root, '.nanocoder', 'agents', 'ci-watcher.md'),
+			`---
+name: ci-watcher
+description: A user-authored skill watching CI failures.
+subscribe:
+  - kind: ci.job.failed
+---
+Watch CI.`,
+			'utf-8',
+		);
+
+		const originalConsoleWarn = console.warn;
+		const warnLines: string[] = [];
+		console.warn = (...args: unknown[]) => {
+			warnLines.push(args.map(String).join(' '));
+		};
+		const stub = noopCiEventSourceFactory();
+		try {
+			const handle = await startDaemon({
+				projectRoot: root,
+				buildExecutor: stubBuildExecutor,
+				ciWatch: {enabled: true},
+				ciEventSourceFactory: stub.factory,
+				isGhAvailableFn: () => true,
+				fileWatcherFactory: noopFileWatcherFactory(),
+			});
+			try {
+				t.false(warnLines.some(line => line.includes('ci.job.failed')));
+			} finally {
+				await handle.stop();
+			}
+		} finally {
+			console.warn = originalConsoleWarn;
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);

--- a/source/daemon/daemon.ts
+++ b/source/daemon/daemon.ts
@@ -9,7 +9,8 @@
  *      and register the loaded skills.
  *   3. Wire the EventRouter through the BackpressureDispatcher into the
  *      SkillDispatcher.
- *   4. Start event sources (file watcher + cron) and the IPC server.
+ *   4. Start event sources (file watcher + cron + optional CI watch) and
+ *      the IPC server.
  *   5. Write the lockfile, trap SIGTERM/SIGINT for clean shutdown.
  *
  * The daemon does not draw a TUI - the IPC socket is its surface. The
@@ -21,8 +22,16 @@
 import {CustomCommandLoader} from '@/custom-commands/loader';
 import {BackpressureDispatcher} from '@/events/backpressure';
 import {EventRouter} from '@/events/event-router';
-import {FileWatcherSource} from '@/events/sources/file-watcher';
+import {
+	type FileWatcherOptions,
+	FileWatcherSource,
+} from '@/events/sources/file-watcher';
+import {
+	CiEventSource,
+	type CiEventSourceOptions,
+} from '@/events/sources/github-checkrun';
 import {ScheduleEventSource} from '@/events/sources/schedule';
+import type {CiJobFailedPayload} from '@/events/types';
 import {bootSkillPipeline} from '@/skills/bootstrap';
 import {
 	type ActivityListener,
@@ -31,8 +40,16 @@ import {
 	SkillDispatcher,
 } from '@/skills/dispatcher';
 import {getSubagentLoader} from '@/subagents/subagent-loader';
+import {
+	getPrNumberForBranch,
+	isGhAvailable,
+	postPrComment,
+} from '@/tools/git/utils';
 import {ToolManager} from '@/tools/tool-manager';
+import type {CiWatchConfig} from '@/types/config';
+import {formatError} from '@/utils/error-formatter';
 import {sendNotification} from '@/utils/notifications';
+import {formatCiReport} from '@/verify/format-ci-report';
 import {DaemonIpcServer} from './ipc';
 import {
 	getSocketPath,
@@ -59,6 +76,31 @@ export interface DaemonOptions {
 	 * IPC.
 	 */
 	onActivity?: ActivityListener;
+	/**
+	 * Background CI-watch config. Disabled unless `ciWatch.enabled` is
+	 * true — this is a new always-on-network, GitHub-API-polling feature,
+	 * so it's opt-in rather than on by default like file-watching/cron.
+	 */
+	ciWatch?: CiWatchConfig;
+	/**
+	 * Test seam: override how the CI-watch event source is constructed.
+	 * Defaults to the real `CiEventSource`. Lets specs verify the
+	 * enable/gh-availability wiring without a real `CiEventSource.start()`
+	 * making a network call.
+	 */
+	ciEventSourceFactory?: (
+		router: EventRouter,
+		options: CiEventSourceOptions,
+	) => Pick<CiEventSource, 'start' | 'stop'>;
+	/**
+	 * Test seam: override how the file watcher is constructed. Defaults to
+	 * the real `FileWatcherSource`. Lets specs avoid standing up a real,
+	 * persistent chokidar watcher against the filesystem.
+	 */
+	fileWatcherFactory?: (
+		router: EventRouter,
+		options: FileWatcherOptions,
+	) => Pick<FileWatcherSource, 'start' | 'stop'>;
 }
 
 export interface DaemonHandle {
@@ -103,6 +145,35 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 		},
 	});
 
+	// A finished CI investigation needs its own post-processing (format the
+	// report, post it to the branch's open PR if one exists, fire a
+	// CI-specific notification) rather than the generic "a subscription
+	// fired" notification every other triggered run gets. Failures aren't
+	// posted anywhere — swallow-and-log, same fallback posture as
+	// `verify --post-review`'s failed post.
+	const handleCiInvestigationComplete = async (
+		payload: CiJobFailedPayload,
+		subagentOutput: string,
+	): Promise<void> => {
+		const report = formatCiReport({
+			runId: payload.runId,
+			workflowName: payload.workflowName,
+			branch: payload.branch,
+			url: payload.url,
+			subagentOutput,
+		});
+		console.log(report);
+		try {
+			const prNumber = await getPrNumberForBranch(payload.branch);
+			if (prNumber) await postPrComment(prNumber, report);
+		} catch (err) {
+			console.error(
+				`Failed to post CI investigation to PR for branch "${payload.branch}": ${formatError(err)}`,
+			);
+		}
+		sendNotification('ciInvestigationComplete');
+	};
+
 	const defaultOnActivity: ActivityListener = activity => {
 		const target = `${activity.subscription.target.kind}:${activity.subscription.target.name}`;
 		const status = activity.result.success ? 'ok' : 'error';
@@ -118,6 +189,15 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 				`event=${activity.event.kind} subscription=${activity.subscription.id} ` +
 				`duration=${activity.durationMs}ms${checkpoint}${errSuffix}`,
 		);
+
+		if (activity.event.kind === 'ci.job.failed' && activity.result.success) {
+			void handleCiInvestigationComplete(
+				activity.event.payload,
+				activity.result.output,
+			);
+			return;
+		}
+
 		sendNotification('triggeredRunComplete');
 	};
 
@@ -171,12 +251,44 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 		console.warn(`Deprecation: ${warning}`);
 	}
 
-	const watcher = new FileWatcherSource(router, {root: opts.projectRoot});
+	const buildFileWatcher =
+		opts.fileWatcherFactory ??
+		((r: EventRouter, o: FileWatcherOptions) => new FileWatcherSource(r, o));
+	const watcher = buildFileWatcher(router, {root: opts.projectRoot});
 	const cron = new ScheduleEventSource(router);
 
 	for (const sub of router.listByKind('schedule.cron')) {
 		if (sub.kind !== 'schedule.cron' || !sub.filter) continue;
 		cron.register(sub.filter.cron);
+	}
+
+	// CI watch is opt-in and requires `gh` — construct the source and its
+	// built-in subscription only when both hold. The
+	// subscription is hardcoded (not derived from any skill file) because
+	// this is a built-in feature, not something users author YAML for; it
+	// still flows through the exact same router/dispatcher pipeline a
+	// skill-declared subscription would.
+	let ciSource: Pick<CiEventSource, 'start' | 'stop'> | undefined;
+	if (opts.ciWatch?.enabled) {
+		if (isGhAvailable()) {
+			router.subscribe({
+				id: 'builtin:ci-investigator',
+				kind: 'ci.job.failed',
+				target: {kind: 'agent', name: 'verify-ci-investigator'},
+				source: 'manifest',
+				ownerSkill: 'builtin',
+			});
+			const buildCiEventSource =
+				opts.ciEventSourceFactory ??
+				((r: EventRouter, o: CiEventSourceOptions) => new CiEventSource(r, o));
+			ciSource = buildCiEventSource(router, {
+				pollIntervalMs: opts.ciWatch.pollIntervalMs,
+				maxPollIntervalMs: opts.ciWatch.maxPollIntervalMs,
+				onDetected: () => sendNotification('ciFailureDetected'),
+			});
+		} else {
+			console.log('CI watch is enabled but gh CLI was not found — skipping.');
+		}
 	}
 
 	let stopPromise: Promise<void> | null = null;
@@ -187,6 +299,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 		stopPromise = (async () => {
 			await watcher.stop();
 			cron.stop();
+			ciSource?.stop();
 			backpressure.dispose();
 			await ipcServer.stop();
 			await removeLockfile(opts.projectRoot);
@@ -196,6 +309,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 	stopHandler.fn = stop;
 
 	await watcher.start();
+	await ciSource?.start();
 	await ipcServer.start();
 
 	try {

--- a/source/daemon/daemon.ts
+++ b/source/daemon/daemon.ts
@@ -9,9 +9,13 @@
  *      and register the loaded skills.
  *   3. Wire the EventRouter through the BackpressureDispatcher into the
  *      SkillDispatcher.
- *   4. Start event sources (file watcher + cron + optional CI watch) and
- *      the IPC server.
- *   5. Write the lockfile, trap SIGTERM/SIGINT for clean shutdown.
+ *   4. Start the file watcher and cron sources, the IPC server, and write
+ *      the lockfile.
+ *   5. Start CI watch (if enabled) last, once the daemon is otherwise fully
+ *      up — its first poll is scheduled rather than awaited, but starting
+ *      it after the lockfile write keeps `daemon start`'s report of success
+ *      tied to the parts of boot that are actually synchronous/fast.
+ *   6. Trap SIGTERM/SIGINT for clean shutdown.
  *
  * The daemon does not draw a TUI - the IPC socket is its surface. The
  * `onActivity` callback writes a log line and fires the OS notification.
@@ -50,6 +54,7 @@ import type {CiWatchConfig} from '@/types/config';
 import {formatError} from '@/utils/error-formatter';
 import {sendNotification} from '@/utils/notifications';
 import {formatCiReport} from '@/verify/format-ci-report';
+import {readCiWatchState, writeCiWatchState} from './ci-watch-state';
 import {DaemonIpcServer} from './ipc';
 import {
 	getSocketPath,
@@ -101,6 +106,21 @@ export interface DaemonOptions {
 		router: EventRouter,
 		options: FileWatcherOptions,
 	) => Pick<FileWatcherSource, 'start' | 'stop'>;
+	/**
+	 * Test seam: override the gh-availability check gating CI watch.
+	 * Defaults to the real `isGhAvailable`.
+	 */
+	isGhAvailableFn?: () => boolean;
+	/**
+	 * Test seam: override PR lookup for CI-investigation posting. Defaults
+	 * to the real `getPrNumberForBranch`.
+	 */
+	getPrNumberForBranchFn?: typeof getPrNumberForBranch;
+	/**
+	 * Test seam: override PR comment posting for CI-investigation posting.
+	 * Defaults to the real `postPrComment`.
+	 */
+	postPrCommentFn?: typeof postPrComment;
 }
 
 export interface DaemonHandle {
@@ -145,12 +165,20 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 		},
 	});
 
+	const getPrNumberForBranchImpl =
+		opts.getPrNumberForBranchFn ?? getPrNumberForBranch;
+	const postPrCommentImpl = opts.postPrCommentFn ?? postPrComment;
+
 	// A finished CI investigation needs its own post-processing (format the
 	// report, post it to the branch's open PR if one exists, fire a
 	// CI-specific notification) rather than the generic "a subscription
-	// fired" notification every other triggered run gets. Failures aren't
-	// posted anywhere — swallow-and-log, same fallback posture as
-	// `verify --post-review`'s failed post.
+	// fired" notification every other triggered run gets. Failures to post
+	// aren't fatal — swallow-and-log, same fallback posture as
+	// `verify --post-review`'s failed post — but the "investigation
+	// complete" notification still fires either way, since it reports that
+	// the daemon finished investigating and logged a report (true
+	// regardless of whether posting to GitHub succeeded), not that the post
+	// itself succeeded.
 	const handleCiInvestigationComplete = async (
 		payload: CiJobFailedPayload,
 		subagentOutput: string,
@@ -164,8 +192,8 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 		});
 		console.log(report);
 		try {
-			const prNumber = await getPrNumberForBranch(payload.branch);
-			if (prNumber) await postPrComment(prNumber, report);
+			const prNumber = await getPrNumberForBranchImpl(payload.branch);
+			if (prNumber) await postPrCommentImpl(prNumber, report);
 		} catch (err) {
 			console.error(
 				`Failed to post CI investigation to PR for branch "${payload.branch}": ${formatError(err)}`,
@@ -190,7 +218,16 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 				`duration=${activity.durationMs}ms${checkpoint}${errSuffix}`,
 		);
 
-		if (activity.event.kind === 'ci.job.failed' && activity.result.success) {
+		// Only the daemon's own hardcoded CI-investigator subscription gets
+		// its output auto-posted to a PR. A user-authored skill that also
+		// subscribes to `ci.job.failed` gets the same generic notification
+		// as any other triggered run — its output was never vetted for
+		// "safe to post publicly."
+		if (
+			activity.event.kind === 'ci.job.failed' &&
+			activity.result.success &&
+			activity.subscription.id === 'builtin:ci-investigator'
+		) {
 			void handleCiInvestigationComplete(
 				activity.event.payload,
 				activity.result.output,
@@ -268,9 +305,10 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 	// this is a built-in feature, not something users author YAML for; it
 	// still flows through the exact same router/dispatcher pipeline a
 	// skill-declared subscription would.
+	const isGhAvailableImpl = opts.isGhAvailableFn ?? isGhAvailable;
 	let ciSource: Pick<CiEventSource, 'start' | 'stop'> | undefined;
 	if (opts.ciWatch?.enabled) {
-		if (isGhAvailable()) {
+		if (isGhAvailableImpl()) {
 			router.subscribe({
 				id: 'builtin:ci-investigator',
 				kind: 'ci.job.failed',
@@ -278,16 +316,52 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 				source: 'manifest',
 				ownerSkill: 'builtin',
 			});
+			const ciWatchState = await readCiWatchState(opts.projectRoot);
 			const buildCiEventSource =
 				opts.ciEventSourceFactory ??
 				((r: EventRouter, o: CiEventSourceOptions) => new CiEventSource(r, o));
+			// Serialize state writes through a promise chain: `pollOnce()` can
+			// fire this callback again before the previous write lands (a short
+			// custom pollIntervalMs, or a slow filesystem), and unserialized
+			// writes could complete out of order, leaving a smaller id set
+			// persisted than what was actually last seen.
+			let writeQueue = Promise.resolve();
 			ciSource = buildCiEventSource(router, {
 				pollIntervalMs: opts.ciWatch.pollIntervalMs,
 				maxPollIntervalMs: opts.ciWatch.maxPollIntervalMs,
 				onDetected: () => sendNotification('ciFailureDetected'),
+				initialSeenFailedRunIds: ciWatchState.seenFailedRunIds,
+				onSeenFailedRunIdsChanged: ids => {
+					writeQueue = writeQueue.then(() =>
+						writeCiWatchState(opts.projectRoot, {seenFailedRunIds: ids}).catch(
+							err =>
+								console.error(
+									`Failed to persist CI-watch state: ${formatError(err)}`,
+								),
+						),
+					);
+				},
 			});
 		} else {
 			console.log('CI watch is enabled but gh CLI was not found — skipping.');
+		}
+	}
+
+	// A user-authored skill can subscribe to `ci.job.failed` even when CI
+	// watch itself is off (disabled in config, or `gh` missing) — nothing
+	// will ever emit that kind in that case, so the subscription is silently
+	// dead. Warn at boot rather than leaving the user to debug "my skill
+	// never runs" with no clue why.
+	if (!ciSource) {
+		const dormantCiSubs = router
+			.listByKind('ci.job.failed')
+			.filter(sub => sub.id !== 'builtin:ci-investigator');
+		if (dormantCiSubs.length > 0) {
+			console.warn(
+				`Warning: ${dormantCiSubs.length} skill subscription(s) to 'ci.job.failed' will never fire ` +
+					`because CI watch is not active (nanocoder.ciWatch.enabled is false, or gh CLI was not found): ` +
+					dormantCiSubs.map(sub => sub.id).join(', '),
+			);
 		}
 	}
 
@@ -309,7 +383,6 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 	stopHandler.fn = stop;
 
 	await watcher.start();
-	await ciSource?.start();
 	await ipcServer.start();
 
 	try {
@@ -319,6 +392,22 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 			startedAt: Date.now(),
 			projectRoot: opts.projectRoot,
 		});
+	} catch (err) {
+		await stop();
+		throw err;
+	}
+
+	// Started last, and after the lockfile write: `CiEventSource.start()`
+	// only schedules a 0ms timer (it doesn't await a live `gh` call), so
+	// this doesn't block boot either way — but keeping it after the parts
+	// `daemon start` actually waits on keeps that invariant obviously true
+	// rather than relying on `CiEventSource`'s internals staying that way.
+	// Wrapped the same way as the lockfile write above: a custom
+	// `ciEventSourceFactory` (test seam) could hand back a `start()` that
+	// throws, and without this the watcher/IPC server/lockfile would already
+	// be live with nothing cleaning them up.
+	try {
+		await ciSource?.start();
 	} catch (err) {
 		await stop();
 		throw err;

--- a/source/daemon/entry.ts
+++ b/source/daemon/entry.ts
@@ -22,7 +22,26 @@ import type {DevelopmentMode} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
 import {setNotificationsConfig} from '@/utils/notifications';
 import {getShutdownManager} from '@/utils/shutdown';
+import {getAllowedToolNames} from '@/verify/trust';
 import {startDaemon} from './daemon';
+
+// Built-in, daemon-triggered subagents that must be pinned to a trust-level
+// tool allowlist at execution time rather than trusting their frontmatter
+// `tools:` list alone — see `source/verify/trust.ts`. Mirrors the same
+// `toolOverride` use `verify/cli.ts` makes for `verify-pr-review`: name-level
+// only, so it doesn't stop `git_pr`'s comment/review/create argument shapes
+// on its own. What actually blocks those calls today is that this
+// `buildExecutor` never registers a tool-approval-queue handler, so any
+// `git_pr` call requiring confirmation is auto-denied by
+// `signalToolApproval()`'s default — a property of headless mode, not of
+// this list. If a future change ever registers an approval handler here,
+// this override alone would no longer be sufficient.
+const TRUST_OVERRIDDEN_SUBAGENTS: Record<
+	string,
+	ReturnType<typeof getAllowedToolNames>
+> = {
+	'verify-ci-investigator': getAllowedToolNames('comment-only'),
+};
 
 async function main(): Promise<void> {
 	const projectRoot = process.env.NANOCODER_PROJECT_ROOT || process.cwd();
@@ -70,8 +89,16 @@ async function main(): Promise<void> {
 			mode,
 		);
 		return {
-			execute: (task: SubagentTask): Promise<SubagentResult> =>
-				executor.execute(task),
+			execute: (task: SubagentTask): Promise<SubagentResult> => {
+				const tools = TRUST_OVERRIDDEN_SUBAGENTS[task.subagent_type];
+				return executor.execute(
+					task,
+					undefined,
+					0,
+					undefined,
+					tools ? {tools} : undefined,
+				);
+			},
 		};
 	};
 
@@ -102,6 +129,7 @@ async function main(): Promise<void> {
 		projectRoot,
 		buildExecutor,
 		checkpointer,
+		ciWatch: getAppConfig().ciWatch,
 	});
 
 	// Wire shutdown through the existing ShutdownManager rather than

--- a/source/daemon/entry.ts
+++ b/source/daemon/entry.ts
@@ -36,6 +36,10 @@ import {startDaemon} from './daemon';
 // `signalToolApproval()`'s default — a property of headless mode, not of
 // this list. If a future change ever registers an approval handler here,
 // this override alone would no longer be sufficient.
+// `resolveToolApproval`'s first check (`ctx.alwaysAllow`) would also bypass
+// approval, but is equally unreachable here: `SubagentExecutor`'s own
+// `needsApprovalForTool` builds that context as just `{mode:
+// this.currentMode()}`, never populating `alwaysAllow`.
 const TRUST_OVERRIDDEN_SUBAGENTS: Record<
 	string,
 	ReturnType<typeof getAllowedToolNames>

--- a/source/events/event-router.spec.ts
+++ b/source/events/event-router.spec.ts
@@ -54,6 +54,34 @@ function cronEvent(cron: string): Event {
 	return {kind: 'schedule.cron', payload: {cron}, at: Date.now()};
 }
 
+function ciJobFailedSub(
+	id: string,
+	overrides: Partial<Subscription> = {},
+): Subscription {
+	return {
+		id,
+		kind: 'ci.job.failed',
+		target: {kind: 'agent', name: 'verify-ci-investigator'},
+		source: 'manifest',
+		ownerSkill: 'builtin',
+		...overrides,
+	} as Subscription;
+}
+
+function ciJobFailedEvent(branch: string): Event {
+	return {
+		kind: 'ci.job.failed',
+		payload: {
+			runId: 1,
+			workflowName: 'CI',
+			branch,
+			headSha: 'abc123',
+			url: 'https://example.com/run/1',
+		},
+		at: Date.now(),
+	};
+}
+
 test('subscribe + emit dispatches matching subscription', async t => {
 	const d = makeDispatcher();
 	const router = new EventRouter(d);
@@ -145,6 +173,26 @@ test('listByKind returns the registered subscriptions for that kind only', t => 
 
 	t.is(router.listByKind('file.changed').length, 1);
 	t.is(router.listByKind('schedule.cron').length, 1);
+});
+
+test('ci.job.failed with no filter dispatches for any branch', async t => {
+	const d = makeDispatcher();
+	const router = new EventRouter(d);
+	router.subscribe(ciJobFailedSub('s1'));
+
+	await router.emit(ciJobFailedEvent('main'));
+	t.is(d.calls.length, 1);
+});
+
+test('ci.job.failed branches filter glob-matches the payload branch', async t => {
+	const d = makeDispatcher();
+	const router = new EventRouter(d);
+	router.subscribe(ciJobFailedSub('s1', {filter: {branches: ['release/**']}}));
+
+	await router.emit(ciJobFailedEvent('feature-x'));
+	t.is(d.calls.length, 0);
+	await router.emit(ciJobFailedEvent('release/1.0'));
+	t.is(d.calls.length, 1);
 });
 
 test('matchesFilter on kind mismatch returns false', t => {

--- a/source/events/event-router.ts
+++ b/source/events/event-router.ts
@@ -95,6 +95,14 @@ export function matchesFilter(sub: Subscription, event: Event): boolean {
 		return filter.cron === event.payload.cron;
 	}
 
+	if (event.kind === 'ci.job.failed' && sub.kind === 'ci.job.failed') {
+		const filter = sub.filter;
+		if (!filter?.branches || filter.branches.length === 0) return true;
+		return filter.branches.some(pattern =>
+			matchGlob(pattern, event.payload.branch),
+		);
+	}
+
 	return false;
 }
 

--- a/source/events/sources/github-checkrun.spec.ts
+++ b/source/events/sources/github-checkrun.spec.ts
@@ -1,0 +1,221 @@
+import test from 'ava';
+import {EventRouter} from '@/events/event-router';
+import type {Event, Subscription, SubscriptionDispatcher} from '@/events/types';
+import {CiEventSource} from './github-checkrun';
+
+console.log('\ngithub-checkrun.spec.ts');
+
+function captureRouter(): {router: EventRouter; events: Event[]} {
+	const events: Event[] = [];
+	const dispatcher: SubscriptionDispatcher = {
+		dispatch(_sub, event) {
+			events.push(event);
+		},
+	};
+	const router = new EventRouter(dispatcher);
+	return {router, events};
+}
+
+function ciSub(): Subscription {
+	return {
+		id: 'builtin:ci-investigator',
+		kind: 'ci.job.failed',
+		target: {kind: 'agent', name: 'verify-ci-investigator'},
+		source: 'manifest',
+		ownerSkill: 'builtin',
+	};
+}
+
+function stubScheduler(): {
+	scheduleFn: (fn: () => void, ms: number) => NodeJS.Timeout;
+	clearFn: (handle: NodeJS.Timeout) => void;
+	calls: Array<{fn: () => void; ms: number}>;
+} {
+	const calls: Array<{fn: () => void; ms: number}> = [];
+	const scheduleFn = (fn: () => void, ms: number): NodeJS.Timeout => {
+		calls.push({fn, ms});
+		return {} as NodeJS.Timeout;
+	};
+	return {scheduleFn, clearFn: () => {}, calls};
+}
+
+function runListJson(entries: unknown[]): string {
+	return JSON.stringify(entries);
+}
+
+const FAILED_RUN = {
+	databaseId: 42,
+	conclusion: 'failure',
+	headSha: 'abc1234',
+	workflowName: 'CI',
+	url: 'https://github.com/o/r/actions/runs/42',
+	headBranch: 'feature-x',
+};
+
+test('emits ci.job.failed and calls onDetected for a new failing run', async t => {
+	const {router, events} = captureRouter();
+	router.subscribe(ciSub());
+	const scheduler = stubScheduler();
+	const detected: unknown[] = [];
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () => runListJson([FAILED_RUN]),
+		onDetected: payload => detected.push(payload),
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+
+	t.is(events.length, 1);
+	t.is(events[0]?.kind, 'ci.job.failed');
+	if (events[0]?.kind === 'ci.job.failed') {
+		t.is(events[0].payload.runId, 42);
+		t.is(events[0].payload.branch, 'feature-x');
+	}
+	t.is(detected.length, 1);
+});
+
+test('does not re-emit for a run already seen', async t => {
+	const {router, events} = captureRouter();
+	router.subscribe(ciSub());
+	const scheduler = stubScheduler();
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () => runListJson([FAILED_RUN]),
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+	t.is(events.length, 1);
+
+	// Simulate the next scheduled poll tick.
+	scheduler.calls[0]?.fn();
+	await new Promise(r => setImmediate(r));
+
+	t.is(events.length, 1, 'same run id must not emit twice');
+});
+
+test('a passing run emits nothing', async t => {
+	const {router, events} = captureRouter();
+	router.subscribe(ciSub());
+	const scheduler = stubScheduler();
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () =>
+			runListJson([{...FAILED_RUN, conclusion: 'success'}]),
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+
+	t.is(events.length, 0);
+});
+
+test('a gh error grows the backoff interval instead of throwing', async t => {
+	const {router} = captureRouter();
+	const scheduler = stubScheduler();
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		pollIntervalMs: 100,
+		execGhFn: async () => {
+			throw new Error('gh: rate limited');
+		},
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await t.notThrowsAsync(() => source.start());
+	t.is(scheduler.calls[0]?.ms, 100);
+
+	scheduler.calls[0]?.fn();
+	await new Promise(r => setImmediate(r));
+
+	t.is(scheduler.calls[1]?.ms, 200, 'second consecutive failure should back off further');
+});
+
+test('unparseable output backs off instead of retrying at the fixed interval', async t => {
+	const {router} = captureRouter();
+	const scheduler = stubScheduler();
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		pollIntervalMs: 100,
+		execGhFn: async () => 'not json {{{',
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+	t.is(scheduler.calls[0]?.ms, 100);
+
+	scheduler.calls[0]?.fn();
+	await new Promise(r => setImmediate(r));
+
+	t.is(
+		scheduler.calls[1]?.ms,
+		200,
+		'a second consecutive parse failure should back off further, not retry at the base interval',
+	);
+});
+
+test('a successful poll resets the backoff after prior failures', async t => {
+	const {router} = captureRouter();
+	const scheduler = stubScheduler();
+	let callCount = 0;
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		pollIntervalMs: 100,
+		execGhFn: async () => {
+			callCount++;
+			if (callCount === 1) throw new Error('transient');
+			if (callCount === 2) return runListJson([]);
+			throw new Error('transient again');
+		},
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start(); // call 1: fails, backoff -> 100, attempt now 1
+	t.is(scheduler.calls[0]?.ms, 100);
+
+	scheduler.calls[0]?.fn();
+	await new Promise(r => setImmediate(r)); // call 2: succeeds, resets backoff
+	t.is(scheduler.calls[1]?.ms, 100);
+
+	scheduler.calls[1]?.fn();
+	await new Promise(r => setImmediate(r)); // call 3: fails again, should back off from a fresh attempt=0
+	t.is(scheduler.calls[2]?.ms, 100, 'backoff should restart from base after the reset');
+});
+
+test('stop prevents any further polls from being scheduled', async t => {
+	const {router, events} = captureRouter();
+	router.subscribe(ciSub());
+	const scheduler = stubScheduler();
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () => runListJson([FAILED_RUN]),
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+	const callsBefore = scheduler.calls.length;
+	source.stop();
+
+	// Even if a stray already-scheduled callback fires after stop(), it must
+	// not schedule another poll.
+	scheduler.calls[callsBefore - 1]?.fn();
+	await new Promise(r => setImmediate(r));
+
+	t.is(scheduler.calls.length, callsBefore, 'no new poll should be scheduled after stop()');
+	t.is(events.length, 1, 'the already-emitted event count should be unaffected');
+});

--- a/source/events/sources/github-checkrun.spec.ts
+++ b/source/events/sources/github-checkrun.spec.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import {TIMEOUT_GH_METADATA_MS} from '@/constants';
 import {EventRouter} from '@/events/event-router';
 import type {Event, Subscription, SubscriptionDispatcher} from '@/events/types';
 import {CiEventSource} from './github-checkrun';
@@ -43,6 +44,13 @@ function runListJson(entries: unknown[]): string {
 	return JSON.stringify(entries);
 }
 
+/** Fires the given scheduled call and drains microtasks so `pollOnce`'s
+ * chain of awaits (execGhFn, router.emit) settles before assertions run. */
+async function fireScheduled(call: {fn: () => void} | undefined): Promise<void> {
+	call?.fn();
+	await new Promise(r => setImmediate(r));
+}
+
 const FAILED_RUN = {
 	databaseId: 42,
 	conclusion: 'failure',
@@ -51,6 +59,30 @@ const FAILED_RUN = {
 	url: 'https://github.com/o/r/actions/runs/42',
 	headBranch: 'feature-x',
 };
+
+test('start() schedules the first poll rather than awaiting it inline', async t => {
+	const {router} = captureRouter();
+	const scheduler = stubScheduler();
+	let execGhCalls = 0;
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () => {
+			execGhCalls++;
+			return runListJson([]);
+		},
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+
+	t.is(execGhCalls, 0, 'start() must resolve before the first gh call happens');
+	t.is(scheduler.calls[0]?.ms, 0, 'the first poll is scheduled for 0ms');
+
+	await fireScheduled(scheduler.calls[0]);
+	t.is(execGhCalls, 1, 'firing the scheduled call performs the first poll');
+});
 
 test('emits ci.job.failed and calls onDetected for a new failing run', async t => {
 	const {router, events} = captureRouter();
@@ -67,6 +99,7 @@ test('emits ci.job.failed and calls onDetected for a new failing run', async t =
 	});
 
 	await source.start();
+	await fireScheduled(scheduler.calls[0]);
 
 	t.is(events.length, 1);
 	t.is(events[0]?.kind, 'ci.job.failed');
@@ -75,6 +108,28 @@ test('emits ci.job.failed and calls onDetected for a new failing run', async t =
 		t.is(events[0].payload.branch, 'feature-x');
 	}
 	t.is(detected.length, 1);
+});
+
+test('pollOnce passes TIMEOUT_GH_METADATA_MS to execGhFn', async t => {
+	const {router} = captureRouter();
+	const scheduler = stubScheduler();
+	const calls: Array<[string[], number | undefined]> = [];
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async (args, timeoutMs) => {
+			calls.push([args, timeoutMs]);
+			return runListJson([]);
+		},
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+	await fireScheduled(scheduler.calls[0]);
+
+	t.is(calls.length, 1);
+	t.is(calls[0]?.[1], TIMEOUT_GH_METADATA_MS);
 });
 
 test('does not re-emit for a run already seen', async t => {
@@ -90,13 +145,146 @@ test('does not re-emit for a run already seen', async t => {
 	});
 
 	await source.start();
+	await fireScheduled(scheduler.calls[0]);
 	t.is(events.length, 1);
 
 	// Simulate the next scheduled poll tick.
-	scheduler.calls[0]?.fn();
-	await new Promise(r => setImmediate(r));
+	await fireScheduled(scheduler.calls[1]);
 
 	t.is(events.length, 1, 'same run id must not emit twice');
+});
+
+test('initialSeenFailedRunIds suppresses re-emit of a run seen before construction', async t => {
+	const {router, events} = captureRouter();
+	router.subscribe(ciSub());
+	const scheduler = stubScheduler();
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () => runListJson([FAILED_RUN]),
+		initialSeenFailedRunIds: [FAILED_RUN.databaseId],
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+	await fireScheduled(scheduler.calls[0]);
+
+	t.is(events.length, 0, 'a run id seeded via initialSeenFailedRunIds must not re-emit');
+});
+
+test('onSeenFailedRunIdsChanged fires with updated ids on a new failure, not on a repeat', async t => {
+	const {router} = captureRouter();
+	router.subscribe(ciSub());
+	const scheduler = stubScheduler();
+	const changes: number[][] = [];
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () => runListJson([FAILED_RUN]),
+		onSeenFailedRunIdsChanged: ids => changes.push(ids),
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+	await fireScheduled(scheduler.calls[0]);
+	t.deepEqual(changes, [[FAILED_RUN.databaseId]]);
+
+	await fireScheduled(scheduler.calls[1]);
+	t.is(changes.length, 1, 'no callback fires when the poll finds nothing new');
+});
+
+test('two workflows failing in the same poll both emit', async t => {
+	const {router, events} = captureRouter();
+	router.subscribe(ciSub());
+	const scheduler = stubScheduler();
+	const otherFailedRun = {
+		...FAILED_RUN,
+		databaseId: 43,
+		workflowName: 'Lint',
+	};
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () => runListJson([FAILED_RUN, otherFailedRun]),
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+	await fireScheduled(scheduler.calls[0]);
+
+	t.is(events.length, 2);
+	const workflowNames = events
+		.filter((e): e is Extract<Event, {kind: 'ci.job.failed'}> => e.kind === 'ci.job.failed')
+		.map(e => e.payload.workflowName);
+	t.deepEqual(new Set(workflowNames), new Set(['CI', 'Lint']));
+});
+
+test('only the latest run per workflow is considered — older failures of the same workflow in the fetch window are ignored', async t => {
+	const {router, events} = captureRouter();
+	router.subscribe(ciSub());
+	const scheduler = stubScheduler();
+
+	// A single fresh activation on a branch whose last few completed runs for
+	// one workflow are all historically-broken failures. Only the newest
+	// (first in gh's newest-first ordering) should be treated as "currently
+	// red" for that workflow — the rest are stale backlog, not fresh
+	// detections, and must not each trigger their own investigation.
+	const staleFailures = [
+		{...FAILED_RUN, databaseId: 10, workflowName: 'CI'},
+		{...FAILED_RUN, databaseId: 9, workflowName: 'CI'},
+		{...FAILED_RUN, databaseId: 8, workflowName: 'CI'},
+	];
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () => runListJson(staleFailures),
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+	await fireScheduled(scheduler.calls[0]);
+
+	t.is(events.length, 1, 'only the newest run for the workflow should emit');
+	if (events[0]?.kind === 'ci.job.failed') {
+		t.is(events[0].payload.runId, 10);
+	}
+});
+
+test('timed_out and startup_failure conclusions emit; cancelled/success/neutral do not', async t => {
+	const {router, events} = captureRouter();
+	router.subscribe(ciSub());
+	const scheduler = stubScheduler();
+
+	// Distinct workflow names: pollOnce only ever considers the latest run
+	// per workflow, so each conclusion needs its own workflow to be
+	// evaluated independently rather than being collapsed into one.
+	const runs = [
+		{...FAILED_RUN, databaseId: 1, workflowName: 'wf-1', conclusion: 'timed_out'},
+		{...FAILED_RUN, databaseId: 2, workflowName: 'wf-2', conclusion: 'startup_failure'},
+		{...FAILED_RUN, databaseId: 3, workflowName: 'wf-3', conclusion: 'cancelled'},
+		{...FAILED_RUN, databaseId: 4, workflowName: 'wf-4', conclusion: 'success'},
+		{...FAILED_RUN, databaseId: 5, workflowName: 'wf-5', conclusion: 'neutral'},
+	];
+
+	const source = new CiEventSource(router, {
+		branch: 'feature-x',
+		execGhFn: async () => runListJson(runs),
+		scheduleFn: scheduler.scheduleFn,
+		clearFn: scheduler.clearFn,
+	});
+
+	await source.start();
+	await fireScheduled(scheduler.calls[0]);
+
+	t.is(events.length, 2);
+	const emittedIds = events
+		.filter((e): e is Extract<Event, {kind: 'ci.job.failed'}> => e.kind === 'ci.job.failed')
+		.map(e => e.payload.runId);
+	t.deepEqual(new Set(emittedIds), new Set([1, 2]));
 });
 
 test('a passing run emits nothing', async t => {
@@ -113,6 +301,7 @@ test('a passing run emits nothing', async t => {
 	});
 
 	await source.start();
+	await fireScheduled(scheduler.calls[0]);
 
 	t.is(events.length, 0);
 });
@@ -132,12 +321,12 @@ test('a gh error grows the backoff interval instead of throwing', async t => {
 	});
 
 	await t.notThrowsAsync(() => source.start());
-	t.is(scheduler.calls[0]?.ms, 100);
+	await fireScheduled(scheduler.calls[0]);
+	t.is(scheduler.calls[1]?.ms, 100);
 
-	scheduler.calls[0]?.fn();
-	await new Promise(r => setImmediate(r));
+	await fireScheduled(scheduler.calls[1]);
 
-	t.is(scheduler.calls[1]?.ms, 200, 'second consecutive failure should back off further');
+	t.is(scheduler.calls[2]?.ms, 200, 'second consecutive failure should back off further');
 });
 
 test('unparseable output backs off instead of retrying at the fixed interval', async t => {
@@ -153,13 +342,13 @@ test('unparseable output backs off instead of retrying at the fixed interval', a
 	});
 
 	await source.start();
-	t.is(scheduler.calls[0]?.ms, 100);
+	await fireScheduled(scheduler.calls[0]);
+	t.is(scheduler.calls[1]?.ms, 100);
 
-	scheduler.calls[0]?.fn();
-	await new Promise(r => setImmediate(r));
+	await fireScheduled(scheduler.calls[1]);
 
 	t.is(
-		scheduler.calls[1]?.ms,
+		scheduler.calls[2]?.ms,
 		200,
 		'a second consecutive parse failure should back off further, not retry at the base interval',
 	);
@@ -183,16 +372,15 @@ test('a successful poll resets the backoff after prior failures', async t => {
 		clearFn: scheduler.clearFn,
 	});
 
-	await source.start(); // call 1: fails, backoff -> 100, attempt now 1
-	t.is(scheduler.calls[0]?.ms, 100);
-
-	scheduler.calls[0]?.fn();
-	await new Promise(r => setImmediate(r)); // call 2: succeeds, resets backoff
+	await source.start(); // scheduled poll 1 (0ms)
+	await fireScheduled(scheduler.calls[0]); // call 1: fails, backoff -> 100
 	t.is(scheduler.calls[1]?.ms, 100);
 
-	scheduler.calls[1]?.fn();
-	await new Promise(r => setImmediate(r)); // call 3: fails again, should back off from a fresh attempt=0
-	t.is(scheduler.calls[2]?.ms, 100, 'backoff should restart from base after the reset');
+	await fireScheduled(scheduler.calls[1]); // call 2: succeeds, resets backoff
+	t.is(scheduler.calls[2]?.ms, 100);
+
+	await fireScheduled(scheduler.calls[2]); // call 3: fails again, fresh attempt=0
+	t.is(scheduler.calls[3]?.ms, 100, 'backoff should restart from base after the reset');
 });
 
 test('stop prevents any further polls from being scheduled', async t => {
@@ -208,13 +396,13 @@ test('stop prevents any further polls from being scheduled', async t => {
 	});
 
 	await source.start();
+	await fireScheduled(scheduler.calls[0]);
 	const callsBefore = scheduler.calls.length;
 	source.stop();
 
 	// Even if a stray already-scheduled callback fires after stop(), it must
 	// not schedule another poll.
-	scheduler.calls[callsBefore - 1]?.fn();
-	await new Promise(r => setImmediate(r));
+	await fireScheduled(scheduler.calls[callsBefore - 1]);
 
 	t.is(scheduler.calls.length, callsBefore, 'no new poll should be scheduled after stop()');
 	t.is(events.length, 1, 'the already-emitted event count should be unaffected');

--- a/source/events/sources/github-checkrun.ts
+++ b/source/events/sources/github-checkrun.ts
@@ -1,0 +1,170 @@
+/**
+ * CI check-run event source for the skill event router.
+ *
+ * Polls `gh run list` for the most recent *completed* GitHub Actions run on
+ * a branch (defaulting to whatever branch is currently checked out, so it
+ * tracks the developer switching branches on a long-running daemon). When
+ * that run's conclusion is `failure` and it hasn't been seen before, it
+ * emits a `ci.job.failed` event and calls the optional `onDetected` hook
+ * first, so a caller can fire an OS notification before the (potentially
+ * slow) investigation dispatch that follows from `router.emit()` resolving.
+ *
+ * On a `gh` error or unparseable output (rate limit, network, a CLI banner
+ * on stdout) the poll interval grows via `ExponentialBackoff` instead of
+ * hammering the API; a poll that both succeeds and parses resets it. Dedup
+ * (`lastSeenRunId`) is in-memory only and does not survive a daemon restart
+ * — an accepted limitation, consistent with subscriptions themselves not
+ * being persisted either. A single scalar is enough (rather than a set of
+ * every run id ever seen) because `--limit 1` only ever returns the single
+ * latest run, and GitHub run ids are unique across the whole repo.
+ *
+ * Modeled structurally on `ScheduleEventSource`: injectable dependencies for
+ * testability, `start()`/`stop()` lifecycle, emits into the shared
+ * `EventRouter` and otherwise knows nothing about subagents, formatting, or
+ * notifications.
+ */
+
+import type {EventRouter} from '@/events/event-router';
+import type {CiJobFailedPayload} from '@/events/types';
+import {execGh, getCurrentBranch} from '@/tools/git/utils';
+import {ExponentialBackoff} from '@/utils/backoff';
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_MAX_POLL_INTERVAL_MS = 300_000;
+
+interface RunListEntry {
+	databaseId: number;
+	conclusion: string | null;
+	headSha: string;
+	workflowName: string;
+	url: string;
+	headBranch: string;
+}
+
+export interface CiEventSourceOptions {
+	/** Fixed branch to poll. Defaults to resolving the current branch on every poll. */
+	branch?: string;
+	pollIntervalMs?: number;
+	maxPollIntervalMs?: number;
+	/** Fired right before `router.emit()`, so detection can notify before dispatch finishes. */
+	onDetected?: (payload: CiJobFailedPayload) => void;
+	execGhFn?: typeof execGh;
+	getCurrentBranchFn?: typeof getCurrentBranch;
+	now?: () => number;
+	scheduleFn?: (fn: () => void, ms: number) => NodeJS.Timeout;
+	clearFn?: (handle: NodeJS.Timeout) => void;
+}
+
+export class CiEventSource {
+	private lastSeenRunId: number | null = null;
+	private readonly backoff: ExponentialBackoff;
+	private readonly execGhFn: typeof execGh;
+	private readonly getCurrentBranchFn: typeof getCurrentBranch;
+	private readonly now: () => number;
+	private readonly scheduleFn: (fn: () => void, ms: number) => NodeJS.Timeout;
+	private readonly clearFn: (handle: NodeJS.Timeout) => void;
+	private readonly pollIntervalMs: number;
+
+	private timer: NodeJS.Timeout | null = null;
+	private started = false;
+	private stopped = false;
+
+	constructor(
+		private readonly router: EventRouter,
+		private readonly options: CiEventSourceOptions = {},
+	) {
+		this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+		this.backoff = new ExponentialBackoff({
+			baseMs: this.pollIntervalMs,
+			maxMs: options.maxPollIntervalMs ?? DEFAULT_MAX_POLL_INTERVAL_MS,
+		});
+		this.execGhFn = options.execGhFn ?? execGh;
+		this.getCurrentBranchFn = options.getCurrentBranchFn ?? getCurrentBranch;
+		this.now = options.now ?? Date.now;
+		this.scheduleFn = options.scheduleFn ?? ((fn, ms) => setTimeout(fn, ms));
+		this.clearFn = options.clearFn ?? clearTimeout;
+	}
+
+	/** Idempotent. Polls immediately, then schedules subsequent polls. */
+	async start(): Promise<void> {
+		if (this.started) return;
+		this.started = true;
+		this.stopped = false;
+		await this.pollOnce();
+	}
+
+	/** Idempotent. Cancels any pending poll. */
+	stop(): void {
+		this.stopped = true;
+		this.started = false;
+		if (this.timer) {
+			this.clearFn(this.timer);
+			this.timer = null;
+		}
+	}
+
+	private scheduleNext(delayMs: number): void {
+		if (this.stopped) return;
+		this.timer = this.scheduleFn(() => {
+			void this.pollOnce();
+		}, delayMs);
+	}
+
+	private async pollOnce(): Promise<void> {
+		const branch = this.options.branch ?? (await this.getCurrentBranchFn());
+
+		let raw: string;
+		try {
+			raw = await this.execGhFn([
+				'run',
+				'list',
+				'--branch',
+				branch,
+				'--status',
+				'completed',
+				'--limit',
+				'1',
+				'--json',
+				'databaseId,conclusion,headSha,workflowName,url,headBranch',
+			]);
+		} catch {
+			this.scheduleNext(this.backoff.next());
+			return;
+		}
+
+		let runs: RunListEntry[];
+		try {
+			runs = JSON.parse(raw) as RunListEntry[];
+		} catch {
+			// Treat unparseable output (a CLI update banner, truncated stdout)
+			// the same as a `gh` exec failure: back off instead of retrying at
+			// the fixed interval, since a real backoff.reset() already fired on
+			// the *previous* success and we don't want to hammer a source that
+			// keeps returning garbage.
+			this.scheduleNext(this.backoff.next());
+			return;
+		}
+
+		this.backoff.reset();
+
+		const run = runs[0];
+		if (
+			run &&
+			run.conclusion === 'failure' &&
+			run.databaseId !== this.lastSeenRunId
+		) {
+			this.lastSeenRunId = run.databaseId;
+			const payload: CiJobFailedPayload = {
+				runId: run.databaseId,
+				workflowName: run.workflowName,
+				branch: run.headBranch,
+				headSha: run.headSha,
+				url: run.url,
+			};
+			this.options.onDetected?.(payload);
+			await this.router.emit({kind: 'ci.job.failed', payload, at: this.now()});
+		}
+
+		this.scheduleNext(this.pollIntervalMs);
+	}
+}

--- a/source/events/sources/github-checkrun.ts
+++ b/source/events/sources/github-checkrun.ts
@@ -1,22 +1,33 @@
 /**
  * CI check-run event source for the skill event router.
  *
- * Polls `gh run list` for the most recent *completed* GitHub Actions run on
- * a branch (defaulting to whatever branch is currently checked out, so it
- * tracks the developer switching branches on a long-running daemon). When
- * that run's conclusion is `failure` and it hasn't been seen before, it
- * emits a `ci.job.failed` event and calls the optional `onDetected` hook
- * first, so a caller can fire an OS notification before the (potentially
- * slow) investigation dispatch that follows from `router.emit()` resolving.
+ * Polls `gh run list` for the most recently *completed* GitHub Actions runs
+ * on a branch (defaulting to whatever branch is currently checked out, so it
+ * tracks the developer switching branches on a long-running daemon), then
+ * looks only at the single latest run *per workflow* within that window
+ * (fetching more than one run guards against a second workflow completing
+ * between polls and pushing an earlier failure out of "the latest run" —
+ * see `RUN_LIST_LIMIT`). A workflow whose latest run's conclusion counts as
+ * a failure (`failure`, `timed_out`, `startup_failure`) and hasn't been seen
+ * before emits a `ci.job.failed` event, calling the optional `onDetected`
+ * hook first so a caller can fire an OS notification before the
+ * (potentially slow) investigation dispatch that follows from
+ * `router.emit()` resolving. Grouping by workflow (rather than emitting for
+ * every failing run in the fetch window) matters most on a fresh
+ * activation: it reports "which workflows are currently red," not a
+ * backlog of every stale failure in that workflow's recent history.
+ * Filtering by a specific workflow name is not supported — there's no config
+ * surface naming which workflow(s) to watch; `nanocoder.ciWatch.workflows?:
+ * string[]` would be a natural follow-up.
  *
  * On a `gh` error or unparseable output (rate limit, network, a CLI banner
  * on stdout) the poll interval grows via `ExponentialBackoff` instead of
  * hammering the API; a poll that both succeeds and parses resets it. Dedup
- * (`lastSeenRunId`) is in-memory only and does not survive a daemon restart
- * — an accepted limitation, consistent with subscriptions themselves not
- * being persisted either. A single scalar is enough (rather than a set of
- * every run id ever seen) because `--limit 1` only ever returns the single
- * latest run, and GitHub run ids are unique across the whole repo.
+ * (`seenFailedRunIds`) is capped at `MAX_TRACKED_RUN_IDS` and, by default,
+ * in-memory only. A caller that wants dedup to survive a daemon restart can
+ * seed `initialSeenFailedRunIds` from its own persisted state and observe
+ * `onSeenFailedRunIdsChanged` to keep that state up to date — this class
+ * itself does no filesystem I/O.
  *
  * Modeled structurally on `ScheduleEventSource`: injectable dependencies for
  * testability, `start()`/`stop()` lifecycle, emits into the shared
@@ -24,6 +35,7 @@
  * notifications.
  */
 
+import {TIMEOUT_GH_METADATA_MS} from '@/constants';
 import type {EventRouter} from '@/events/event-router';
 import type {CiJobFailedPayload} from '@/events/types';
 import {execGh, getCurrentBranch} from '@/tools/git/utils';
@@ -31,6 +43,13 @@ import {ExponentialBackoff} from '@/utils/backoff';
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_MAX_POLL_INTERVAL_MS = 300_000;
+const RUN_LIST_LIMIT = 10;
+const MAX_TRACKED_RUN_IDS = 50;
+const FAILING_CONCLUSIONS = new Set([
+	'failure',
+	'timed_out',
+	'startup_failure',
+]);
 
 interface RunListEntry {
 	databaseId: number;
@@ -48,6 +67,10 @@ export interface CiEventSourceOptions {
 	maxPollIntervalMs?: number;
 	/** Fired right before `router.emit()`, so detection can notify before dispatch finishes. */
 	onDetected?: (payload: CiJobFailedPayload) => void;
+	/** Seeds dedup state, e.g. from a caller's persisted last-seen run ids. */
+	initialSeenFailedRunIds?: number[];
+	/** Fired synchronously after `seenFailedRunIds` changes, so a caller can persist it. */
+	onSeenFailedRunIdsChanged?: (ids: number[]) => void;
 	execGhFn?: typeof execGh;
 	getCurrentBranchFn?: typeof getCurrentBranch;
 	now?: () => number;
@@ -56,7 +79,7 @@ export interface CiEventSourceOptions {
 }
 
 export class CiEventSource {
-	private lastSeenRunId: number | null = null;
+	private seenFailedRunIds: number[];
 	private readonly backoff: ExponentialBackoff;
 	private readonly execGhFn: typeof execGh;
 	private readonly getCurrentBranchFn: typeof getCurrentBranch;
@@ -73,6 +96,7 @@ export class CiEventSource {
 		private readonly router: EventRouter,
 		private readonly options: CiEventSourceOptions = {},
 	) {
+		this.seenFailedRunIds = [...(options.initialSeenFailedRunIds ?? [])];
 		this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
 		this.backoff = new ExponentialBackoff({
 			baseMs: this.pollIntervalMs,
@@ -85,12 +109,16 @@ export class CiEventSource {
 		this.clearFn = options.clearFn ?? clearTimeout;
 	}
 
-	/** Idempotent. Polls immediately, then schedules subsequent polls. */
+	/**
+	 * Idempotent. Schedules the first poll for 0ms rather than awaiting it
+	 * inline, so a caller awaiting `start()` (e.g. daemon boot) never blocks
+	 * on a live `gh` call.
+	 */
 	async start(): Promise<void> {
 		if (this.started) return;
 		this.started = true;
 		this.stopped = false;
-		await this.pollOnce();
+		this.scheduleNext(0);
 	}
 
 	/** Idempotent. Cancels any pending poll. */
@@ -115,18 +143,21 @@ export class CiEventSource {
 
 		let raw: string;
 		try {
-			raw = await this.execGhFn([
-				'run',
-				'list',
-				'--branch',
-				branch,
-				'--status',
-				'completed',
-				'--limit',
-				'1',
-				'--json',
-				'databaseId,conclusion,headSha,workflowName,url,headBranch',
-			]);
+			raw = await this.execGhFn(
+				[
+					'run',
+					'list',
+					'--branch',
+					branch,
+					'--status',
+					'completed',
+					'--limit',
+					String(RUN_LIST_LIMIT),
+					'--json',
+					'databaseId,conclusion,headSha,workflowName,url,headBranch',
+				],
+				TIMEOUT_GH_METADATA_MS,
+			);
 		} catch {
 			this.scheduleNext(this.backoff.next());
 			return;
@@ -147,13 +178,29 @@ export class CiEventSource {
 
 		this.backoff.reset();
 
-		const run = runs[0];
-		if (
-			run &&
-			run.conclusion === 'failure' &&
-			run.databaseId !== this.lastSeenRunId
-		) {
-			this.lastSeenRunId = run.databaseId;
+		// Only ever consider the single most recent completed run *per
+		// workflow* (gh returns `runs` newest-first, so the first entry seen
+		// for a given workflow name is its latest). Without this grouping,
+		// widening the fetch to RUN_LIST_LIMIT would treat every failing run
+		// in that window as "newly detected" — flooding a fresh activation
+		// with a backlog of stale, already-known-broken history instead of
+		// just "which workflows are currently red."
+		const latestPerWorkflow = new Map<string, RunListEntry>();
+		for (const run of runs) {
+			if (!latestPerWorkflow.has(run.workflowName)) {
+				latestPerWorkflow.set(run.workflowName, run);
+			}
+		}
+
+		const newlyFailed = [...latestPerWorkflow.values()].filter(
+			run =>
+				run.conclusion &&
+				FAILING_CONCLUSIONS.has(run.conclusion) &&
+				!this.seenFailedRunIds.includes(run.databaseId),
+		);
+
+		for (const run of newlyFailed) {
+			this.seenFailedRunIds.push(run.databaseId);
 			const payload: CiJobFailedPayload = {
 				runId: run.databaseId,
 				workflowName: run.workflowName,
@@ -163,6 +210,15 @@ export class CiEventSource {
 			};
 			this.options.onDetected?.(payload);
 			await this.router.emit({kind: 'ci.job.failed', payload, at: this.now()});
+		}
+
+		if (newlyFailed.length > 0) {
+			if (this.seenFailedRunIds.length > MAX_TRACKED_RUN_IDS) {
+				this.seenFailedRunIds = this.seenFailedRunIds.slice(
+					-MAX_TRACKED_RUN_IDS,
+				);
+			}
+			this.options.onSeenFailedRunIdsChanged?.([...this.seenFailedRunIds]);
 		}
 
 		this.scheduleNext(this.pollIntervalMs);

--- a/source/events/types.ts
+++ b/source/events/types.ts
@@ -12,7 +12,7 @@
 
 import type {FileChangeEventKind, SkillMemberRef} from '@/types/skills';
 
-export type EventKind = 'file.changed' | 'schedule.cron';
+export type EventKind = 'file.changed' | 'schedule.cron' | 'ci.job.failed';
 
 export interface FileChangedPayload {
 	file: string;
@@ -21,6 +21,16 @@ export interface FileChangedPayload {
 
 export interface ScheduleCronPayload {
 	cron: string;
+}
+
+export interface CiJobFailedPayload {
+	/** GitHub Actions run database id. */
+	runId: number;
+	workflowName: string;
+	branch: string;
+	headSha: string;
+	/** HTML URL of the run, for linking from a diagnosis/notification. */
+	url: string;
 }
 
 interface EventBase {
@@ -38,7 +48,12 @@ export interface ScheduleCronEvent extends EventBase {
 	payload: ScheduleCronPayload;
 }
 
-export type Event = FileChangedEvent | ScheduleCronEvent;
+export interface CiJobFailedEvent extends EventBase {
+	kind: 'ci.job.failed';
+	payload: CiJobFailedPayload;
+}
+
+export type Event = FileChangedEvent | ScheduleCronEvent | CiJobFailedEvent;
 
 /**
  * Convenience alias for code that wants to talk about a specific kind's
@@ -48,7 +63,9 @@ export type EventPayload<K extends EventKind> = K extends 'file.changed'
 	? FileChangedPayload
 	: K extends 'schedule.cron'
 		? ScheduleCronPayload
-		: never;
+		: K extends 'ci.job.failed'
+			? CiJobFailedPayload
+			: never;
 
 export interface FileChangedFilter {
 	paths?: string[];
@@ -57,6 +74,11 @@ export interface FileChangedFilter {
 
 export interface ScheduleCronFilter {
 	cron: string;
+}
+
+export interface CiJobFailedFilter {
+	/** Glob-matched against payload.branch. Omitted = match every branch. */
+	branches?: string[];
 }
 
 export type SubscriptionSource = 'frontmatter' | 'manifest';
@@ -83,7 +105,15 @@ export interface ScheduleCronSubscription extends SubscriptionBase {
 	filter?: ScheduleCronFilter;
 }
 
-export type Subscription = FileChangedSubscription | ScheduleCronSubscription;
+export interface CiJobFailedSubscription extends SubscriptionBase {
+	kind: 'ci.job.failed';
+	filter?: CiJobFailedFilter;
+}
+
+export type Subscription =
+	| FileChangedSubscription
+	| ScheduleCronSubscription
+	| CiJobFailedSubscription;
 
 /**
  * Trigger context propagated into a subagent task's `context` field when

--- a/source/skills/dispatcher.spec.ts
+++ b/source/skills/dispatcher.spec.ts
@@ -70,6 +70,35 @@ test('buildTriggeredTask: schedule.cron event produces matching trigger context'
 	});
 });
 
+test('buildTriggeredTask: ci.job.failed event produces matching trigger context (not mislabeled as schedule.cron)', t => {
+	const sub: Subscription = {
+		id: 'builtin:ci-investigator',
+		kind: 'ci.job.failed',
+		target: {kind: 'agent', name: 'verify-ci-investigator'},
+		source: 'manifest',
+		ownerSkill: 'builtin',
+	};
+	const event: Event = {
+		kind: 'ci.job.failed',
+		payload: {
+			runId: 42,
+			workflowName: 'CI',
+			branch: 'feature-x',
+			headSha: 'abc123',
+			url: 'https://example.com/run/42',
+		},
+		at: 1_700_000_000_000,
+	};
+	const task = buildTriggeredTask(sub, event);
+	t.deepEqual(task.context, {
+		trigger: {
+			type: 'event',
+			kind: 'ci.job.failed',
+			payload: event.payload,
+		},
+	});
+});
+
 test('dispatch: routes agent target through executor.execute', async t => {
 	const calls: SubagentTask[] = [];
 	const dispatcher = new SkillDispatcher({

--- a/source/skills/dispatcher.ts
+++ b/source/skills/dispatcher.ts
@@ -171,10 +171,27 @@ export function buildTriggeredTask(
 	subscription: Subscription,
 	event: Event,
 ): SubagentTask {
-	const trigger: TriggerContext =
-		event.kind === 'file.changed'
-			? {type: 'event', kind: 'file.changed', payload: event.payload}
-			: {type: 'event', kind: 'schedule.cron', payload: event.payload};
+	let trigger: TriggerContext;
+	switch (event.kind) {
+		case 'file.changed':
+			trigger = {type: 'event', kind: 'file.changed', payload: event.payload};
+			break;
+		case 'schedule.cron':
+			trigger = {type: 'event', kind: 'schedule.cron', payload: event.payload};
+			break;
+		case 'ci.job.failed':
+			trigger = {type: 'event', kind: 'ci.job.failed', payload: event.payload};
+			break;
+		default: {
+			// Exhaustiveness check: a new EventKind added without a case here
+			// fails the build instead of silently mislabeling the trigger
+			// context with the wrong kind/payload pairing.
+			const exhaustive: never = event;
+			throw new Error(
+				`buildTriggeredTask: unhandled event kind "${(exhaustive as Event).kind}"`,
+			);
+		}
+	}
 
 	const payloadJson = JSON.stringify(event.payload);
 	const prompt = `An event of kind \`${event.kind}\` fired. Payload: \`${payloadJson}\`. Proceed according to your instructions.`;

--- a/source/skills/parse-subscribe.spec.ts
+++ b/source/skills/parse-subscribe.spec.ts
@@ -38,6 +38,31 @@ test('parses schedule.cron with cron expression', t => {
 	t.deepEqual(result, [{kind: 'schedule.cron', cron: '0 9 * * MON'}]);
 });
 
+test('parses ci.job.failed with branches', t => {
+	const result = parseSubscribeBlock([
+		{kind: 'ci.job.failed', branches: ['main', 'release/**']},
+	]);
+	t.deepEqual(result, [
+		{kind: 'ci.job.failed', branches: ['main', 'release/**']},
+	]);
+});
+
+test('parses ci.job.failed with no branches', t => {
+	const result = parseSubscribeBlock([{kind: 'ci.job.failed'}]);
+	t.deepEqual(result, [{kind: 'ci.job.failed'}]);
+});
+
+test('rejects bad ci.job.failed branches entry', t => {
+	t.throws(
+		() =>
+			parseSubscribeBlock([{kind: 'ci.job.failed', branches: [42]}]),
+		{
+			instanceOf: SubscribeParseError,
+			message: /branches must be an array/,
+		},
+	);
+});
+
 test('carries through target and confirm fields', t => {
 	const result = parseSubscribeBlock([
 		{

--- a/source/skills/parse-subscribe.ts
+++ b/source/skills/parse-subscribe.ts
@@ -13,6 +13,7 @@
  */
 
 import type {
+	CiJobFailedTrigger,
 	FileChangedTrigger,
 	FileChangeEventKind,
 	ScheduleCronTrigger,
@@ -69,8 +70,11 @@ function parseTrigger(raw: unknown, index: number): SkillTrigger {
 	if (kind === 'schedule.cron') {
 		return {...base, ...parseScheduleCron(obj, index)};
 	}
+	if (kind === 'ci.job.failed') {
+		return {...base, ...parseCiJobFailed(obj, index)};
+	}
 	throw new SubscribeParseError(
-		`subscribe[${index}].kind "${kind}" is not a supported event kind (expected: file.changed, schedule.cron)`,
+		`subscribe[${index}].kind "${kind}" is not a supported event kind (expected: file.changed, schedule.cron, ci.job.failed)`,
 	);
 }
 
@@ -149,4 +153,25 @@ function parseScheduleCron(
 		);
 	}
 	return {kind: 'schedule.cron', cron};
+}
+
+function parseCiJobFailed(
+	obj: Record<string, unknown>,
+	index: number,
+): CiJobFailedTrigger {
+	const trigger: CiJobFailedTrigger = {kind: 'ci.job.failed'};
+
+	if (obj.branches !== undefined) {
+		if (
+			!Array.isArray(obj.branches) ||
+			!obj.branches.every((b): b is string => typeof b === 'string')
+		) {
+			throw new SubscribeParseError(
+				`subscribe[${index}].branches must be an array of glob strings`,
+			);
+		}
+		trigger.branches = obj.branches;
+	}
+
+	return trigger;
 }

--- a/source/skills/registrar.ts
+++ b/source/skills/registrar.ts
@@ -20,6 +20,7 @@
 import type {CustomCommandLoader} from '@/custom-commands/loader';
 import type {EventRouter} from '@/events/event-router';
 import type {
+	CiJobFailedFilter,
 	FileChangedFilter,
 	ScheduleCronFilter,
 	Subscription,
@@ -301,6 +302,15 @@ function buildSubscription(
 			...base,
 			kind: 'schedule.cron',
 			filter,
+		};
+	}
+	if (trig.kind === 'ci.job.failed') {
+		const filter: CiJobFailedFilter = {};
+		if (trig.branches) filter.branches = trig.branches;
+		return {
+			...base,
+			kind: 'ci.job.failed',
+			...(Object.keys(filter).length > 0 ? {filter} : {}),
 		};
 	}
 	return null;

--- a/source/subagents/built-in/verify-ci-investigator.md
+++ b/source/subagents/built-in/verify-ci-investigator.md
@@ -1,0 +1,39 @@
+---
+name: verify-ci-investigator
+description: Read-only CI failure investigator. Given a failed GitHub Actions run, fetches the failure logs and produces a root-cause diagnosis. Never posts to GitHub itself.
+model: inherit
+tools:
+  - read_file
+  - find_files
+  - search_file_contents
+  - list_directory
+  - git_status
+  - git_diff
+  - git_log
+  - lsp_get_diagnostics
+  - git_pr
+---
+
+You are an automated, read-only CI failure investigator. Your task context supplies `runId`, `workflowName`, `branch`, `headSha`, and `url` for a GitHub Actions run that just failed.
+
+Investigate using your tools:
+- `git_pr` with `logs: {run: <runId>, failedOnly: true}` to fetch the failing steps' log output. Narrow further with `logs.search` once you know which step/test failed.
+- `git_pr` with `checks: {pr: <pr>}` if a PR number is available in context, to see the full check-run picture.
+- `git_diff` / `read_file` / `search_file_contents` / `lsp_get_diagnostics` against the locally checked-out tree (already on `branch`, at `headSha`) to understand what changed and why it might have broken.
+
+IMPORTANT — you are strictly read-only:
+- Never call `git_pr` with `comment`, `review`, or `create`. Those calls are not your job — the harness that invoked you handles posting the diagnosis after you return your analysis. Attempting them will simply be denied.
+- Do not modify any files.
+
+Return your diagnosis in exactly this structure:
+
+### Summary
+One or two sentences on what failed.
+
+### Root Cause
+Your best determination of why it failed, citing log lines and `file:line` where relevant. If you genuinely cannot determine a root cause from the available logs, write "Could not determine root cause from available logs." rather than guessing.
+
+### Suggested Fix
+Optional, non-blocking. Omit this section if you have no concrete suggestion. Do not attempt to apply a fix yourself — that's a different, more privileged workflow.
+
+Keep it concise and cite specifics. This is advisory only.

--- a/source/tools/git/utils.ts
+++ b/source/tools/git/utils.ts
@@ -462,6 +462,32 @@ export async function getPrChangedFiles(pr: number): Promise<string[]> {
 }
 
 /**
+ * Resolve the open PR number for a branch, if one exists. Used by the daemon
+ * to decide whether a CI-failure diagnosis should be posted as a PR comment
+ * (no PR yet — e.g. a branch pushed before opening one — just means there's
+ * nowhere to post it). Bounded by TIMEOUT_GH_METADATA_MS — see {@link getPrRefs}.
+ */
+export async function getPrNumberForBranch(
+	branch: string,
+): Promise<number | undefined> {
+	const output = await execGh(
+		['pr', 'list', '--head', branch, '--json', 'number', '--limit', '1'],
+		TIMEOUT_GH_METADATA_MS,
+	);
+	const results = JSON.parse(output) as Array<{number: number}>;
+	return results[0]?.number;
+}
+
+/**
+ * Post a comment-only review to a PR. Shared by `verify --pr`'s
+ * `--post-review` and the daemon's CI-investigation posting — both want the
+ * exact same `gh pr review --comment` call.
+ */
+export async function postPrComment(pr: number, body: string): Promise<void> {
+	await execGh(['pr', 'review', pr.toString(), '--comment', '--body', body]);
+}
+
+/**
  * Get the default branch (main or master)
  */
 export async function getDefaultBranch(): Promise<string> {

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -120,13 +120,33 @@ export interface NotificationsConfig {
 		questionPrompt?: boolean;
 		generationComplete?: boolean;
 		triggeredRunComplete?: boolean;
+		ciFailureDetected?: boolean;
+		ciInvestigationComplete?: boolean;
 	};
 	customMessages?: {
 		toolConfirmation?: {title: string; message: string};
 		questionPrompt?: {title: string; message: string};
 		generationComplete?: {title: string; message: string};
 		triggeredRunComplete?: {title: string; message: string};
+		ciFailureDetected?: {title: string; message: string};
+		ciInvestigationComplete?: {title: string; message: string};
 	};
+}
+
+/**
+ * Background CI-watch configuration. Governs whether the per-project daemon
+ * polls GitHub Actions for check-run failures on the currently checked-out
+ * branch and automatically runs the `verify-ci-investigator` subagent when
+ * one is found. Opt-in (`enabled` defaults to false) since this is a new
+ * always-on-network, GitHub-API-rate-limit-consuming background feature,
+ * unlike file-watching/cron which have no such external cost.
+ */
+export interface CiWatchConfig {
+	enabled: boolean;
+	/** Base poll interval in ms. Defaults to 30_000. */
+	pollIntervalMs?: number;
+	/** Backoff cap in ms for consecutive `gh` errors. Defaults to 300_000. */
+	maxPollIntervalMs?: number;
 }
 
 // Note: temperature is intentionally excluded from this interface.
@@ -205,6 +225,9 @@ export interface AppConfig {
 
 	// Desktop notification configuration
 	notifications?: NotificationsConfig;
+
+	// Background CI-watch configuration (daemon-side)
+	ciWatch?: CiWatchConfig;
 
 	// Model mode defaults (global)
 	tune?: Partial<TuneConfig>;
@@ -414,6 +437,7 @@ export interface UserPreferences {
 	nanocoderShape?: NanocoderShape;
 	tune?: TuneConfig;
 	notifications?: NotificationsConfig;
+	ciWatch?: CiWatchConfig;
 	paste?: PasteConfig;
 	reasoningExpanded?: boolean;
 	compactToolDisplay?: boolean;

--- a/source/types/skills.ts
+++ b/source/types/skills.ts
@@ -81,12 +81,21 @@ export interface ScheduleCronTrigger extends SkillTriggerBase {
 	cron: string;
 }
 
+export interface CiJobFailedTrigger extends SkillTriggerBase {
+	kind: 'ci.job.failed';
+	/** Glob patterns; omitted = every branch the source polls. */
+	branches?: string[];
+}
+
 /**
  * A subscription declaration as it appears in user-authored YAML (either a
  * bundle manifest's `subscribe:` block or a member file's frontmatter).
  * The registrar resolves these into runtime `Subscription` objects.
  */
-export type SkillTrigger = FileChangedTrigger | ScheduleCronTrigger;
+export type SkillTrigger =
+	| FileChangedTrigger
+	| ScheduleCronTrigger
+	| CiJobFailedTrigger;
 
 export interface SkillSource {
 	priority: SkillPriority;

--- a/source/utils/backoff.spec.ts
+++ b/source/utils/backoff.spec.ts
@@ -1,0 +1,40 @@
+import test from 'ava';
+import {ExponentialBackoff} from './backoff';
+
+console.log('\nbackoff.spec.ts');
+
+test('first call returns baseMs', t => {
+	const backoff = new ExponentialBackoff({baseMs: 100, maxMs: 10_000});
+	t.is(backoff.next(), 100);
+});
+
+test('grows by the default factor of 2 each call', t => {
+	const backoff = new ExponentialBackoff({baseMs: 100, maxMs: 10_000});
+	t.is(backoff.next(), 100);
+	t.is(backoff.next(), 200);
+	t.is(backoff.next(), 400);
+	t.is(backoff.next(), 800);
+});
+
+test('honors a custom factor', t => {
+	const backoff = new ExponentialBackoff({baseMs: 10, maxMs: 10_000, factor: 3});
+	t.is(backoff.next(), 10);
+	t.is(backoff.next(), 30);
+	t.is(backoff.next(), 90);
+});
+
+test('caps at maxMs', t => {
+	const backoff = new ExponentialBackoff({baseMs: 100, maxMs: 350});
+	t.is(backoff.next(), 100);
+	t.is(backoff.next(), 200);
+	t.is(backoff.next(), 350); // would be 400, capped
+	t.is(backoff.next(), 350);
+});
+
+test('reset returns the counter to baseMs', t => {
+	const backoff = new ExponentialBackoff({baseMs: 50, maxMs: 10_000});
+	backoff.next();
+	backoff.next();
+	backoff.reset();
+	t.is(backoff.next(), 50);
+});

--- a/source/utils/backoff.ts
+++ b/source/utils/backoff.ts
@@ -1,0 +1,39 @@
+/**
+ * Minimal exponential backoff. No jitter, no timers — just tracks an attempt
+ * counter and returns the delay the caller should wait before its next
+ * retry. Pure and dependency-free so it's trivially unit-testable; callers
+ * own their own `setTimeout`/scheduling.
+ */
+
+export interface BackoffOptions {
+	/** Delay before the first retry, in ms. */
+	baseMs: number;
+	/** Upper bound on the returned delay, in ms. */
+	maxMs: number;
+	/** Multiplier applied per attempt. Defaults to 2. */
+	factor?: number;
+}
+
+export class ExponentialBackoff {
+	private attempt = 0;
+
+	constructor(private readonly opts: BackoffOptions) {}
+
+	/**
+	 * Returns the delay (ms) to wait before the next retry, then advances the
+	 * attempt counter. The first call returns `baseMs`.
+	 */
+	next(): number {
+		const delay = Math.min(
+			this.opts.baseMs * (this.opts.factor ?? 2) ** this.attempt,
+			this.opts.maxMs,
+		);
+		this.attempt++;
+		return delay;
+	}
+
+	/** Reset the attempt counter — call this after a successful operation. */
+	reset(): void {
+		this.attempt = 0;
+	}
+}

--- a/source/utils/notifications.ts
+++ b/source/utils/notifications.ts
@@ -9,7 +9,9 @@ export type NotificationEvent =
 	| 'toolConfirmation'
 	| 'questionPrompt'
 	| 'generationComplete'
-	| 'triggeredRunComplete';
+	| 'triggeredRunComplete'
+	| 'ciFailureDetected'
+	| 'ciInvestigationComplete';
 
 const DEFAULT_CONFIG: NotificationsConfig = {
 	enabled: false,
@@ -18,6 +20,8 @@ const DEFAULT_CONFIG: NotificationsConfig = {
 		questionPrompt: true,
 		generationComplete: true,
 		triggeredRunComplete: true,
+		ciFailureDetected: true,
+		ciInvestigationComplete: true,
 	},
 };
 
@@ -50,6 +54,15 @@ const EVENT_MESSAGES: Record<
 	triggeredRunComplete: {
 		title: projectName => `Triggered Run Completed in ${projectName}`,
 		message: 'A skill subscription fired and its target finished running.',
+	},
+	ciFailureDetected: {
+		title: projectName => `CI Failure Detected in ${projectName}`,
+		message: 'A CI run failed. Investigating…',
+	},
+	ciInvestigationComplete: {
+		title: projectName => `CI Investigation Complete in ${projectName}`,
+		message:
+			'Nanocoder finished diagnosing a CI failure — see the daemon log or PR comment.',
 	},
 };
 

--- a/source/verify/cli.ts
+++ b/source/verify/cli.ts
@@ -18,12 +18,12 @@ import {existsSync} from 'node:fs';
 import {join} from 'node:path';
 import type {SubagentTask} from '@/subagents/types';
 import {
-	execGh,
 	getCurrentCommitSha,
 	getPrChangedFiles,
 	getPrRefs,
 	isGhAvailable,
 	type PrRefs,
+	postPrComment,
 } from '@/tools/git/utils';
 import {formatError} from '@/utils/error-formatter';
 import {formatReviewBody} from './format-review';
@@ -88,7 +88,7 @@ async function defaultRunSubagent(
 }
 
 async function defaultPostReview(pr: number, body: string): Promise<void> {
-	await execGh(['pr', 'review', pr.toString(), '--comment', '--body', body]);
+	await postPrComment(pr, body);
 }
 
 const USAGE =

--- a/source/verify/format-ci-report.spec.ts
+++ b/source/verify/format-ci-report.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * format-ci-report.ts Tests
+ */
+
+import test from 'ava';
+import {formatCiReport} from './format-ci-report';
+
+const baseInput = {
+	runId: 42,
+	workflowName: 'CI',
+	branch: 'feature-x',
+	url: 'https://github.com/o/r/actions/runs/42',
+};
+
+test('formatCiReport includes the run id, workflow, and branch', t => {
+	const body = formatCiReport({
+		...baseInput,
+		subagentOutput: '### Summary\nBuild failed.',
+	});
+	t.true(body.includes('#42'));
+	t.true(body.includes('CI'));
+	t.true(body.includes('feature-x'));
+});
+
+test('formatCiReport includes the run URL deterministically', t => {
+	const body = formatCiReport({
+		...baseInput,
+		subagentOutput: 'No mention of any URL here.',
+	});
+	t.true(body.includes(baseInput.url));
+});
+
+test('formatCiReport passes the subagent output through verbatim', t => {
+	const body = formatCiReport({
+		...baseInput,
+		subagentOutput: '### Root Cause\nSpecific unique marker text here.',
+	});
+	t.true(body.includes('Specific unique marker text here.'));
+});
+
+test('formatCiReport notes the diagnosis is advisory with no auto-fix', t => {
+	const body = formatCiReport({
+		...baseInput,
+		subagentOutput: 'Looks like a flaky test.',
+	});
+	t.true(body.includes('no auto-fix applied'));
+});

--- a/source/verify/format-ci-report.ts
+++ b/source/verify/format-ci-report.ts
@@ -1,0 +1,29 @@
+export interface FormatCiReportInput {
+	runId: number;
+	workflowName: string;
+	branch: string;
+	url: string;
+	subagentOutput: string;
+}
+
+/**
+ * Composes a deterministic header (run id, workflow, branch, URL — never
+ * re-derived from the LLM's own text) with the investigator subagent's
+ * narrative diagnosis into a single report body, mirroring
+ * `format-review.ts`'s split between deterministic and model-generated
+ * content.
+ */
+export function formatCiReport(input: FormatCiReportInput): string {
+	const {runId, workflowName, branch, url, subagentOutput} = input;
+
+	return [
+		`## Nanocoder CI Investigation — "${workflowName}" failed on \`${branch}\``,
+		'',
+		`Run: [#${runId}](${url})`,
+		'',
+		subagentOutput.trim(),
+		'',
+		'---',
+		'*Generated automatically by the Nanocoder daemon — advisory diagnosis, no auto-fix applied.*',
+	].join('\n');
+}

--- a/source/verify/trust.spec.ts
+++ b/source/verify/trust.spec.ts
@@ -148,3 +148,22 @@ test.serial(
 		);
 	},
 );
+
+test.serial(
+	"verify-ci-investigator's frontmatter tools match trust.ts's comment-only allowlist",
+	async t => {
+		const loader = new SubagentLoader();
+		await loader.initialize();
+		const config = await loader.getSubagent('verify-ci-investigator');
+
+		t.truthy(config, 'verify-ci-investigator subagent should exist');
+		const frontmatterTools = new Set(config?.tools ?? []);
+		const trustTools = new Set(getAllowedToolNames('comment-only'));
+
+		t.deepEqual(
+			frontmatterTools,
+			trustTools,
+			'verify-ci-investigator.md tools: list has drifted from trust.ts comment-only allowlist',
+		);
+	},
+);


### PR DESCRIPTION
Description

Adds background CI Watch Mode to the daemon (issue #862, Phase 3 of the Agentic CI/CD Gate roadmap). The daemon can now poll a branch's GitHub Actions runs, detect a failure, run a read-only verify-ci-investigator subagent to diagnose it, and automatically post the diagnosis as a PR comment  all without a human invoking anything. Opt-in via ciWatch.enabled config; disabled by default.

Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

Changeset

- [x] Added a changeset (pnpm changeset) describing this change for the changelog

Testing

Automated Tests

- [x] New features include passing tests in .spec.ts/tsx files
- [ ] All existing tests pass (pnpm test:all completes successfully)
- [x] Tests cover both success and error scenarios

Note on the unchecked item: pnpm run test:all doesn't invoke cleanly in my local Windows shell (a ./scripts/test.sh invocation issue, not a code issue), so I ran the constituent checks individually instead: test:format, test:lint, test:types, test:knip all pass clean, and the new/changed spec files (90 tests across backoff, github-checkrun, event-router, parse-subscribe, dispatcher, format-ci-report, daemon, trust, verify/cli) all pass. The full repo-wide test:ava run shows 62 pre-existing failures on this machine; I diffed against the pre-Phase-3 base commit on the same machine and it has 70 failing (more), with identical failure signatures (Windows path-separator assertions, a known chokidar timing flake, Windows-specific directory checks) — so these predate this branch. CI only runs on ubuntu-latest, so these are very likely Windows-local-only, but I haven't watched an actual Linux CI run of this branch complete, so I'm not checking this box outright.

Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Not applicable to this change (no provider-facing code touched); manual end-to-end sanity check of CI Watch Mode itself (real gh-authenticated repo, a branch with a failing run) wasn't done — gh isn't installed in this environment.

Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see CONTRIBUTING.md#logging)