### PR TITLE
fix(cli): support --flag=value syntax for value options

### DIFF
--- a/.changeset/cli-equals-value-flags.md
+++ b/.changeset/cli-equals-value-flags.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix `--model=value`, `--provider=value`, `--vscode-port=value`, and `--context-max=value` being ignored and included in prompts after `run`. Closes #1238.

--- a/source/cli-value-flags.cli-integration.spec.ts
+++ b/source/cli-value-flags.cli-integration.spec.ts
@@ -1,0 +1,163 @@
+import {spawnSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import test from 'ava';
+
+// Run the real CLI, replacing only runtime boundaries. In particular, argument
+// extraction, validation, context parsing and prompt filtering are not mocked.
+const runtimeModules = {
+	'@/models/index': `export function setSessionContextLimit(value) {
+		globalThis.cliTestContextLimit = value;
+	}`,
+	'@/app': 'export default function App() {}',
+	'@/utils/perf-buffer': 'export function installPerfBufferGuard() {}',
+	'@/config/preferences': 'export function loadPreferences() { return {}; }',
+	ink: `export function render(element) {
+		console.log(JSON.stringify({...element.props, contextLimit: globalThis.cliTestContextLimit}));
+		process.exit(0);
+	}`,
+};
+const loader = `const modules = ${JSON.stringify(runtimeModules)};
+export function resolve(specifier, context, nextResolve) {
+	if (Object.hasOwn(modules, specifier)) {
+		return {url: 'data:text/javascript,' + encodeURIComponent(modules[specifier]), shortCircuit: true};
+	}
+	return nextResolve(specifier, context);
+}`;
+const loaderUrl = `data:text/javascript,${encodeURIComponent(
+	`import {register} from 'node:module'; register(${JSON.stringify(
+		`data:text/javascript,${encodeURIComponent(loader)}`,
+	)});`,
+)}`;
+const cliPath = fileURLToPath(new URL('./cli.tsx', import.meta.url));
+
+function runCli(args: string[]) {
+	return spawnSync(
+		process.execPath,
+		[
+			'--import=tsx',
+			'--import',
+			loaderUrl,
+			cliPath,
+			'--no-plain',
+			'--no-alt-screen',
+			...args,
+		],
+		{
+			encoding: 'utf8',
+			timeout: 15_000,
+			env: {
+				...process.env,
+				NODE_DISABLE_COMPILE_CACHE: '1',
+				TSX_DISABLE_CACHE: '1',
+			},
+		},
+	);
+}
+
+const flags = [
+	{
+		flag: '--model',
+		value: 'qwen2.5:7b',
+		property: 'cliModel',
+		expected: 'qwen2.5:7b',
+	},
+	{
+		flag: '--provider',
+		value: 'ollama',
+		property: 'cliProvider',
+		expected: 'ollama',
+	},
+	{
+		flag: '--vscode-port',
+		value: '3000',
+		property: 'vscodePort',
+		expected: 3000,
+	},
+	{
+		flag: '--context-max',
+		value: '128k',
+		property: 'contextLimit',
+		expected: 128000,
+	},
+] as const;
+
+for (const {flag, value, property, expected} of flags) {
+	for (const fused of [false, true]) {
+		for (const beforeRun of [false, true]) {
+			test(`${flag}: ${fused ? 'fused' : 'separate'} ${beforeRun ? 'before' : 'after'} run`, t => {
+				const option = fused ? [`${flag}=${value}`] : [flag, value];
+				const args = beforeRun
+					? [...option, 'run', 'analyze', 'code']
+					: ['run', 'analyze', ...option, 'code'];
+				const result = runCli(args);
+				t.is(result.status, 0, result.stderr);
+				const props = JSON.parse(result.stdout);
+				t.is(props[property], expected);
+				t.is(props.nonInteractivePrompt, 'analyze code');
+			});
+		}
+	}
+
+	test(`${flag}: similarly prefixed unknown flag stays in prompt`, t => {
+		const unknown = `${flag}-extra=${value}`;
+		const result = runCli(['run', 'analyze', unknown, 'code']);
+		t.is(result.status, 0, result.stderr);
+		const props = JSON.parse(result.stdout);
+		t.is(props[property], undefined);
+		t.is(props.nonInteractivePrompt, `analyze ${unknown} code`);
+	});
+
+	test(`${flag}: missing and empty values retain unset behavior`, t => {
+		for (const option of [[flag], [flag, ''], [`${flag}=`]]) {
+			const result = runCli(['run', 'analyze code', ...option]);
+			t.is(result.status, 0, result.stderr);
+			const props = JSON.parse(result.stdout);
+			t.is(props[property], undefined);
+			t.is(props.nonInteractivePrompt, 'analyze code');
+		}
+	});
+
+	test(`${flag}: first occurrence wins across both forms`, t => {
+		for (const firstFused of [false, true]) {
+			for (const secondFused of [false, true]) {
+				const first = firstFused ? [`${flag}=${value}`] : [flag, value];
+				const second = secondFused ? [`${flag}=invalid!`] : [flag, 'invalid!'];
+				const result = runCli([...first, 'run', 'analyze', ...second, 'code']);
+				t.is(result.status, 0, result.stderr);
+				const props = JSON.parse(result.stdout);
+				t.is(props[property], expected);
+				t.is(props.nonInteractivePrompt, 'analyze code');
+			}
+		}
+	});
+}
+
+test('fused values preserve additional equals signs for existing validation', t => {
+	for (const flag of ['--model', '--provider', '--context-max']) {
+		const result = runCli(['run', 'hello', `${flag}=123=extra`]);
+		t.is(result.status, 1);
+		t.true(
+			result.stderr.includes(`Invalid ${flag} value: "123=extra"`),
+			result.stderr,
+		);
+	}
+	// Port parsing intentionally continues to accept a numeric prefix.
+	const result = runCli(['run', 'hello', '--vscode-port=3000=extra', 'world']);
+	t.is(result.status, 0, result.stderr);
+	const props = JSON.parse(result.stdout);
+	t.is(props.vscodePort, 3000);
+	t.is(props.nonInteractivePrompt, 'hello world');
+});
+
+test('all four fused flags are removed without consuming prompt words', t => {
+	const result = runCli([
+		'run',
+		'analyze',
+		...flags.map(({flag, value}) => `${flag}=${value}`),
+		'code',
+	]);
+	t.is(result.status, 0, result.stderr);
+	const props = JSON.parse(result.stdout);
+	for (const {property, expected} of flags) t.is(props[property], expected);
+	t.is(props.nonInteractivePrompt, 'analyze code');
+});

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -214,9 +214,17 @@ async function main(): Promise<void> {
 
 	// Extract VS Code port if specified
 	let vscodePort: number | undefined;
-	const portArgIndex = args.findIndex(arg => arg === '--vscode-port');
-	if (portArgIndex !== -1 && args[portArgIndex + 1]) {
-		const port = parseInt(args[portArgIndex + 1], 10);
+	const portArgIndex = args.findIndex(
+		arg => arg === '--vscode-port' || arg.startsWith('--vscode-port='),
+	);
+	const portValue =
+		portArgIndex === -1
+			? undefined
+			: args[portArgIndex].startsWith('--vscode-port=')
+				? args[portArgIndex].slice('--vscode-port='.length)
+				: args[portArgIndex + 1];
+	if (portValue) {
+		const port = parseInt(portValue, 10);
 		if (!isNaN(port) && port > 0 && port < 65536) {
 			vscodePort = port;
 		}
@@ -224,10 +232,18 @@ async function main(): Promise<void> {
 
 	// Extract --provider if specified — validate against allowlist pattern
 	let cliProvider: string | undefined;
-	const providerArgIndex = args.findIndex(arg => arg === '--provider');
-	if (providerArgIndex !== -1 && args[providerArgIndex + 1]) {
+	const providerArgIndex = args.findIndex(
+		arg => arg === '--provider' || arg.startsWith('--provider='),
+	);
+	const providerValue =
+		providerArgIndex === -1
+			? undefined
+			: args[providerArgIndex].startsWith('--provider=')
+				? args[providerArgIndex].slice('--provider='.length)
+				: args[providerArgIndex + 1];
+	if (providerValue) {
 		// Allow alphanumeric, hyphen, underscore only to prevent injection
-		const value = args[providerArgIndex + 1];
+		const value = providerValue;
 		if (/^[a-zA-Z0-9_-]+$/.test(value)) {
 			cliProvider = value;
 		} else {
@@ -240,10 +256,18 @@ async function main(): Promise<void> {
 
 	// Extract --model if specified — validate against allowlist pattern
 	let cliModel: string | undefined;
-	const modelArgIndex = args.findIndex(arg => arg === '--model');
-	if (modelArgIndex !== -1 && args[modelArgIndex + 1]) {
+	const modelArgIndex = args.findIndex(
+		arg => arg === '--model' || arg.startsWith('--model='),
+	);
+	const modelValue =
+		modelArgIndex === -1
+			? undefined
+			: args[modelArgIndex].startsWith('--model=')
+				? args[modelArgIndex].slice('--model='.length)
+				: args[modelArgIndex + 1];
+	if (modelValue) {
 		// Allow alphanumeric, hyphen, underscore, dot, slash for model names like "claude-3.5-sonnet"
-		const value = args[modelArgIndex + 1];
+		const value = modelValue;
 		if (/^[a-zA-Z0-9_/.:-]+$/.test(value)) {
 			cliModel = value;
 		} else {
@@ -255,18 +279,26 @@ async function main(): Promise<void> {
 	}
 
 	// Extract --context-max if specified (framework-free parser — no React/Ink)
-	const contextMaxArgIndex = args.findIndex(arg => arg === '--context-max');
-	if (contextMaxArgIndex !== -1 && args[contextMaxArgIndex + 1]) {
+	const contextMaxArgIndex = args.findIndex(
+		arg => arg === '--context-max' || arg.startsWith('--context-max='),
+	);
+	const contextMaxValue =
+		contextMaxArgIndex === -1
+			? undefined
+			: args[contextMaxArgIndex].startsWith('--context-max=')
+				? args[contextMaxArgIndex].slice('--context-max='.length)
+				: args[contextMaxArgIndex + 1];
+	if (contextMaxValue) {
 		const [{parseContextLimit}, {setSessionContextLimit}] = await Promise.all([
 			import('@/utils/parse-context-limit'),
 			import('@/models/index'),
 		]);
-		const limit = parseContextLimit(args[contextMaxArgIndex + 1]);
+		const limit = parseContextLimit(contextMaxValue);
 		if (limit !== null) {
 			setSessionContextLimit(limit);
 		} else {
 			console.error(
-				`Invalid --context-max value: "${args[contextMaxArgIndex + 1]}". Use a positive number, e.g. 8192 or 128k`,
+				`Invalid --context-max value: "${contextMaxValue}". Use a positive number, e.g. 8192 or 128k`,
 			);
 			process.exit(1);
 		}
@@ -342,15 +374,23 @@ async function main(): Promise<void> {
 			} else if (arg === '--vscode-port') {
 				i++; // skip this flag and its value
 				continue;
+			} else if (arg.startsWith('--vscode-port=')) {
+				continue; // skip fused form
 			} else if (arg === '--provider') {
 				i++; // skip this flag and its value
 				continue;
+			} else if (arg.startsWith('--provider=')) {
+				continue; // skip fused form
 			} else if (arg === '--model') {
 				i++; // skip this flag and its value
 				continue;
+			} else if (arg.startsWith('--model=')) {
+				continue; // skip fused form
 			} else if (arg === '--context-max') {
 				i++; // skip this flag and its value
 				continue;
+			} else if (arg.startsWith('--context-max=')) {
+				continue; // skip fused form
 			} else if (arg === '--mode') {
 				i++; // skip this flag and its value
 				continue;


### PR DESCRIPTION
## Description

Fixes #1238.

Adds support for the `--flag=value` syntax for:

* `--model`
* `--provider`
* `--vscode-port`
* `--context-max`

These options are now parsed consistently in both their separated and fused forms. Fused options appearing after `run` are also removed from the prompt without consuming the following prompt word.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

## Changeset

* [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

* [x] New features include passing tests in `.spec.ts/tsx` files
* [ ] All existing tests pass (`pnpm test:all` completes successfully)
* [x] Tests cover both success and error scenarios

Added regression coverage for:

* Separate and fused forms of all four options
* Options before and after `run`
* Exact prompt filtering
* Values containing additional `=` characters
* Similarly prefixed unknown options
* Empty and missing values
* First-occurrence behavior across both forms

The following focused test command passes with 84 tests:

```bash
pnpm exec ava source/cli.spec.ts source/cli-value-flags.cli-integration.spec.ts
```

The complete `scripts/test.sh` suite was also attempted locally on Windows. It did not complete successfully because of failures in unrelated platform-sensitive suites, including `EBUSY` errors during temporary-directory cleanup, daemon IPC/socket tests, and custom shell-execution tests. The relevant CLI suites pass.

### Manual Testing

* [ ] Tested with Ollama
* [ ] Tested with OpenRouter
* [ ] Tested with OpenAI-compatible API
* [ ] Tested MCP integration (if applicable)

## Follow-up Findings

During investigation, I also noticed existing related behavior around `--resume=value` and separated options with missing values. These are outside the scope of #1238 and were intentionally left unchanged. They can be tracked separately if desired.

## Checklist

* [x] If this was for an open issue, I was assigned to it
* [x] Code follows project style guidelines
* [x] Self-review completed
* [x] Documentation updated (if needed)
* [x] No breaking changes (or clearly documented)
* [x] Appropriate logging added using structured logging (see [[CONTRIBUTING.md](https://chatgpt.com/g/g-p-6a945444ffac8191a0b571549412c644/CONTRIBUTING.md#logging)](../CONTRIBUTING.md#logging))