### PR TITLE
fix(nc-review): stop set -e killing the step on exactly one nit

### DIFF
--- a/.github/workflows/nc-review.yml
+++ b/.github/workflows/nc-review.yml
@@ -460,14 +460,31 @@ jobs:
           fi
 
           CLAIMED=$(jq -r '.verdict // "(none)"' "$V")
-          [ "$CLAIMED" != "$VERDICT" ] && \
+          if [ "$CLAIMED" != "$VERDICT" ]; then
             echo "::notice::model said '$CLAIMED', findings imply '$VERDICT' — using '$VERDICT'"
+          fi
 
           # Human-readable tally, e.g. "1 blocking, 2 important, 2 nits".
+          # Plain if-blocks, not `[ ... ] && VAR=...`. Under `set -e` an
+          # assignment takes the exit status of its command substitution, so
+          #
+          #   COUNTS="...${N_NIT} nit$([ "$N_NIT" -gt 1 ] && echo s)"
+          #
+          # killed the whole step whenever there was exactly ONE nit: the inner
+          # test returned 1, the substitution inherited it, and the assignment
+          # failed. Silently, because every echo below is redirected into
+          # comment.md. It survived earlier runs only because they had no nits.
           COUNTS=""
-          [ "$N_BLOCK" -gt 0 ] && COUNTS="${N_BLOCK} blocking"
-          [ "$N_IMP" -gt 0 ] && COUNTS="${COUNTS:+$COUNTS, }${N_IMP} important"
-          [ "$N_NIT" -gt 0 ] && COUNTS="${COUNTS:+$COUNTS, }${N_NIT} nit$([ "$N_NIT" -gt 1 ] && echo s)"
+          if [ "$N_BLOCK" -gt 0 ]; then
+            COUNTS="${N_BLOCK} blocking"
+          fi
+          if [ "$N_IMP" -gt 0 ]; then
+            COUNTS="${COUNTS:+$COUNTS, }${N_IMP} important"
+          fi
+          if [ "$N_NIT" -gt 0 ]; then
+            if [ "$N_NIT" -eq 1 ]; then NITW="nit"; else NITW="nits"; fi
+            COUNTS="${COUNTS:+$COUNTS, }${N_NIT} ${NITW}"
+          fi
 
           {
             case "$VERDICT" in


### PR DESCRIPTION
The review job failed on #1213 after producing a **correct** verdict. The agent wrote the file, the workflow read it, then the step exited 1 having printed nothing at all.

## Cause

```bash
COUNTS="...${N_NIT} nit$([ "$N_NIT" -gt 1 ] && echo s)"
```

With exactly one nit, the inner `[ 1 -gt 1 ]` returns 1, the command substitution inherits that status, and under `set -e` **an assignment fails with the status of its substitution**. The step died on that line.

Nothing appeared in the log because every `echo` after that point is redirected into `comment.md` — so a hard failure looked like a step that silently did nothing.

It fires only when `N_NIT == 1`. Zero nits short-circuits at the `[ "$N_NIT" -gt 0 ]` guard before reaching the substitution, which is why this survived six earlier runs and then broke on the first PR that produced a single nit.

## Fix

Plain `if` blocks, with explicit `nit` / `nits` selection. The `CLAIMED` mismatch notice above it had the identical hazard (`[ ... ] && echo`) and got the same treatment.

## Verified

Extracted the real step from the workflow and ran it against eight combinations — `0/0/0`, `1/0/0`, `0/1/0`, `0/0/1`, `0/0/2`, `1/1/1`, `2/3/4`, `0/2/1`. All exit 0 with the expected heading and correct pluralisation.
