### PR TITLE
fix(tools): hide dotfiles when list_directory defaults to .

### DIFF
--- a/.changeset/hide-default-list-directory-dotfiles.md
+++ b/.changeset/hide-default-list-directory-dotfiles.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Hide dotfiles when `list_directory` uses its default project-root path. Closes #1237.

--- a/source/tools/list-directory.spec.tsx
+++ b/source/tools/list-directory.spec.tsx
@@ -571,6 +571,34 @@ test.serial('list_directory hides dotfiles by default', async t => {
 	}
 });
 
+test.serial('list_directory hides dotfiles when listing the project root (.)', async t => {
+	t.timeout(10000);
+	const originalCwd = process.cwd();
+
+	try {
+		const testDir = join(process.cwd(), 'test-listdir-hidden-root-temp');
+		mkdirSync(testDir, {recursive: true});
+		writeFileSync(join(testDir, '.hidden'), 'secret');
+		writeFileSync(join(testDir, 'visible.ts'), 'content');
+		writeFileSync(join(testDir, '.env'), 'API_KEY=leak');
+
+		process.chdir(testDir);
+
+		for (const path of [undefined, '.', './']) {
+			const result = await listDirectoryTool.tool.execute!(
+				path === undefined ? {} : {path},
+				{toolCallId: 'test', messages: []},
+			);
+			t.false(result.includes('.hidden'), `path=${path} should hide .hidden`);
+			t.false(result.includes('.env'), `path=${path} should hide .env`);
+			t.true(result.includes('visible.ts'), `path=${path} should list visible.ts`);
+		}
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(join(originalCwd, 'test-listdir-hidden-root-temp'), {recursive: true, force: true});
+	}
+});
+
 test.serial('list_directory showHiddenFiles=true shows dotfiles', async t => {
 	t.timeout(10000);
 	const originalCwd = process.cwd();

--- a/source/tools/list-directory.tsx
+++ b/source/tools/list-directory.tsx
@@ -66,11 +66,17 @@ const executeListDirectory = async (
 				const items = await readdir(currentPath, {withFileTypes: true});
 
 				for (const item of items) {
-					// Skip hidden files unless showHiddenFiles is true
+					// Skip hidden files unless showHiddenFiles is true. The extra
+					// path check keeps nested hidden entries visible when the user
+					// explicitly listed a hidden directory (`.github`, `.config`).
+					// Do not treat the project root (`.` / `./`) as a hidden dir —
+					// `'.'.startsWith('.')` is true and used to leak every dotfile.
+					// See #1237.
+					const listingHiddenDir = /(^|[/\\])\.[^./\\]/.test(dirPath);
 					if (
 						!showHiddenFiles &&
 						item.name.startsWith('.') &&
-						!dirPath.startsWith('.')
+						!listingHiddenDir
 					) {
 						continue;
 					}


### PR DESCRIPTION
## Problem

list_directory skips hidden entries with:

`	s
if (!showHiddenFiles && item.name.startsWith('.') && !dirPath.startsWith('.')) {
  continue;
}
`

The default dirPath is '.', and '.'.startsWith('.') is true, so the filter is disabled. Listing the project root (or ./) leaks `.env`, `.git`, `.vscode`, etc. even when `showHiddenFiles` is false. The existing default-hidden test only listed an explicit `subdir` and missed this. See #1237.

## Fix

Treat a path as a hidden-directory request only when a path segment actually starts with a non-. character (e.g. `.github`, `./.config`) — not when it is the project root (`.` / `./`):

`	s
const listingHiddenDir = /(^|[/\\])\.[^./\\]/.test(dirPath);
`

Explicit `showHiddenFiles: true` and listing a real hidden directory still work as before.

## Tests

- New: `list_directory hides dotfiles when listing the project root (.)` covering `undefined`, `.`, and `./`.
- Full list-directory.spec.tsx: **31 passed**.

`
pnpm run test:ava source/tools/list-directory.spec.tsx
`

Fixes #1237