### PR TITLE
chore: remove @Avtrkrb as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
-# All files - main maintainers
-* @will-lamerton @Avtrkrb @akramcodez
+# Ownership is held by the team, not by individuals: adding a maintainer is a
+# team membership change rather than a pull request against seven files.
+#
+# @Avtrkrb was removed here: the account was moved to `triage`, and a code
+# owner without write access cannot satisfy a code-owner review requirement.
+* @Nano-Collective/core-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,13 @@
-# Ownership is held by the team, not by individuals: adding a maintainer is a
-# team membership change rather than a pull request against seven files.
+# @Avtrkrb was removed here: the account was moved to `triage`, and a code owner
+# without write access cannot satisfy a code-owner review requirement. GitHub's
+# own CODEOWNERS validator was reporting it as an unknown owner.
 #
-# @Avtrkrb was removed here: the account was moved to `triage`, and a code
-# owner without write access cannot satisfy a code-owner review requirement.
-* @Nano-Collective/core-team
+# Individuals rather than @Nano-Collective/core-team, deliberately:
+# .github/workflows/stale-prs.yml parses this file for individual logins and
+# explicitly skips team entries (anything containing "/"). A team-only owner line
+# would leave it with zero owners, and it returns early in that case — silently
+# disabling stale-PR escalation.
+#
+# Move to the team once that workflow resolves team membership, or once it is
+# centralised into Nano-Collective/.github (step 9).
+* @will-lamerton @akramcodez


### PR DESCRIPTION
Removes `@Avtrkrb` as a code owner.

## This is fixing a live defect, not tidying

GitHub's own CODEOWNERS validator currently reports on `main`:

```
Unknown owner on line 2: make sure @Avtrkrb exists and has write access
to the repository
```

That is fallout from moving the account to `triage` during the permissions pass. **A code owner without write access cannot satisfy a code-owner review requirement**, and `Review gates` sets `require_code_owner_review: true`. The replacement validates clean.

## Individuals, not the team — and why

The other six repos in this batch move to `@Nano-Collective/core-team`. This one deliberately does not.

`nc-review` flagged the reason on the first version of this PR, correctly, as blocking:

> `stale-prs.yml` parses CODEOWNERS for individual logins and explicitly skips team entries (those containing `/`). After this PR, the workflow finds zero owners, logs a warning, and returns — silently disabling stale-PR escalation on the main repo.

Verified against the file:

```js
// Teams (containing a slash, e.g. @org/team) are skipped since we
// can't cheaply resolve team membership here.
if (tok.startsWith('@') && !tok.includes('/')) { owners.add(...) }
...
if (owners.size === 0) {
  core.warning('No codeowners parsed; nothing to escalate.');
  return;
}
```

nanocoder is the only repo in the org with a workflow that reads CODEOWNERS, which is why the other six are safe on the team.

The file now carries a comment explaining the coupling, so the next person to reach for the team knows what to fix first: teach `stale-prs.yml` to resolve team membership, or centralise it into `Nano-Collective/.github` per step 9.
