### PR TITLE
fix(timeline): write timeline.json atomically

### DIFF
--- a/.changeset/fix-timeline-index-atomic-write.md
+++ b/.changeset/fix-timeline-index-atomic-write.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+Timeline index saves are now atomic: `timeline.json` is written to a temporary file and renamed into place instead of being overwritten in place. A crash or kill mid-save can no longer leave a truncated index behind, which previously cost the session every checkpoint (the corrupted index was discarded on next load). Thanks to @puri-adityakumar. Closes #1130.

--- a/.changeset/fix-timeline-index-atomic-write.md
+++ b/.changeset/fix-timeline-index-atomic-write.md
@@ -2,4 +2,4 @@
 '@nanocollective/nanocoder': patch
 ---
 
-Timeline index saves are now atomic: `timeline.json` is written to a temporary file and renamed into place instead of being overwritten in place. A crash or kill mid-save can no longer leave a truncated index behind, which previously cost the session every checkpoint (the corrupted index was discarded on next load). Thanks to @puri-adityakumar. Closes #1130.
+Timeline index saves are now atomic: `timeline.json` is written to a temporary file and renamed into place instead of being overwritten in place. If the process dies mid-save, readers only ever see the complete old or complete new index, so a torn write can no longer silently discard every checkpoint of the session. Thanks to @puri-adityakumar. Closes #1130.

--- a/source/services/timeline-manager.spec.ts
+++ b/source/services/timeline-manager.spec.ts
@@ -407,6 +407,152 @@ test.serial('TimelineManager refuses index paths that escape the workspace', asy
 	}
 });
 
+test.serial('TimelineManager saves the index atomically over a read-only live file', async t => {
+	const tempDir = await createTempDir();
+	try {
+		const manager = new TimelineManager(tempDir, 'session-atomic');
+		const indexPath = path.join(
+			tempDir,
+			'.nanocoder',
+			'timeline',
+			'session-atomic',
+			'timeline.json',
+		);
+		await manager.capture({
+			toolCallId: 'c1',
+			toolName: 'write_file',
+			title: 'step 1',
+			truncateToMessageIndex: 0,
+			files: filesMap([['a.ts', 'v1']]),
+		});
+
+		// rename(2) only needs write permission on the directory, so an atomic
+		// save replaces the file; an in-place write would fail with EACCES.
+		await fs.chmod(indexPath, 0o444);
+
+		const second = await manager.capture({
+			toolCallId: 'c2',
+			toolName: 'write_file',
+			title: 'step 2',
+			truncateToMessageIndex: 2,
+			files: filesMap([['b.ts', 'v2']]),
+		});
+
+		t.truthy(second);
+		t.is((await manager.list()).length, 2);
+		const saved = JSON.parse(await fs.readFile(indexPath, 'utf-8'));
+		t.is(saved.entries.length, 2);
+		const dirListing = await fs.readdir(path.dirname(indexPath));
+		t.false(dirListing.some(name => name.endsWith('.tmp')));
+	} finally {
+		const indexPath = path.join(
+			tempDir,
+			'.nanocoder',
+			'timeline',
+			'session-atomic',
+			'timeline.json',
+		);
+		await fs.chmod(indexPath, 0o644).catch(() => {});
+		await cleanupTempDir(tempDir);
+	}
+});
+
+test.serial('TimelineManager keeps the previous index intact when a save fails', async t => {
+	const tempDir = await createTempDir();
+	try {
+		const sessionDir = path.join(
+			tempDir,
+			'.nanocoder',
+			'timeline',
+			'session-fail',
+		);
+		const manager = new TimelineManager(tempDir, 'session-fail');
+		await manager.capture({
+			toolCallId: 'c1',
+			toolName: 'write_file',
+			title: 'step 1',
+			truncateToMessageIndex: 0,
+			files: filesMap([['a.ts', 'v1']]),
+		});
+		const previousIndex = await fs.readFile(
+			path.join(sessionDir, 'timeline.json'),
+			'utf-8',
+		);
+
+		// A crash or full disk mid-save must not leave a truncated index: the
+		// previous checkpoint list stays readable until a save succeeds. A
+		// read-only session directory blocks any new write, including the save.
+		await fs.chmod(path.join(sessionDir, 'timeline.json'), 0o444);
+		await fs.chmod(sessionDir, 0o555);
+		await t.throwsAsync(
+			manager.capture({
+				toolCallId: 'c2',
+				toolName: 'write_file',
+				title: 'step 2',
+				truncateToMessageIndex: 2,
+				files: filesMap([['b.ts', 'v2']]),
+			}),
+		);
+
+		const saved = await fs.readFile(
+			path.join(sessionDir, 'timeline.json'),
+			'utf-8',
+		);
+		t.is(saved, previousIndex);
+		t.is(JSON.parse(saved).entries.length, 1);
+		const dirListing = await fs.readdir(sessionDir);
+		t.false(dirListing.some(name => name.endsWith('.tmp')));
+	} finally {
+		const sessionDir = path.join(
+			tempDir,
+			'.nanocoder',
+			'timeline',
+			'session-fail',
+		);
+		await fs.chmod(path.join(sessionDir, 'timeline.json'), 0o644).catch(() => {});
+		await fs.chmod(sessionDir, 0o755).catch(() => {});
+		await cleanupTempDir(tempDir);
+	}
+});
+
+test.serial('TimelineManager starts empty when the index file is corrupted', async t => {
+	const tempDir = await createTempDir();
+	try {
+		const manager = new TimelineManager(tempDir, 'session-corrupt');
+		await manager.capture({
+			toolCallId: 'c1',
+			toolName: 'write_file',
+			title: 'step',
+			truncateToMessageIndex: 0,
+			files: filesMap([['a.ts', 'v1']]),
+		});
+		const indexPath = path.join(
+			tempDir,
+			'.nanocoder',
+			'timeline',
+			'session-corrupt',
+			'timeline.json',
+		);
+		// A torn write leaves truncated JSON behind.
+		await fs.writeFile(indexPath, '{"entries": [', 'utf-8');
+
+		const fresh = new TimelineManager(tempDir, 'session-corrupt');
+		t.deepEqual(await fresh.list(), []);
+
+		const entry = await fresh.capture({
+			toolCallId: 'c2',
+			toolName: 'write_file',
+			title: 'recover',
+			truncateToMessageIndex: 1,
+			files: filesMap([['b.ts', 'v2']]),
+		});
+		t.truthy(entry);
+		t.is(JSON.parse(await fs.readFile(indexPath, 'utf-8')).entries.length, 1);
+	} finally {
+		await cleanupTempDir(tempDir);
+	}
+});
+
 test.serial('TimelineManager prunes timelines from abandoned sessions', async t => {
 	const tempDir = await createTempDir();
 	try {

--- a/source/services/timeline-manager.spec.ts
+++ b/source/services/timeline-manager.spec.ts
@@ -407,113 +407,130 @@ test.serial('TimelineManager refuses index paths that escape the workspace', asy
 	}
 });
 
-test.serial('TimelineManager saves the index atomically over a read-only live file', async t => {
-	const tempDir = await createTempDir();
-	try {
-		const manager = new TimelineManager(tempDir, 'session-atomic');
-		const indexPath = path.join(
-			tempDir,
-			'.nanocoder',
-			'timeline',
-			'session-atomic',
-			'timeline.json',
-		);
-		await manager.capture({
-			toolCallId: 'c1',
-			toolName: 'write_file',
-			title: 'step 1',
-			truncateToMessageIndex: 0,
-			files: filesMap([['a.ts', 'v1']]),
-		});
+// chmod-based permission tests: root ignores mode bits and Windows ignores
+// chmod on directories, so skip there instead of failing confusingly.
+const permissionTest =
+	process.platform === 'win32' || process.getuid?.() === 0
+		? test.serial.skip
+		: test.serial;
 
-		// rename(2) only needs write permission on the directory, so an atomic
-		// save replaces the file; an in-place write would fail with EACCES.
-		await fs.chmod(indexPath, 0o444);
+permissionTest(
+	'TimelineManager saves the index atomically over a read-only live file',
+	async t => {
+		const tempDir = await createTempDir();
+		try {
+			const manager = new TimelineManager(tempDir, 'session-atomic');
+			const indexPath = path.join(
+				tempDir,
+				'.nanocoder',
+				'timeline',
+				'session-atomic',
+				'timeline.json',
+			);
+			await manager.capture({
+				toolCallId: 'c1',
+				toolName: 'write_file',
+				title: 'step 1',
+				truncateToMessageIndex: 0,
+				files: filesMap([['a.ts', 'v1']]),
+			});
 
-		const second = await manager.capture({
-			toolCallId: 'c2',
-			toolName: 'write_file',
-			title: 'step 2',
-			truncateToMessageIndex: 2,
-			files: filesMap([['b.ts', 'v2']]),
-		});
+			// rename(2) only needs write permission on the directory, so an
+			// atomic save replaces the file; an in-place write fails with EACCES.
+			await fs.chmod(indexPath, 0o444);
 
-		t.truthy(second);
-		t.is((await manager.list()).length, 2);
-		const saved = JSON.parse(await fs.readFile(indexPath, 'utf-8'));
-		t.is(saved.entries.length, 2);
-		const dirListing = await fs.readdir(path.dirname(indexPath));
-		t.false(dirListing.some(name => name.endsWith('.tmp')));
-	} finally {
-		const indexPath = path.join(
-			tempDir,
-			'.nanocoder',
-			'timeline',
-			'session-atomic',
-			'timeline.json',
-		);
-		await fs.chmod(indexPath, 0o644).catch(() => {});
-		await cleanupTempDir(tempDir);
-	}
-});
-
-test.serial('TimelineManager keeps the previous index intact when a save fails', async t => {
-	const tempDir = await createTempDir();
-	try {
-		const sessionDir = path.join(
-			tempDir,
-			'.nanocoder',
-			'timeline',
-			'session-fail',
-		);
-		const manager = new TimelineManager(tempDir, 'session-fail');
-		await manager.capture({
-			toolCallId: 'c1',
-			toolName: 'write_file',
-			title: 'step 1',
-			truncateToMessageIndex: 0,
-			files: filesMap([['a.ts', 'v1']]),
-		});
-		const previousIndex = await fs.readFile(
-			path.join(sessionDir, 'timeline.json'),
-			'utf-8',
-		);
-
-		// A crash or full disk mid-save must not leave a truncated index: the
-		// previous checkpoint list stays readable until a save succeeds. A
-		// read-only session directory blocks any new write, including the save.
-		await fs.chmod(path.join(sessionDir, 'timeline.json'), 0o444);
-		await fs.chmod(sessionDir, 0o555);
-		await t.throwsAsync(
-			manager.capture({
+			const second = await manager.capture({
 				toolCallId: 'c2',
 				toolName: 'write_file',
 				title: 'step 2',
 				truncateToMessageIndex: 2,
 				files: filesMap([['b.ts', 'v2']]),
-			}),
-		);
+			});
 
-		const saved = await fs.readFile(
-			path.join(sessionDir, 'timeline.json'),
-			'utf-8',
-		);
-		t.is(saved, previousIndex);
-		t.is(JSON.parse(saved).entries.length, 1);
-		const dirListing = await fs.readdir(sessionDir);
-		t.false(dirListing.some(name => name.endsWith('.tmp')));
-	} finally {
-		const sessionDir = path.join(
-			tempDir,
-			'.nanocoder',
-			'timeline',
-			'session-fail',
-		);
-		await fs.chmod(path.join(sessionDir, 'timeline.json'), 0o644).catch(() => {});
-		await fs.chmod(sessionDir, 0o755).catch(() => {});
-		await cleanupTempDir(tempDir);
-	}
-});
+			t.truthy(second);
+			t.is((await manager.list()).length, 2);
+			const saved = JSON.parse(await fs.readFile(indexPath, 'utf-8'));
+			t.is(saved.entries.length, 2);
+			const dirListing = await fs.readdir(path.dirname(indexPath));
+			t.false(dirListing.some(name => name.endsWith('.tmp')));
+		} finally {
+			const indexPath = path.join(
+				tempDir,
+				'.nanocoder',
+				'timeline',
+				'session-atomic',
+				'timeline.json',
+			);
+			await fs.chmod(indexPath, 0o644).catch(() => {});
+			await cleanupTempDir(tempDir);
+		}
+	},
+);
+
+permissionTest(
+	'TimelineManager keeps the previous index intact when a save fails',
+	async t => {
+		const tempDir = await createTempDir();
+		try {
+			const sessionDir = path.join(
+				tempDir,
+				'.nanocoder',
+				'timeline',
+				'session-fail',
+			);
+			const manager = new TimelineManager(tempDir, 'session-fail');
+			await manager.capture({
+				toolCallId: 'c1',
+				toolName: 'write_file',
+				title: 'step 1',
+				truncateToMessageIndex: 0,
+				files: filesMap([['a.ts', 'v1']]),
+			});
+			const previousIndex = await fs.readFile(
+				path.join(sessionDir, 'timeline.json'),
+				'utf-8',
+			);
+
+			// The failed save must not promote unsaved checkpoints either:
+			// reads after the failure report the index on disk. A read-only
+			// session directory blocks any new write, including the save.
+			await fs.chmod(path.join(sessionDir, 'timeline.json'), 0o444);
+			await fs.chmod(sessionDir, 0o555);
+			await t.throwsAsync(
+				manager.capture({
+					toolCallId: 'c2',
+					toolName: 'write_file',
+					title: 'step 2',
+					truncateToMessageIndex: 2,
+					files: filesMap([['b.ts', 'v2']]),
+				}),
+			);
+
+			const saved = await fs.readFile(
+				path.join(sessionDir, 'timeline.json'),
+				'utf-8',
+			);
+			t.is(saved, previousIndex);
+			t.is(JSON.parse(saved).entries.length, 1);
+			const dirListing = await fs.readdir(sessionDir);
+			t.false(dirListing.some(name => name.endsWith('.tmp')));
+			// The in-memory cache must match the disk, not the unpersisted write.
+			t.is((await manager.list()).length, 1);
+		} finally {
+			const sessionDir = path.join(
+				tempDir,
+				'.nanocoder',
+				'timeline',
+				'session-fail',
+			);
+			await fs
+				.chmod(path.join(sessionDir, 'timeline.json'), 0o644)
+				.catch(() => {});
+			await fs.chmod(sessionDir, 0o755).catch(() => {});
+			await cleanupTempDir(tempDir);
+		}
+	},
+);
 
 test.serial('TimelineManager starts empty when the index file is corrupted', async t => {
 	const tempDir = await createTempDir();

--- a/source/services/timeline-manager.ts
+++ b/source/services/timeline-manager.ts
@@ -42,6 +42,23 @@ function isProbablyBinary(content: string | Buffer): boolean {
 		: content.includes(0);
 }
 
+/** Write data to a temp file then atomically rename into place. */
+async function atomicWriteFile(filePath: string, data: string): Promise<void> {
+	const tmpPath = `${filePath}.${crypto.randomUUID()}.tmp`;
+	try {
+		await fs.writeFile(tmpPath, data, 'utf-8');
+		await fs.rename(tmpPath, filePath);
+	} catch (error) {
+		// Clean up temp file on failure
+		try {
+			await fs.unlink(tmpPath);
+		} catch {
+			// Ignore cleanup errors
+		}
+		throw error;
+	}
+}
+
 /**
  * Per-session log of before-images captured ahead of mutating tool calls.
  * Stored under `.nanocoder/timeline/<sessionId>/`.
@@ -450,11 +467,9 @@ export class TimelineManager {
 	private async saveIndex(index: TimelineIndex): Promise<void> {
 		this.index = index;
 		await this.ensureDir();
-		await fs.writeFile(
-			this.indexPath(),
-			JSON.stringify(index, null, 2),
-			'utf-8',
-		);
+		// The index is the session's only record of its checkpoints, so a torn
+		// write must never replace a readable index with a truncated one.
+		await atomicWriteFile(this.indexPath(), JSON.stringify(index, null, 2));
 	}
 
 	private assertSafeId(id: string): void {

--- a/source/services/timeline-manager.ts
+++ b/source/services/timeline-manager.ts
@@ -14,6 +14,7 @@ import type {
 	TimelineRevertResult,
 	TimelineScanResult,
 } from '@/types/timeline';
+import {atomicWriteFile} from '@/utils/atomic-write';
 import {formatError} from '@/utils/error-formatter';
 import {logWarning} from '@/utils/message-queue';
 import {FileSnapshotService} from './file-snapshot';
@@ -40,23 +41,6 @@ function isProbablyBinary(content: string | Buffer): boolean {
 	return typeof content === 'string'
 		? content.includes('\u0000')
 		: content.includes(0);
-}
-
-/** Write data to a temp file then atomically rename into place. */
-async function atomicWriteFile(filePath: string, data: string): Promise<void> {
-	const tmpPath = `${filePath}.${crypto.randomUUID()}.tmp`;
-	try {
-		await fs.writeFile(tmpPath, data, 'utf-8');
-		await fs.rename(tmpPath, filePath);
-	} catch (error) {
-		// Clean up temp file on failure
-		try {
-			await fs.unlink(tmpPath);
-		} catch {
-			// Ignore cleanup errors
-		}
-		throw error;
-	}
 }
 
 /**
@@ -467,9 +451,21 @@ export class TimelineManager {
 	private async saveIndex(index: TimelineIndex): Promise<void> {
 		this.index = index;
 		await this.ensureDir();
-		// The index is the session's only record of its checkpoints, so a torn
-		// write must never replace a readable index with a truncated one.
-		await atomicWriteFile(this.indexPath(), JSON.stringify(index, null, 2));
+		try {
+			// The index is the session's only record of its checkpoints, so a
+			// torn write must never replace a readable index with a truncated
+			// one. This covers process death mid-save; rename without fsync
+			// does not cover power loss.
+			await atomicWriteFile(this.indexPath(), JSON.stringify(index, null, 2));
+		} catch (error) {
+			// The rename either never ran or failed before replacing the live
+			// file, so the previous on-disk index is still the source of truth.
+			// Drop the unpersisted cache entry or later reads would report
+			// checkpoints that were never saved.
+			this.index = null;
+			await this.loadIndex();
+			throw error;
+		}
 	}
 
 	private assertSafeId(id: string): void {

--- a/source/utils/atomic-write.spec.ts
+++ b/source/utils/atomic-write.spec.ts
@@ -1,0 +1,80 @@
+import * as path from 'path';
+import test from 'ava';
+import * as fs from 'fs/promises';
+import {atomicWriteFile} from './atomic-write';
+
+async function createTempDir(): Promise<string> {
+	const tempDir = path.join(
+		process.cwd(),
+		'.test-temp',
+		`atomic-write-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	await fs.mkdir(tempDir, {recursive: true});
+	return tempDir;
+}
+
+async function cleanupTempDir(dir: string): Promise<void> {
+	try {
+		await fs.rm(dir, {recursive: true, force: true});
+	} catch {
+		// Ignore cleanup errors
+	}
+}
+
+test.serial('atomicWriteFile writes content via rename', async t => {
+	const tempDir = await createTempDir();
+	try {
+		const filePath = path.join(tempDir, 'out.txt');
+		await atomicWriteFile(filePath, 'hello');
+
+		t.is(await fs.readFile(filePath, 'utf-8'), 'hello');
+		const dirListing = await fs.readdir(tempDir);
+		t.false(dirListing.some(name => name.endsWith('.tmp')));
+	} finally {
+		await cleanupTempDir(tempDir);
+	}
+});
+
+test.serial('atomicWriteFile replaces an existing file atomically', async t => {
+	const tempDir = await createTempDir();
+	try {
+		const filePath = path.join(tempDir, 'out.txt');
+		await fs.writeFile(filePath, 'before', 'utf-8');
+		await atomicWriteFile(filePath, 'after');
+
+		t.is(await fs.readFile(filePath, 'utf-8'), 'after');
+	} finally {
+		await cleanupTempDir(tempDir);
+	}
+});
+
+test.serial('atomicWriteFile honours the requested file mode', async t => {
+	if (process.platform === 'win32') {
+		t.pass('skipped: POSIX file modes are not meaningful on Windows');
+		return;
+	}
+	const tempDir = await createTempDir();
+	try {
+		const filePath = path.join(tempDir, 'restricted.txt');
+		await atomicWriteFile(filePath, 'secret', {mode: 0o600});
+
+		const stats = await fs.stat(filePath);
+		t.is(stats.mode & 0o777, 0o600);
+	} finally {
+		await cleanupTempDir(tempDir);
+	}
+});
+
+test.serial('atomicWriteFile leaves no temp file behind on failure', async t => {
+	const tempDir = await createTempDir();
+	try {
+		// The parent directory does not exist, so the temp write cannot succeed.
+		const filePath = path.join(tempDir, 'missing-dir', 'out.txt');
+		await t.throwsAsync(atomicWriteFile(filePath, 'hello'));
+
+		const dirListing = await fs.readdir(tempDir);
+		t.false(dirListing.some(name => name.endsWith('.tmp')));
+	} finally {
+		await cleanupTempDir(tempDir);
+	}
+});

--- a/source/utils/atomic-write.ts
+++ b/source/utils/atomic-write.ts
@@ -1,5 +1,6 @@
 import {randomUUID} from 'node:crypto';
 import {mkdirSync, renameSync, unlinkSync, writeFileSync} from 'node:fs';
+import {rename, unlink, writeFile} from 'node:fs/promises';
 import {dirname} from 'node:path';
 
 /**
@@ -15,6 +16,31 @@ export function atomicWriteFileSync(filePath: string, data: string): void {
 	} catch (error) {
 		try {
 			unlinkSync(tmpPath);
+		} catch {}
+		throw error;
+	}
+}
+
+/**
+ * Async variant of {@link atomicWriteFileSync}. The optional mode covers call
+ * sites that create permission-restricted files (for example session files).
+ */
+export async function atomicWriteFile(
+	filePath: string,
+	data: string,
+	options?: {mode?: number},
+): Promise<void> {
+	const tmpPath = `${filePath}.${randomUUID()}.tmp`;
+	try {
+		if (options?.mode === undefined) {
+			await writeFile(tmpPath, data, 'utf-8');
+		} else {
+			await writeFile(tmpPath, data, {encoding: 'utf-8', mode: options.mode});
+		}
+		await rename(tmpPath, filePath);
+	} catch (error) {
+		try {
+			await unlink(tmpPath);
 		} catch {}
 		throw error;
 	}


### PR DESCRIPTION
## Description

Closes #1130.

`TimelineManager.saveIndex()` overwrote the live `timeline.json` in place, so a crash mid-save could truncate the index. `loadIndex()` then discards an unparseable index and starts empty, silently losing every checkpoint of the session.

**What changed:**
- Added async `atomicWriteFile(filePath, data, options?: {mode?: number})` to the shared `source/utils/atomic-write.ts` (with spec coverage) and switched `saveIndex()` to it: write to a temp file, rename into place. Readers only ever see the complete old or complete new index
- On a failed save, the unpersisted cache entry is dropped and the index reloaded from disk, so later reads report what was actually persisted
- Temp file is unlinked when the write or rename fails, so no `.tmp` litter

This covers process death mid-save; rename without fsync does not cover power loss (noted in a code comment).

**Not changed on purpose:** before-image files in `capture()` stay non-atomic. They land in a fresh per-entry UUID dir before the index is saved, so a torn write there only leaves an orphan that `pruneStaleSessions` cleans up later. The index is the single point that needed atomicity. Migrating the two remaining private async copies in `session-manager.ts` and `semantic-memory-manager.ts` to the shared util is left as follow-up material.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests

- [x] Bug fix includes passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)

Note: 4 git-tool tests (`git-diff`, `getGitStatusSummarySync`) fail on a clean `main` checkout too. They spawn temp repos and the repo's own commit-msg hook rejects their fixture commits in this environment. Unrelated to this PR.

- [x] Tests cover both success and error scenarios

New tests:
- `timeline-manager.spec.ts`: saves atomically over a read-only live file (the discriminating test, fails on the old implementation), keeps the previous index intact on disk and in memory when a save fails, recovers from a corrupted index
- `atomic-write.spec.ts` (new file): rename-based write, replace-existing, `mode` honored, no `.tmp` left on failure
- The chmod-based tests skip on Windows and as root, where mode bits do not fail writes

### Manual Testing

Verified failure modes via read-only file/directory injection (EACCES) and truncated-JSON corruption. Biome, tsc and knip all clean.

## Checklist

- [ ] If this was for an open issue, I was assigned to it (assignment requested in #1130)
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
