### PR TITLE
fix(summariser): keep truncate() within its character budget

### DIFF
--- a/.changeset/summariser-truncate-budget.md
+++ b/.changeset/summariser-truncate-budget.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+Fixed the conversation summariser's truncation overshooting its character budget. The `... [truncated N chars]` notice was appended *after* slicing to the limit, so every truncated system prompt, tool-call argument, and tool result sent to the summariser ran over budget by the width of that notice. The kept length is now solved for so the notice fits inside the limit, and a budget too small for the notice at all falls back to a plain slice. Thanks to @aashu2006. Closes #1135.

--- a/source/utils/llm-summariser.spec.ts
+++ b/source/utils/llm-summariser.spec.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import type {LLMChatResponse, LLMClient, Message} from '@/types/core';
 import type {Tokenizer} from '@/types/tokenization';
-import {summariseWithLLM} from './llm-summariser';
+import {summariseWithLLM, truncate} from './llm-summariser';
 
 function makeTokenizer(): Tokenizer {
 	return {
@@ -45,6 +45,55 @@ const systemMessage: Message = {
 	role: 'system',
 	content: 'You are a coding agent.',
 };
+
+test('truncate returns text untouched when it already fits', t => {
+	t.is(truncate('short', 10), 'short');
+	t.is(truncate('exact', 5), 'exact', 'a string of exactly max is not truncated');
+	t.is(truncate('', 0), '');
+});
+
+test('truncate never exceeds max, suffix included', t => {
+	// The suffix is part of the budget, so the total must fit — the bug was
+	// returning `max + suffix.length` characters.
+	for (const max of [30, 31, 40, 100, 400, 1200, 1500]) {
+		for (const length of [max + 1, max + 9, max + 10, max * 3, 100_000]) {
+			const result = truncate('a'.repeat(length), max);
+			t.true(
+				result.length <= max,
+				`truncate(${length} chars, ${max}) returned ${result.length} chars`,
+			);
+		}
+	}
+});
+
+test('truncate keeps as much content as the budget allows', t => {
+	const max = 60;
+	const result = truncate('a'.repeat(500), max);
+
+	t.is(result.length, max, 'the budget is spent, not undershot');
+	const kept = result.indexOf('...');
+	t.is(result, `${'a'.repeat(kept)}... [truncated ${500 - kept} chars]`);
+	// One more kept character would push the total past the budget.
+	t.true(kept + 1 + `... [truncated ${500 - kept - 1} chars]`.length > max);
+});
+
+test('truncate degrades to a hard slice when the notice would crowd out content', t => {
+	// Budgets too small for the notice at all.
+	for (const max of [1, 5, 20, 25]) {
+		const result = truncate('a'.repeat(1000), max);
+		t.is(result, 'a'.repeat(max));
+	}
+
+	// The boundary: for 30 chars of text a budget of 24 fits the notice
+	// `... [truncated 30 chars]` exactly, but with zero characters left beside
+	// it. A notice saying everything was dropped carries less than the text it
+	// displaced, so content wins — and the cap holds either way.
+	t.is(truncate('a'.repeat(30), 24), 'a'.repeat(24));
+
+	// One character of headroom more and the notice earns its place.
+	t.is(truncate('a'.repeat(30), 25), 'a... [truncated 29 chars]');
+	t.is(truncate('a'.repeat(30), 26), 'aa... [truncated 28 chars]');
+});
 
 test('summariseWithLLM returns [summary, ...recent] when segment is non-empty', async t => {
 	const tokenizer = makeTokenizer();

--- a/source/utils/llm-summariser.ts
+++ b/source/utils/llm-summariser.ts
@@ -169,7 +169,34 @@ function serialiseTranscript(messages: Message[]): string {
 	return lines.join('\n\n');
 }
 
-function truncate(text: string, max: number): string {
+function truncationSuffix(omitted: number): string {
+	return `... [truncated ${omitted} chars]`;
+}
+
+/**
+ * Truncate `text` so the result — suffix included — is never longer than `max`.
+ *
+ * The suffix counts against the budget, and its own width depends on how many
+ * characters were dropped, so the kept length has to be solved for rather than
+ * assumed. `keep + truncationSuffix(text.length - keep).length` is
+ * non-decreasing in `keep` (growing `keep` by one drops at most one digit from
+ * the omitted count), so budgeting for the widest possible suffix gives a
+ * valid starting point that can then be widened one character at a time.
+ *
+ * @internal exported for tests
+ */
+export function truncate(text: string, max: number): string {
 	if (text.length <= max) return text;
-	return `${text.slice(0, max)}... [truncated ${text.length - max} chars]`;
+	if (max <= 0) return '';
+
+	let keep = max - truncationSuffix(text.length).length;
+	// The suffix would eat the whole budget, leaving no room for content beside
+	// it. A notice reporting that everything was dropped carries less than the
+	// text it displaced, so spend the budget on content instead.
+	if (keep <= 0) return text.slice(0, max);
+
+	while (keep + 1 + truncationSuffix(text.length - keep - 1).length <= max) {
+		keep++;
+	}
+	return `${text.slice(0, keep)}${truncationSuffix(text.length - keep)}`;
 }


### PR DESCRIPTION
## Description

`truncate()` in `source/utils/llm-summariser.ts` cut text to `max`, then appended `... [truncated N chars]`. So it always returned `max` plus the notice length, over budget every time. Hits all three call sites: system prompt (1500), tool call args (400), tool results (1200).

The notice's length depends on how many chars got dropped, which depends on how many you keep, so you can't subtract a fixed amount up front. The fix budgets for the longest the notice could be, then adds chars back one at a time while the total still fits.

Edge case: if the budget is too small to fit the notice and any text, the notice is dropped and the whole budget goes to content. Still within `max`. Unreachable at the real call sites, but tested.

Closes #1135.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

`.changeset/summariser-truncate-budget.md` (patch)

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Four tests in `source/utils/llm-summariser.spec.ts`. I also ran the algorithm against a brute force reference over 24,012 budget and length combos (nothing exceeds `max`), and put the old buggy line back to confirm 3 of the 4 tests actually catch it.

`pnpm test:all` exits 0 (7522 passed, 1 skipped). On a fresh checkout run `pnpm run build` first, the CLI integration tests need `dist/`.

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Skipped on purpose. Pure string function, no provider or network involved.

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

No docs or logging needed, it's a small internal helper with nothing user facing.

Worth a look in review: `truncate` is now exported so tests can call it directly, tagged `@internal` like the test only exports in `source/utils/file-search.ts`. Knip prints an "unused tag" hint for it, same as it does for those two. Hint, not a failure.