### PR TITLE
feat(daemon): add --trust auto-fix/full-commit for CI investigations

### DIFF
--- a/.changeset/ci-auto-fix-trust.md
+++ b/.changeset/ci-auto-fix-trust.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": minor
+---
+
+Added `nanocoder daemon start --trust <auto-fix|full-commit>`, letting the CI-watch daemon's `verify-ci-investigator` subagent actually fix a detected failure instead of only diagnosing it: `auto-fix` implements and commits a fix in an isolated `git worktree`, then opens a draft PR for human review; `full-commit` pushes the fix directly to the failing branch and requires a one-time confirmation warning per project. Trust level and CI-watch poll cadence can now also be set project-wide via `agents.config.json`'s new `verify` block, taking precedence over the existing per-user preferences.

--- a/docs/configuration/preferences.md
+++ b/docs/configuration/preferences.md
@@ -107,6 +107,32 @@ There's no `/settings` wizard for this yet — set it by hand-editing the prefer
 }
 ```
 
+### Project-Level Verify Policy (`agents.config.json`)
+
+Whether CI-watch investigations can auto-fix a failure — and how aggressively — is a project policy, not a personal preference, so it lives in the project's own committed `agents.config.json` under `nanocoder.verify` instead:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `nanocoder.verify.trustLevel` | `"comment-only"` \| `"auto-fix"` \| `"full-commit"` | `comment-only` | See `nanocoder daemon start --trust` below. |
+| `nanocoder.verify.pollIntervalMs` | number | — | Overrides `ciWatch.pollIntervalMs` above when set. |
+| `nanocoder.verify.maxPollIntervalMs` | number | — | Overrides `ciWatch.maxPollIntervalMs` above when set. |
+
+```json
+{
+  "nanocoder": {
+    "verify": {
+      "trustLevel": "auto-fix"
+    }
+  }
+}
+```
+
+`nanocoder daemon start --trust <comment-only|auto-fix|full-commit>` overrides this for a single run; the config value is used when the flag is omitted, falling back to `comment-only` if neither is set:
+
+- **`comment-only`** (default) — investigates and diagnoses a CI failure, posting the diagnosis as a PR comment. Never mutates anything.
+- **`auto-fix`** — additionally implements and commits a fix in an isolated `git worktree`, then pushes a new branch and opens a **draft PR** for human review. The original failing branch is never touched directly.
+- **`full-commit`** — pushes the fix **directly to the failing branch**, with no draft PR and no review step. `daemon start --trust full-commit` shows a one-time security warning per project before starting; subsequent starts for the same project skip it.
+
 When you restart Nanocoder, it automatically restores your last provider, model, theme, shape, paste threshold, and notification preferences.
 
 ## Manual Management

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -53,6 +53,7 @@ if (args[0] === 'daemon') {
 	const {runDaemonCli} = await import('@/daemon/cli');
 	const result = await runDaemonCli(sub as DaemonSub, {
 		projectRoot: process.cwd(),
+		args: args.slice(2),
 	});
 	if (result.output) console.log(result.output);
 	process.exit(result.exitCode);
@@ -79,6 +80,10 @@ Commands:
   copilot login [provider-name]   Log in to GitHub Copilot (device flow). Saves credentials for the "GitHub Copilot" provider.
   daemon <subcommand>             Manage the per-project skill daemon.
                                   Subcommands: start, stop, status, logs, install, uninstall.
+                                  start [--trust <comment-only|auto-fix|full-commit>]
+                                  Trust level for daemon-triggered CI investigation/auto-fix;
+                                  defaults to agents.config.json's verify.trustLevel, then
+                                  comment-only. full-commit prompts a one-time confirmation.
   verify --pr <n> [--post-review] [--provider <name>] [--model <name>]
                                   Headless, read-only PR review: runs the verify-pr-review
                                   subagent plus a semgrep pass. Prints the review to stdout

--- a/source/config/index.spec.ts
+++ b/source/config/index.spec.ts
@@ -833,3 +833,119 @@ test.serial(
 		);
 	},
 );
+
+// ============================================================================
+// verify / ciWatch (Phase 4): project-level trust level + poll cadence
+// override the preferences-backed ciWatch values.
+// ============================================================================
+
+const verifyTestDir = join(tmpdir(), `nanocoder-verify-test-${Date.now()}`);
+
+async function withVerifyConfig(
+	subdir: string,
+	configBody: unknown,
+	preferencesBody: unknown,
+	assertion: (appConfig: AppConfig) => void,
+): Promise<void> {
+	const originalCwd = process.cwd();
+	const originalConfigDir = process.env.NANOCODER_CONFIG_DIR;
+	const testSubdir = join(verifyTestDir, subdir);
+	const globalConfigDir = join(testSubdir, 'global-config');
+	mkdirSync(testSubdir, {recursive: true});
+	mkdirSync(globalConfigDir, {recursive: true});
+
+	try {
+		writeFileSync(
+			join(testSubdir, 'agents.config.json'),
+			JSON.stringify(configBody),
+			'utf-8',
+		);
+		// getClosestConfigFile skips the cwd check entirely once
+		// NANOCODER_CONFIG_DIR is set, so the preferences fixture must live
+		// there — unlike agents.config.json's loadHierarchicalConfig, which
+		// always tries cwd first regardless of this env var.
+		writeFileSync(
+			join(globalConfigDir, 'nanocoder-preferences.json'),
+			JSON.stringify(preferencesBody),
+			'utf-8',
+		);
+		process.chdir(testSubdir);
+		process.env.NANOCODER_CONFIG_DIR = globalConfigDir;
+
+		const {resetPreferencesCache} = await import('./preferences.js');
+		resetPreferencesCache();
+		const {reloadAppConfig: reload, getAppConfig} = await import('./index.js');
+		reload();
+		assertion(getAppConfig());
+	} finally {
+		clearAppConfig();
+		process.chdir(originalCwd);
+		if (originalConfigDir !== undefined) {
+			process.env.NANOCODER_CONFIG_DIR = originalConfigDir;
+		} else {
+			delete process.env.NANOCODER_CONFIG_DIR;
+		}
+		const {resetPreferencesCache} = await import('./preferences.js');
+		resetPreferencesCache();
+	}
+}
+
+test.serial(
+	'loadAppConfig reads nanocoder.verify.trustLevel/pollIntervalMs from agents.config.json',
+	async t => {
+		await withVerifyConfig(
+			'verify-basic',
+			{nanocoder: {verify: {trustLevel: 'auto-fix', pollIntervalMs: 5000}}},
+			{},
+			appConfig => {
+				t.is(appConfig.verify?.trustLevel, 'auto-fix');
+				t.is(appConfig.verify?.pollIntervalMs, 5000);
+			},
+		);
+	},
+);
+
+test.serial(
+	'loadAppConfig ignores an invalid nanocoder.verify.trustLevel value',
+	async t => {
+		await withVerifyConfig(
+			'verify-invalid-trust',
+			{nanocoder: {verify: {trustLevel: 'yolo'}}},
+			{},
+			appConfig => {
+				t.is(appConfig.verify?.trustLevel, undefined);
+			},
+		);
+	},
+);
+
+test.serial(
+	"ciWatch.enabled always comes from preferences, even when agents.config.json sets verify",
+	async t => {
+		await withVerifyConfig(
+			'ciwatch-enabled-from-preferences',
+			{nanocoder: {verify: {trustLevel: 'full-commit'}}},
+			{ciWatch: {enabled: true}},
+			appConfig => {
+				t.true(appConfig.ciWatch?.enabled);
+			},
+		);
+	},
+);
+
+test.serial(
+	"ciWatch's pollIntervalMs prefers the project-level verify override over preferences",
+	async t => {
+		await withVerifyConfig(
+			'ciwatch-poll-override',
+			{nanocoder: {verify: {pollIntervalMs: 5000}}},
+			{ciWatch: {enabled: true, pollIntervalMs: 60000, maxPollIntervalMs: 600000}},
+			appConfig => {
+				t.is(appConfig.ciWatch?.pollIntervalMs, 5000);
+				// maxPollIntervalMs has no project override in this fixture, so
+				// the preferences value still comes through.
+				t.is(appConfig.ciWatch?.maxPollIntervalMs, 600000);
+			},
+		);
+	},
+);

--- a/source/config/index.ts
+++ b/source/config/index.ts
@@ -28,9 +28,11 @@ import type {
 	ProviderConfig,
 	SystemPromptConfig,
 	TuneConfig,
+	VerifyConfig,
 } from '@/types/index';
 import {logError} from '@/utils/message-queue';
 import {DEFAULT_SINGLE_LINE_PASTE_THRESHOLD} from '@/utils/paste-utils';
+import {isTrustLevel} from '@/verify/trust';
 
 // Load .env file from working directory (shell environment takes precedence)
 // Suppress dotenv console output by temporarily redirecting stdout
@@ -493,9 +495,46 @@ function loadNotificationsConfig(): NotificationsConfig | undefined {
 	return getNotificationsPreference();
 }
 
-// Load CI-watch configuration from preferences
+// Load project-level verify policy (trust level, poll cadence overrides)
+// from agents.config.json. Unlike ciWatch.enabled (a personal, per-machine
+// opt-in kept in preferences), trust level and cadence are security/policy
+// decisions appropriate to commit and review with the rest of the project.
+function loadVerifyConfig(): VerifyConfig | undefined {
+	return (
+		loadHierarchicalConfig('agents.config.json', 'verify', config => {
+			const verify = config.nanocoder?.verify;
+			if (!verify || typeof verify !== 'object') return null;
+			const result: VerifyConfig = {};
+			if (isTrustLevel(verify.trustLevel)) {
+				result.trustLevel = verify.trustLevel;
+			}
+			if (typeof verify.pollIntervalMs === 'number') {
+				result.pollIntervalMs = verify.pollIntervalMs;
+			}
+			if (typeof verify.maxPollIntervalMs === 'number') {
+				result.maxPollIntervalMs = verify.maxPollIntervalMs;
+			}
+			return Object.keys(result).length > 0 ? result : null;
+		}) ?? undefined
+	);
+}
+
+// Load CI-watch configuration: `enabled` always comes from preferences (a
+// personal opt-in); `pollIntervalMs`/`maxPollIntervalMs` prefer the
+// project-level `verify` overrides from agents.config.json when set, since
+// poll cadence is more appropriately a reviewable project policy.
 function loadCiWatchConfig(): CiWatchConfig | undefined {
-	return getCiWatchPreference();
+	const preferencesValue = getCiWatchPreference();
+	const projectOverrides = loadVerifyConfig();
+	if (!preferencesValue && !projectOverrides) return undefined;
+	return {
+		enabled: preferencesValue?.enabled ?? false,
+		pollIntervalMs:
+			projectOverrides?.pollIntervalMs ?? preferencesValue?.pollIntervalMs,
+		maxPollIntervalMs:
+			projectOverrides?.maxPollIntervalMs ??
+			preferencesValue?.maxPollIntervalMs,
+	};
 }
 
 export function loadDefaultMode(): CliMode | undefined {
@@ -548,6 +587,9 @@ function loadAppConfig(): AppConfig {
 
 	// Load notifications configuration
 	const notifications = loadNotificationsConfig();
+	// Load project-level verify policy (must load before ciWatch, which
+	// layers its poll-cadence overrides on top of the preferences value)
+	const verify = loadVerifyConfig();
 	// Load CI-watch configuration
 	const ciWatch = loadCiWatchConfig();
 
@@ -569,6 +611,7 @@ function loadAppConfig(): AppConfig {
 		systemPrompt,
 		notifications,
 		ciWatch,
+		verify,
 		modeProviders,
 		tune,
 	};

--- a/source/constants.ts
+++ b/source/constants.ts
@@ -28,9 +28,19 @@ export const TIMEOUT_GH_LOG_MS = 60_000;
 // never legitimately take long; a hang here (auth prompt, network stall)
 // should fail fast rather than block an unattended caller indefinitely.
 export const TIMEOUT_GH_METADATA_MS = 30_000;
+// Bound for `git push` (daemon auto-fix/full-commit): a network op that
+// should never legitimately hang for an unattended background caller.
+export const TIMEOUT_GIT_PUSH_MS = 60_000;
 // `semgrep scan --config auto` can fetch/update its rule registry on first
 // run, which is slower than a typical local scan.
 export const TIMEOUT_SEMGREP_MS = 120_000;
+// Ceiling for the daemon's auto-fix/full-commit one-shot fix subprocess
+// (investigate + edit files + run tests/build + commit). Generous since it
+// covers a full LLM-driven edit-and-verify loop, but bounded because
+// BackpressureDispatcher's per-subscription in-flight cap would otherwise
+// let one runaway attempt block all future ci.job.failed triggers for the
+// builtin CI investigator.
+export const TIMEOUT_CI_FIX_RUNNER_MS = 900_000; // 15 minutes
 // Ceiling on the pricing lookup for the per-response usage footer: past
 // this the message renders with token counts only rather than holding the
 // streaming-to-static swap hostage to a cold models.dev fetch.

--- a/source/daemon/ci-fix-orchestrator.spec.ts
+++ b/source/daemon/ci-fix-orchestrator.spec.ts
@@ -1,0 +1,209 @@
+import test from 'ava';
+import type {CiJobFailedPayload} from '@/events/types';
+import type {SubagentTask} from '@/subagents/types';
+import type {CiFixWorktree} from './ci-fix-worktree';
+import {runCiAutoFixFlow, type CiFixOrchestratorDeps} from './ci-fix-orchestrator';
+
+console.log('\nci-fix-orchestrator.spec.ts');
+
+const PAYLOAD: CiJobFailedPayload = {
+	runId: 42,
+	workflowName: 'CI',
+	branch: 'feature-x',
+	headSha: 'abc123',
+	url: 'https://github.com/o/r/actions/runs/42',
+};
+
+function ciTask(): SubagentTask {
+	return {
+		subagent_type: 'verify-ci-investigator',
+		description: 'Investigate CI failure',
+		context: {
+			trigger: {type: 'event', kind: 'ci.job.failed', payload: PAYLOAD},
+		},
+	};
+}
+
+const FAKE_WORKTREE: CiFixWorktree = {
+	path: '/tmp/fake-worktree',
+	branch: 'nanocoder/ci-fix/feature-x-42',
+	isNewBranch: true,
+};
+
+function stubDeps(overrides: Partial<CiFixOrchestratorDeps> = {}) {
+	const calls = {
+		createWorktree: 0,
+		removeWorktree: 0,
+		spawnFixRunner: 0,
+		pushBranch: [] as Array<[string, {setUpstream?: boolean; cwd?: string} | undefined]>,
+		createDraftPr: [] as Array<{title: string; body: string; base: string; head: string}>,
+	};
+	const deps: CiFixOrchestratorDeps = {
+		createWorktree: async () => {
+			calls.createWorktree++;
+			return FAKE_WORKTREE;
+		},
+		removeWorktree: async () => {
+			calls.removeWorktree++;
+		},
+		spawnFixRunner: async () => {
+			calls.spawnFixRunner++;
+			return {success: true, committed: false, commitShas: [], output: 'no fix needed'};
+		},
+		pushBranch: async (branch, opts) => {
+			calls.pushBranch.push([branch, opts]);
+		},
+		createDraftPr: async opts => {
+			calls.createDraftPr.push(opts);
+			return 'https://github.com/o/r/pull/99';
+		},
+		...overrides,
+	};
+	return {deps, calls};
+}
+
+test('no ci.job.failed payload on the task fails immediately without creating a worktree', async t => {
+	const {deps, calls} = stubDeps();
+	const task: SubagentTask = {
+		subagent_type: 'verify-ci-investigator',
+		description: 'no payload',
+	};
+
+	const result = await runCiAutoFixFlow(task, 'auto-fix', '/repo', deps);
+
+	t.false(result.success);
+	t.is(calls.createWorktree, 0);
+});
+
+test('createWorktree throwing is a clean failure, no removeWorktree call', async t => {
+	const {deps, calls} = stubDeps({
+		createWorktree: async () => {
+			throw new Error('git clone failed: could not resolve host');
+		},
+	});
+
+	const result = await runCiAutoFixFlow(ciTask(), 'full-commit', '/repo', deps);
+
+	t.false(result.success);
+	t.regex(result.error ?? '', /Failed to create CI-fix worktree/);
+	t.is(calls.removeWorktree, 0);
+});
+
+test('runner failure returns a failed result, worktree still removed', async t => {
+	const {deps, calls} = stubDeps({
+		spawnFixRunner: async () => ({
+			success: false,
+			committed: false,
+			commitShas: [],
+			output: '',
+			error: 'subagent crashed',
+		}),
+	});
+
+	const result = await runCiAutoFixFlow(ciTask(), 'auto-fix', '/repo', deps);
+
+	t.false(result.success);
+	t.regex(result.error ?? '', /subagent crashed/);
+	t.is(calls.removeWorktree, 1);
+	t.is(calls.pushBranch.length, 0);
+});
+
+test('committed: false returns a successful result with no push/PR call', async t => {
+	const {deps, calls} = stubDeps();
+
+	const result = await runCiAutoFixFlow(ciTask(), 'auto-fix', '/repo', deps);
+
+	t.true(result.success);
+	t.is(result.output, 'no fix needed');
+	t.is(calls.pushBranch.length, 0);
+	t.is(calls.createDraftPr.length, 0);
+	t.is(calls.removeWorktree, 1);
+});
+
+test('auto-fix + committed pushes the fix branch and opens a draft PR against the original branch', async t => {
+	const {deps, calls} = stubDeps({
+		spawnFixRunner: async () => ({
+			success: true,
+			committed: true,
+			commitShas: ['deadbeef'],
+			output: 'fixed the flaky test',
+		}),
+	});
+
+	const result = await runCiAutoFixFlow(ciTask(), 'auto-fix', '/repo', deps);
+
+	t.true(result.success);
+	t.true(result.fixApplied);
+	t.is(calls.pushBranch.length, 1);
+	t.is(calls.pushBranch[0]?.[0], FAKE_WORKTREE.branch);
+	t.true(calls.pushBranch[0]?.[1]?.setUpstream);
+	t.is(calls.pushBranch[0]?.[1]?.cwd, FAKE_WORKTREE.path);
+	t.is(calls.createDraftPr.length, 1);
+	t.is(calls.createDraftPr[0]?.base, PAYLOAD.branch);
+	t.is(calls.createDraftPr[0]?.head, FAKE_WORKTREE.branch);
+	t.true(result.output.includes('https://github.com/o/r/pull/99'));
+	t.is(calls.removeWorktree, 1);
+});
+
+test('full-commit + committed pushes directly to the branch with no draft PR', async t => {
+	const {deps, calls} = stubDeps({
+		spawnFixRunner: async () => ({
+			success: true,
+			committed: true,
+			commitShas: ['deadbeef'],
+			output: 'fixed the flaky test',
+		}),
+	});
+
+	const result = await runCiAutoFixFlow(ciTask(), 'full-commit', '/repo', deps);
+
+	t.true(result.success);
+	t.true(result.fixApplied);
+	t.is(calls.pushBranch.length, 1);
+	t.is(calls.pushBranch[0]?.[0], FAKE_WORKTREE.branch);
+	t.falsy(calls.pushBranch[0]?.[1]?.setUpstream);
+	t.is(calls.pushBranch[0]?.[1]?.cwd, FAKE_WORKTREE.path);
+	t.is(calls.createDraftPr.length, 0);
+	t.is(calls.removeWorktree, 1);
+});
+
+test('worktree is still removed when createDraftPr throws after a successful commit', async t => {
+	const {deps, calls} = stubDeps({
+		spawnFixRunner: async () => ({
+			success: true,
+			committed: true,
+			commitShas: ['deadbeef'],
+			output: 'fixed it',
+		}),
+		createDraftPr: async () => {
+			throw new Error('gh pr create failed: no auth');
+		},
+	});
+
+	const result = await runCiAutoFixFlow(ciTask(), 'auto-fix', '/repo', deps);
+
+	t.false(result.success);
+	t.regex(result.error ?? '', /opening a PR for pushed branch "nanocoder\/ci-fix\/feature-x-42" failed/);
+	t.is(calls.removeWorktree, 1);
+});
+
+test('a failure before the push (no createDraftPr call yet) reports "pushing the fix failed", not the branch-specific wording', async t => {
+	const {deps, calls} = stubDeps({
+		spawnFixRunner: async () => ({
+			success: true,
+			committed: true,
+			commitShas: ['deadbeef'],
+			output: 'fixed it',
+		}),
+		pushBranch: async () => {
+			throw new Error('network unreachable');
+		},
+	});
+
+	const result = await runCiAutoFixFlow(ciTask(), 'auto-fix', '/repo', deps);
+
+	t.false(result.success);
+	t.regex(result.error ?? '', /Fix was committed but pushing the fix failed/);
+	t.is(calls.createDraftPr.length, 0);
+	t.is(calls.removeWorktree, 1);
+});

--- a/source/daemon/ci-fix-orchestrator.ts
+++ b/source/daemon/ci-fix-orchestrator.ts
@@ -1,0 +1,245 @@
+/**
+ * Ties together the isolated worktree, the one-shot fix subprocess, and the
+ * harness-mediated push/PR step for auto-fix/full-commit CI investigations.
+ * Invoked from `entry.ts`'s `buildExecutor` in place of running
+ * `verify-ci-investigator` inline, whenever the resolved trust level is
+ * `auto-fix` or `full-commit`.
+ */
+
+import {type ChildProcess, spawn} from 'node:child_process';
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {TIMEOUT_CI_FIX_RUNNER_MS} from '@/constants';
+import type {CiFixRunnerInput, CiFixRunnerResult} from '@/daemon/ci-fix-runner';
+import type {CiJobFailedPayload} from '@/events/types';
+import type {SubagentResult, SubagentTask} from '@/subagents/types';
+import {createDraftPr, pushBranch} from '@/tools/git/utils';
+import type {TrustLevel} from '@/verify/trust';
+import {
+	type CiFixWorktree,
+	createCiFixWorktree,
+	removeCiFixWorktree,
+} from './ci-fix-worktree';
+
+export interface CiFixOrchestratorDeps {
+	createWorktree: typeof createCiFixWorktree;
+	removeWorktree: typeof removeCiFixWorktree;
+	spawnFixRunner: (input: CiFixRunnerInput) => Promise<CiFixRunnerResult>;
+	pushBranch: typeof pushBranch;
+	createDraftPr: typeof createDraftPr;
+}
+
+function extractCiPayload(task: SubagentTask): CiJobFailedPayload | undefined {
+	const trigger = task.context?.trigger as
+		| {kind?: string; payload?: CiJobFailedPayload}
+		| undefined;
+	if (trigger?.kind !== 'ci.job.failed' || !trigger.payload) return undefined;
+	return trigger.payload;
+}
+
+function defaultSpawnFixRunner(
+	input: CiFixRunnerInput,
+): Promise<CiFixRunnerResult> {
+	return new Promise((resolve, reject) => {
+		const runnerEntry = fileURLToPath(
+			new URL('./ci-fix-runner.js', import.meta.url),
+		);
+		const workDir = mkdtempSync(join(tmpdir(), 'nanocoder-ci-fix-io-'));
+		const inputPath = join(workDir, 'input.json');
+		const resultPath = join(workDir, 'result.json');
+		writeFileSync(inputPath, JSON.stringify(input), 'utf-8');
+
+		const cleanupIoDir = () => rmSync(workDir, {recursive: true, force: true});
+
+		let child: ChildProcess;
+		try {
+			child = spawn(process.execPath, [runnerEntry], {
+				env: {
+					...process.env,
+					NANOCODER_CI_FIX_INPUT_PATH: inputPath,
+					NANOCODER_CI_FIX_RESULT_PATH: resultPath,
+				},
+				stdio: 'inherit',
+			});
+		} catch (err) {
+			cleanupIoDir();
+			reject(err);
+			return;
+		}
+
+		const timer = setTimeout(() => {
+			child.kill('SIGTERM');
+			const forceKill = setTimeout(() => child.kill('SIGKILL'), 5000);
+			forceKill.unref();
+		}, TIMEOUT_CI_FIX_RUNNER_MS);
+		timer.unref();
+
+		child.on('error', err => {
+			clearTimeout(timer);
+			cleanupIoDir();
+			reject(err);
+		});
+
+		child.on('close', () => {
+			clearTimeout(timer);
+			try {
+				const result = JSON.parse(
+					readFileSync(resultPath, 'utf-8'),
+				) as CiFixRunnerResult;
+				resolve(result);
+			} catch (err) {
+				resolve({
+					success: false,
+					committed: false,
+					commitShas: [],
+					output: '',
+					error: `ci-fix-runner produced no readable result: ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+				});
+			} finally {
+				cleanupIoDir();
+			}
+		});
+	});
+}
+
+const defaultDeps: CiFixOrchestratorDeps = {
+	createWorktree: createCiFixWorktree,
+	removeWorktree: removeCiFixWorktree,
+	spawnFixRunner: defaultSpawnFixRunner,
+	pushBranch,
+	createDraftPr,
+};
+
+function toSubagentResult(
+	subagentName: string,
+	startTime: number,
+	overrides: Partial<SubagentResult>,
+): SubagentResult {
+	return {
+		subagentName,
+		output: '',
+		success: false,
+		executionTimeMs: Date.now() - startTime,
+		...overrides,
+	};
+}
+
+export async function runCiAutoFixFlow(
+	task: SubagentTask,
+	trustLevel: Extract<TrustLevel, 'auto-fix' | 'full-commit'>,
+	projectRoot: string,
+	deps: Partial<CiFixOrchestratorDeps> = {},
+): Promise<SubagentResult> {
+	const {
+		createWorktree,
+		removeWorktree,
+		spawnFixRunner,
+		pushBranch,
+		createDraftPr,
+	} = {...defaultDeps, ...deps};
+	const startTime = Date.now();
+
+	const payload = extractCiPayload(task);
+	if (!payload) {
+		return toSubagentResult(task.subagent_type, startTime, {
+			error: 'ci-fix-orchestrator: task carries no ci.job.failed payload',
+		});
+	}
+
+	let worktree: CiFixWorktree;
+	try {
+		worktree = await createWorktree({
+			projectRoot,
+			originalBranch: payload.branch,
+			runId: payload.runId,
+			trustLevel,
+		});
+	} catch (err) {
+		return toSubagentResult(task.subagent_type, startTime, {
+			error: `Failed to create CI-fix worktree: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		});
+	}
+
+	try {
+		let runnerResult: CiFixRunnerResult;
+		try {
+			runnerResult = await spawnFixRunner({
+				worktreePath: worktree.path,
+				trustLevel,
+				payload,
+				taskDescription: task.description,
+			});
+		} catch (err) {
+			return toSubagentResult(task.subagent_type, startTime, {
+				error: `CI-fix subprocess failed to run: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			});
+		}
+
+		if (!runnerResult.success) {
+			return toSubagentResult(task.subagent_type, startTime, {
+				output: runnerResult.output,
+				error: runnerResult.error ?? 'CI-fix subprocess did not succeed',
+			});
+		}
+
+		if (!runnerResult.committed) {
+			return toSubagentResult(task.subagent_type, startTime, {
+				success: true,
+				output: runnerResult.output,
+			});
+		}
+
+		let pushed = false;
+		try {
+			if (trustLevel === 'auto-fix') {
+				await pushBranch(worktree.branch, {
+					setUpstream: true,
+					cwd: worktree.path,
+				});
+				pushed = true;
+				const prUrl = await createDraftPr({
+					title: `fix(ci): ${payload.workflowName} failed on ${payload.branch}`,
+					body: runnerResult.output,
+					base: payload.branch,
+					head: worktree.branch,
+				});
+				return toSubagentResult(task.subagent_type, startTime, {
+					success: true,
+					fixApplied: true,
+					output: `Opened draft PR: ${prUrl}\n\n${runnerResult.output}`,
+				});
+			}
+
+			await pushBranch(worktree.branch, {cwd: worktree.path});
+			return toSubagentResult(task.subagent_type, startTime, {
+				success: true,
+				fixApplied: true,
+				output: `Pushed directly to ${worktree.branch}.\n\n${runnerResult.output}`,
+			});
+		} catch (err) {
+			// If the push itself succeeded and only createDraftPr failed
+			// afterward, the fix branch is now live on origin with nothing
+			// referencing it — name it explicitly so it's discoverable (and
+			// cleanable) from the daemon log rather than only implied.
+			const publishStage = pushed
+				? `opening a PR for pushed branch "${worktree.branch}"`
+				: 'pushing the fix';
+			return toSubagentResult(task.subagent_type, startTime, {
+				output: runnerResult.output,
+				error: `Fix was committed but ${publishStage} failed: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			});
+		}
+	} finally {
+		await removeWorktree(worktree);
+	}
+}

--- a/source/daemon/ci-fix-runner.ts
+++ b/source/daemon/ci-fix-runner.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * One-shot CI-fix subprocess entry point.
+ *
+ * Spawned by `ci-fix-orchestrator.ts` for a single auto-fix/full-commit
+ * attempt. Unlike `entry.ts` (a long-running event loop), this process
+ * does one thing and exits: run `verify-ci-investigator` at an elevated
+ * trust level against an isolated `git worktree`, then report what
+ * happened. Its own `process.cwd()` is set to the worktree path — safe
+ * here specifically because this process has no other concurrent work
+ * sharing that cwd, unlike the daemon's own long-running process.
+ *
+ * Handoff is via two JSON files (paths in env vars), not stdout scraping —
+ * same "state lives on disk" precedent as `daemon/lockfile.ts` — so nothing
+ * the subagent itself prints to stdout can corrupt the result.
+ */
+
+import {readFileSync, writeFileSync} from 'node:fs';
+import {createLLMClient} from '@/client-factory';
+import type {CiJobFailedPayload} from '@/events/types';
+import {SubagentExecutor} from '@/subagents/subagent-executor';
+import type {SubagentTask} from '@/subagents/types';
+import {execGit} from '@/tools/git/utils';
+import {ToolManager} from '@/tools/tool-manager';
+import {formatError} from '@/utils/error-formatter';
+import {
+	getAllowedToolNames,
+	getHeadlessAutoApproveToolNames,
+	type TrustLevel,
+} from '@/verify/trust';
+
+export interface CiFixRunnerInput {
+	worktreePath: string;
+	trustLevel: Extract<TrustLevel, 'auto-fix' | 'full-commit'>;
+	payload: CiJobFailedPayload;
+	taskDescription: string;
+}
+
+export interface CiFixRunnerResult {
+	success: boolean;
+	committed: boolean;
+	commitShas: string[];
+	output: string;
+	error?: string;
+}
+
+async function main(): Promise<void> {
+	const inputPath = process.env.NANOCODER_CI_FIX_INPUT_PATH;
+	const resultPath = process.env.NANOCODER_CI_FIX_RESULT_PATH;
+	if (!inputPath || !resultPath) {
+		console.error(
+			'ci-fix-runner: NANOCODER_CI_FIX_INPUT_PATH/NANOCODER_CI_FIX_RESULT_PATH not set.',
+		);
+		process.exit(1);
+	}
+
+	const input = JSON.parse(
+		readFileSync(inputPath, 'utf-8'),
+	) as CiFixRunnerInput;
+
+	// Safe here — this process has no other concurrent work sharing its cwd,
+	// which is the entire reason it's a separate process from the daemon.
+	process.chdir(input.worktreePath);
+
+	let result: CiFixRunnerResult;
+	try {
+		const {client} = await createLLMClient();
+		const toolManager = new ToolManager();
+		const executor = new SubagentExecutor(
+			toolManager,
+			client,
+			input.worktreePath,
+			'headless',
+		);
+
+		const baselineSha = (await execGit(['rev-parse', 'HEAD'])).trim();
+
+		const task: SubagentTask = {
+			subagent_type: 'verify-ci-investigator',
+			description: input.taskDescription,
+			context: {
+				trigger: {
+					type: 'event',
+					kind: 'ci.job.failed',
+					payload: input.payload,
+				},
+				trustLevel: input.trustLevel,
+			},
+		};
+
+		const subagentResult = await executor.execute(
+			task,
+			undefined,
+			0,
+			undefined,
+			{
+				tools: getAllowedToolNames(input.trustLevel),
+				alwaysAllow: getHeadlessAutoApproveToolNames(input.trustLevel),
+			},
+		);
+
+		const commitLog = await execGit([
+			'log',
+			`${baselineSha}..HEAD`,
+			'--format=%H',
+		]);
+		const commitShas = commitLog.split('\n').filter(Boolean);
+
+		result = {
+			success: subagentResult.success,
+			committed: commitShas.length > 0,
+			commitShas,
+			output: subagentResult.output,
+			error: subagentResult.error,
+		};
+	} catch (err) {
+		result = {
+			success: false,
+			committed: false,
+			commitShas: [],
+			output: '',
+			error: formatError(err),
+		};
+	}
+
+	writeFileSync(resultPath, JSON.stringify(result, null, 2), 'utf-8');
+	process.exit(result.success ? 0 : 1);
+}
+
+main().catch(err => {
+	console.error('ci-fix-runner failed:', err);
+	process.exit(1);
+});

--- a/source/daemon/ci-fix-worktree.spec.ts
+++ b/source/daemon/ci-fix-worktree.spec.ts
@@ -1,0 +1,151 @@
+import {execFileSync} from 'node:child_process';
+import {existsSync} from 'node:fs';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import {createCiFixWorktree, removeCiFixWorktree} from './ci-fix-worktree';
+
+console.log('\nci-fix-worktree.spec.ts');
+
+function git(cwd: string, args: string[]): string {
+	return execFileSync('git', args, {cwd, encoding: 'utf-8'});
+}
+
+/** A real bare "remote" repo plus a clone of it acting as the daemon's own
+ * `projectRoot` — checked out ON `failing-branch` itself, mirroring the
+ * guaranteed real-world case: `CiEventSource` defaults to whatever branch
+ * is currently checked out, so the failing branch IS always the daemon's
+ * own checkout. `createCiFixWorktree` must still succeed here (this is
+ * exactly the scenario a `git worktree add` approach cannot handle, since
+ * git refuses to check out a branch that's already checked out elsewhere —
+ * cloning from the bare remote sidesteps that entirely). */
+async function tempProjectWithFailingBranchCheckedOut(): Promise<{
+	projectRoot: string;
+	remoteDir: string;
+}> {
+	const remoteDir = await mkdtemp(join(tmpdir(), 'ci-fix-remote-'));
+	git(remoteDir, ['init', '--bare', '--initial-branch=main']);
+
+	const projectRoot = await mkdtemp(join(tmpdir(), 'ci-fix-project-'));
+	execFileSync('git', ['clone', remoteDir, projectRoot], {encoding: 'utf-8'});
+	git(projectRoot, ['config', 'user.email', 'test@example.com']);
+	git(projectRoot, ['config', 'user.name', 'Test']);
+	git(projectRoot, ['commit', '--allow-empty', '-m', 'initial']);
+	git(projectRoot, ['push', 'origin', 'main']);
+	git(projectRoot, ['checkout', '-b', 'failing-branch']);
+	git(projectRoot, ['commit', '--allow-empty', '-m', 'broke ci']);
+	git(projectRoot, ['push', 'origin', 'failing-branch']);
+	// Left checked out on failing-branch — the realistic case.
+
+	return {projectRoot, remoteDir};
+}
+
+test('auto-fix clones and creates a new branch, even though the failing branch is checked out at projectRoot', async t => {
+	const {projectRoot, remoteDir} = await tempProjectWithFailingBranchCheckedOut();
+	try {
+		const worktree = await createCiFixWorktree({
+			projectRoot,
+			originalBranch: 'failing-branch',
+			runId: 42,
+			trustLevel: 'auto-fix',
+		});
+		try {
+			t.true(worktree.isNewBranch);
+			t.is(worktree.branch, 'nanocoder/ci-fix/failing-branch-42');
+			t.true(existsSync(worktree.path));
+			t.not(worktree.path, projectRoot);
+
+			const branchInClone = git(worktree.path, [
+				'rev-parse',
+				'--abbrev-ref',
+				'HEAD',
+			]).trim();
+			t.is(branchInClone, 'nanocoder/ci-fix/failing-branch-42');
+		} finally {
+			await removeCiFixWorktree(worktree);
+		}
+	} finally {
+		await rm(projectRoot, {recursive: true, force: true});
+		await rm(remoteDir, {recursive: true, force: true});
+	}
+});
+
+test('full-commit clones and checks out the failing branch directly, without conflicting with projectRoot\'s own checkout', async t => {
+	const {projectRoot, remoteDir} = await tempProjectWithFailingBranchCheckedOut();
+	try {
+		// projectRoot itself is already checked out on failing-branch — a
+		// `git worktree add` for the same branch would fail here; cloning
+		// from the remote must not.
+		const worktree = await createCiFixWorktree({
+			projectRoot,
+			originalBranch: 'failing-branch',
+			runId: 42,
+			trustLevel: 'full-commit',
+		});
+		try {
+			t.false(worktree.isNewBranch);
+			t.is(worktree.branch, 'failing-branch');
+
+			const branchInClone = git(worktree.path, [
+				'rev-parse',
+				'--abbrev-ref',
+				'HEAD',
+			]).trim();
+			t.is(branchInClone, 'failing-branch');
+		} finally {
+			await removeCiFixWorktree(worktree);
+		}
+	} finally {
+		await rm(projectRoot, {recursive: true, force: true});
+		await rm(remoteDir, {recursive: true, force: true});
+	}
+});
+
+test('the clone has its own independent commit history from projectRoot', async t => {
+	const {projectRoot, remoteDir} = await tempProjectWithFailingBranchCheckedOut();
+	try {
+		const worktree = await createCiFixWorktree({
+			projectRoot,
+			originalBranch: 'failing-branch',
+			runId: 1,
+			trustLevel: 'full-commit',
+		});
+		try {
+			git(worktree.path, ['commit', '--allow-empty', '-m', 'a fix']);
+			const cloneLog = git(worktree.path, ['log', '--oneline']).trim();
+			const projectLog = git(projectRoot, ['log', '--oneline']).trim();
+
+			t.true(cloneLog.includes('a fix'));
+			t.false(
+				projectLog.includes('a fix'),
+				'a commit made in the clone must not appear in projectRoot until explicitly pushed there',
+			);
+		} finally {
+			await removeCiFixWorktree(worktree);
+		}
+	} finally {
+		await rm(projectRoot, {recursive: true, force: true});
+		await rm(remoteDir, {recursive: true, force: true});
+	}
+});
+
+test('removeCiFixWorktree cleans up the clone directory and is tolerant of an already-gone directory', async t => {
+	const {projectRoot, remoteDir} = await tempProjectWithFailingBranchCheckedOut();
+	try {
+		const worktree = await createCiFixWorktree({
+			projectRoot,
+			originalBranch: 'failing-branch',
+			runId: 7,
+			trustLevel: 'auto-fix',
+		});
+		await removeCiFixWorktree(worktree);
+		t.false(existsSync(worktree.path));
+
+		// Removing again (directory already gone) must not throw.
+		await t.notThrowsAsync(() => removeCiFixWorktree(worktree));
+	} finally {
+		await rm(projectRoot, {recursive: true, force: true});
+		await rm(remoteDir, {recursive: true, force: true});
+	}
+});

--- a/source/daemon/ci-fix-worktree.ts
+++ b/source/daemon/ci-fix-worktree.ts
@@ -1,0 +1,108 @@
+/**
+ * Isolated git clone lifecycle for auto-fix/full-commit CI investigations.
+ * Harness-only (not an agent tool) — used by `ci-fix-orchestrator.ts` to
+ * give the one-shot fix subprocess its own `process.cwd()`, decoupled from
+ * the daemon's own working directory and event loop. See the Phase 4 plan's
+ * Context section for why this isolation is necessary: every tool in this
+ * codebase resolves paths against the single process-global
+ * `process.cwd()`, which the daemon shares across every
+ * concurrently-dispatchable triggered run.
+ *
+ * Deliberately a full `git clone`, not a `git worktree add`: a linked
+ * worktree shares its parent repo's refs, so git refuses to check out a
+ * branch that's already checked out elsewhere — and the branch CI just
+ * failed on is *always* the daemon's own currently-checked-out branch
+ * (`CiEventSource` defaults to `getCurrentBranch()`; nothing configures it
+ * otherwise), so `full-commit` would deterministically fail to ever create
+ * a worktree. A clone has its own independent object database, so checking
+ * out that same branch a second time here is never a conflict. The
+ * trade-off: the clone's new commits exist only in its own `.git`, so
+ * publishing them (`pushBranch`) must run with this clone as its `cwd`,
+ * not the daemon's project root — see `ci-fix-orchestrator.ts`.
+ */
+
+import {mkdtempSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {execGit} from '@/tools/git/utils';
+
+export interface CiFixWorktree {
+	path: string;
+	/** Branch checked out inside the clone. */
+	branch: string;
+	/** true for auto-fix (a fresh branch off the failing branch); false for
+	 * full-commit (the failing branch itself, checked out directly). */
+	isNewBranch: boolean;
+}
+
+export interface CreateCiFixWorktreeOptions {
+	projectRoot: string;
+	originalBranch: string;
+	runId: number;
+	trustLevel: 'auto-fix' | 'full-commit';
+}
+
+function fixBranchName(originalBranch: string, runId: number): string {
+	// Slashes in the original branch name are fine in a git ref, but keep
+	// this readable and collision-resistant across repeated attempts.
+	return `nanocoder/ci-fix/${originalBranch}-${runId}`;
+}
+
+async function getRemoteUrl(projectRoot: string): Promise<string> {
+	const output = await execGit([
+		'-C',
+		projectRoot,
+		'remote',
+		'get-url',
+		'origin',
+	]);
+	return output.trim();
+}
+
+export async function createCiFixWorktree(
+	opts: CreateCiFixWorktreeOptions,
+): Promise<CiFixWorktree> {
+	const clonePath = mkdtempSync(join(tmpdir(), 'nanocoder-ci-fix-'));
+	try {
+		const remoteUrl = await getRemoteUrl(opts.projectRoot);
+		// --single-branch: this is a throwaway, single-purpose checkout, not
+		// a general-purpose clone — no need to fetch every branch.
+		await execGit([
+			'clone',
+			'--origin',
+			'origin',
+			'--branch',
+			opts.originalBranch,
+			'--single-branch',
+			remoteUrl,
+			clonePath,
+		]);
+
+		if (opts.trustLevel === 'auto-fix') {
+			const branch = fixBranchName(opts.originalBranch, opts.runId);
+			await execGit(['-C', clonePath, 'checkout', '-b', branch]);
+			return {path: clonePath, branch, isNewBranch: true};
+		}
+
+		return {path: clonePath, branch: opts.originalBranch, isNewBranch: false};
+	} catch (err) {
+		rmSync(clonePath, {recursive: true, force: true});
+		throw err;
+	}
+}
+
+export async function removeCiFixWorktree(
+	worktree: CiFixWorktree,
+): Promise<void> {
+	// A full clone, not a linked worktree — there's no registration in the
+	// main repo to clean up (no `git worktree remove`), just the directory.
+	try {
+		rmSync(worktree.path, {recursive: true, force: true});
+	} catch (err) {
+		console.error(
+			`Failed to clean up CI-fix clone directory (${worktree.path}): ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+	}
+}

--- a/source/daemon/cli.spec.ts
+++ b/source/daemon/cli.spec.ts
@@ -1,0 +1,190 @@
+import {mkdir, mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import {runDaemonCli} from './cli';
+import {getSocketPath, removeLockfile, writeLockfile} from './lockfile';
+
+console.log('\ncli.spec.ts');
+
+async function tempProject(): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), 'daemon-cli-'));
+	await mkdir(join(root, '.nanocoder'), {recursive: true});
+	return root;
+}
+
+/** A launchDaemon stub that simulates a successful boot by writing a real,
+ * live lockfile (pid = this test process's own pid, so isProcessAlive sees
+ * it as live) — lets `start()`'s real waitForLockfile polling succeed
+ * quickly without spawning an actual child process. */
+function successfulLaunchDaemon(projectRoot: string) {
+	const calls: Array<{projectRoot: string; trustLevel: string}> = [];
+	return {
+		launch: (root: string, trustLevel: import('@/verify/trust').TrustLevel) => {
+			calls.push({projectRoot: root, trustLevel});
+			void writeLockfile({
+				pid: process.pid,
+				socketPath: getSocketPath(projectRoot),
+				startedAt: Date.now(),
+				projectRoot,
+			});
+			return {} as import('node:child_process').ChildProcess;
+		},
+		calls,
+	};
+}
+
+test.serial('unknown flag is rejected with exit 1 and no daemon spawned', async t => {
+	const root = await tempProject();
+	const launcher = successfulLaunchDaemon(root);
+	try {
+		const result = await runDaemonCli('start', {
+			projectRoot: root,
+			args: ['--bogus'],
+			launchDaemon: launcher.launch,
+		});
+		t.is(result.exitCode, 1);
+		t.regex(result.output, /Unknown flag/);
+		t.is(launcher.calls.length, 0);
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test.serial('invalid --trust value is rejected with exit 1', async t => {
+	const root = await tempProject();
+	const launcher = successfulLaunchDaemon(root);
+	try {
+		const result = await runDaemonCli('start', {
+			projectRoot: root,
+			args: ['--trust', 'yolo'],
+			launchDaemon: launcher.launch,
+		});
+		t.is(result.exitCode, 1);
+		t.regex(result.output, /Invalid --trust value/);
+		t.is(launcher.calls.length, 0);
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test.serial('--trust flag takes precedence over the project config value', async t => {
+	const root = await tempProject();
+	const launcher = successfulLaunchDaemon(root);
+	try {
+		const result = await runDaemonCli('start', {
+			projectRoot: root,
+			args: ['--trust', 'auto-fix'],
+			launchDaemon: launcher.launch,
+			loadVerifyConfigFn: () => ({trustLevel: 'comment-only'}),
+		});
+		t.is(result.exitCode, 0);
+		t.is(launcher.calls[0]?.trustLevel, 'auto-fix');
+	} finally {
+		await rm(root, {recursive: true, force: true});
+		await removeLockfile(root);
+	}
+});
+
+test.serial('project config trust level is used when no flag is given', async t => {
+	const root = await tempProject();
+	const launcher = successfulLaunchDaemon(root);
+	try {
+		const result = await runDaemonCli('start', {
+			projectRoot: root,
+			args: [],
+			launchDaemon: launcher.launch,
+			loadVerifyConfigFn: () => ({trustLevel: 'auto-fix'}),
+		});
+		t.is(result.exitCode, 0);
+		t.is(launcher.calls[0]?.trustLevel, 'auto-fix');
+	} finally {
+		await rm(root, {recursive: true, force: true});
+		await removeLockfile(root);
+	}
+});
+
+test.serial('defaults to comment-only when neither flag nor config is given', async t => {
+	const root = await tempProject();
+	const launcher = successfulLaunchDaemon(root);
+	try {
+		const result = await runDaemonCli('start', {
+			projectRoot: root,
+			args: [],
+			launchDaemon: launcher.launch,
+			loadVerifyConfigFn: () => undefined,
+		});
+		t.is(result.exitCode, 0);
+		t.is(launcher.calls[0]?.trustLevel, 'comment-only');
+	} finally {
+		await rm(root, {recursive: true, force: true});
+		await removeLockfile(root);
+	}
+});
+
+test.serial('full-commit: declining the confirmation aborts without spawning the daemon', async t => {
+	const root = await tempProject();
+	const launcher = successfulLaunchDaemon(root);
+	try {
+		const result = await runDaemonCli('start', {
+			projectRoot: root,
+			args: ['--trust', 'full-commit'],
+			launchDaemon: launcher.launch,
+			isFullCommitTrustConfirmedFn: () => false,
+			confirmFullCommitTrust: async () => false,
+		});
+		t.is(result.exitCode, 1);
+		t.regex(result.output, /not confirmed/);
+		t.is(launcher.calls.length, 0);
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test.serial('full-commit: accepting the confirmation records it and spawns the daemon', async t => {
+	const root = await tempProject();
+	const launcher = successfulLaunchDaemon(root);
+	let recorded: string | undefined;
+	try {
+		const result = await runDaemonCli('start', {
+			projectRoot: root,
+			args: ['--trust', 'full-commit'],
+			launchDaemon: launcher.launch,
+			isFullCommitTrustConfirmedFn: () => false,
+			confirmFullCommitTrust: async () => true,
+			recordFullCommitTrustConfirmedFn: p => {
+				recorded = p;
+			},
+		});
+		t.is(result.exitCode, 0);
+		t.is(launcher.calls[0]?.trustLevel, 'full-commit');
+		t.is(recorded, root);
+	} finally {
+		await rm(root, {recursive: true, force: true});
+		await removeLockfile(root);
+	}
+});
+
+test.serial('full-commit: already-confirmed projects skip the prompt entirely', async t => {
+	const root = await tempProject();
+	const launcher = successfulLaunchDaemon(root);
+	let promptCalled = false;
+	try {
+		const result = await runDaemonCli('start', {
+			projectRoot: root,
+			args: ['--trust', 'full-commit'],
+			launchDaemon: launcher.launch,
+			isFullCommitTrustConfirmedFn: () => true,
+			confirmFullCommitTrust: async () => {
+				promptCalled = true;
+				return true;
+			},
+		});
+		t.is(result.exitCode, 0);
+		t.false(promptCalled, 'the prompt must not run when already confirmed');
+		t.is(launcher.calls[0]?.trustLevel, 'full-commit');
+	} finally {
+		await rm(root, {recursive: true, force: true});
+		await removeLockfile(root);
+	}
+});

--- a/source/daemon/cli.ts
+++ b/source/daemon/cli.ts
@@ -15,8 +15,15 @@ import {type ChildProcess, spawn} from 'node:child_process';
 import {existsSync, mkdirSync, openSync, statSync} from 'node:fs';
 import {readFile} from 'node:fs/promises';
 import {dirname, join} from 'node:path';
+import {createInterface} from 'node:readline/promises';
 import {fileURLToPath} from 'node:url';
+import {getAppConfig} from '@/config/index';
 import {formatError} from '@/utils/error-formatter';
+import {isTrustLevel, resolveTrustLevel, type TrustLevel} from '@/verify/trust';
+import {
+	isFullCommitTrustConfirmed,
+	recordFullCommitTrustConfirmed,
+} from './full-commit-trust';
 import {
 	getLockfilePath,
 	getSocketPath,
@@ -27,6 +34,79 @@ import {
 
 function getLogPath(projectRoot: string): string {
 	return join(projectRoot, '.nanocoder', 'daemon.log');
+}
+
+const START_USAGE =
+	'Usage: nanocoder daemon start [--trust <comment-only|auto-fix|full-commit>]';
+
+interface ParsedStartArgs {
+	trustLevel?: TrustLevel;
+}
+
+/**
+ * Parse `daemon start`'s flags. Mirrors `verify/cli.ts`'s `parseArgs`:
+ * hand-rolled loop, unknown-flag rejection, discriminated-union return.
+ */
+function parseStartArgs(args: string[]): ParsedStartArgs | {error: string} {
+	let trustLevel: TrustLevel | undefined;
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === '--trust') {
+			const value = args[i + 1];
+			i++;
+			if (!isTrustLevel(value)) {
+				return {
+					error: `Invalid --trust value: "${value ?? ''}". Must be one of comment-only, auto-fix, full-commit.`,
+				};
+			}
+			trustLevel = value;
+		} else {
+			return {error: `Unknown flag: "${arg}".`};
+		}
+	}
+
+	return {trustLevel};
+}
+
+const FULL_COMMIT_WARNING = (projectRoot: string) => `
+⚠️  Security Warning — full-commit trust
+
+You're starting the daemon with --trust full-commit for:
+  ${projectRoot}
+
+At this trust level, when CI watch detects a failure, the daemon will
+autonomously edit files, commit, and PUSH DIRECTLY to the failing branch —
+with no human review step and no draft PR. This is equivalent to yolo mode
+for an unattended background process watching your repository.
+
+Only enable this on a project/branch where you're comfortable with an
+automated agent pushing commits without your review.
+
+This warning will not be shown again for this project.
+`;
+
+/**
+ * Default confirmation prompt for `--trust full-commit`. `daemon start`
+ * runs in the plain CLI fast-path (no Ink tree is ever mounted for it —
+ * `cli.tsx`'s daemon block exits via `process.exit()` before importing
+ * `@/app`), so a plain readline prompt is the correct mechanism here, not
+ * a stopgap.
+ */
+async function defaultConfirmFullCommitTrust(
+	projectRoot: string,
+): Promise<boolean> {
+	process.stdout.write(FULL_COMMIT_WARNING(projectRoot));
+	const rl = createInterface({input: process.stdin, output: process.stdout});
+	try {
+		const answer = await rl.question('Proceed? [y/N] ');
+		return (
+			answer.trim().toLowerCase() === 'y' ||
+			answer.trim().toLowerCase() === 'yes'
+		);
+	} finally {
+		rl.close();
+	}
 }
 
 export interface DaemonCliResult {
@@ -49,7 +129,21 @@ export interface DaemonCliOptions {
 	 * arguments without actually forking. Production uses
 	 * `defaultLaunchDaemon`.
 	 */
-	launchDaemon?: (projectRoot: string) => ChildProcess | null;
+	launchDaemon?: (
+		projectRoot: string,
+		trustLevel: TrustLevel,
+	) => ChildProcess | null;
+	/** Raw argv after the subcommand — only `start` consumes this. */
+	args?: string[];
+	/** Test seam: override the one-time full-commit confirmation prompt. */
+	confirmFullCommitTrust?: (projectRoot: string) => Promise<boolean>;
+	/** Test seam: override the persisted confirmation check. */
+	isFullCommitTrustConfirmedFn?: typeof isFullCommitTrustConfirmed;
+	/** Test seam: override persisting the confirmation. */
+	recordFullCommitTrustConfirmedFn?: typeof recordFullCommitTrustConfirmed;
+	/** Test seam: override reading the project-level trust-level config,
+	 * avoiding `getAppConfig()`'s real cwd-based filesystem reads in tests. */
+	loadVerifyConfigFn?: () => {trustLevel?: TrustLevel} | undefined;
 }
 
 /**
@@ -60,6 +154,7 @@ export interface DaemonCliOptions {
 function defaultLaunchDaemon(
 	projectRoot: string,
 	daemonEntry: string,
+	trustLevel: TrustLevel,
 ): ChildProcess {
 	const logPath = getLogPath(projectRoot);
 	mkdirSync(dirname(logPath), {recursive: true});
@@ -71,6 +166,7 @@ function defaultLaunchDaemon(
 			...process.env,
 			NANOCODER_PROJECT_ROOT: projectRoot,
 			NANOCODER_DAEMON_PROCESS: '1',
+			NANOCODER_CI_TRUST_LEVEL: trustLevel,
 		},
 		detached: true,
 		stdio: ['ignore', logFd, logFd],
@@ -127,8 +223,39 @@ async function start(opts: DaemonCliOptions): Promise<DaemonCliResult> {
 		};
 	}
 
+	const parsed = parseStartArgs(opts.args ?? []);
+	if ('error' in parsed) {
+		return {exitCode: 1, output: `${parsed.error}\n${START_USAGE}`};
+	}
+
+	const loadVerifyConfig =
+		opts.loadVerifyConfigFn ?? (() => getAppConfig().verify);
+	const trustLevel = resolveTrustLevel(
+		parsed.trustLevel,
+		loadVerifyConfig()?.trustLevel,
+	);
+
+	if (trustLevel === 'full-commit') {
+		const isConfirmed =
+			opts.isFullCommitTrustConfirmedFn ?? isFullCommitTrustConfirmed;
+		if (!isConfirmed(opts.projectRoot)) {
+			const confirm =
+				opts.confirmFullCommitTrust ?? defaultConfirmFullCommitTrust;
+			const confirmed = await confirm(opts.projectRoot);
+			if (!confirmed) {
+				return {
+					exitCode: 1,
+					output: 'Aborted: full-commit trust was not confirmed.',
+				};
+			}
+			(opts.recordFullCommitTrustConfirmedFn ?? recordFullCommitTrustConfirmed)(
+				opts.projectRoot,
+			);
+		}
+	}
+
 	const launcher = opts.launchDaemon ?? launchSelfHosted;
-	const child = launcher(opts.projectRoot);
+	const child = launcher(opts.projectRoot, trustLevel);
 	if (!child) {
 		return {
 			exitCode: 1,
@@ -254,9 +381,12 @@ async function logs(opts: DaemonCliOptions): Promise<DaemonCliResult> {
 	return {exitCode: 0, output: buf.slice(start)};
 }
 
-function launchSelfHosted(projectRoot: string): ChildProcess {
+function launchSelfHosted(
+	projectRoot: string,
+	trustLevel: TrustLevel,
+): ChildProcess {
 	const daemonEntry = fileURLToPath(new URL('./entry.js', import.meta.url));
-	return defaultLaunchDaemon(projectRoot, daemonEntry);
+	return defaultLaunchDaemon(projectRoot, daemonEntry, trustLevel);
 }
 
 async function waitForLockfile(

--- a/source/daemon/daemon.spec.ts
+++ b/source/daemon/daemon.spec.ts
@@ -27,12 +27,13 @@ const stubBuildExecutor = () => ({
 	}),
 });
 
-function successBuildExecutor(output: string) {
+function successBuildExecutor(output: string, fixApplied = false) {
 	return () => ({
 		execute: async (_task: SubagentTask): Promise<SubagentResult> => ({
 			subagentName: 'stub',
 			output,
 			success: true,
+			fixApplied,
 			executionTimeMs: 0,
 		}),
 	});
@@ -246,6 +247,36 @@ test.serial('posts the CI investigation to the PR when one exists for the branch
 			t.is(postCalls.length, 1);
 			t.is(postCalls[0]?.[0], 42);
 			t.true(postCalls[0]?.[1].includes('diagnosis text'));
+		} finally {
+			await handle.stop();
+		}
+	} finally {
+		await rm(root, {recursive: true, force: true});
+	}
+});
+
+test.serial('posted report says a fix was applied when the SubagentResult says so', async t => {
+	const root = await tempProject();
+	const ciFactory = detectingCiEventSourceFactory(CI_PAYLOAD);
+	const postCalls: Array<[number, string]> = [];
+	try {
+		const handle = await startDaemon({
+			projectRoot: root,
+			buildExecutor: successBuildExecutor('Opened draft PR: https://x/pull/1', true),
+			ciWatch: {enabled: true},
+			ciEventSourceFactory: ciFactory.factory,
+			isGhAvailableFn: () => true,
+			fileWatcherFactory: noopFileWatcherFactory(),
+			getPrNumberForBranchFn: async () => 42,
+			postPrCommentFn: async (pr, body) => {
+				postCalls.push([pr, body]);
+			},
+		});
+		try {
+			await flush();
+			t.is(postCalls.length, 1);
+			t.false(postCalls[0]?.[1].includes('no auto-fix applied'));
+			t.true(postCalls[0]?.[1].includes('a fix was implemented, committed, and published'));
 		} finally {
 			await handle.stop();
 		}

--- a/source/daemon/daemon.ts
+++ b/source/daemon/daemon.ts
@@ -182,6 +182,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 	const handleCiInvestigationComplete = async (
 		payload: CiJobFailedPayload,
 		subagentOutput: string,
+		fixApplied: boolean,
 	): Promise<void> => {
 		const report = formatCiReport({
 			runId: payload.runId,
@@ -189,6 +190,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 			branch: payload.branch,
 			url: payload.url,
 			subagentOutput,
+			fixApplied,
 		});
 		console.log(report);
 		try {
@@ -231,6 +233,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<DaemonHandle> {
 			void handleCiInvestigationComplete(
 				activity.event.payload,
 				activity.result.output,
+				activity.result.fixApplied ?? false,
 			);
 			return;
 		}

--- a/source/daemon/entry.ts
+++ b/source/daemon/entry.ts
@@ -13,6 +13,7 @@
 
 import {createLLMClient} from '@/client-factory';
 import {getAppConfig} from '@/config/index';
+import {runCiAutoFixFlow} from '@/daemon/ci-fix-orchestrator';
 import {CheckpointManager} from '@/services/checkpoint-manager';
 import type {Checkpointer} from '@/skills/dispatcher';
 import {SubagentExecutor} from '@/subagents/subagent-executor';
@@ -22,29 +23,35 @@ import type {DevelopmentMode} from '@/types/core';
 import {formatError} from '@/utils/error-formatter';
 import {setNotificationsConfig} from '@/utils/notifications';
 import {getShutdownManager} from '@/utils/shutdown';
-import {getAllowedToolNames} from '@/verify/trust';
+import {
+	getAllowedToolNames,
+	getHeadlessAutoApproveToolNames,
+	isTrustLevel,
+} from '@/verify/trust';
 import {startDaemon} from './daemon';
 
-// Built-in, daemon-triggered subagents that must be pinned to a trust-level
-// tool allowlist at execution time rather than trusting their frontmatter
-// `tools:` list alone — see `source/verify/trust.ts`. Mirrors the same
-// `toolOverride` use `verify/cli.ts` makes for `verify-pr-review`: name-level
-// only, so it doesn't stop `git_pr`'s comment/review/create argument shapes
-// on its own. What actually blocks those calls today is that this
-// `buildExecutor` never registers a tool-approval-queue handler, so any
-// `git_pr` call requiring confirmation is auto-denied by
-// `signalToolApproval()`'s default — a property of headless mode, not of
-// this list. If a future change ever registers an approval handler here,
-// this override alone would no longer be sufficient.
-// `resolveToolApproval`'s first check (`ctx.alwaysAllow`) would also bypass
-// approval, but is equally unreachable here: `SubagentExecutor`'s own
-// `needsApprovalForTool` builds that context as just `{mode:
-// this.currentMode()}`, never populating `alwaysAllow`.
-const TRUST_OVERRIDDEN_SUBAGENTS: Record<
-	string,
-	ReturnType<typeof getAllowedToolNames>
-> = {
-	'verify-ci-investigator': getAllowedToolNames('comment-only'),
+// The daemon's own `verify-ci-investigator` subagent must be pinned to a
+// trust-level tool allowlist at execution time rather than trusting its
+// frontmatter `tools:` list alone — see `source/verify/trust.ts`. Mirrors
+// the same `toolOverride` use `verify/cli.ts` makes for `verify-pr-review`:
+// name-level only, so it doesn't stop `git_pr`'s comment/review/create
+// argument shapes on its own. What actually blocks those calls at
+// `comment-only` is that this `buildExecutor` never registers a
+// tool-approval-queue handler, so any `git_pr` call requiring confirmation
+// is auto-denied by `signalToolApproval()`'s default — a property of
+// headless mode, not of this list. `resolveToolApproval`'s first check
+// (`ctx.alwaysAllow`) would also bypass approval; at `auto-fix`/
+// `full-commit` it's deliberately populated with `git_commit` (see
+// `getHeadlessAutoApproveToolNames`) but never `git_pr` — GitHub-mutating
+// calls stay harness-mediated (`ci-fix-orchestrator.ts`'s push/PR step)
+// even at the most-trusted level.
+const trustLevel = isTrustLevel(process.env.NANOCODER_CI_TRUST_LEVEL)
+	? process.env.NANOCODER_CI_TRUST_LEVEL
+	: 'comment-only';
+
+const ciInvestigatorOverride = {
+	tools: getAllowedToolNames(trustLevel),
+	alwaysAllow: getHeadlessAutoApproveToolNames(trustLevel),
 };
 
 async function main(): Promise<void> {
@@ -94,13 +101,18 @@ async function main(): Promise<void> {
 		);
 		return {
 			execute: (task: SubagentTask): Promise<SubagentResult> => {
-				const tools = TRUST_OVERRIDDEN_SUBAGENTS[task.subagent_type];
+				if (task.subagent_type !== 'verify-ci-investigator') {
+					return executor.execute(task);
+				}
+				if (trustLevel !== 'comment-only') {
+					return runCiAutoFixFlow(task, trustLevel, projectRoot);
+				}
 				return executor.execute(
 					task,
 					undefined,
 					0,
 					undefined,
-					tools ? {tools} : undefined,
+					ciInvestigatorOverride,
 				);
 			},
 		};

--- a/source/daemon/full-commit-trust.spec.ts
+++ b/source/daemon/full-commit-trust.spec.ts
@@ -1,0 +1,57 @@
+import {existsSync, mkdirSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'ava';
+import {resetPreferencesCache} from '@/config/preferences';
+import {
+	isFullCommitTrustConfirmed,
+	recordFullCommitTrustConfirmed,
+} from './full-commit-trust';
+
+console.log('\nfull-commit-trust.spec.ts');
+
+const testConfigDir = join(tmpdir(), `nanocoder-test-full-commit-${Date.now()}`);
+
+test.before(() => {
+	process.env.NANOCODER_CONFIG_DIR = testConfigDir;
+	mkdirSync(testConfigDir, {recursive: true});
+	resetPreferencesCache();
+});
+
+test.after.always(() => {
+	if (existsSync(testConfigDir)) {
+		rmSync(testConfigDir, {recursive: true, force: true});
+	}
+	delete process.env.NANOCODER_CONFIG_DIR;
+	resetPreferencesCache();
+});
+
+test.serial('a project is not confirmed until recorded', t => {
+	t.false(isFullCommitTrustConfirmed('/some/fresh/project'));
+});
+
+test.serial('recording confirmation makes isFullCommitTrustConfirmed true', t => {
+	recordFullCommitTrustConfirmed('/some/confirmed/project');
+	t.true(isFullCommitTrustConfirmed('/some/confirmed/project'));
+});
+
+test.serial('confirmation is scoped to the project path — other paths stay unconfirmed', t => {
+	recordFullCommitTrustConfirmed('/project/a');
+	t.true(isFullCommitTrustConfirmed('/project/a'));
+	t.false(isFullCommitTrustConfirmed('/project/b'));
+});
+
+test.serial('recording the same project twice does not duplicate entries', t => {
+	recordFullCommitTrustConfirmed('/project/dup');
+	recordFullCommitTrustConfirmed('/project/dup');
+	// Not observable via the confirmed check alone, but exercises the
+	// dedup branch without throwing — the real assertion is just that this
+	// doesn't error and the project stays confirmed.
+	t.true(isFullCommitTrustConfirmed('/project/dup'));
+});
+
+test.serial('path normalization: relative and absolute forms of the same path are equivalent', t => {
+	const absolute = join(process.cwd(), 'some-nested-dir');
+	recordFullCommitTrustConfirmed(absolute);
+	t.true(isFullCommitTrustConfirmed(join(absolute, '..', 'some-nested-dir')));
+});

--- a/source/daemon/full-commit-trust.ts
+++ b/source/daemon/full-commit-trust.ts
@@ -1,0 +1,38 @@
+/**
+ * Persisted confirmation for the one-time `--trust full-commit` security
+ * warning. Mirrors `useDirectoryTrust.tsx`'s `trustedDirectories` shape and
+ * comparison logic (a list of already-confirmed resolved paths, not a
+ * single global flag — a user may run the daemon against several projects
+ * with different trust postures), but has no React dependency: `daemon
+ * start` runs in the plain CLI fast-path, which never mounts Ink.
+ */
+
+import path from 'node:path';
+import {loadPreferences, savePreferences} from '@/config/preferences';
+
+// Windows filesystems are case-insensitive (NTFS preserves case but doesn't
+// distinguish it), so a resolved path can be re-encountered with different
+// casing (a different shell, a case-differing junction) and must still
+// match. path.resolve() alone doesn't normalize this.
+function normalize(projectRoot: string): string {
+	const resolved = path.resolve(projectRoot); // nosemgrep
+	return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+export function isFullCommitTrustConfirmed(projectRoot: string): boolean {
+	const preferences = loadPreferences();
+	const confirmed = preferences.fullCommitConfirmedProjects ?? [];
+	const normalizedRoot = normalize(projectRoot);
+	return confirmed.some(p => normalize(p) === normalizedRoot);
+}
+
+export function recordFullCommitTrustConfirmed(projectRoot: string): void {
+	const preferences = loadPreferences();
+	const confirmed = preferences.fullCommitConfirmedProjects ?? [];
+	const normalizedRoot = normalize(projectRoot);
+	if (!confirmed.some(p => normalize(p) === normalizedRoot)) {
+		confirmed.push(path.resolve(projectRoot)); // nosemgrep
+		preferences.fullCommitConfirmedProjects = confirmed;
+		savePreferences(preferences);
+	}
+}

--- a/source/subagents/built-in/verify-ci-investigator.md
+++ b/source/subagents/built-in/verify-ci-investigator.md
@@ -1,6 +1,6 @@
 ---
 name: verify-ci-investigator
-description: Read-only CI failure investigator. Given a failed GitHub Actions run, fetches the failure logs and produces a root-cause diagnosis. Never posts to GitHub itself.
+description: CI failure investigator. Given a failed GitHub Actions run, fetches the failure logs and produces a root-cause diagnosis. At elevated trust, may also implement and commit a fix. Never posts to or pushes on GitHub itself — that's always done by the harness that invoked you.
 model: inherit
 tools:
   - read_file
@@ -11,17 +11,24 @@ tools:
   - git_diff
   - git_log
   - lsp_get_diagnostics
+  - write_file
+  - string_replace
+  - git_add
+  - git_commit
+  - execute_bash
   - git_pr
 ---
 
-You are an automated, read-only CI failure investigator. Your task context supplies `runId`, `workflowName`, `branch`, `headSha`, and `url` for a GitHub Actions run that just failed.
+You are an automated CI failure investigator. Your task context supplies `runId`, `workflowName`, `branch`, `headSha`, and `url` for a GitHub Actions run that just failed, and — when running above the default trust level — a `trustLevel` field of `auto-fix` or `full-commit`. If `trustLevel` is absent from your context, treat it as `comment-only`.
 
 Investigate using your tools:
 - `git_pr` with `logs: {run: <runId>, failedOnly: true}` to fetch the failing steps' log output. Narrow further with `logs.search` once you know which step/test failed.
 - `git_pr` with `checks: {pr: <pr>}` if a PR number is available in context, to see the full check-run picture.
 - `git_diff` / `read_file` / `search_file_contents` / `lsp_get_diagnostics` against the locally checked-out tree (already on `branch`, at `headSha`) to understand what changed and why it might have broken.
 
-IMPORTANT — you are strictly read-only:
+## At `comment-only` trust (the default)
+
+You are strictly read-only:
 - Never call `git_pr` with `comment`, `review`, or `create`. Those calls are not your job — the harness that invoked you handles posting the diagnosis after you return your analysis. Attempting them will simply be denied.
 - Do not modify any files.
 
@@ -34,6 +41,16 @@ One or two sentences on what failed.
 Your best determination of why it failed, citing log lines and `file:line` where relevant. If you genuinely cannot determine a root cause from the available logs, write "Could not determine root cause from available logs." rather than guessing.
 
 ### Suggested Fix
-Optional, non-blocking. Omit this section if you have no concrete suggestion. Do not attempt to apply a fix yourself — that's a different, more privileged workflow.
+Optional, non-blocking. Omit this section if you have no concrete suggestion.
 
 Keep it concise and cite specifics. This is advisory only.
+
+## At `auto-fix` or `full-commit` trust
+
+You are running inside an isolated checkout dedicated to this fix attempt — nothing else depends on this working tree, so edit and run commands freely here. After diagnosing the root cause (as above):
+
+1. Implement the smallest change that fixes the failure. Don't refactor unrelated code or "improve" things beyond what's needed to make CI pass again.
+2. Verify your fix before committing: find the project's actual test/build command (check `package.json` scripts, CI workflow files, or `CLAUDE.md`/`README.md` — don't guess a generic command) and run it via `execute_bash`. If it still fails, keep iterating rather than committing a broken fix.
+3. Commit with `git_add` + `git_commit`, using a message in the form `fix(ci): <what was wrong>` and a body that references the workflow and run (e.g. `Fixes ${workflowName} failure in run #${runId}`).
+4. **Still never** call `git_pr` with `create`, `comment`, or `review` yourself, at either trust level — publishing (opening a draft PR at `auto-fix`, or pushing directly at `full-commit`) is always done by the harness after you finish, exactly like at `comment-only`. Attempting these calls will simply be denied.
+5. If you cannot find or verify a real fix, do not commit a guess — return the same diagnosis-only output described under `comment-only` above instead. An uncommitted, accurate diagnosis is more useful than an unverified commit.

--- a/source/subagents/subagent-executor.spec.ts
+++ b/source/subagents/subagent-executor.spec.ts
@@ -853,6 +853,86 @@ test('mode resolver overrides the static parentMode and is read live', async t =
 	t.true(await needsApproval('execute_bash'));
 });
 
+// ============================================================================
+// Phase 4: toolOverride.alwaysAllow bypasses approval for otherwise
+// mode-blind, unconditionally-approval-required tools (e.g. git_commit's
+// `approval: true`, which would otherwise be silently auto-denied in
+// headless mode since no approval-queue handler is ever registered there).
+// ============================================================================
+
+test.serial('needsApprovalForTool: alwaysAllow bypasses an unconditional approval:true policy', async t => {
+	const toolManager = createMockToolManager({
+		git_commit: {handler: async () => 'committed', readOnly: false, needsApproval: true},
+	});
+	const client = createMockClient([]);
+	const executor = new SubagentExecutor(toolManager, client, process.cwd(), 'headless');
+
+	const needsApproval = (alwaysAllow?: string[]) =>
+		(executor as unknown as {
+			needsApprovalForTool: (
+				n: string,
+				a: unknown,
+				alwaysAllow?: string[],
+			) => Promise<boolean>;
+		}).needsApprovalForTool('git_commit', {}, alwaysAllow);
+
+	t.true(
+		await needsApproval(undefined),
+		'without alwaysAllow, git_commit still requires approval even in headless mode',
+	);
+	t.false(
+		await needsApproval(['git_commit']),
+		'alwaysAllow including git_commit bypasses its approval:true policy',
+	);
+	t.true(
+		await needsApproval(['some_other_tool']),
+		'alwaysAllow not including git_commit does not bypass it',
+	);
+});
+
+test.serial('execute(): toolOverride.alwaysAllow lets an approval-required tool run without signalToolApproval', async t => {
+	const commitHandler = async () => 'committed';
+	const toolManager = createMockToolManager({
+		git_commit: {handler: commitHandler, readOnly: false, needsApproval: true},
+	});
+
+	let approvalRequested = false;
+	setGlobalToolApprovalHandler(async () => {
+		approvalRequested = true;
+		return true;
+	});
+
+	const client = createMockClient([
+		{
+			content: '',
+			tool_calls: [
+				{id: 'tc1', function: {name: 'git_commit', arguments: '{"message":"fix"}'}},
+			],
+		},
+		{content: 'Committed the fix'},
+	]);
+
+	const executor = new SubagentExecutor(toolManager, client, process.cwd(), 'headless');
+
+	const result = await executor.execute(
+		{subagent_type: 'explore', description: 'Commit a fix'},
+		undefined,
+		0,
+		undefined,
+		{tools: ['git_commit'], alwaysAllow: ['git_commit']},
+	);
+
+	t.true(result.success);
+	t.is(result.output, 'Committed the fix');
+	t.false(
+		approvalRequested,
+		'signalToolApproval should never be reached when alwaysAllow covers the tool',
+	);
+
+	// Restore auto-approve handler for other tests
+	setGlobalToolApprovalHandler(async () => true);
+});
+
 test('without a resolver, approval falls back to the static parentMode', async t => {
 	const toolManager = createMockToolManager({
 		execute_bash: {handler: async () => 'ok', readOnly: false, needsApproval: true},

--- a/source/subagents/subagent-executor.ts
+++ b/source/subagents/subagent-executor.ts
@@ -115,13 +115,23 @@ export class SubagentExecutor {
 	 *                  caller enforce a trust-level allowlist (see
 	 *                  `source/verify/trust.ts`) without needing a second,
 	 *                  hand-maintained tool list in the subagent's own file.
+	 *                  `alwaysAllow` additionally skips the approval prompt
+	 *                  for the named tools (see `resolveToolApproval`'s
+	 *                  `ctx.alwaysAllow`) — for tools whose `approval` policy
+	 *                  isn't mode-aware and would otherwise be silently
+	 *                  auto-denied in headless mode (no approval-queue
+	 *                  handler is ever registered there).
 	 */
 	async execute(
 		task: SubagentTask,
 		signal?: AbortSignal,
 		depth = 0,
 		agentId?: string,
-		toolOverride?: {tools?: string[]; disallowedTools?: string[]},
+		toolOverride?: {
+			tools?: string[];
+			disallowedTools?: string[];
+			alwaysAllow?: string[];
+		},
 	): Promise<SubagentResult> {
 		const startTime = Date.now();
 
@@ -183,6 +193,7 @@ export class SubagentExecutor {
 					config,
 					signal,
 					agentId,
+					toolOverride?.alwaysAllow,
 				);
 
 				// Read final token count from the correct progress source
@@ -395,6 +406,7 @@ export class SubagentExecutor {
 		config: SubagentConfigWithSource,
 		signal?: AbortSignal,
 		agentId?: string,
+		alwaysAllow?: string[],
 	): Promise<string> {
 		let iterations = 0;
 		let totalToolCalls = 0;
@@ -551,6 +563,7 @@ export class SubagentExecutor {
 					toolCall.id,
 					config,
 					signal,
+					alwaysAllow,
 				);
 
 				// Count tokens from tool results
@@ -582,10 +595,12 @@ export class SubagentExecutor {
 	private async needsApprovalForTool(
 		toolName: string,
 		rawArguments: unknown,
+		alwaysAllow?: string[],
 	): Promise<boolean> {
 		const toolEntry = this.toolManager.getToolEntry(toolName);
 		return resolveToolApproval(toolName, toolEntry, rawArguments, {
 			mode: this.currentMode(),
+			alwaysAllow,
 		});
 	}
 
@@ -598,6 +613,7 @@ export class SubagentExecutor {
 		toolCallId: string,
 		config: SubagentConfigWithSource,
 		signal?: AbortSignal,
+		alwaysAllow?: string[],
 	): Promise<string> {
 		if (signal?.aborted) {
 			return 'Error: Execution was cancelled';
@@ -612,6 +628,7 @@ export class SubagentExecutor {
 		const needsApproval = await this.needsApprovalForTool(
 			toolName,
 			rawArguments,
+			alwaysAllow,
 		);
 		if (needsApproval) {
 			const parsedArgs = parseToolArguments(rawArguments);

--- a/source/subagents/types.ts
+++ b/source/subagents/types.ts
@@ -65,6 +65,12 @@ export interface SubagentResult {
 	tokensUsed?: number;
 	/** Execution time in milliseconds */
 	executionTimeMs: number;
+	/** Set by `ci-fix-orchestrator.ts` when a CI-fix run actually committed
+	 * and published a fix (auto-fix's draft PR, or full-commit's direct
+	 * push) — lets a caller distinguish "a fix was applied" from "just a
+	 * diagnosis" without string-sniffing `output`. Undefined/false for every
+	 * other kind of subagent run. */
+	fixApplied?: boolean;
 }
 
 /**

--- a/source/tools/git/utils.spec.ts
+++ b/source/tools/git/utils.spec.ts
@@ -14,6 +14,7 @@ import {
 	getCurrentBranchSync,
 	getDefaultBranchSync,
 	getGitStatusSummarySync,
+	pushBranch,
 	truncateDiff,
 } from './utils';
 
@@ -354,3 +355,75 @@ test.serial(
 		}
 	},
 );
+
+// ============================================================================
+// pushBranch — real local bare-repo "remote", no network/gh dependency.
+// Mirrors postPrComment/getPrNumberForBranch/createDraftPr in never being
+// mocked: those need a real `gh` session and have no direct tests either,
+// consistent with this file's convention of testing execGit-backed
+// functions against a real (offline) repo rather than mocking child_process.
+// ============================================================================
+
+test.serial('pushBranch pushes the current branch to a local remote', async t => {
+	if (!isGitAvailable()) {
+		t.pass('git not available; skipping');
+		return;
+	}
+	const remoteDir = mkdtempSync(join(tmpdir(), 'nanocoder-git-remote-'));
+	const cloneDir = mkdtempSync(join(tmpdir(), 'nanocoder-git-clone-'));
+	const originalCwd = process.cwd();
+	try {
+		execSync('git init -q --bare', {cwd: remoteDir});
+		execSync(`git clone -q ${JSON.stringify(remoteDir)} ${JSON.stringify(cloneDir)}`);
+		execSync('git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init', {
+			cwd: cloneDir,
+		});
+		execSync('git checkout -q -b feature/push-test', {cwd: cloneDir});
+		execSync('git -c user.email=t@t -c user.name=t commit --allow-empty -q -m fix', {
+			cwd: cloneDir,
+		});
+
+		process.chdir(cloneDir);
+		await pushBranch('feature/push-test', {setUpstream: true});
+
+		const remoteBranches = execSync('git branch', {cwd: remoteDir}).toString();
+		t.true(remoteBranches.includes('feature/push-test'));
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(remoteDir, {recursive: true, force: true});
+		rmSync(cloneDir, {recursive: true, force: true});
+	}
+});
+
+test.serial('pushBranch with an explicit cwd pushes from that directory, not process.cwd()', async t => {
+	if (!isGitAvailable()) {
+		t.pass('git not available; skipping');
+		return;
+	}
+	const remoteDir = mkdtempSync(join(tmpdir(), 'nanocoder-git-remote-'));
+	const cloneDir = mkdtempSync(join(tmpdir(), 'nanocoder-git-clone-'));
+	try {
+		execSync('git init -q --bare', {cwd: remoteDir});
+		execSync(`git clone -q ${JSON.stringify(remoteDir)} ${JSON.stringify(cloneDir)}`);
+		execSync('git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init', {
+			cwd: cloneDir,
+		});
+		execSync('git checkout -q -b feature/push-cwd-test', {cwd: cloneDir});
+		execSync('git -c user.email=t@t -c user.name=t commit --allow-empty -q -m fix', {
+			cwd: cloneDir,
+		});
+
+		// Deliberately do NOT chdir the test process — the whole point of
+		// `cwd` is to work without it, since the daemon's own process.cwd()
+		// is a different, unrelated directory (this is the mechanism that
+		// lets ci-fix-orchestrator.ts publish a fix committed inside an
+		// isolated clone).
+		await pushBranch('feature/push-cwd-test', {setUpstream: true, cwd: cloneDir});
+
+		const remoteBranches = execSync('git branch', {cwd: remoteDir}).toString();
+		t.true(remoteBranches.includes('feature/push-cwd-test'));
+	} finally {
+		rmSync(remoteDir, {recursive: true, force: true});
+		rmSync(cloneDir, {recursive: true, force: true});
+	}
+});

--- a/source/tools/git/utils.ts
+++ b/source/tools/git/utils.ts
@@ -8,7 +8,7 @@
 import {execSync, spawn} from 'node:child_process';
 import {existsSync, readFileSync} from 'node:fs';
 import {isAbsolute, join} from 'node:path';
-import {TIMEOUT_GH_METADATA_MS} from '@/constants';
+import {TIMEOUT_GH_METADATA_MS, TIMEOUT_GIT_PUSH_MS} from '@/constants';
 import {getLogger} from '@/utils/logging';
 
 const logger = getLogger();
@@ -326,8 +326,11 @@ function execProcess(
 /**
  * Execute a git command and return the output
  */
-export async function execGit(args: string[]): Promise<string> {
-	return execProcess('git', args, 'Git');
+export async function execGit(
+	args: string[],
+	timeoutMs?: number,
+): Promise<string> {
+	return execProcess('git', args, 'Git', timeoutMs);
 }
 
 /**
@@ -485,6 +488,62 @@ export async function getPrNumberForBranch(
  */
 export async function postPrComment(pr: number, body: string): Promise<void> {
 	await execGh(['pr', 'review', pr.toString(), '--comment', '--body', body]);
+}
+
+/**
+ * Push a branch to `origin`. Harness-only (not an agent-facing tool) —
+ * used by the daemon's auto-fix/full-commit flow to publish a fix that was
+ * committed inside an isolated clone (see `ci-fix-worktree.ts`). Pass `cwd`
+ * to run this against that clone rather than the current process's own
+ * directory — the clone has its own independent object database, so the
+ * new commits only exist there, not wherever this function happens to be
+ * called from. Bounded by TIMEOUT_GIT_PUSH_MS since this backs an
+ * unattended background caller that must not hang forever on a stalled
+ * network push.
+ */
+export async function pushBranch(
+	branch: string,
+	opts?: {setUpstream?: boolean; cwd?: string},
+): Promise<void> {
+	const args: string[] = [];
+	if (opts?.cwd) args.push('-C', opts.cwd);
+	args.push('push');
+	if (opts?.setUpstream) args.push('-u');
+	args.push('origin', branch);
+	await execGit(args, TIMEOUT_GIT_PUSH_MS);
+}
+
+/**
+ * Open a draft PR. Harness-only (not an agent-facing tool) — deliberately
+ * NOT a reuse of `git-pr.tsx`'s `create` action, which infers `head` from
+ * `getCurrentBranch()` (the *caller's* current branch). That's wrong here:
+ * the daemon's own cwd is `projectRoot`, not the worktree whose branch is
+ * the actual PR head, so `head` must be passed explicitly. Bounded by
+ * TIMEOUT_GH_METADATA_MS — see {@link getPrRefs}.
+ */
+export async function createDraftPr(opts: {
+	title: string;
+	body: string;
+	base: string;
+	head: string;
+}): Promise<string> {
+	const output = await execGh(
+		[
+			'pr',
+			'create',
+			'--title',
+			opts.title,
+			'--base',
+			opts.base,
+			'--head',
+			opts.head,
+			'--draft',
+			'--body',
+			opts.body,
+		],
+		TIMEOUT_GH_METADATA_MS,
+	);
+	return output.trim();
 }
 
 /**

--- a/source/types/config.ts
+++ b/source/types/config.ts
@@ -1,6 +1,7 @@
 import type {TitleShape} from '@/components/ui/styled-title';
 import type {DevelopmentMode} from '@/types/core';
 import type {NanocoderShape, ThemePreset} from '@/types/ui';
+import type {TrustLevel} from '@/verify/trust';
 
 // Supported AI SDK provider packages
 export type SdkProvider =
@@ -149,6 +150,24 @@ export interface CiWatchConfig {
 	maxPollIntervalMs?: number;
 }
 
+/**
+ * Project-level (`agents.config.json`) verify/CI-watch policy — trust level
+ * and poll cadence. Unlike `CiWatchConfig.enabled` (a personal, per-machine
+ * opt-in to background GitHub polling, kept in preferences), trust level
+ * and cadence are security/policy decisions appropriate to commit and
+ * review with the rest of the project, so they live here instead. When
+ * set, `pollIntervalMs`/`maxPollIntervalMs` here override the
+ * preferences-backed `CiWatchConfig` values of the same name — see
+ * `loadCiWatchConfig` in `source/config/index.ts`.
+ */
+export interface VerifyConfig {
+	/** Trust level for daemon-triggered CI investigation/auto-fix. Undefined
+	 * defers to the `--trust` CLI flag, then 'comment-only'. */
+	trustLevel?: TrustLevel;
+	pollIntervalMs?: number;
+	maxPollIntervalMs?: number;
+}
+
 // Note: temperature is intentionally excluded from this interface.
 // It cannot be applied during a mode switch without proper integration into
 // the tune/ModelParameters pipeline (tune.ts). Tracked as a follow-up.
@@ -228,6 +247,9 @@ export interface AppConfig {
 
 	// Background CI-watch configuration (daemon-side)
 	ciWatch?: CiWatchConfig;
+
+	// Project-level verify/CI-watch policy: trust level, poll cadence overrides
+	verify?: VerifyConfig;
 
 	// Model mode defaults (global)
 	tune?: Partial<TuneConfig>;
@@ -451,4 +473,12 @@ export interface UserPreferences {
 	 * content. Also switchable per-run with the --no-alt-screen flag.
 	 */
 	alternateScreen?: boolean;
+	/**
+	 * Absolute project-root paths for which the one-time `--trust
+	 * full-commit` security warning has already been shown and confirmed.
+	 * Mirrors `trustedDirectories`'s shape/semantics: a list of
+	 * already-confirmed targets, not a single global flag, since a user may
+	 * run the daemon against several projects with different trust postures.
+	 */
+	fullCommitConfirmedProjects?: string[];
 }

--- a/source/verify/format-ci-report.spec.ts
+++ b/source/verify/format-ci-report.spec.ts
@@ -45,3 +45,21 @@ test('formatCiReport notes the diagnosis is advisory with no auto-fix', t => {
 	});
 	t.true(body.includes('no auto-fix applied'));
 });
+
+test('formatCiReport does not claim "no auto-fix applied" when fixApplied is true', t => {
+	const body = formatCiReport({
+		...baseInput,
+		subagentOutput: 'Opened draft PR: https://github.com/o/r/pull/99',
+		fixApplied: true,
+	});
+	t.false(body.includes('no auto-fix applied'));
+	t.true(body.includes('a fix was implemented, committed, and published'));
+});
+
+test('formatCiReport falls back to the advisory footer when fixApplied is omitted', t => {
+	const body = formatCiReport({
+		...baseInput,
+		subagentOutput: 'Looks like a flaky test.',
+	});
+	t.false(body.includes('a fix was implemented'));
+});

--- a/source/verify/format-ci-report.ts
+++ b/source/verify/format-ci-report.ts
@@ -4,6 +4,10 @@ export interface FormatCiReportInput {
 	branch: string;
 	url: string;
 	subagentOutput: string;
+	/** True when this run actually committed and published a fix (auto-fix's
+	 * draft PR, or full-commit's direct push) — adjusts the footer so it
+	 * doesn't falsely claim "no auto-fix applied" when one was. */
+	fixApplied?: boolean;
 }
 
 /**
@@ -14,7 +18,11 @@ export interface FormatCiReportInput {
  * content.
  */
 export function formatCiReport(input: FormatCiReportInput): string {
-	const {runId, workflowName, branch, url, subagentOutput} = input;
+	const {runId, workflowName, branch, url, subagentOutput, fixApplied} = input;
+
+	const footer = fixApplied
+		? '*Generated automatically by the Nanocoder daemon — a fix was implemented, committed, and published as described above. Review before merging.*'
+		: '*Generated automatically by the Nanocoder daemon — advisory diagnosis, no auto-fix applied.*';
 
 	return [
 		`## Nanocoder CI Investigation — "${workflowName}" failed on \`${branch}\``,
@@ -24,6 +32,6 @@ export function formatCiReport(input: FormatCiReportInput): string {
 		subagentOutput.trim(),
 		'',
 		'---',
-		'*Generated automatically by the Nanocoder daemon — advisory diagnosis, no auto-fix applied.*',
+		footer,
 	].join('\n');
 }

--- a/source/verify/trust.spec.ts
+++ b/source/verify/trust.spec.ts
@@ -4,7 +4,13 @@
 
 import test from 'ava';
 import {SubagentLoader} from '@/subagents/subagent-loader';
-import {getAllowedToolNames, isActionAllowed} from './trust';
+import {
+	getAllowedToolNames,
+	getHeadlessAutoApproveToolNames,
+	isActionAllowed,
+	isTrustLevel,
+	resolveTrustLevel,
+} from './trust';
 
 console.log('\ntrust.spec.ts – Trust Levels');
 
@@ -150,20 +156,73 @@ test.serial(
 );
 
 test.serial(
-	"verify-ci-investigator's frontmatter tools match trust.ts's comment-only allowlist",
+	"verify-ci-investigator's frontmatter tools match trust.ts's auto-fix allowlist",
 	async t => {
+		// Unlike verify-pr-review (always comment-only), this subagent runs at
+		// a runtime-resolved trust level (Phase 4: comment-only/auto-fix/
+		// full-commit — see source/daemon/entry.ts and ci-fix-runner.ts, both
+		// of which pass an explicit toolOverride that always wins at runtime).
+		// Its frontmatter is therefore checked against the *widest* level
+		// (auto-fix, identical to full-commit by design) it can ever run at,
+		// so a human reading the file isn't misled into thinking it's
+		// unconditionally read-only.
 		const loader = new SubagentLoader();
 		await loader.initialize();
 		const config = await loader.getSubagent('verify-ci-investigator');
 
 		t.truthy(config, 'verify-ci-investigator subagent should exist');
 		const frontmatterTools = new Set(config?.tools ?? []);
-		const trustTools = new Set(getAllowedToolNames('comment-only'));
+		const trustTools = new Set(getAllowedToolNames('auto-fix'));
 
 		t.deepEqual(
 			frontmatterTools,
 			trustTools,
-			'verify-ci-investigator.md tools: list has drifted from trust.ts comment-only allowlist',
+			'verify-ci-investigator.md tools: list has drifted from trust.ts auto-fix allowlist',
 		);
 	},
 );
+
+// ============================================================================
+// isTrustLevel / getHeadlessAutoApproveToolNames / resolveTrustLevel (Phase 4)
+// ============================================================================
+
+test('isTrustLevel accepts exactly the three known levels', t => {
+	t.true(isTrustLevel('comment-only'));
+	t.true(isTrustLevel('auto-fix'));
+	t.true(isTrustLevel('full-commit'));
+});
+
+test('isTrustLevel rejects anything else', t => {
+	t.false(isTrustLevel('yolo'));
+	t.false(isTrustLevel(''));
+	t.false(isTrustLevel(undefined));
+	t.false(isTrustLevel(null));
+	t.false(isTrustLevel(42));
+});
+
+test('getHeadlessAutoApproveToolNames is empty at comment-only', t => {
+	t.deepEqual(getHeadlessAutoApproveToolNames('comment-only'), []);
+});
+
+test('getHeadlessAutoApproveToolNames includes git_commit at auto-fix and full-commit', t => {
+	t.deepEqual(getHeadlessAutoApproveToolNames('auto-fix'), ['git_commit']);
+	t.deepEqual(getHeadlessAutoApproveToolNames('full-commit'), ['git_commit']);
+});
+
+test('getHeadlessAutoApproveToolNames never includes git_pr at any level', t => {
+	for (const level of ['comment-only', 'auto-fix', 'full-commit'] as const) {
+		t.false(getHeadlessAutoApproveToolNames(level).includes('git_pr'));
+	}
+});
+
+test('resolveTrustLevel: CLI flag wins when given', t => {
+	t.is(resolveTrustLevel('full-commit', 'auto-fix'), 'full-commit');
+});
+
+test('resolveTrustLevel: config value used when no flag given', t => {
+	t.is(resolveTrustLevel(undefined, 'auto-fix'), 'auto-fix');
+});
+
+test('resolveTrustLevel: defaults to comment-only when neither is given', t => {
+	t.is(resolveTrustLevel(undefined, undefined), 'comment-only');
+});

--- a/source/verify/trust.ts
+++ b/source/verify/trust.ts
@@ -149,3 +149,51 @@ export function isActionAllowed(
 export function getAllowedToolNames(level: TrustLevel): string[] {
 	return TRUST_POLICIES[level].map(a => a.tool);
 }
+
+const ALL_TRUST_LEVELS: readonly TrustLevel[] = [
+	'comment-only',
+	'auto-fix',
+	'full-commit',
+];
+
+export function isTrustLevel(value: unknown): value is TrustLevel {
+	return (
+		typeof value === 'string' &&
+		(ALL_TRUST_LEVELS as readonly string[]).includes(value)
+	);
+}
+
+// Tools whose mutation is safe to auto-approve in headless mode once a
+// trust level has already vetted them into getAllowedToolNames() above.
+// Deliberately excludes `git_pr` at every level, even full-commit: posting
+// to / mutating GitHub must always be harness-mediated (see
+// `postPrComment`/`pushBranch`/`createDraftPr` in `source/tools/git/utils.ts`),
+// never an auto-approved raw tool call from the subagent itself — that
+// invariant is what makes the "harness posts, not the LLM" pattern from
+// Phase 2/3 hold even at the most-trusted level. The other MUTATION_TOOLS
+// (`write_file`/`string_replace`/`git_add`/`execute_bash`) don't need to be
+// listed here: their own approval policies already treat headless mode as
+// not needing approval. Only `git_commit` has an unconditional
+// `approval: true`, which is otherwise silently auto-denied in headless
+// mode (no approval-queue handler is ever registered there).
+const HEADLESS_AUTO_APPROVE_TOOLS: Record<TrustLevel, readonly string[]> = {
+	'comment-only': [],
+	'auto-fix': ['git_commit'],
+	'full-commit': ['git_commit'],
+};
+
+export function getHeadlessAutoApproveToolNames(level: TrustLevel): string[] {
+	return [...HEADLESS_AUTO_APPROVE_TOOLS[level]];
+}
+
+/**
+ * Resolve the effective trust level from a CLI flag and a config value:
+ * flag wins when given, else the config value, else the safe default.
+ * Never infers a more permissive level than what was explicitly set.
+ */
+export function resolveTrustLevel(
+	cliFlag: TrustLevel | undefined,
+	configValue: TrustLevel | undefined,
+): TrustLevel {
+	return cliFlag ?? configValue ?? 'comment-only';
+}


### PR DESCRIPTION
Description

Phase 4 of the Agentic CI/CD Gate roadmap (issue #863): --trust auto-fix|full-commit for the daemon's CI-watch investigations. At auto-fix, the verify-ci-investigator subagent can now implement and commit a fix (in an isolated git clone, never the daemon's own working directory) and the harness opens a draft PR for human review. At full-commit, the harness pushes the fix directly to the failing branch instead, gated
behind a one-time per-project security confirmation showl and CI-watch poll cadence are now also configurableproject-wide via a new verify block in agents.config.json, taking precedence over the existing per-user preferences.

Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

Changeset

- [x] Added a changeset (pnpm changeset) describing this

Testing

Automated Tests

- [x] New features include passing tests in .spec.ts/tsx files
- [ ] All existing tests pass (pnpm test:all completes s
- [x] Tests cover both success and error scenarios

Note on the unchecked item: same limitation as before : pnpm run test:all doesn't invoke cleanly end-to-end in my Windows Bash tool
environment, so I ran its pieces individually instead: tip all pass clean, and 178 tests across every new/changed spec file (trust, subagent-executor, daemon/cli, full-commit-trust, ci-fix-worktree, ci-fix-orchestrator, daemon, git/utils, config/index, plus Phase 3's github-checkrun/ci-watch-state for regression coverage) pass. I ran the full repo-wide pnpm run test:ava twice (once before,
once after a code-review pass) : both times it produced iled/1 skipped, identical to this branch's pre-existingWindows-local baseline, with zero mentions of any file this PR touches. I haven't watched an actual Linux CI run of this branch complete, so I'm not checking this box outright.

Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Not performed — exercising --trust auto-fix/full-commit thenticated repo with a genuinely failing workflow, andgh isn't installed in this environment.

Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see CONTRIBUTING.md (../CONTRIBUTING.md#logging))