### PR TITLE
fix: classify commands without source as built-in

### DIFF
--- a/source/commands/custom-commands.tsx
+++ b/source/commands/custom-commands.tsx
@@ -183,8 +183,8 @@ function CommandDetail({command}: {command: CustomCommand}) {
 	const {colors} = useTheme();
 
 	const sourceLabel = command.path
-		? `${command.source ?? 'project'} (${command.path})`
-		: (command.source ?? 'project');
+		? `${command.source ?? 'built-in'} (${command.path})`
+		: (command.source ?? 'built-in');
 
 	const fields: Array<{label: string; value: string}> = [
 		{label: 'Source', value: sourceLabel},

--- a/source/custom-commands/loader.ts
+++ b/source/custom-commands/loader.ts
@@ -56,8 +56,8 @@ export class CustomCommandLoader {
 	 */
 	private scanDirectory(
 		dir: string,
-		namespace?: string,
-		source?: 'personal' | 'project',
+		namespace: string | undefined,
+		source: 'personal' | 'project',
 	): void {
 		const entries = readdirSync(dir);
 
@@ -90,8 +90,8 @@ export class CustomCommandLoader {
 	 */
 	private loadCommand(
 		filePath: string,
-		namespace?: string,
-		source?: 'personal' | 'project',
+		namespace: string | undefined,
+		source: 'personal' | 'project',
 		commandDir?: string,
 	): void {
 		try {

--- a/source/skills/bootstrap.spec.ts
+++ b/source/skills/bootstrap.spec.ts
@@ -1,98 +1,106 @@
-import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
-import {tmpdir} from 'node:os';
-import {join} from 'node:path';
-import test from 'ava';
-import {CustomCommandLoader} from '@/custom-commands/loader';
-import {EventRouter} from '@/events/event-router';
-import {SubagentLoader} from '@/subagents/subagent-loader';
-import {ToolManager} from '@/tools/tool-manager';
-import {bootSkillPipeline} from './bootstrap';
-import {resetSkillRegistry, getLoadedSkills} from './skill-registry';
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "ava";
+import { CustomCommandLoader } from "@/custom-commands/loader";
+import { EventRouter } from "@/events/event-router";
+import { SubagentLoader } from "@/subagents/subagent-loader";
+import { ToolManager } from "@/tools/tool-manager";
+import { bootSkillPipeline } from "./bootstrap";
+import { resetSkillRegistry, getLoadedSkills } from "./skill-registry";
 
 console.log(`\nbootstrap.spec.ts`);
 
 function noopRouter(): EventRouter {
-	return new EventRouter({dispatch: () => {}});
+	return new EventRouter({ dispatch: () => {} });
 }
 
 async function tempProject(): Promise<string> {
-	const root = await mkdtemp(join(tmpdir(), 'boot-spec-'));
-	await mkdir(join(root, '.nanocoder'), {recursive: true});
+	const root = await mkdtemp(join(tmpdir(), "boot-spec-"));
+	await mkdir(join(root, ".nanocoder"), { recursive: true });
 	return root;
 }
 
-test.serial('loads bundle skills and writes to the global registry', async t => {
-	resetSkillRegistry();
-	const root = await tempProject();
-	try {
-		const bundleRoot = join(root, '.nanocoder', 'skills', 'docs');
-		await mkdir(bundleRoot, {recursive: true});
-		await writeFile(
-			join(bundleRoot, 'skill.yaml'),
-			'name: docs\ndescription: docs.',
-			'utf-8',
-		);
-
-		const result = await bootSkillPipeline({
-			projectRoot: root,
-			toolManager: new ToolManager(),
-			commandLoader: new CustomCommandLoader(root),
-			subagentLoader: new SubagentLoader(root),
-			eventRouter: noopRouter(),
-		});
-		// Bundle skill is present alongside any built-in flat skills that
-		// the legacy loaders picked up (e.g. shipped built-in subagents).
-		t.true(
-			result.skills.some(s => s.name === 'docs' && s.source.shape === 'bundle'),
-		);
-		t.deepEqual(result.deprecations, []);
-		t.is(getLoadedSkills().length, result.skills.length);
-	} finally {
-		await rm(root, {recursive: true, force: true});
-	}
-});
-
-test.serial('reports schedules.json deprecation warning when present', async t => {
-	resetSkillRegistry();
-	const root = await tempProject();
-	try {
-		await writeFile(
-			join(root, '.nanocoder', 'schedules.json'),
-			'[]',
-			'utf-8',
-		);
-		const result = await bootSkillPipeline({
-			projectRoot: root,
-			toolManager: new ToolManager(),
-			commandLoader: new CustomCommandLoader(root),
-			subagentLoader: new SubagentLoader(root),
-			eventRouter: noopRouter(),
-			bundleOnly: true,
-		});
-		t.is(result.deprecations.length, 1);
-		t.regex(result.deprecations[0] ?? '', /schedules\.json is deprecated/);
-	} finally {
-		await rm(root, {recursive: true, force: true});
-	}
-});
-
 test.serial(
-	'cross-kind flat skill name collision: command "foo" + tool "foo" → reported, first (command) wins',
-	async t => {
+	"loads bundle skills and writes to the global registry",
+	async (t) => {
 		resetSkillRegistry();
 		const root = await tempProject();
 		try {
-			await mkdir(join(root, '.nanocoder', 'commands'), {recursive: true});
-			await mkdir(join(root, '.nanocoder', 'tools'), {recursive: true});
+			const bundleRoot = join(root, ".nanocoder", "skills", "docs");
+			await mkdir(bundleRoot, { recursive: true });
 			await writeFile(
-				join(root, '.nanocoder', 'commands', 'foo.md'),
+				join(bundleRoot, "skill.yaml"),
+				"name: docs\ndescription: docs.",
+				"utf-8",
+			);
+
+			const result = await bootSkillPipeline({
+				projectRoot: root,
+				toolManager: new ToolManager(),
+				commandLoader: new CustomCommandLoader(root),
+				subagentLoader: new SubagentLoader(root),
+				eventRouter: noopRouter(),
+			});
+			// Bundle skill is present alongside any built-in flat skills that
+			// the legacy loaders picked up (e.g. shipped built-in subagents).
+			t.true(
+				result.skills.some(
+					(s) => s.name === "docs" && s.source.shape === "bundle",
+				),
+			);
+			t.deepEqual(result.deprecations, []);
+			t.is(getLoadedSkills().length, result.skills.length);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	},
+);
+
+test.serial(
+	"reports schedules.json deprecation warning when present",
+	async (t) => {
+		resetSkillRegistry();
+		const root = await tempProject();
+		try {
+			await writeFile(
+				join(root, ".nanocoder", "schedules.json"),
+				"[]",
+				"utf-8",
+			);
+			const result = await bootSkillPipeline({
+				projectRoot: root,
+				toolManager: new ToolManager(),
+				commandLoader: new CustomCommandLoader(root),
+				subagentLoader: new SubagentLoader(root),
+				eventRouter: noopRouter(),
+				bundleOnly: true,
+			});
+			t.is(result.deprecations.length, 1);
+			t.regex(result.deprecations[0] ?? "", /schedules\.json is deprecated/);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	},
+);
+
+test.serial(
+	'cross-kind flat skill name collision: command "foo" + tool "foo" → reported, first (command) wins',
+	async (t) => {
+		resetSkillRegistry();
+		const root = await tempProject();
+		try {
+			await mkdir(join(root, ".nanocoder", "commands"), { recursive: true });
+			await mkdir(join(root, ".nanocoder", "tools"), { recursive: true });
+			await writeFile(
+				join(root, ".nanocoder", "commands", "foo.md"),
 				`---\ndescription: foo command\n---\nbody`,
-				'utf-8',
+				"utf-8",
 			);
 			await writeFile(
-				join(root, '.nanocoder', 'tools', 'foo.md'),
+				join(root, ".nanocoder", "tools", "foo.md"),
 				`---\nname: foo\ndescription: foo tool\napproval: never\nread_only: true\nparameters: {}\n---\necho hi`,
-				'utf-8',
+				"utf-8",
 			);
 
 			const result = await bootSkillPipeline({
@@ -103,37 +111,82 @@ test.serial(
 				eventRouter: noopRouter(),
 			});
 
-			const fooSkills = result.skills.filter(s => s.name === 'foo');
+
+			const fooSkills = result.skills.filter((s) => s.name === "foo");
 			t.is(fooSkills.length, 1, 'exactly one "foo" should appear in /skills');
 			t.truthy(
 				fooSkills[0]?.commands && fooSkills[0].commands.length > 0,
-				'the command flavor wins (first in synthesizer order)',
+				"the command flavor wins (first in synthesizer order)",
 			);
 
 			const fooCollisions = result.registration.collisions.filter(
-				c => c.name === 'foo',
+				(c) => c.name === "foo",
 			);
-			t.is(fooCollisions.length, 1, 'a single collision is reported');
-			t.regex(fooCollisions[0]?.message ?? '', /collides with already-loaded/);
-			t.regex(fooCollisions[0]?.message ?? '', /Keeping the first/);
+			t.is(fooCollisions.length, 1, "a single collision is reported");
+			t.regex(fooCollisions[0]?.message ?? "", /collides with already-loaded/);
+			t.regex(fooCollisions[0]?.message ?? "", /Keeping the first/);
 		} finally {
-			await rm(root, {recursive: true, force: true});
+			await rm(root, { recursive: true, force: true });
 		}
 	},
 );
 
+
+test.serial("project bundle command has project priority", async (t) => {
+	resetSkillRegistry();
+	const root = await tempProject();
+
+	try {
+
+		const bundleRoot = join(root, ".nanocoder", "skills", "foo");
+		await mkdir(join(bundleRoot, "commands"), { recursive: true });
+
+		await writeFile(
+			join(bundleRoot, "skill.yaml"),
+			"name: foo\ndescription: foo skill",
+            "utf-8",
+        );
+
+		await writeFile(
+			join(bundleRoot, "commands", "foo.md"),
+			`---
+description: foo command
+---
+body`,
+			"utf-8",
+		);
+
+		const result = await bootSkillPipeline({
+			projectRoot: root,
+			toolManager: new ToolManager(),
+			commandLoader: new CustomCommandLoader(root),
+			subagentLoader: new SubagentLoader(root),
+			eventRouter: noopRouter(),
+		});
+
+		const foo = result.skills.find((s) => s.name === "foo");
+
+		t.truthy(foo);
+		t.is(foo?.source.priority, "project");
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+
 test.serial(
-	'flat-dir commands are picked up via the legacy loader and surfaced as skills',
-	async t => {
+	"flat-dir commands are picked up via the legacy loader and surfaced as skills",
+	async (t) => {
 		resetSkillRegistry();
 		const root = await tempProject();
 		try {
-			await mkdir(join(root, '.nanocoder', 'commands'), {recursive: true});
+			await mkdir(join(root, ".nanocoder", "commands"), { recursive: true });
 			await writeFile(
-				join(root, '.nanocoder', 'commands', 'flat-test.md'),
+				join(root, ".nanocoder", "commands", "flat-test.md"),
 				`---\ndescription: a flat command\n---\nbody`,
-				'utf-8',
+				"utf-8",
 			);
+
 			const result = await bootSkillPipeline({
 				projectRoot: root,
 				toolManager: new ToolManager(),
@@ -144,11 +197,12 @@ test.serial(
 			// `flat-test` should show up as a single-file skill.
 			t.true(
 				result.skills.some(
-					s => s.name === 'flat-test' && s.source.shape === 'single-file',
+					(s) => s.name === "flat-test" && s.source.shape === "single-file",
 				),
 			);
 		} finally {
-			await rm(root, {recursive: true, force: true});
+			await rm(root, { recursive: true, force: true });
 		}
 	},
 );
+

--- a/source/skills/bootstrap.ts
+++ b/source/skills/bootstrap.ts
@@ -217,7 +217,7 @@ function synthesizeCommandSkills(loader: CustomCommandLoader): Skill[] {
 				? 'project'
 				: command.source === 'personal'
 					? 'personal'
-					: 'project';
+					: 'built-in';
 		out.push(
 			commandToSkill(command, {
 				filePath: command.path,

--- a/source/skills/bootstrap.ts
+++ b/source/skills/bootstrap.ts
@@ -54,6 +54,8 @@ export interface SkillBootOptions {
 	builtInBundleRoot?: string;
 }
 
+export type {SkillCollision};
+
 export async function bootSkillPipeline(
 	opts: SkillBootOptions,
 ): Promise<SkillBootResult> {
@@ -212,12 +214,8 @@ function kindOf(skill: Skill): 'command' | 'agent' | 'tool' {
 function synthesizeCommandSkills(loader: CustomCommandLoader): Skill[] {
 	const out: Skill[] = [];
 	for (const command of loader.getAllCommands()) {
-		const priority: SkillPriority =
-			command.source === 'project'
-				? 'project'
-				: command.source === 'personal'
-					? 'personal'
-					: 'built-in';
+		const priority: SkillPriority = command.source ?? 'built-in';
+
 		out.push(
 			commandToSkill(command, {
 				filePath: command.path,
@@ -281,5 +279,3 @@ function detectDeprecations(projectRoot: string): string[] {
 	}
 	return warnings;
 }
-
-export type {SkillCollision};

--- a/source/skills/bundle-loader.ts
+++ b/source/skills/bundle-loader.ts
@@ -280,6 +280,7 @@ async function loadCommandMembers(
 			fullName,
 			metadata: entry.parsed.metadata,
 			content: entry.parsed.content,
+			source: 'project',
 		};
 		loaded.push({
 			member: {command, filePath: entry.filePath},

--- a/source/types/commands.ts
+++ b/source/types/commands.ts
@@ -88,7 +88,7 @@ export interface CustomCommand {
 	metadata: CustomCommandMetadata;
 	content: string; // The markdown content without frontmatter
 	// Skill-like fields (populated for commands with auto-injection capabilities)
-	source?: 'personal' | 'project';
+	source: 'personal' | 'project' | 'built-in';
 	lastModified?: Date;
 	loadedResources?: CommandResource[];
 	/**


### PR DESCRIPTION
Fixes the issue where custom commands without a defined source were incorrectly
classified as `project` skills.

## Changes

- Changed the fallback `SkillPriority` from `project` to `built-in`.
- Verified TypeScript and formatting checks.

fix:#1134