### PR TITLE
fix: guard queued prompt draining across modes

### DIFF
--- a/.changeset/calm-queues-compact.md
+++ b/.changeset/calm-queues-compact.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Resume queued prompts after slash commands and manual context compaction complete. Closes #1060.

--- a/.changeset/calm-queues-compact.md
+++ b/.changeset/calm-queues-compact.md
@@ -2,4 +2,4 @@
 "@nanocollective/nanocoder": patch
 ---
 
-Resume queued prompts after slash commands and manual context compaction complete. Closes #1060.
+Resume queued prompts after slash commands and manual context compaction complete. Refs #1060.

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -32,7 +32,7 @@ jobs:
               owner,
               repo,
               path: '.github/labeler.yml',
-              ref: context.payload.pull_request.head.sha,
+              ref: context.payload.pull_request.base.sha,
             });
             if (data.type !== 'file' || typeof data.content !== 'string') {
               throw new Error('labeler.yml is not a file');

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -32,7 +32,7 @@ jobs:
               owner,
               repo,
               path: '.github/labeler.yml',
-              ref: context.payload.pull_request.base.sha,
+              ref: context.payload.pull_request.head.sha,
             });
             if (data.type !== 'file' || typeof data.content !== 'string') {
               throw new Error('labeler.yml is not a file');

--- a/source/app/App.tsx
+++ b/source/app/App.tsx
@@ -44,7 +44,6 @@ import {useUserMessageQueue} from '@/hooks/useUserMessageQueue';
 import {useVSCodeServer} from '@/hooks/useVSCodeServer';
 import {getAllSubagentProgress} from '@/services/subagent-events';
 import {generateKey} from '@/session/key-generator';
-import type {ImageAttachment} from '@/types/core';
 import type {ThemePreset} from '@/types/ui';
 import {createPinoLogger} from '@/utils/logging/pino-logger';
 import {setGlobalMessageQueue} from '@/utils/message-queue';
@@ -84,14 +83,6 @@ export default function App({
 	// Use extracted hooks
 	const appState = useAppState(initialDevelopmentMode);
 	const userMessageQueue = useUserMessageQueue();
-	const queuedUserSubmitRef = React.useRef<
-		| ((
-				message: string,
-				displayValue: string,
-				images?: ImageAttachment[],
-		  ) => Promise<void>)
-		| null
-	>(null);
 	const {exit} = useApp();
 	const {isTrusted, handleConfirmTrust, isTrustLoading, isTrustedError} =
 		useDirectoryTrust();
@@ -249,35 +240,6 @@ export default function App({
 		}
 	}, []);
 
-	const drainQueuedUserMessage = React.useCallback(() => {
-		// Defer to a macrotask, not a microtask. `onConversationComplete` fires
-		// deep inside the finishing turn's await chain, so a microtask drain would
-		// start the next turn BEFORE that turn's `resetStreamingState()` finally
-		// runs — and the stale reset would then wipe the new turn's abortController
-		// and isGenerating, leaving the busy indicator (and Escape-to-cancel) dead.
-		// A timeout runs after those continuations, so the drained turn keeps its
-		// busy state.
-		setTimeout(() => {
-			void userMessageQueue.drainNextMessage(async message => {
-				const submitQueuedMessage = queuedUserSubmitRef.current;
-				if (!submitQueuedMessage || !appState.client || !appState.toolManager) {
-					return false;
-				}
-
-				await submitQueuedMessage(
-					message.message,
-					message.displayValue,
-					message.images,
-				);
-				return true;
-			});
-		}, 0);
-	}, [
-		appState.client,
-		appState.toolManager,
-		userMessageQueue.drainNextMessage,
-	]);
-
 	// Setup chat handler
 	const chatHandler = useChatHandler({
 		client: appState.client,
@@ -299,7 +261,6 @@ export default function App({
 			appState.setCompactToolCounts(null);
 			appState.compactToolCountsRef.current = {};
 			appState.setLiveTaskList(null);
-			drainQueuedUserMessage();
 		},
 		// A turn that started in plan mode finished uninterrupted — a plan was
 		// produced. Flag it so the interactive UI can show the plan review bar.
@@ -577,10 +538,6 @@ export default function App({
 		handleMessageSubmit: appHandlers.handleMessageSubmit,
 		activeEditor: vscodeServer.activeEditor,
 	});
-
-	React.useEffect(() => {
-		queuedUserSubmitRef.current = handleUserSubmit;
-	}, [handleUserSubmit]);
 
 	// Setup non-interactive mode
 	const {nonInteractiveLoadingMessage} = useNonInteractiveMode({

--- a/source/app/sections/interactive-app.spec.tsx
+++ b/source/app/sections/interactive-app.spec.tsx
@@ -162,10 +162,28 @@ function makeProps(o: Overrides = {}) {
 				displayValue: '',
 			}),
 			removeMessage: noop,
-			drainNextMessage: o.drainNextMessage ?? (() => false),
+			drainNextMessage: o.drainNextMessage ?? (async () => false),
 		},
 		handleIdeSelect: noop,
 	} as never;
+}
+
+function QueuedPromptHarness({overrides}: {overrides: Overrides}) {
+	const userMessageQueue = useUserMessageQueue();
+
+	React.useEffect(() => {
+		userMessageQueue.enqueueMessage({
+			message: 'queued prompt',
+			displayValue: 'queued prompt',
+		});
+	}, [userMessageQueue.enqueueMessage]);
+
+	return (
+		<InteractiveApp
+			{...makeProps(overrides)}
+			userMessageQueue={userMessageQueue}
+		/>
+	);
 }
 
 test('renders without crashing in default state', t => {
@@ -174,77 +192,113 @@ test('renders without crashing in default state', t => {
 });
 
 test('does not drain queued prompts while a turn is generating', async t => {
-	let submitted = false;
+	let dispatchAttempts = 0;
 	const {unmount} = renderWithTheme(
-		<InteractiveApp
-			{...makeProps({
+		<QueuedPromptHarness
+			overrides={{
 				startChat: true,
 				client: {},
 				toolManager: {},
 				isGenerating: true,
 				isConversationComplete: true,
-				queuedMessages: [
-					{id: 'queued-1', message: 'queued prompt', displayValue: 'queued prompt'},
-				],
 				handleUserSubmit: async () => {
-					submitted = true;
+					dispatchAttempts++;
 				},
-			})}
+			}}
 		/>,
 	);
 
 	await new Promise(resolve => setTimeout(resolve, 25));
-	t.false(submitted);
+	t.is(dispatchAttempts, 0);
 	unmount();
 });
 
 test('does not drain queued prompts while a modal mode is active', async t => {
-	let submitted = false;
+	let dispatchAttempts = 0;
 	const {unmount} = renderWithTheme(
-		<InteractiveApp
-			{...makeProps({
+		<QueuedPromptHarness
+			overrides={{
 				startChat: true,
 				client: {},
 				toolManager: {},
 				activeMode: 'model',
 				isConversationComplete: true,
-				queuedMessages: [
-					{id: 'queued-1', message: 'queued prompt', displayValue: 'queued prompt'},
-				],
 				handleUserSubmit: async () => {
-					submitted = true;
+					dispatchAttempts++;
 				},
-			})}
+			}}
 		/>,
 	);
 
 	await new Promise(resolve => setTimeout(resolve, 25));
-	t.false(submitted);
+	t.is(dispatchAttempts, 0);
 	unmount();
 });
 
 test('does not drain queued prompts while plan review is active', async t => {
-	let submitted = false;
+	let dispatchAttempts = 0;
 	const {unmount} = renderWithTheme(
-		<InteractiveApp
-			{...makeProps({
+		<QueuedPromptHarness
+			overrides={{
 				startChat: true,
 				client: {},
 				toolManager: {},
 				planReviewState: {show: true, originalMessage: 'make a plan'},
 				isConversationComplete: true,
-				queuedMessages: [
-					{id: 'queued-1', message: 'queued prompt', displayValue: 'queued prompt'},
-				],
 				handleUserSubmit: async () => {
-					submitted = true;
+					dispatchAttempts++;
 				},
-			})}
+			}}
 		/>,
 	);
 
 	await new Promise(resolve => setTimeout(resolve, 25));
-	t.false(submitted);
+	t.is(dispatchAttempts, 0);
+	unmount();
+});
+
+test('does not drain queued prompts while plan proceed is pending', async t => {
+	let dispatchAttempts = 0;
+	const {unmount} = renderWithTheme(
+		<QueuedPromptHarness
+			overrides={{
+				startChat: true,
+				client: {},
+				toolManager: {},
+				developmentMode: 'plan',
+				pendingPlanProceed: 'approved plan',
+				isConversationComplete: true,
+				handleUserSubmit: async () => {
+					dispatchAttempts++;
+				},
+			}}
+		/>,
+	);
+
+	await new Promise(resolve => setTimeout(resolve, 25));
+	t.is(dispatchAttempts, 0);
+	unmount();
+});
+
+test('does not immediately retry a failed queued dispatch', async t => {
+	let dispatchAttempts = 0;
+	const {unmount} = renderWithTheme(
+		<QueuedPromptHarness
+			overrides={{
+				startChat: true,
+				client: {},
+				toolManager: {},
+				isConversationComplete: true,
+				handleUserSubmit: async () => {
+					dispatchAttempts++;
+					throw new Error('dispatch failed');
+				},
+			}}
+		/>,
+	);
+
+	await new Promise(resolve => setTimeout(resolve, 50));
+	t.is(dispatchAttempts, 1);
 	unmount();
 });
 

--- a/source/app/sections/interactive-app.spec.tsx
+++ b/source/app/sections/interactive-app.spec.tsx
@@ -1,6 +1,8 @@
 import test from 'ava';
 import {Text} from 'ink';
 import React from 'react';
+import {DELAY_COMMAND_COMPLETE_MS} from '@/constants';
+import {useUserMessageQueue} from '@/hooks/useUserMessageQueue';
 import stripAnsi from 'strip-ansi';
 import type {Message} from '@/types';
 import {renderWithTheme} from '../../test-utils/render-with-theme.js';
@@ -43,6 +45,13 @@ interface Overrides {
 	setPendingPlanProceed?: (v: string | null) => void;
 	handleMessageSubmit?: (message: string) => Promise<void>;
 	currentSessionId?: string | null;
+	toolManager?: unknown;
+	queuedMessages?: Array<{id: string; message: string; displayValue: string}>;
+	handleUserSubmit?: (message: string) => Promise<void>;
+	drainNextMessage?: (
+		dispatch: (message: {id: string; message: string; displayValue: string}) =>
+			boolean | Promise<boolean>,
+	) => boolean | Promise<boolean>;
 }
 
 function makeProps(o: Overrides = {}) {
@@ -51,6 +60,7 @@ function makeProps(o: Overrides = {}) {
 
 	const appState = {
 		client: o.client ?? null,
+		toolManager: o.toolManager ?? null,
 		messages: o.messages ?? [],
 		currentModel: 'mock-model',
 		currentProvider: 'mock',
@@ -143,16 +153,16 @@ function makeProps(o: Overrides = {}) {
 		pendingToolConfirmation: null,
 		handleToolConfirmation: noop,
 		handleQuestionAnswer: noop,
-		handleUserSubmit: noopAsync,
+		handleUserSubmit: o.handleUserSubmit ?? noopAsync,
 		userMessageQueue: {
-			queuedMessages: [],
+			queuedMessages: o.queuedMessages ?? [],
 			enqueueMessage: () => ({
 				id: 'queued-test',
 				message: '',
 				displayValue: '',
 			}),
 			removeMessage: noop,
-			drainNextMessage: () => false,
+			drainNextMessage: o.drainNextMessage ?? (() => false),
 		},
 		handleIdeSelect: noop,
 	} as never;
@@ -161,6 +171,166 @@ function makeProps(o: Overrides = {}) {
 test('renders without crashing in default state', t => {
 	const {lastFrame} = renderWithTheme(<InteractiveApp {...makeProps()} />);
 	t.truthy(lastFrame());
+});
+
+test('does not drain queued prompts while a turn is generating', async t => {
+	let submitted = false;
+	const {unmount} = renderWithTheme(
+		<InteractiveApp
+			{...makeProps({
+				startChat: true,
+				client: {},
+				toolManager: {},
+				isGenerating: true,
+				isConversationComplete: true,
+				queuedMessages: [
+					{id: 'queued-1', message: 'queued prompt', displayValue: 'queued prompt'},
+				],
+				handleUserSubmit: async () => {
+					submitted = true;
+				},
+			})}
+		/>,
+	);
+
+	await new Promise(resolve => setTimeout(resolve, 25));
+	t.false(submitted);
+	unmount();
+});
+
+test('does not drain queued prompts while a modal mode is active', async t => {
+	let submitted = false;
+	const {unmount} = renderWithTheme(
+		<InteractiveApp
+			{...makeProps({
+				startChat: true,
+				client: {},
+				toolManager: {},
+				activeMode: 'model',
+				isConversationComplete: true,
+				queuedMessages: [
+					{id: 'queued-1', message: 'queued prompt', displayValue: 'queued prompt'},
+				],
+				handleUserSubmit: async () => {
+					submitted = true;
+				},
+			})}
+		/>,
+	);
+
+	await new Promise(resolve => setTimeout(resolve, 25));
+	t.false(submitted);
+	unmount();
+});
+
+test('does not drain queued prompts while plan review is active', async t => {
+	let submitted = false;
+	const {unmount} = renderWithTheme(
+		<InteractiveApp
+			{...makeProps({
+				startChat: true,
+				client: {},
+				toolManager: {},
+				planReviewState: {show: true, originalMessage: 'make a plan'},
+				isConversationComplete: true,
+				queuedMessages: [
+					{id: 'queued-1', message: 'queued prompt', displayValue: 'queued prompt'},
+				],
+				handleUserSubmit: async () => {
+					submitted = true;
+				},
+			})}
+		/>,
+	);
+
+	await new Promise(resolve => setTimeout(resolve, 25));
+	t.false(submitted);
+	unmount();
+});
+
+test('drains every queued prompt after each dispatched turn returns to idle', async t => {
+	const submitted: string[] = [];
+
+	const QueueDrainHarness = () => {
+		const userMessageQueue = useUserMessageQueue();
+		const [isConversationComplete, setIsConversationComplete] =
+			React.useState(true);
+
+		React.useEffect(() => {
+			userMessageQueue.enqueueMessage({message: 'first', displayValue: 'first'});
+			userMessageQueue.enqueueMessage({message: 'second', displayValue: 'second'});
+		}, [userMessageQueue.enqueueMessage]);
+
+		return (
+			<InteractiveApp
+				{...makeProps({
+					startChat: true,
+					client: {},
+					toolManager: {},
+					isConversationComplete,
+					handleUserSubmit: async message => {
+						submitted.push(message);
+						setIsConversationComplete(false);
+						await new Promise(resolve => setTimeout(resolve, 10));
+						setIsConversationComplete(true);
+					},
+				})}
+				userMessageQueue={userMessageQueue}
+			/>
+		);
+	};
+
+	const {unmount} = renderWithTheme(<QueueDrainHarness />);
+	await new Promise(resolve => setTimeout(resolve, 100));
+	t.deepEqual(submitted, ['first', 'second']);
+	unmount();
+});
+
+test('drains a prompt after delayed command completion when the app is idle', async t => {
+	const submitted: string[] = [];
+
+	const DelayedCommandHarness = () => {
+		const userMessageQueue = useUserMessageQueue();
+		const [isToolExecuting, setIsToolExecuting] = React.useState(true);
+		const [isConversationComplete, setIsConversationComplete] =
+			React.useState(false);
+
+		React.useEffect(() => {
+			userMessageQueue.enqueueMessage({
+				message: 'after compact',
+				displayValue: 'after compact',
+			});
+			const timeout = setTimeout(() => {
+				setIsToolExecuting(false);
+				setIsConversationComplete(true);
+			}, DELAY_COMMAND_COMPLETE_MS);
+
+			return () => clearTimeout(timeout);
+		}, [userMessageQueue.enqueueMessage]);
+
+		return (
+			<InteractiveApp
+				{...makeProps({
+					startChat: true,
+					client: {},
+					toolManager: {},
+					isToolExecuting,
+					isConversationComplete,
+					handleUserSubmit: async message => {
+						submitted.push(message);
+					},
+				})}
+				userMessageQueue={userMessageQueue}
+			/>
+		);
+	};
+
+	const {unmount} = renderWithTheme(<DelayedCommandHarness />);
+	await new Promise(resolve =>
+		setTimeout(resolve, DELAY_COMMAND_COMPLETE_MS + 40),
+	);
+	t.deepEqual(submitted, ['after compact']);
+	unmount();
 });
 
 test('renders the static-component marker through ChatHistory', t => {

--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -101,6 +101,8 @@ export function InteractiveApp({
 		React.useState<SubmittedInputDraft | null>(null);
 	const [restoredDraft, setRestoredDraft] =
 		React.useState<RestoredInputDraft | null>(null);
+	const drainInProgressRef = React.useRef(false);
+	const [drainAttempt, setDrainAttempt] = React.useState(0);
 
 	const handleToggleCompactDisplay = () => {
 		const expanding = appState.compactToolDisplay;
@@ -182,6 +184,84 @@ export function InteractiveApp({
 			appState.isToolExecuting ||
 			appState.abortController !== null) &&
 		!appState.liveComponentCapturesInput;
+
+	// Drain queued prompts only after the previous turn is fully idle and all
+	// modal modes have closed. Command handlers and conversation completion can
+	// both signal completion, so keeping the drain here makes it idempotent and
+	// prevents nested or duplicate turns.
+	const queueDrainBlocked =
+		appState.isCancelling ||
+		chatHandler.isGenerating ||
+		appState.isToolExecuting ||
+		appState.abortController !== null ||
+		appState.isToolConfirmationMode ||
+		appState.isQuestionMode ||
+		pendingSubagentApproval !== null ||
+		pendingToolConfirmation !== null ||
+		appState.planReviewState?.show === true ||
+		appState.pendingPlanProceed !== null;
+
+	React.useEffect(() => {
+		// Re-run after a successful dispatch settles, once its queue update has
+		// rendered and the next item can be considered.
+		void drainAttempt;
+		if (
+			queueDrainBlocked ||
+			appState.activeMode !== null ||
+			appState.isSettingsMode ||
+			!appState.isConversationComplete ||
+			userMessageQueue.queuedMessages.length === 0 ||
+			drainInProgressRef.current
+		) {
+			return;
+		}
+
+		drainInProgressRef.current = true;
+		let started = false;
+		const timeout = setTimeout(() => {
+			started = true;
+			void userMessageQueue
+				.drainNextMessage(async message => {
+					if (!appState.client || !appState.toolManager) return false;
+					await handleUserSubmit(
+						message.message,
+						message.displayValue,
+						message.images,
+					);
+					return true;
+				})
+				.then(
+					dispatched => {
+						drainInProgressRef.current = false;
+						// The queue state update happens before the dispatch resolves. A
+						// separate render is needed to notice and drain the next item after
+						// the dispatched turn returns to idle.
+						if (dispatched) {
+							setDrainAttempt(attempt => attempt + 1);
+						}
+					},
+					() => {
+						drainInProgressRef.current = false;
+					},
+				);
+		}, 0);
+
+		return () => {
+			clearTimeout(timeout);
+			if (!started) drainInProgressRef.current = false;
+		};
+	}, [
+		appState.activeMode,
+		appState.client,
+		appState.isConversationComplete,
+		appState.isSettingsMode,
+		appState.toolManager,
+		queueDrainBlocked,
+		handleUserSubmit,
+		userMessageQueue.drainNextMessage,
+		userMessageQueue.queuedMessages.length,
+		drainAttempt,
+	]);
 
 	const recallableSubmittedDraft =
 		cancellable &&

--- a/source/app/sections/interactive-app.tsx
+++ b/source/app/sections/interactive-app.tsx
@@ -102,6 +102,7 @@ export function InteractiveApp({
 	const [restoredDraft, setRestoredDraft] =
 		React.useState<RestoredInputDraft | null>(null);
 	const drainInProgressRef = React.useRef(false);
+	const lastFailedDrainIdRef = React.useRef<string | null>(null);
 	const [drainAttempt, setDrainAttempt] = React.useState(0);
 
 	const handleToggleCompactDisplay = () => {
@@ -200,6 +201,8 @@ export function InteractiveApp({
 		pendingToolConfirmation !== null ||
 		appState.planReviewState?.show === true ||
 		appState.pendingPlanProceed !== null;
+	const queuedMessageCount = userMessageQueue.queuedMessages.length;
+	const queuedMessageId = userMessageQueue.queuedMessages[0]?.id;
 
 	React.useEffect(() => {
 		// Re-run after a successful dispatch settles, once its queue update has
@@ -209,8 +212,11 @@ export function InteractiveApp({
 			queueDrainBlocked ||
 			appState.activeMode !== null ||
 			appState.isSettingsMode ||
+			!appState.client ||
+			!appState.toolManager ||
 			!appState.isConversationComplete ||
-			userMessageQueue.queuedMessages.length === 0 ||
+			queuedMessageCount === 0 ||
+			lastFailedDrainIdRef.current === queuedMessageId ||
 			drainInProgressRef.current
 		) {
 			return;
@@ -220,28 +226,37 @@ export function InteractiveApp({
 		let started = false;
 		const timeout = setTimeout(() => {
 			started = true;
-			void userMessageQueue
-				.drainNextMessage(async message => {
-					if (!appState.client || !appState.toolManager) return false;
-					await handleUserSubmit(
-						message.message,
-						message.displayValue,
-						message.images,
-					);
-					return true;
-				})
+			let drainedMessageId = queuedMessageId ?? null;
+			void Promise.resolve()
+				.then(() =>
+					userMessageQueue.drainNextMessage(async message => {
+						drainedMessageId = message.id;
+						await handleUserSubmit(
+							message.message,
+							message.displayValue,
+							message.images,
+						);
+						return true;
+					}),
+				)
 				.then(
 					dispatched => {
 						drainInProgressRef.current = false;
+						if (!dispatched) {
+							// Keep a failed head queued, but do not immediately re-enter
+							// the effect while it still has the same identity.
+							lastFailedDrainIdRef.current = drainedMessageId;
+							return;
+						}
+						lastFailedDrainIdRef.current = null;
 						// The queue state update happens before the dispatch resolves. A
 						// separate render is needed to notice and drain the next item after
 						// the dispatched turn returns to idle.
-						if (dispatched) {
-							setDrainAttempt(attempt => attempt + 1);
-						}
+						setDrainAttempt(attempt => attempt + 1);
 					},
 					() => {
 						drainInProgressRef.current = false;
+						lastFailedDrainIdRef.current = drainedMessageId;
 					},
 				);
 		}, 0);
@@ -259,7 +274,8 @@ export function InteractiveApp({
 		queueDrainBlocked,
 		handleUserSubmit,
 		userMessageQueue.drainNextMessage,
-		userMessageQueue.queuedMessages.length,
+		queuedMessageCount,
+		queuedMessageId,
 		drainAttempt,
 	]);
 

--- a/source/app/utils/app-util.spec.ts
+++ b/source/app/utils/app-util.spec.ts
@@ -431,6 +431,22 @@ test.serial('chat message - displayValue is optional (callers without a placehol
 	t.is(received.displayValue, undefined);
 });
 
+test.serial('delayed slash-command completion is delivered after the handler returns', async t => {
+	let completed = false;
+	const options = createResumeTestOptions({
+		onCommandComplete: () => {
+			completed = true;
+		},
+	});
+	options.onShowStatus = () => {};
+
+	await handleMessageSubmission('/status', options);
+
+	t.false(completed);
+	await new Promise(resolve => setTimeout(resolve, 125));
+	t.true(completed);
+});
+
 test.serial('retry command - /retry without a prior user turn shows an error', async t => {
 	let queued: React.ReactNode = null;
 	let submitted = false;

--- a/source/app/utils/handlers/retry-handler.spec.ts
+++ b/source/app/utils/handlers/retry-handler.spec.ts
@@ -1,0 +1,24 @@
+import test from 'ava';
+import type {MessageSubmissionOptions} from '@/types';
+import {handleRetryCommand} from './retry-handler.js';
+
+test('does not signal command completion after the retried turn returns', async t => {
+	let chatCalls = 0;
+	let completionCalls = 0;
+
+	const options = {
+		messages: [{role: 'user', content: 'retry me'}],
+		provider: 'mock',
+		onAddToChatQueue: () => {},
+		onHandleChatMessage: async () => {
+			chatCalls++;
+		},
+		onCommandComplete: () => {
+			completionCalls++;
+		},
+	} as unknown as MessageSubmissionOptions;
+
+	t.true(await handleRetryCommand(['retry'], options));
+	t.is(chatCalls, 1);
+	t.is(completionCalls, 0);
+});

--- a/source/app/utils/handlers/retry-handler.ts
+++ b/source/app/utils/handlers/retry-handler.ts
@@ -86,6 +86,7 @@ export async function handleRetryCommand(
 		lastUserMessage.content,
 		lastUserMessage.content,
 	);
-	options.onCommandComplete?.();
+	// The retried chat turn owns its completion signal. Emitting another one
+	// here can start the next queued prompt while that turn is still unwinding.
 	return true;
 }

--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -450,6 +450,37 @@ test('UserInput loads selected queued message for editing while idle', async t =
 	unmount();
 });
 
+test('UserInput loads selected queued message for editing while busy', async t => {
+	let removedId = '';
+
+	const {stdin, lastFrame, unmount} = render(
+		<TestWrapper>
+			<UserInput
+				forceFocus={true}
+				isBusy={true}
+				queuedMessages={[
+					{id: 'queued-1', message: 'first', displayValue: 'first queued'},
+					{id: 'queued-2', message: 'second', displayValue: 'second queued'},
+				]}
+				onRemoveQueuedMessage={id => {
+					removedId = id;
+				}}
+			/>
+		</TestWrapper>,
+	);
+
+	stdin.write('\u001B[B');
+	await wait(50);
+	stdin.write('\u001B[B');
+	await wait(50);
+	stdin.write('\r');
+	await wait(50);
+
+	t.is(removedId, 'queued-2');
+	t.regex(lastFrame()!, /second queued/);
+	unmount();
+});
+
 test('UserInput up arrow returns from the first queued message to the input', async t => {
 	const {stdin, lastFrame, unmount} = render(
 		<TestWrapper>

--- a/source/components/user-input.spec.tsx
+++ b/source/components/user-input.spec.tsx
@@ -420,14 +420,13 @@ test('UserInput navigates queued messages while busy with empty input', async t 
 	unmount();
 });
 
-test('UserInput loads selected queued message for editing', async t => {
+test('UserInput loads selected queued message for editing while idle', async t => {
 	let removedId = '';
 
 	const {stdin, lastFrame, unmount} = render(
 		<TestWrapper>
 			<UserInput
 				forceFocus={true}
-				isBusy={true}
 				queuedMessages={[
 					{id: 'queued-1', message: 'first', displayValue: 'first queued'},
 					{id: 'queued-2', message: 'second', displayValue: 'second queued'},

--- a/source/components/user-input.tsx
+++ b/source/components/user-input.tsx
@@ -633,7 +633,7 @@ export default function UserInput({
 
 	const handleQueueNavigation = useCallback(
 		(direction: 'up' | 'down') => {
-			if (!isBusy || input.length > 0 || queuedMessages.length === 0) {
+			if (input.length > 0 || queuedMessages.length === 0) {
 				return false;
 			}
 
@@ -656,12 +656,11 @@ export default function UserInput({
 			setSelectedQueuedIndex(selectedQueuedIndex + 1);
 			return true;
 		},
-		[isBusy, input.length, queuedMessages.length, selectedQueuedIndex],
+		[input.length, queuedMessages.length, selectedQueuedIndex],
 	);
 
 	const loadSelectedQueuedMessage = useCallback(() => {
 		if (
-			!isBusy ||
 			input.length > 0 ||
 			selectedQueuedIndex < 0 ||
 			selectedQueuedIndex >= queuedMessages.length
@@ -682,7 +681,6 @@ export default function UserInput({
 		setTextInputKey(prev => prev + 1);
 		return true;
 	}, [
-		isBusy,
 		input.length,
 		selectedQueuedIndex,
 		queuedMessages,
@@ -692,7 +690,6 @@ export default function UserInput({
 
 	const removeSelectedQueuedMessage = useCallback(() => {
 		if (
-			!isBusy ||
 			input.length > 0 ||
 			selectedQueuedIndex < 0 ||
 			selectedQueuedIndex >= queuedMessages.length
@@ -706,7 +703,6 @@ export default function UserInput({
 		);
 		return true;
 	}, [
-		isBusy,
 		input.length,
 		selectedQueuedIndex,
 		queuedMessages,

--- a/source/hooks/chat-handler/useChatHandler.spec.tsx
+++ b/source/hooks/chat-handler/useChatHandler.spec.tsx
@@ -293,6 +293,30 @@ test('useChatHandler - handles null client gracefully', t => {
 	t.truthy(hookResult);
 });
 
+test('useChatHandler - signals completion when chat dependencies are unavailable', async t => {
+	let hookResult: ChatHandlerReturn | null = null;
+	let completionCalls = 0;
+
+	const rendered = render(
+		<TestHookComponent
+			{...createMockProps({
+				onConversationComplete: () => {
+					completionCalls++;
+				},
+			})}
+			onResult={result => {
+				hookResult = result;
+			}}
+		/>,
+	);
+
+	await waitForCondition(() => hookResult !== null);
+	await hookResult!.handleChatMessage('queued after unavailable setup');
+
+	t.is(completionCalls, 1);
+	rendered.unmount();
+});
+
 test('useChatHandler - setMessages callback works', t => {
 	let hookResult: ChatHandlerReturn | null = null;
 

--- a/source/hooks/chat-handler/useChatHandler.tsx
+++ b/source/hooks/chat-handler/useChatHandler.tsx
@@ -343,7 +343,13 @@ export function useChatHandler({
 		displayValue?: string,
 		images?: ImageAttachment[],
 	) => {
-		if (!client || !toolManager) return;
+		if (!client || !toolManager) {
+			// handleMessageSubmit marks a turn as incomplete before reaching this
+			// hook. Signal completion here as well so an unavailable setup cannot
+			// leave the queue blocked forever.
+			onConversationComplete?.();
+			return;
+		}
 		const sessionId = ensureCurrentSessionId?.();
 		let wrotePlan = false;
 		let finalAssistantText = '';

--- a/source/hooks/useAppHandlers.spec.tsx
+++ b/source/hooks/useAppHandlers.spec.tsx
@@ -247,6 +247,7 @@ test('declining execution keeps Plan Mode active and asks for revisions', t => {
 
 	handlers.handlePlanModify();
 
+	t.deepEqual(spies.setIsConversationComplete.calls, [[false]]);
 	t.deepEqual(spies.setPlanReviewState.calls, [[null]]);
 	t.deepEqual(spies.setDevelopmentMode.calls, []);
 	const notice = spies.addToChatQueue.calls.at(-1)?.[0];
@@ -262,6 +263,18 @@ test('declining execution keeps Plan Mode active and asks for revisions', t => {
 				'what to change',
 			),
 	);
+});
+
+test('asking for clarification blocks queued prompts until the turn starts', async t => {
+	const {handlers, spies} = setup({developmentMode: 'plan'});
+
+	await handlers.handlePlanAskMore();
+
+	t.deepEqual(spies.setIsConversationComplete.calls, [[false]]);
+	t.deepEqual(spies.setPlanReviewState.calls, [[null]]);
+	t.deepEqual(spies.handleChatMessage.calls, [
+		['please ask me any additional clarifying questions before proceeding'],
+	]);
 });
 
 async function withMockConfig(

--- a/source/hooks/useAppHandlers.spec.tsx
+++ b/source/hooks/useAppHandlers.spec.tsx
@@ -198,6 +198,14 @@ test('returns the expected handler surface', t => {
 	t.is(typeof handlers.handleMessageSubmit, 'function');
 });
 
+test('signals slash-command completion so queued work can resume', async t => {
+	const {handlers, spies} = setup();
+
+	await handlers.handleMessageSubmit('/compact');
+
+	t.deepEqual(spies.setIsConversationComplete.calls, [[false], [true]]);
+});
+
 test('handleCancel without an abort controller is a no-op', t => {
 	const { handlers, spies } = setup({ abortController: null });
 

--- a/source/hooks/useAppHandlers.tsx
+++ b/source/hooks/useAppHandlers.tsx
@@ -645,6 +645,7 @@ export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 	const handlePlanAskMore = React.useCallback(async () => {
 		// Hide the review bar and stay in plan mode; the model asks its questions
 		// and the user answers before a new plan is produced.
+		props.setIsConversationComplete(false);
 		props.setPlanReviewState(null);
 		await props.handleChatMessage(
 			'please ask me any additional clarifying questions before proceeding',
@@ -653,6 +654,8 @@ export function useAppHandlers(props: UseAppHandlersProps): AppHandlers {
 
 	const handlePlanModify = React.useCallback(() => {
 		// Return to input without changing mode so the user can request revisions.
+		// Keep the queue blocked until that revision turn has completed.
+		props.setIsConversationComplete(false);
 		props.setPlanReviewState(null);
 		props.addToChatQueue(
 			<SuccessMessage


### PR DESCRIPTION
## Summary / Problem

Follow-up to PR #1210. Queued prompts could start concurrently when a plan-review action dismissed the review bar, and a failed queued dispatch could be retried in a tight loop.

## Changes

- Keep queue draining disabled until the client and tool manager are ready.
- Stop re-dispatching the same queue head after a failed or throwing dispatch while keeping the message queued for an explicit retry/edit.
- Keep the queue blocked while plan clarification or plan modification is being requested.
- Signal conversation completion when chat dependencies are unavailable so a queued prompt cannot remain blocked indefinitely.
- Strengthen regression coverage with the real user-message queue, pending-plan guards, failed dispatches, and both busy and idle queue editing.
- Clarify the changeset issue reference as `Refs #1060`.

## Tests

- Focused AVA suites for `interactive-app`, `useAppHandlers`, `useChatHandler`, and `user-input`: all passed (31, 22, 24, and 52 tests respectively).
- `pnpm run test:format`, `pnpm run test:types`, `pnpm run test:types:vscode`, `pnpm run test:lint`, and `pnpm run test:changesets`: passed.
- `pnpm run test:audit` against the official npm registry: passed with no new vulnerabilities.
- `pnpm run test:knip`: passed with existing hints about ignored `.github/**` and unused tags.
- `pnpm run test:ava`: attempted on Windows; the changed suites pass, while platform-sensitive CLI, ACP, filesystem, subprocess, and network suites report existing failures/timeouts (90 failures, 245 pending after timeout, and one uncaught exception).
- `pnpm run build`: TypeScript compilation and alias rewriting passed; the final copy/chmod step cannot run on Windows because the package script uses Unix `cp` and `chmod`.

## Compatibility / Known limitations

The queue remains intact after a failed dispatch, but the same queue head is not automatically retried until the user edits or otherwise changes that queued item. This prevents an unavailable or failing setup from hot-looping.

## Issue

Refs #1060
