### PR TITLE
fix(scripts): the changelog extractor could not survive a metacharacter or a nested heading

### DIFF
--- a/scripts/extract-changelog.js
+++ b/scripts/extract-changelog.js
@@ -1,73 +1,114 @@
 #!/usr/bin/env node
 
 /**
- * Extract changelog section for a specific version from CHANGELOG.md
- * Usage: node scripts/extract-changelog.js [version]
- * If no version is provided, reads from package.json
+ * Print one version's section of CHANGELOG.md, for a GitHub Release body.
+ *
+ *   node extract-changelog.js [version]
+ *
+ * The version defaults to the one in package.json.
+ *
+ * Kept in this repository rather than shared, unlike the other package repos:
+ * nanocoder publishes through its own release workflow (it needs fetch-depth 0,
+ * a credits build and a contributors section the shared one does not carry), so
+ * it invokes this path directly. It is otherwise identical to
+ * Nano-Collective/.github scripts/extract-changelog.mjs — keep them in step.
+ *
+ * Resolves against the current working directory, which is the repository root
+ * when the release workflow runs it.
+ *
+ * **Boundaries are found by walking lines, not by one big regex.** The previous
+ * version terminated its capture at `(?=\n##+ )`, which also matches `###`. A
+ * changesets changelog opens every version with `### Patch Changes`, so the
+ * lookahead fired on the very first line of the body, the capture came back
+ * empty, and the script exited 0 having printed nothing. Every release across
+ * every repo shipped with a blank body and no error anywhere to say so.
+ *
+ * Walking lines also means the version is never interpolated into a pattern, so
+ * the regex-injection this script used to carry cannot come back.
  */
 
-import {readFileSync} from 'fs';
-import {dirname, join} from 'path';
-import {fileURLToPath} from 'url';
+import {readFileSync} from 'node:fs';
+import {join} from 'node:path';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const rootDir = join(__dirname, '..');
+const rootDir = process.env.CHANGELOG_ROOT ?? process.cwd();
 
-// Get version from command line arg or package.json
 let version = process.argv[2];
 if (!version) {
-	const packageJson = JSON.parse(
-		readFileSync(join(rootDir, 'package.json'), 'utf-8'),
-	);
-	version = packageJson.version;
+	try {
+		version = JSON.parse(
+			readFileSync(join(rootDir, 'package.json'), 'utf-8'),
+		).version;
+	} catch (error) {
+		console.error(
+			`Could not read a version from ${join(rootDir, 'package.json')}: ${error.message}`,
+		);
+		process.exit(1);
+	}
 }
 
-// Read CHANGELOG.md
 let changelogContent;
 try {
 	changelogContent = readFileSync(join(rootDir, 'CHANGELOG.md'), 'utf-8');
 } catch (error) {
-	console.error('Error reading CHANGELOG.md:', error.message);
+	console.error(`Error reading CHANGELOG.md: ${error.message}`);
 	process.exit(1);
 }
 
-// Extract section for this version
-// Support multiple formats:
-// 1. ## [version] - date (Keep a Changelog format)
-// 2. ## version (simple heading)
-// 3. # version (simple heading with single #)
-const versionPatterns = [
-	// Pattern 1: ## [version] or ## version
-	new RegExp(
-		`##+ \\[?${version.replace(
-			/\./g,
-			'\\.',
-		)}\\]?.*?\\n([\\s\\S]*?)(?=\\n##+ |$)`,
-	),
-	// Pattern 2: # version
-	new RegExp(
-		`#+ ${version.replace(/\./g, '\\.')}.*?\\n([\\s\\S]*?)(?=\\n#+ |$)`,
-	),
-];
-
-let match = null;
-for (const pattern of versionPatterns) {
-	match = changelogContent.match(pattern);
-	if (match) break;
+/** `## [1.2.3] - 2026-01-01` -> {depth: 2, title: "[1.2.3] - 2026-01-01"} */
+function parseHeading(line) {
+	const match = /^(#{1,6})\s+(.*)$/.exec(line);
+	return match ? {depth: match[1].length, title: match[2].trim()} : null;
 }
 
-if (!match) {
+/**
+ * Whether a heading announces this version.
+ *
+ * Accepts `## 1.2.3`, `## [1.2.3]`, and `## [1.2.3] - 2026-01-01`, which covers
+ * what changesets writes and the Keep a Changelog convention. Compared as
+ * strings rather than matched as a pattern.
+ */
+function announcesVersion(title) {
+	const firstToken = title.split(/\s+/)[0] ?? '';
+	const bare = firstToken.replace(/^\[/, '').replace(/\]$/, '');
+	return bare === version;
+}
+
+const lines = changelogContent.split('\n');
+const startIndex = lines.findIndex(line => {
+	const heading = parseHeading(line);
+	return heading !== null && announcesVersion(heading.title);
+});
+
+if (startIndex === -1) {
 	console.error(`No changelog entry found for version ${version}`);
-	console.error(
-		'Please add a changelog entry in CHANGELOG.md with one of these formats:',
-	);
-	console.error(`## [${version}] - ${new Date().toISOString().split('T')[0]}`);
-	console.error(`or`);
-	console.error(`# ${version}`);
+	console.error('Expected a heading in CHANGELOG.md such as:');
+	console.error(`  ## ${version}`);
+	console.error(`  ## [${version}] - YYYY-MM-DD`);
 	process.exit(1);
 }
 
-// Output the changelog section (trim leading/trailing whitespace)
-const changelogSection = match[1].trim();
-console.log(changelogSection);
+// The section runs until the next heading at the same level or shallower.
+// Deeper headings — `### Patch Changes` and friends — are part of the body.
+const startDepth = parseHeading(lines[startIndex]).depth;
+let endIndex = lines.length;
+for (let i = startIndex + 1; i < lines.length; i++) {
+	const heading = parseHeading(lines[i]);
+	if (heading !== null && heading.depth <= startDepth) {
+		endIndex = i;
+		break;
+	}
+}
+
+const body = lines
+	.slice(startIndex + 1, endIndex)
+	.join('\n')
+	.trim();
+
+if (body.length === 0) {
+	// Distinct from "no entry found", and worth its own message: a version whose
+	// section exists but is empty is a changelog problem, not a lookup failure.
+	console.error(`The changelog entry for ${version} is empty`);
+	process.exit(1);
+}
+
+console.log(body);


### PR DESCRIPTION
Two bugs, both silent, found while centralising this script for the repos on the shared release workflow.

**nanocoder keeps its own copy** — it publishes through its own workflow, which needs `fetch-depth: 0`, a credits build and a contributors section the shared one does not carry. So the fix is applied here rather than the file deleted.

## The version was interpolated into a regex with only `.` escaped

```
$ node scripts/extract-changelog.js '1.0.0('
SyntaxError: Invalid regular expression: /##+ \[?1\.0\.0(\]?…/: Unterminated group
```

That fails a release **at the point of writing its notes — after the package is already on npm.** CodeQL rates it high severity and flagged five alerts on the identical file when it was copied into nanoterm.

The version is no longer put into a pattern at all, which is a better answer than escaping it.

## Section boundaries terminated on `###`

`(?=\n##+ )` also matches `###`. Any version heading followed directly by a deeper heading captured nothing and the script **exited 0 having printed nothing**.

**This one has never fired here** — `changeset:version` post-processes CHANGELOG.md into plain bullets, so no sub-heading sits under a version, and nanocoder's release bodies have always had content. I checked before claiming otherwise. But it is one changelog-format change away, and the failure mode is a blank release body with nothing anywhere to say so. It did fire on sentinel, whose changelog is raw changesets output.

Boundaries are now found by walking lines and comparing heading depth, so deeper headings stay in the body.

## Verification

`1.30.0` extracts identically to before the change. Kept byte-comparable with [Nano-Collective/.github `scripts/extract-changelog.mjs`](https://github.com/Nano-Collective/.github/blob/main/scripts/extract-changelog.mjs), which the other package repos now share — the docstring notes they should be kept in step.