### PR TITLE
feat(nc-review): do a real code review, not just contribution checks

### DIFF
--- a/.github/nc-review/rubric.md
+++ b/.github/nc-review/rubric.md
@@ -2,82 +2,120 @@
 
 You are reviewing a pull request to Nanocoder on behalf of the maintainers.
 
-Your job is to judge the **contribution**, not the code quality. Automated
-checks already gate lint, formatting, types, unused dependencies, unit tests and
-build — six required status checks that must be green before anything merges.
-**Never comment on anything those checks cover.** Saying "consider adding types"
-about a PR that already passes `Type Checks` wastes a human's attention and
-teaches them to ignore you.
+Do a **real code review**. Read the diff properly, read the surrounding source
+to understand what the changed code interacts with, and judge whether the change
+is correct, safe, and well-made. Then also judge the contribution around it —
+duplicates, scope, tests, changeset.
 
-You never merge, never close, and never push. You produce one JSON verdict.
+You never merge, close, or push. You produce one JSON verdict.
+
+## Read the code before judging it
+
+You have `read_file`, `find_files`, `search_file_contents` and `list_directory`,
+and the repository is checked out at the **base** commit. Use them. A diff on its
+own does not tell you whether a change is correct — you need the function it
+sits in, the callers, the types it depends on.
+
+Before writing a finding about a specific line, read the file around it. A
+finding that turns out to be wrong because you did not read the surrounding code
+is worse than no finding: it costs a maintainer time and it teaches them to stop
+reading your reviews.
+
+Note the diff shows changes against base. If the diff is truncated, say so in
+your summary and scope your confidence accordingly.
 
 ## What to judge
 
-Five things, in rough order of how much they matter:
+### 1. Correctness
 
-### 1. Does it duplicate an open pull request?
+Does the code do what it claims? Look for:
 
-The open PR list is provided. Two PRs touching the same files are not
-necessarily duplicates — two PRs *solving the same problem* are. If you find
-one, name its number. This is the single most valuable thing you can catch,
-because it is the thing a human reviewer is least likely to notice across a
-70-PR queue.
+- Logic errors — off-by-one, inverted conditions, wrong operator, wrong variable
+- Unhandled cases — null/undefined, empty collections, zero, negative numbers
+- Error handling — swallowed errors, unchecked returns, `catch` blocks that hide
+  failures, promises without rejection handling
+- Async problems — race conditions, missing `await`, unhandled rejection,
+  concurrent mutation of shared state
+- Resource handling — unclosed handles, listeners never removed, timers never
+  cleared, leaks in the React/Ink component lifecycle
+- State bugs — stale closures, dependency arrays that do not match what the
+  effect reads, mutation of state that should be immutable
 
-Be conservative. A wrong duplicate claim sends a contributor to read an
-unrelated PR, and one false positive costs more trust than three missed
-duplicates.
+### 2. Security
 
-### 2. Has the scope crept beyond the linked issue?
+This is a CLI agent that executes tools, reads and writes files, spawns
+processes, and talks to model providers. Look hard at:
 
-If the PR links an issue, does the diff do what the issue asked, and only that?
-A bug fix that also renames twenty variables is harder to review and harder to
-revert. Flag drive-by refactors mixed into a functional change.
+- Command construction and shell execution — injection via unescaped input
+- Path handling — traversal, symlink following, writes outside the project
+- Anything touching credentials, API keys, tokens, or config files
+- Network calls — URL validation, SSRF, following redirects to internal hosts
+- Deserialization of untrusted data, including model output treated as trusted
+- Prompt injection surfaces where model output reaches a tool call
+- Permission and approval logic — a change that widens what a tool may do
+  without confirmation is significant even if it looks small
 
-If no issue is linked and the change is non-trivial, note it — CONTRIBUTING asks
-contributors to open a PR *referencing the issue*.
+### 3. Design and fit
 
-### 3. Are tests present where CONTRIBUTING requires them?
+- Does it match the architecture described in `CLAUDE.md`? Tools registered in
+  the tool registry, state through `useAppState`, commands in the lazy registry.
+- Does it duplicate something that already exists? Search before concluding.
+- Does it break a public contract — CLI flags, config schema, tool interfaces,
+  the session or `RunRecord` formats?
+- Is the abstraction reasonable for the problem, or does it add layers the
+  change does not need?
+
+### 4. Tests
 
 CONTRIBUTING is explicit: new features **must** include passing tests in
-`.spec.ts` / `.spec.tsx` files, and bug fixes should include regression tests
-where possible. Tests live alongside source (`source/utils/parser.spec.ts`).
+`.spec.ts` / `.spec.tsx`, and bug fixes should include regression tests.
 
-The coverage gate proves that *lines* are covered. It cannot tell you whether a
-new user-facing behaviour has a test that would actually fail if the behaviour
-regressed. That judgement is yours.
+Judge whether the tests that exist actually cover the change — a test that
+imports the new function and asserts nothing meaningful satisfies the coverage
+gate while proving nothing. Ask whether a test would fail if the behaviour
+regressed. If not, say so.
 
 Do not demand tests for docs-only, comment-only or config-only changes.
 
-### 4. Is a changeset present when one is needed?
+### 5. Contribution hygiene
 
-User-facing changes need a changeset. Internal refactors, CI changes, test-only
-changes and documentation do not. If the diff changes behaviour a user would
-notice and there is no `.changeset/*.md`, flag it.
-
-### 5. Does it otherwise follow CONTRIBUTING?
-
-The full text is provided. Judge against what it actually says, not against
-general good practice.
+- **Duplicates.** The open PR list is provided. Two PRs touching the same files
+  are not necessarily duplicates — two PRs *solving the same problem* are. Name
+  the number if you find one. Be conservative: a wrong duplicate claim sends
+  someone to read an unrelated PR, and one false positive costs more trust than
+  three missed duplicates.
+- **Scope.** If an issue is linked, does the diff do what it asked and only
+  that? Flag drive-by refactors mixed into a functional change — they are harder
+  to review and harder to revert.
+- **Changeset.** User-facing changes need one. Internal refactors, CI, tests and
+  docs do not.
 
 ## What NOT to do
 
-- **Do not review code style, formatting, typing, or lint.** Six status checks
-  already do, and they are authoritative.
+- **Do not repeat the mechanical checks.** Six required status checks already
+  run Biome lint, Biome format, `tsc`, knip, the AVA suite and the build. Never
+  file a finding about formatting, import order, unused variables, missing type
+  annotations, or "this does not compile". If those were broken the PR would
+  already be red, and saying it again teaches people to skip your comments.
 - **Do not restate the diff.** The reviewer can read it.
-- **Do not speculate about runtime behaviour you cannot verify.** You have the
-  diff, not a running program.
-- **Do not pad.** A clean PR gets a one-line summary and an empty findings list.
+- **Do not speculate.** If you did not read the code, do not assert a bug in it.
+  Where you are unsure, say so and mark it `advisory` — an honest "worth
+  checking" is useful; a confident wrong claim is not.
+- **Do not pad.** A clean PR gets a short summary and an empty findings list.
   That is a good outcome, not a failure to find something.
-- **Do not moralise about contribution quality.** Many contributors here are
-  new. Findings should be specific and actionable, never a verdict on a person.
+- **Do not moralise.** Many contributors here are new. Findings are about the
+  code, never about the person.
 
 ## Severity
 
-- `blocking` — a maintainer should not merge until this is resolved. Duplicates,
-  missing tests on a new feature, significant scope creep.
-- `advisory` — worth mentioning; a maintainer may merge anyway.
+- `blocking` — a maintainer should not merge until this is resolved. Correctness
+  bugs, security problems, broken contracts, duplicates, a new feature with no
+  meaningful test.
+- `advisory` — worth raising; a maintainer may reasonably merge anyway. Style of
+  approach, minor edge cases, suggestions, anything you are less than confident
+  about.
 
-If you have no `blocking` findings, the verdict is `clean`.
+If nothing is `blocking`, the verdict is `clean`.
 
 ## Output
 
@@ -87,12 +125,14 @@ before or after, no markdown fences. Schema:
 ```json
 {
   "verdict": "clean",
-  "summary": "One or two sentences. What this PR does and whether it is ready.",
+  "summary": "Two or three sentences. What the change does, whether it is correct, and whether it is ready.",
   "findings": [
     {
-      "area": "tests",
+      "area": "correctness",
       "severity": "blocking",
-      "detail": "Specific, actionable. Reference files and line ranges where useful."
+      "file": "source/tools/execute-bash.ts",
+      "line": 142,
+      "detail": "Specific and actionable. What is wrong, why it matters, and what would fix it."
     }
   ],
   "duplicate_of": null
@@ -101,6 +141,8 @@ before or after, no markdown fences. Schema:
 
 - `verdict` — `"clean"` or `"needs-work"`. `needs-work` if and only if at least
   one finding is `blocking`.
-- `area` — one of `duplicate`, `scope`, `tests`, `changeset`, `contributing`.
-- `duplicate_of` — the PR number as an integer, or `null`. Only set this when
-  you are confident.
+- `area` — one of `correctness`, `security`, `design`, `tests`, `duplicate`,
+  `scope`, `changeset`, `contributing`.
+- `file` / `line` — where the finding is. Omit both if it is not tied to a
+  specific location. Never guess a line number; omit it instead.
+- `duplicate_of` — PR number as an integer, or `null`. Only when confident.

--- a/.github/workflows/nc-review.yml
+++ b/.github/workflows/nc-review.yml
@@ -1,11 +1,17 @@
 name: nc-review
 
-# Headless Nanocoder reviewing the *contribution* — duplicates, scope creep,
-# missing tests, missing changesets, CONTRIBUTING adherence. The six required
-# status checks judge the code; this judges everything they cannot see.
+# Headless Nanocoder doing a full code review: correctness, security, design and
+# test adequacy, plus contribution checks (duplicates, scope, changeset).
+#
+# The six required status checks are NOT a code review. They cover lint,
+# formatting, types, unused dependencies, whether the existing tests pass, and
+# whether it builds. None of that catches a logic error, a race condition, a
+# missing auth check or an unhandled error path — and "the tests pass" says
+# nothing about the tests that should exist but do not. That gap is this
+# workflow's job.
 #
 # It never merges, never closes, never pushes. It writes one comment and applies
-# one label.
+# one label. A human still decides.
 #
 # ---------------------------------------------------------------------------
 # SECURITY: why pull_request_target, and why that is safe here
@@ -76,7 +82,7 @@ jobs:
       || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Resolve PR number
@@ -261,7 +267,7 @@ jobs:
           # tools refuse anything outside the project directory. An earlier
           # version pointed at /tmp and the agent correctly refused to invent a
           # verdict it could not substantiate.
-          PROMPT='Read .github/nc-review/rubric.md for your instructions, CONTRIBUTING.md for the project rules, and .nc-review/context.md for the pull request under review. Then write your verdict as a single JSON object to .nc-review/verdict.json, following the schema in the rubric exactly. All three paths are relative to the current project directory. Write nothing to stdout except a brief note that you have finished.'
+          PROMPT='Read .github/nc-review/rubric.md for your instructions, CONTRIBUTING.md for the project rules, CLAUDE.md for the architecture, and .nc-review/context.md for the pull request under review. This is a real code review: use read_file and search_file_contents to read the source around every changed area before judging it, and do not assert a bug in code you have not read. Then write your verdict as a single JSON object to .nc-review/verdict.json, following the schema in the rubric exactly. All paths are relative to the current project directory. Write nothing to stdout except a brief note that you have finished.'
 
           set +e
           nanocoder run "$PROMPT" \
@@ -310,14 +316,18 @@ jobs:
               echo
             fi
             if [ "$(jq '.findings | length' "$V")" -gt 0 ]; then
-              echo "| | Area | Finding |"
-              echo "|---|---|---|"
-              jq -r '.findings[] | "| \(if .severity == "blocking" then "🔴" else "🟡" end) | `\(.area)` | \(.detail | gsub("\n"; " ")) |"' "$V"
+              echo "| | Area | Where | Finding |"
+              echo "|---|---|---|---|"
+              jq -r '.findings[] |
+                "| \(if .severity == "blocking" then "🔴" else "🟡" end)"
+                + " | `\(.area)`"
+                + " | \(if .file then "`\(.file)\(if .line then ":\(.line)" else "" end)`" else "—" end)"
+                + " | \(.detail | gsub("\n"; " ")) |"' "$V"
               echo
             fi
             echo "---"
             echo
-            echo "<sub>Automated review of the *contribution* — duplicates, scope, tests, changesets, CONTRIBUTING. Code quality is covered by the required status checks. This bot never merges. Maintainers can rerun with \`/re-review\`.</sub>"
+            echo "<sub>Automated code review — correctness, security, design, tests, plus duplicates and scope. Advisory: a human still decides. Not a substitute for review, and not exhaustive. The required status checks separately cover lint, formatting, types, unused dependencies, the test suite and the build. This bot never merges. Maintainers can rerun with \`/re-review\`.</sub>"
           } > /tmp/nc-review/comment.md
 
           gh pr comment "$PR" --repo "$REPO" --body-file /tmp/nc-review/comment.md


### PR DESCRIPTION
The first version reviewed contribution hygiene only — duplicates, scope, tests, changesets — and told every contributor this in its footer:

> Code quality is covered by the required status checks.

**That is false**, and it should not have shipped.

## What the status checks actually cover

Biome lint, Biome format, `tsc`, knip, whether the existing AVA suite passes, and whether it builds.

None of that catches a logic error, an inverted condition, a race condition, a missing auth check, a resource leak, or an unhandled error path. And "the tests pass" says nothing about the tests that *should* exist and do not — the coverage gate proves lines are executed, not that a regression would fail anything.

## It also made the Copilot swap a downgrade

Q7 has `nc-review` replacing Copilot review. Copilot reads the code. Shipping a bot that checks changesets and then turning Copilot off would have been a straight loss of review coverage — which is the opposite of the point.

## What changed

The rubric now leads with the things that actually matter:

1. **Correctness** — logic errors, unhandled cases, error handling, async and race conditions, resource lifecycle, stale closures and effect dependencies
2. **Security** — command injection, path traversal, credential handling, SSRF, untrusted deserialization, prompt-injection surfaces, and any change that widens what a tool may do without confirmation
3. **Design and fit** — does it match the architecture in `CLAUDE.md`, does it duplicate something, does it break a public contract
4. **Tests** — not "is there a `.spec.ts`" but "would this test fail if the behaviour regressed"
5. **Contribution hygiene** — duplicates, scope, changeset, as before

It is explicitly told to **read the surrounding source before asserting a bug**. The repo is checked out at base, and the agent has `read_file`, `search_file_contents`, `find_files` and `list_directory`, so a diff-only judgement is not an excuse. A confidently wrong finding costs more than a missed one — it burns a maintainer's time and teaches them to stop reading.

It still must not repeat the mechanical checks. A finding about import order when `Linting` is already green is noise.

## Other changes

- Findings now carry `file` and `line`, rendered as a location column
- Footer rewritten and honest: advisory, not exhaustive, human still decides
- Timeout 20 → 30 minutes, since reading source costs tool calls

## Still unproven

The deeper rubric has not been run yet. Worth watching for two failure modes specifically:

- **Confident wrong findings** — the reason the "read it first" instruction is stated twice
- **Reverting to lint commentary** — the instruction models most often drift from
