### PR TITLE
fix(nc-review): render findings as blocks, not a table

### DIFF
--- a/.github/nc-review/rubric.md
+++ b/.github/nc-review/rubric.md
@@ -273,4 +273,14 @@ before or after, no markdown fences. Schema:
   `warranted`, `duplicate`, `scope`, `changeset`, `contributing`.
 - `file` / `line` — where the finding is. Omit both if it is not tied to a
   specific location. Never guess a line number; omit it instead.
+- `detail` — Markdown, rendered as its own block under a heading. Line breaks
+  and fenced code blocks are preserved, so quote the offending lines when that
+  makes the point faster than describing them:
+
+  ```
+  "detail": "The captured reference is never used:\n\n```ts\nconst realRename = rename;\nrealRename; // silences unused-locals\n```\n\nSo the failure path is never exercised."
+  ```
+
+  Lead with what is wrong, then why it matters, then what would fix it. Two or
+  three sentences is usually right; go longer only when quoting code earns it.
 - `duplicate_of` — PR number as an integer, or `null`. Only when confident.

--- a/.github/workflows/nc-review.yml
+++ b/.github/workflows/nc-review.yml
@@ -483,14 +483,25 @@ jobs:
               echo
             fi
             if [ "$(jq '.findings | length' "$V")" -gt 0 ]; then
-              echo "| | Area | Where | Finding |"
-              echo "|---|---|---|---|"
-              jq -r '.findings[] |
-                "| \(if .severity == "blocking" then "🔴" elif .severity == "important" then "🟠" else "⚪" end)"
-                + " | `\(.area)`"
-                + " | \(if .file then "`\(.file)\(if .line then ":\(.line)" else "" end)`" else "—" end)"
-                + " | \(.detail | gsub("\n"; " ")) |"' "$V"
-              echo
+              # One block per finding rather than a table. Findings run to a
+              # paragraph or more, and a table cell forces all of that onto one
+              # line with newlines collapsed — unreadable at any width, and it
+              # squeezes the text into a narrow column. Blocks also let the
+              # detail keep its own line breaks and code formatting.
+              jq -r '
+                def icon: if . == "blocking" then "🔴"
+                          elif . == "important" then "🟠"
+                          else "⚪" end;
+                def rank: if . == "blocking" then 0
+                          elif . == "important" then 1
+                          else 2 end;
+                .findings
+                | sort_by(.severity | rank)
+                | .[]
+                | "**\(.severity | icon) \(.severity) · `\(.area)`"
+                  + (if .file then " · `\(.file)\(if .line then ":\(.line)" else "" end)`" else "" end)
+                  + "**\n\n\(.detail)\n"
+              ' "$V"
             fi
             echo "---"
             echo


### PR DESCRIPTION
Findings run to a paragraph or more. A table cell forces all of that onto one line with newlines collapsed, squeezed into a narrow column — run 7's single finding was a 200-word cell and effectively unreadable.

Each finding is now its own block: a bold heading carrying severity, area and location, then the detail at full width. Sorted **blocking → important → nit**, so the thing that matters is at the top rather than wherever the model happened to emit it.

## Before

```
| | Area | Where | Finding |
|---|---|---|---|
| 🟠 | `tests` | `source/vscode/discovery.spec.ts:497` | The test captures rename and never substitutes it: const realRename = rename; realRename; // referenced only to silence unused-locals — so the publish path is never made to fail, and the test asserts started === true regardless of the behaviour it claims to cover. Fix: monkey-patch the mkdir/writeFile call sites, or reuse the chmodSync(parentDir, 0o555) pattern from the neighbouring test. |
```

## After

> **🟠 important · `tests` · `source/vscode/discovery.spec.ts:497`**
>
> The test captures `rename` and never substitutes it:
>
> ```ts
> const realRename = rename;
> // ...
> realRename; // referenced only to silence unused-locals
> ```
>
> So the publish path is never made to fail, and the test asserts `started === true` regardless of the behaviour it claims to cover. Fix: monkey-patch the `mkdir`/`writeFile` call sites, or reuse the `chmodSync(parentDir, 0o555)` pattern from the neighbouring test.

## Not just markup

The table required `gsub("\n"; " ")` on every detail, so the agent **could never quote code**. It can now, and the rubric says so with an example — for a finding like "this captured reference is never used", quoting the two offending lines makes the point faster than any description of them.

Verified against a three-finding fixture covering all severities, a finding with `file` and `line`, one with `file` only, and one with neither (location line omitted cleanly).
