### PR TITLE
fix(nc-review): lock down git tools, stop the base-checkout loop

### DIFF
--- a/.github/nc-review/rubric.md
+++ b/.github/nc-review/rubric.md
@@ -11,18 +11,30 @@ You never merge, close, or push. You produce one JSON verdict.
 
 ## Read the code before judging it
 
-You have `read_file`, `find_files`, `search_file_contents` and `list_directory`,
-and the repository is checked out at the **base** commit. Use them. A diff on its
-own does not tell you whether a change is correct — you need the function it
-sits in, the callers, the types it depends on.
+You have exactly five tools: `read_file`, `find_files`, `search_file_contents`,
+`list_directory` and `write_file`. There is no shell and no git tooling — that is
+deliberate, not an oversight. Do not go looking for them.
 
-Before writing a finding about a specific line, read the file around it. A
+**The working directory is checked out at the BASE commit, not at the pull
+request.** This matters more than anything else on this page:
+
+- Files the PR **adds** are not on disk. Their absence is not a finding.
+- Files the PR **modifies** are on disk in their **pre-change** form.
+- **The diff is the authoritative record of what changed.** Read files on disk
+  only for surrounding context: the function a hunk sits in, its callers, the
+  types it depends on.
+
+So the loop is: read the diff to see what changed, then read the base files
+around it to understand whether that change is correct.
+
+Before writing a finding about a specific line, read the code around it. A
 finding that turns out to be wrong because you did not read the surrounding code
 is worse than no finding: it costs a maintainer time and it teaches them to stop
 reading your reviews.
 
-Note the diff shows changes against base. If the diff is truncated, say so in
-your summary and scope your confidence accordingly.
+If the diff is truncated, or something is genuinely not determinable from what
+you have been given, say so in your summary and scope your confidence
+accordingly. Saying "I could not verify X" is a good review. Guessing is not.
 
 ## What to judge
 

--- a/.github/workflows/nc-review.yml
+++ b/.github/workflows/nc-review.yml
@@ -108,9 +108,18 @@ jobs:
           esac
 
       # No `ref:` — this is the BASE branch. See the security note above.
+      #
+      # persist-credentials: false matters here. The default writes the
+      # GITHUB_TOKEN into .git/config as an http.extraheader, which would make
+      # the token reachable by anything operating on the repo — including a
+      # model driving git tooling with an untrusted diff in its context. Nothing
+      # downstream needs the stored credential: the gh calls carry GH_TOKEN in
+      # their own env.
       - name: Checkout base repository
         # pin: actions/checkout@v4.3.1
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       # pin: pnpm/action-setup@v4
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
@@ -173,6 +182,24 @@ jobs:
             echo "Repository: $REPO"
             echo "PR number: #$PR"
             echo
+            echo "## How to read this — important"
+            echo
+            echo "The working directory is checked out at the **base** commit, NOT at this"
+            echo "pull request. That means:"
+            echo
+            echo "- Files this PR **adds** do not exist on disk. Do not go looking for them,"
+            echo "  and do not treat their absence as a finding. The changeset file is the"
+            echo "  usual one people trip on."
+            echo "- Files this PR **modifies** are on disk in their **pre-change** form."
+            echo "- **The diff below is the authoritative record of what this PR changes.**"
+            echo "  Read it for the change itself; read files on disk only for surrounding"
+            echo "  context — the function a hunk sits in, its callers, the types it uses."
+            echo
+            echo "You have no git tooling and no shell. You do not need them: the diff, the"
+            echo "changed-file list and the open-PR list are all supplied below. If something"
+            echo "is genuinely not determinable from what is here, say so in your summary"
+            echo "rather than guessing or hunting for it."
+            echo
             echo "## Metadata"
             echo '```json'
             jq '{number, title, author: .author.login, headRefName,
@@ -217,10 +244,28 @@ jobs:
       #
       # disabledTools is a security control, not tidiness. The PR diff is
       # untrusted text written by the contributor, and it is fed to a model
-      # running in `yolo` mode with MINIMAX_API_KEY in the environment. A
-      # prompt injection in a diff that could reach `execute_bash` or
-      # `fetch_url` would be able to exfiltrate that key. The review task needs
-      # to read files and write one JSON verdict — nothing more.
+      # running in `yolo` mode. Treat the tool list as an allowlist expressed by
+      # subtraction: the review task needs to READ files and write ONE JSON
+      # verdict. Everything else is off.
+      #
+      #   execute_bash, fetch_url   exfiltration paths for MINIMAX_API_KEY
+      #   git_push, git_commit,
+      #   git_add, git_reset, ...   repository mutation. These are the reason
+      #                             persist-credentials is false above: with the
+      #                             default checkout the token sits in
+      #                             .git/config and git_push would carry it.
+      #   string_replace, diff_edit,
+      #   file_op                   the reviewer has no business editing code
+      #   agent                     subagent spawning, unnecessary here
+      #   ask_user                  would hang a CI run
+      #   git_diff, git_log,
+      #   git_status, git_pr        redundant — the diff and PR metadata are
+      #                             supplied in context.md, and reaching for
+      #                             these sent the model into a repeated-call
+      #                             loop that tripped maxRepeatedToolCalls.
+      #
+      # Remaining: read_file, write_file, find_files, list_directory,
+      # search_file_contents.
       - name: Configure Nanocoder provider
         run: |
           set -euo pipefail
@@ -233,7 +278,21 @@ jobs:
                 "agent",
                 "ask_user",
                 "string_replace",
-                "diff_edit"
+                "diff_edit",
+                "file_op",
+                "write_plan",
+                "write_walkthrough",
+                "git_add",
+                "git_branch",
+                "git_commit",
+                "git_diff",
+                "git_log",
+                "git_pr",
+                "git_pull",
+                "git_push",
+                "git_reset",
+                "git_stash",
+                "git_status"
               ],
               "providers": [
                 {


### PR DESCRIPTION
Run 4 — the first with the deeper rubric from #1205 — failed. The agent read its instructions, went looking for the PR's changed files on disk, could not find them, reached for `git_status` / `git_log` / `git_pr`, and repeated until Nanocoder's `maxRepeatedToolCalls` guard stopped it.

Chasing that turned up something more serious than the loop.

## 1. The git tools were never disabled — including `git_push`

#1203 disabled `execute_bash` and `fetch_url` on the reasoning that they were the exfiltration paths. That list was incomplete. Nanocoder also ships:

```
git_add  git_branch  git_commit  git_diff  git_log
git_pr   git_pull    git_push    git_reset git_stash  git_status
```

And `actions/checkout` defaults to `persist-credentials: true`, which writes `GITHUB_TOKEN` into `.git/config` as an `http.extraheader`.

So: a model running in `yolo` mode, with an **untrusted contributor diff in its context**, had `git_push` available and a credential sitting in the repo config for it to use. Nothing exploited this — the loop guard happened to stop the run — but the path existed and it was my omission in #1202/#1203.

Fixed two ways, independently:

- `persist-credentials: false` on checkout. Nothing downstream needs the stored credential; the `gh` calls carry `GH_TOKEN` in their own step env.
- Every git tool disabled, plus `file_op`, `write_plan` and `write_walkthrough`.

**Five tools remain:** `read_file`, `write_file`, `find_files`, `list_directory`, `search_file_contents`. Read the code, write one verdict. The workflow now documents the list as an allowlist expressed by subtraction, with a reason per group.

## 2. The agent was never told the checkout is at base

This is what actually caused the loop, and it is a flaw in how I framed the task rather than a model failure.

The workspace is checked out at the **base** commit. Files the PR *adds* are not on disk; files it *modifies* are in pre-change form. So hunting for "the changed file" is futile by construction — and the agent's log shows it working this out and then trying to route around it:

> The changeset file doesn't exist yet (it's part of the diff to be added). Let me check the diff via git and start reading the changed source files.

Both `context.md` and the rubric now state up front:

- files the PR adds are **not on disk**, and their absence is not a finding
- files it modifies are **pre-change**
- **the diff is the authoritative record of what changed**; files on disk are for surrounding context — the enclosing function, the callers, the types

The rubric also now says plainly that there is no shell and no git tooling, so the model stops looking for them, and that *"I could not verify X"* is a better review than a guess.

## Verified

- YAML parses
- Enumerated all 25 Nanocoder tools against the disabled list: exactly the intended five remain, nothing unexpected allowed
- `persist-credentials: false` present on the checkout step
