### PR TITLE
ci: smoke npm pack and CLI --version before publish

### DIFF
--- a/.changeset/release-pack-smoke.md
+++ b/.changeset/release-pack-smoke.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI: pack the publish tarball and run CLI --version before npm publish.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,11 @@ jobs:
           echo "$CONTRIBUTORS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      # Workspace `test -f dist/cli.js` is not the publish tarball. Pack listing
+      # must include bin.nanocoder, and that binary must print package.json's version.
+      - name: Smoke pack and CLI --version
+        run: ./scripts/release-smoke.sh
+
       - name: Publish to NPM
         run: npm publish --access public
         env:

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -29,6 +29,10 @@ export NANOCODER_SMOKE_BIN="$bin"
 npm pack --dry-run --json --ignore-scripts --loglevel=error | node -e '
 const pack = JSON.parse(require("fs").readFileSync(0, "utf8").trim());
 const data = Array.isArray(pack) ? pack[0] : pack;
+if (data && data.error) {
+	console.error("npm pack failed: " + JSON.stringify(data.error));
+	process.exit(1);
+}
 const bin = process.env.NANOCODER_SMOKE_BIN;
 const files = (data && data.files ? data.files : []).map((f) =>
 	String(f.path).replace(/^\.\//, ""),

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Catch a publish tarball that omits the CLI, or a CLI that does not print
+# package.json's version. `test -f dist/cli.js` in the workspace is not the
+# same as the tarball: npm only ships `files`.
+#
+# --ignore-scripts: `prepare` is husky. The release job already built dist/.
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+cd "$root"
+
+version=$(node -p "require('./package.json').version")
+bin=$(node -p "require('./package.json').bin.nanocoder || ''")
+
+if [[ -z "$version" || -z "$bin" ]]; then
+	echo "package.json must have version and bin.nanocoder" >&2
+	exit 1
+fi
+
+if [[ ! -f "$bin" ]]; then
+	echo "missing $bin — run pnpm run build first" >&2
+	exit 1
+fi
+
+export NANOCODER_SMOKE_BIN="$bin"
+
+# npm 10 prints one object; some versions wrap it in an array.
+npm pack --dry-run --json --ignore-scripts --loglevel=error | node -e '
+const pack = JSON.parse(require("fs").readFileSync(0, "utf8").trim());
+const data = Array.isArray(pack) ? pack[0] : pack;
+const bin = process.env.NANOCODER_SMOKE_BIN;
+const files = (data && data.files ? data.files : []).map((f) =>
+	String(f.path).replace(/^\.\//, ""),
+);
+if (!files.includes(bin)) {
+	console.error("npm pack is missing " + bin);
+	process.exit(1);
+}
+console.log("npm pack includes " + bin + " (" + files.length + " files)");
+'
+
+got=$(node "$bin" --version | tr -d '\r')
+if [[ "$got" != "$version" ]]; then
+	echo "$bin --version: expected $version, got $got" >&2
+	exit 1
+fi
+echo "$bin --version = $version"


### PR DESCRIPTION
## Description

Release used to publish after `test -f dist/cli.js` in the workspace. That misses a broken `files` / `bin` in `package.json`.

`scripts/release-smoke.sh` runs `npm pack --dry-run --json` and fails if `bin.nanocoder` is not in the tarball, then runs that binary with `--version` and requires it to match `package.json`. Wired in `release.yml` immediately before `npm publish`.

Closes #1053

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

Smoke is `scripts/release-smoke.sh` (not a `.spec.ts`). After `pnpm run build`:
- success: pack lists `dist/cli.js` and `--version` equals `package.json`
- error: `bin.nanocoder` pointing at a file that is not the real CLI, or `--version` not matching `package.json`, fails the script

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

N/A — CI-only, no runtime/provider change.

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))