### PR TITLE
fix(nc-review): keep agent paths inside the project directory

### DIFF
--- a/.github/workflows/nc-review.yml
+++ b/.github/workflows/nc-review.yml
@@ -132,8 +132,11 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          mkdir -p /tmp/nc-review
-          OUT=/tmp/nc-review/context.md
+          # Nanocoder's file tools are sandboxed to the project directory, so
+          # anything the AGENT reads or writes must live inside the workspace.
+          # /tmp is fine for the intermediate files only this shell touches.
+          mkdir -p /tmp/nc-review .nc-review
+          OUT=.nc-review/context.md
 
           # Diffs can be enormous. Cap what we feed the model and say so
           # explicitly, so it does not silently review a fraction of a PR and
@@ -254,7 +257,11 @@ jobs:
           # a multi-KB diff through argv round-trips it via sh -c and pnpm's
           # escaping, which has corrupted backslash-heavy payloads in
           # contentforest before it reached the model.
-          PROMPT='Read .github/nc-review/rubric.md for your instructions, CONTRIBUTING.md for the project rules, and /tmp/nc-review/context.md for the pull request under review. Then write your verdict as a single JSON object to /tmp/nc-review/verdict.json, following the schema in the rubric exactly. Write nothing to stdout except a brief note that you have finished.'
+          # All paths are relative to the repo root, because Nanocoder's file
+          # tools refuse anything outside the project directory. An earlier
+          # version pointed at /tmp and the agent correctly refused to invent a
+          # verdict it could not substantiate.
+          PROMPT='Read .github/nc-review/rubric.md for your instructions, CONTRIBUTING.md for the project rules, and .nc-review/context.md for the pull request under review. Then write your verdict as a single JSON object to .nc-review/verdict.json, following the schema in the rubric exactly. All three paths are relative to the current project directory. Write nothing to stdout except a brief note that you have finished.'
 
           set +e
           nanocoder run "$PROMPT" \
@@ -273,7 +280,7 @@ jobs:
           AGENT_STATUS: ${{ steps.agent.outputs.agent_status }}
         run: |
           set -euo pipefail
-          V=/tmp/nc-review/verdict.json
+          V=.nc-review/verdict.json
 
           # A missing or malformed verdict is a failure of this workflow, not of
           # the contributor. Say so plainly and label nothing — a stale

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ benchmarks/.module-*
 # Auto-generated CSS
 plugins/vscode/media/chat-panel.css
 assets/*.vsix
+
+# nc-review scratch: PR context and verdict, written into the workspace
+# because Nanocoder file tools are sandboxed to the project directory.
+.nc-review/


### PR DESCRIPTION
Second run got further than the first: the provider config from #1203 worked, Nanocoder ran, and it exited **0**. But it still produced no verdict.

## Cause

Nanocoder's file tools are sandboxed to the project directory. Both the context file and the verdict path were under `/tmp`, so the agent could neither read the PR context nor write its result.

It worked this out itself, and — worth noting — refused to guess:

> The `/tmp/nc-review/` paths are outside my reachable filesystem [...] Without the PR context, I cannot honestly judge duplicates, scope, tests, changesets, or CONTRIBUTING compliance, and **any verdict I produced would be fabricated. I am not writing a verdict file.**

That is the behaviour we want from a review agent. It failed loudly rather than inventing a plausible review, which is why this showed up as a missing file instead of a confident fake that someone might have acted on.

## Fix

Moves only the two files the **agent** touches into the workspace as `.nc-review/`:

| File | Where | Why |
|---|---|---|
| `context.md` | `.nc-review/` | agent reads it |
| `verdict.json` | `.nc-review/` | agent writes it |
| raw diff, `pr.json`, `open-prs.json`, `comment.md` | `/tmp` | shell-only, agent never sees them |

The prompt now also says explicitly that the paths are project-relative.

`.nc-review/` is gitignored, so a stray commit can never include a dumped diff.