### PR TITLE
fix(custom-commands): safely handle unreadable directories during scan

### DIFF
--- a/.changeset/fix-custom-commands-unreadable-dir.md
+++ b/.changeset/fix-custom-commands-unreadable-dir.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fixed an issue in `CustomCommandLoader` where encountering an unreadable subdirectory or inaccessible file in custom command directories aborted the entire scan. `scanDirectory` and `loadResources` now catch filesystem permission and inspection errors, log a warning, and continue scanning remaining commands.

--- a/source/custom-commands/loader.spec.ts
+++ b/source/custom-commands/loader.spec.ts
@@ -1,8 +1,8 @@
-import { writeFileSync, rmSync, existsSync, mkdirSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import fs, {existsSync, mkdirSync, rmSync, writeFileSync} from 'fs';
+import {tmpdir} from 'os';
+import {join} from 'path';
 import test from 'ava';
-import { CustomCommandLoader } from './loader';
+import {CustomCommandLoader} from './loader';
 
 // Helper to create a valid custom command file
 function createCommandFile(path: string, content: string) {
@@ -598,3 +598,77 @@ test('CustomCommandLoader - commands have lastModified set', t => {
 	t.true(command!.lastModified instanceof Date);
 });
 
+test.serial(
+	'CustomCommandLoader - continues loading commands when a subdirectory throws permission error',
+	t => {
+		const testDir = createTestDir('permission-error');
+		t.teardown(() => cleanupTestDir(testDir));
+
+		const commandsDir = join(testDir, '.nanocoder', 'commands');
+		const unreadableSubDir = join(commandsDir, 'unreadable');
+		mkdirSync(unreadableSubDir, {recursive: true});
+
+		createCommandFile(join(commandsDir, 'root-cmd.md'), 'Root command');
+		createCommandFile(join(unreadableSubDir, 'hidden.md'), 'Hidden command');
+
+		const originalReaddirSync = fs.readdirSync;
+		(fs as any).readdirSync = ((path: any, options: any) => {
+			if (String(path).includes('unreadable')) {
+				const err: any = new Error('EACCES: permission denied, scandir');
+				err.code = 'EACCES';
+				throw err;
+			}
+			return originalReaddirSync(path, options);
+		}) as typeof fs.readdirSync;
+
+		t.teardown(() => {
+			fs.readdirSync = originalReaddirSync;
+		});
+
+		const loader = new CustomCommandLoader(testDir);
+		t.notThrows(() => loader.loadCommands());
+
+		const commands = loader.getAllCommands();
+		t.is(commands.length, 1);
+		t.is(commands[0]?.name, 'root-cmd');
+	},
+);
+
+test.serial(
+	'CustomCommandLoader - continues scanning when statSync throws on an unreadable entry',
+	t => {
+		const testDir = createTestDir('stat-error');
+		t.teardown(() => cleanupTestDir(testDir));
+
+		const commandsDir = join(testDir, '.nanocoder', 'commands');
+		mkdirSync(commandsDir, {recursive: true});
+
+		createCommandFile(join(commandsDir, 'valid-cmd.md'), 'Valid command');
+		writeFileSync(
+			join(commandsDir, 'corrupted.md'),
+			'Corrupted file',
+			'utf-8',
+		);
+
+		const originalStatSync = fs.statSync;
+		(fs as any).statSync = ((path: any, options: any) => {
+			if (String(path).includes('corrupted')) {
+				const err: any = new Error('EACCES: permission denied, stat');
+				err.code = 'EACCES';
+				throw err;
+			}
+			return originalStatSync(path, options);
+		}) as typeof fs.statSync;
+
+		t.teardown(() => {
+			fs.statSync = originalStatSync;
+		});
+
+		const loader = new CustomCommandLoader(testDir);
+		t.notThrows(() => loader.loadCommands());
+
+		const commands = loader.getAllCommands();
+		t.is(commands.length, 1);
+		t.is(commands[0]?.name, 'valid-cmd');
+	},
+);

--- a/source/custom-commands/loader.spec.ts
+++ b/source/custom-commands/loader.spec.ts
@@ -1,8 +1,35 @@
-import fs, {existsSync, mkdirSync, rmSync, writeFileSync} from 'fs';
-import {tmpdir} from 'os';
-import {join} from 'path';
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import test from 'ava';
 import {CustomCommandLoader} from './loader';
+
+let configDir: string;
+let originalConfigDir: string | undefined;
+
+test.before(() => {
+	originalConfigDir = process.env.NANOCODER_CONFIG_DIR;
+	configDir = join(tmpdir(), `nanocoder-cmd-config-${Date.now()}`);
+	mkdirSync(configDir, {recursive: true});
+	process.env.NANOCODER_CONFIG_DIR = configDir;
+});
+
+test.after.always(() => {
+	if (originalConfigDir !== undefined) {
+		process.env.NANOCODER_CONFIG_DIR = originalConfigDir;
+	} else {
+		delete process.env.NANOCODER_CONFIG_DIR;
+	}
+	if (configDir && existsSync(configDir)) {
+		rmSync(configDir, {recursive: true, force: true});
+	}
+});
 
 // Helper to create a valid custom command file
 function createCommandFile(path: string, content: string) {
@@ -598,12 +625,17 @@ test('CustomCommandLoader - commands have lastModified set', t => {
 	t.true(command!.lastModified instanceof Date);
 });
 
-test.serial(
+test(
 	'CustomCommandLoader - continues loading commands when a subdirectory throws permission error',
 	t => {
-		const testDir = createTestDir('permission-error');
-		t.teardown(() => cleanupTestDir(testDir));
+		if (process.platform === 'win32' || process.getuid?.() === 0) {
+			t.pass(
+				'Skipping on Windows/root where chmod 000 does not block directory access',
+			);
+			return;
+		}
 
+		const testDir = createTestDir('permission-error');
 		const commandsDir = join(testDir, '.nanocoder', 'commands');
 		const unreadableSubDir = join(commandsDir, 'unreadable');
 		mkdirSync(unreadableSubDir, {recursive: true});
@@ -611,18 +643,15 @@ test.serial(
 		createCommandFile(join(commandsDir, 'root-cmd.md'), 'Root command');
 		createCommandFile(join(unreadableSubDir, 'hidden.md'), 'Hidden command');
 
-		const originalReaddirSync = fs.readdirSync;
-		(fs as any).readdirSync = ((path: any, options: any) => {
-			if (String(path).includes('unreadable')) {
-				const err: any = new Error('EACCES: permission denied, scandir');
-				err.code = 'EACCES';
-				throw err;
-			}
-			return originalReaddirSync(path, options);
-		}) as typeof fs.readdirSync;
+		chmodSync(unreadableSubDir, 0o000);
 
 		t.teardown(() => {
-			fs.readdirSync = originalReaddirSync;
+			try {
+				chmodSync(unreadableSubDir, 0o755);
+			} catch {
+				// ignore
+			}
+			cleanupTestDir(testDir);
 		});
 
 		const loader = new CustomCommandLoader(testDir);
@@ -634,34 +663,34 @@ test.serial(
 	},
 );
 
-test.serial(
+test(
 	'CustomCommandLoader - continues scanning when statSync throws on an unreadable entry',
 	t => {
-		const testDir = createTestDir('stat-error');
-		t.teardown(() => cleanupTestDir(testDir));
+		if (process.platform === 'win32' || process.getuid?.() === 0) {
+			t.pass(
+				'Skipping on Windows/root where chmod 000 does not block directory access',
+			);
+			return;
+		}
 
+		const testDir = createTestDir('stat-error');
 		const commandsDir = join(testDir, '.nanocoder', 'commands');
-		mkdirSync(commandsDir, {recursive: true});
+		const unsearchableDir = join(commandsDir, 'unsearchable');
+		mkdirSync(unsearchableDir, {recursive: true});
 
 		createCommandFile(join(commandsDir, 'valid-cmd.md'), 'Valid command');
-		writeFileSync(
-			join(commandsDir, 'corrupted.md'),
-			'Corrupted file',
-			'utf-8',
-		);
+		createCommandFile(join(unsearchableDir, 'child.md'), 'Child command');
 
-		const originalStatSync = fs.statSync;
-		(fs as any).statSync = ((path: any, options: any) => {
-			if (String(path).includes('corrupted')) {
-				const err: any = new Error('EACCES: permission denied, stat');
-				err.code = 'EACCES';
-				throw err;
-			}
-			return originalStatSync(path, options);
-		}) as typeof fs.statSync;
+		// 0o400 allows readdir on unsearchableDir, but statSync on unsearchableDir/child.md fails with EACCES
+		chmodSync(unsearchableDir, 0o400);
 
 		t.teardown(() => {
-			fs.statSync = originalStatSync;
+			try {
+				chmodSync(unsearchableDir, 0o755);
+			} catch {
+				// ignore
+			}
+			cleanupTestDir(testDir);
 		});
 
 		const loader = new CustomCommandLoader(testDir);
@@ -670,57 +699,6 @@ test.serial(
 		const commands = loader.getAllCommands();
 		t.is(commands.length, 1);
 		t.is(commands[0]?.name, 'valid-cmd');
-	},
-);
-
-test.serial(
-	'CustomCommandLoader - loadResources continues loading remaining resources when statSync throws',
-	t => {
-		const testDir = createTestDir('resource-stat-error');
-		t.teardown(() => cleanupTestDir(testDir));
-
-		const commandsDir = join(testDir, '.nanocoder', 'commands');
-		const mySkillDir = join(commandsDir, 'my-skill');
-		const resourcesDir = join(mySkillDir, 'resources');
-		mkdirSync(resourcesDir, {recursive: true});
-
-		writeFileSync(
-			join(mySkillDir, 'my-skill.md'),
-			`---
-description: Skill with resources
----
-Do stuff.`,
-			'utf-8',
-		);
-		writeFileSync(
-			join(resourcesDir, 'valid.sh'),
-			'#!/bin/bash\necho hi',
-			'utf-8',
-		);
-		writeFileSync(join(resourcesDir, 'inaccessible.sh'), 'bad', 'utf-8');
-
-		const originalStatSync = fs.statSync;
-		(fs as any).statSync = ((path: any, options: any) => {
-			if (String(path).includes('inaccessible')) {
-				const err: any = new Error('EACCES: permission denied, stat');
-				err.code = 'EACCES';
-				throw err;
-			}
-			return originalStatSync(path, options);
-		}) as typeof fs.statSync;
-
-		t.teardown(() => {
-			fs.statSync = originalStatSync;
-		});
-
-		const loader = new CustomCommandLoader(testDir);
-		t.notThrows(() => loader.loadCommands());
-
-		const command = loader.getCommand('my-skill');
-		t.truthy(command);
-		t.truthy(command?.loadedResources);
-		t.is(command?.loadedResources?.length, 1);
-		t.is(command?.loadedResources?.[0]?.name, 'valid.sh');
 	},
 );
 

--- a/source/custom-commands/loader.spec.ts
+++ b/source/custom-commands/loader.spec.ts
@@ -672,3 +672,55 @@ test.serial(
 		t.is(commands[0]?.name, 'valid-cmd');
 	},
 );
+
+test.serial(
+	'CustomCommandLoader - loadResources continues loading remaining resources when statSync throws',
+	t => {
+		const testDir = createTestDir('resource-stat-error');
+		t.teardown(() => cleanupTestDir(testDir));
+
+		const commandsDir = join(testDir, '.nanocoder', 'commands');
+		const mySkillDir = join(commandsDir, 'my-skill');
+		const resourcesDir = join(mySkillDir, 'resources');
+		mkdirSync(resourcesDir, {recursive: true});
+
+		writeFileSync(
+			join(mySkillDir, 'my-skill.md'),
+			`---
+description: Skill with resources
+---
+Do stuff.`,
+			'utf-8',
+		);
+		writeFileSync(
+			join(resourcesDir, 'valid.sh'),
+			'#!/bin/bash\necho hi',
+			'utf-8',
+		);
+		writeFileSync(join(resourcesDir, 'inaccessible.sh'), 'bad', 'utf-8');
+
+		const originalStatSync = fs.statSync;
+		(fs as any).statSync = ((path: any, options: any) => {
+			if (String(path).includes('inaccessible')) {
+				const err: any = new Error('EACCES: permission denied, stat');
+				err.code = 'EACCES';
+				throw err;
+			}
+			return originalStatSync(path, options);
+		}) as typeof fs.statSync;
+
+		t.teardown(() => {
+			fs.statSync = originalStatSync;
+		});
+
+		const loader = new CustomCommandLoader(testDir);
+		t.notThrows(() => loader.loadCommands());
+
+		const command = loader.getCommand('my-skill');
+		t.truthy(command);
+		t.truthy(command?.loadedResources);
+		t.is(command?.loadedResources?.length, 1);
+		t.is(command?.loadedResources?.[0]?.name, 'valid.sh');
+	},
+);
+

--- a/source/custom-commands/loader.ts
+++ b/source/custom-commands/loader.ts
@@ -1,5 +1,5 @@
-import fs, {existsSync} from 'fs';
-import {basename, join} from 'path';
+import {existsSync, readdirSync, statSync} from 'node:fs';
+import {basename, join} from 'node:path';
 import {getConfigPath} from '@/config/paths';
 import {parseCommandFile} from '@/custom-commands/parser';
 import type {CommandResource, CustomCommand} from '@/types/index';
@@ -61,20 +61,21 @@ export class CustomCommandLoader {
 	): void {
 		let entries: string[];
 		try {
-			entries = fs.readdirSync(dir);
+			entries = readdirSync(dir);
 		} catch (error) {
 			logWarning(`Failed to read command directory ${dir}: ${String(error)}`);
 			return;
 		}
 
+		let failedEntries = 0;
 		for (const entry of entries) {
 			if (!isSafeEntry(entry)) continue;
 			const fullPath = join(dir, entry); // nosemgrep
-			let stat;
+			let stat: ReturnType<typeof statSync>;
 			try {
-				stat = fs.statSync(fullPath);
-			} catch (error) {
-				logWarning(`Failed to inspect file ${fullPath}: ${String(error)}`);
+				stat = statSync(fullPath);
+			} catch {
+				failedEntries++;
 				continue;
 			}
 
@@ -93,6 +94,12 @@ export class CustomCommandLoader {
 				// Parse and register command
 				this.loadCommand(fullPath, namespace, source);
 			}
+		}
+
+		if (failedEntries > 0) {
+			logWarning(
+				`Failed to inspect ${failedEntries} file(s) in command directory ${dir}`,
+			);
 		}
 	}
 
@@ -120,7 +127,7 @@ export class CustomCommandLoader {
 			// Get file modification time
 			let lastModified: Date | undefined;
 			try {
-				const st = fs.statSync(filePath);
+				const st = statSync(filePath);
 				lastModified = st.mtime;
 			} catch {
 				// ignore
@@ -170,7 +177,7 @@ export class CustomCommandLoader {
 
 		let entries: string[];
 		try {
-			entries = fs.readdirSync(resourcesDir);
+			entries = readdirSync(resourcesDir);
 		} catch (error) {
 			logWarning(
 				`Failed to read resources directory ${resourcesDir}: ${String(error)}`,
@@ -180,16 +187,15 @@ export class CustomCommandLoader {
 
 		const resources: CommandResource[] = [];
 
+		let failedResources = 0;
 		for (const entry of entries) {
 			if (!isSafeEntry(entry)) continue;
 			const resourcePath = join(resourcesDir, entry); // nosemgrep
 			let st: {mode: number; isFile: () => boolean};
 			try {
-				st = fs.statSync(resourcePath);
-			} catch (error) {
-				logWarning(
-					`Failed to inspect resource ${resourcePath}: ${String(error)}`,
-				);
+				st = statSync(resourcePath);
+			} catch {
+				failedResources++;
 				continue;
 			}
 			if (!st.isFile()) continue;
@@ -211,6 +217,12 @@ export class CustomCommandLoader {
 				type,
 				executable: executable || undefined,
 			});
+		}
+
+		if (failedResources > 0) {
+			logWarning(
+				`Failed to inspect ${failedResources} resource(s) in directory ${resourcesDir}`,
+			);
 		}
 
 		return resources;

--- a/source/custom-commands/loader.ts
+++ b/source/custom-commands/loader.ts
@@ -1,9 +1,9 @@
-import {existsSync, readdirSync, statSync} from 'fs';
+import fs, {existsSync} from 'fs';
 import {basename, join} from 'path';
 import {getConfigPath} from '@/config/paths';
 import {parseCommandFile} from '@/custom-commands/parser';
 import type {CommandResource, CustomCommand} from '@/types/index';
-import {logError} from '@/utils/message-queue';
+import {logError, logWarning} from '@/utils/message-queue';
 
 const RESOURCES_DIR = 'resources';
 const RELEVANCE_THRESHOLD = 5;
@@ -59,12 +59,24 @@ export class CustomCommandLoader {
 		namespace?: string,
 		source?: 'personal' | 'project',
 	): void {
-		const entries = readdirSync(dir);
+		let entries: string[];
+		try {
+			entries = fs.readdirSync(dir);
+		} catch (error) {
+			logWarning(`Failed to read command directory ${dir}: ${String(error)}`);
+			return;
+		}
 
 		for (const entry of entries) {
 			if (!isSafeEntry(entry)) continue;
 			const fullPath = join(dir, entry); // nosemgrep
-			const stat = statSync(fullPath);
+			let stat;
+			try {
+				stat = fs.statSync(fullPath);
+			} catch (error) {
+				logWarning(`Failed to inspect file ${fullPath}: ${String(error)}`);
+				continue;
+			}
 
 			if (stat.isDirectory()) {
 				// Check if this is a directory-as-command pattern:
@@ -108,7 +120,7 @@ export class CustomCommandLoader {
 			// Get file modification time
 			let lastModified: Date | undefined;
 			try {
-				const st = statSync(filePath);
+				const st = fs.statSync(filePath);
 				lastModified = st.mtime;
 			} catch {
 				// ignore
@@ -156,7 +168,16 @@ export class CustomCommandLoader {
 			return [];
 		}
 
-		const entries = readdirSync(resourcesDir);
+		let entries: string[];
+		try {
+			entries = fs.readdirSync(resourcesDir);
+		} catch (error) {
+			logWarning(
+				`Failed to read resources directory ${resourcesDir}: ${String(error)}`,
+			);
+			return [];
+		}
+
 		const resources: CommandResource[] = [];
 
 		for (const entry of entries) {
@@ -164,7 +185,7 @@ export class CustomCommandLoader {
 			const resourcePath = join(resourcesDir, entry); // nosemgrep
 			let st: {mode: number; isFile: () => boolean};
 			try {
-				st = statSync(resourcePath);
+				st = fs.statSync(resourcePath);
 			} catch {
 				continue;
 			}

--- a/source/custom-commands/loader.ts
+++ b/source/custom-commands/loader.ts
@@ -186,7 +186,10 @@ export class CustomCommandLoader {
 			let st: {mode: number; isFile: () => boolean};
 			try {
 				st = fs.statSync(resourcePath);
-			} catch {
+			} catch (error) {
+				logWarning(
+					`Failed to inspect resource ${resourcePath}: ${String(error)}`,
+				);
 				continue;
 			}
 			if (!st.isFile()) continue;


### PR DESCRIPTION
## Description

Fixes #1142

In `CustomCommandLoader.scanDirectory`, directory traversal and file inspection used `readdirSync` and `statSync` unguarded. If a subdirectory (e.g. a namespaced folder inside `.nanocoder/commands/`) or file had restricted read permissions, Node.js threw an unhandled exception (such as `EACCES`). This caused the entire scan to abort prematurely and prevented any remaining valid custom commands in the project from being loaded.

This PR:
- Wraps `fs.readdirSync` and `fs.statSync` in `try...catch` within `scanDirectory` and `loadResources`.
- Logs a warning using `logWarning` when a directory or file cannot be read/inspected and continues scanning remaining directories and commands.
- Adds unit tests in `source/custom-commands/loader.spec.ts` ensuring that unreadable subdirectories and corrupted/unreadable entries don't abort the scan and valid commands are still loaded.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing

- [x] Verified unit tests pass via `pnpm run test:ava source/custom-commands/loader.spec.ts`
- [x] Verified types pass via `tsc --noEmit`
- [x] Verified linting and formatting via Biome

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [x] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))
