### PR TITLE
fix(schedule): reference-count shared cron subscriptions

### DIFF
--- a/.changeset/schedule-shared-cron-refcount.md
+++ b/.changeset/schedule-shared-cron-refcount.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Keep shared cron jobs alive until every subscriber unregisters. `ScheduleEventSource.unregister()` used to stop the underlying job on the first call even when other subscriptions still used the same expression. Closes #1239.

--- a/source/events/sources/schedule.spec.ts
+++ b/source/events/sources/schedule.spec.ts
@@ -110,6 +110,30 @@ test('unregister stops the job and removes from the map', t => {
 	t.deepEqual(stub.stops, ['0 9 * * MON']);
 });
 
+test('shared expression stays live until the last unregister', async t => {
+	const {router, events} = captureRouter();
+	const stub = stubFactory();
+	const source = new ScheduleEventSource(router, stub.factory);
+
+	router.subscribe(cronSub('a', '0 9 * * MON'));
+	router.subscribe(cronSub('b', '0 9 * * MON'));
+	source.register('0 9 * * MON');
+	source.register('0 9 * * MON');
+	t.is(stub.jobs.length, 1);
+
+	source.unregister('0 9 * * MON');
+	t.deepEqual(source.listRegistered(), ['0 9 * * MON']);
+	t.deepEqual(stub.stops, []);
+
+	stub.jobs[0]?.onTick();
+	await new Promise(r => setImmediate(r));
+	t.is(events.length, 2);
+
+	source.unregister('0 9 * * MON');
+	t.deepEqual(source.listRegistered(), []);
+	t.deepEqual(stub.stops, ['0 9 * * MON']);
+});
+
 test('unregister on unknown expression is a no-op', t => {
 	const {router} = captureRouter();
 	const stub = stubFactory();

--- a/source/events/sources/schedule.ts
+++ b/source/events/sources/schedule.ts
@@ -32,6 +32,7 @@ const defaultFactory: CronFactory = (expression, onTick) =>
 
 export class ScheduleEventSource {
 	private readonly jobs: Map<string, CronJobLike> = new Map();
+	private readonly refCounts: Map<string, number> = new Map();
 
 	constructor(
 		private readonly router: EventRouter,
@@ -39,13 +40,14 @@ export class ScheduleEventSource {
 	) {}
 
 	/**
-	 * Register a cron expression. Subsequent calls with the same expression
-	 * are no-ops, so multiple subscriptions sharing a cron expression only
-	 * create one underlying job. The router fans the resulting event out to
-	 * all of them.
+	 * Register a cron expression. Shared expressions are reference-counted:
+	 * the first caller creates the underlying job, later callers only bump
+	 * the count. The router fans each tick out to every matching subscription.
 	 */
 	register(expression: string): void {
-		if (this.jobs.has(expression)) return;
+		const count = this.refCounts.get(expression) ?? 0;
+		this.refCounts.set(expression, count + 1);
+		if (count > 0) return;
 		const job = this.factory(expression, () => {
 			void this.router.emit({
 				kind: 'schedule.cron',
@@ -56,7 +58,18 @@ export class ScheduleEventSource {
 		this.jobs.set(expression, job);
 	}
 
+	/**
+	 * Drop one subscription for an expression. The underlying job is stopped
+	 * only when the last remaining subscription unregisters.
+	 */
 	unregister(expression: string): void {
+		const count = this.refCounts.get(expression);
+		if (count === undefined) return;
+		if (count > 1) {
+			this.refCounts.set(expression, count - 1);
+			return;
+		}
+		this.refCounts.delete(expression);
 		const job = this.jobs.get(expression);
 		if (!job) return;
 		job.stop();
@@ -66,6 +79,7 @@ export class ScheduleEventSource {
 	stop(): void {
 		for (const job of this.jobs.values()) job.stop();
 		this.jobs.clear();
+		this.refCounts.clear();
 	}
 
 	listRegistered(): string[] {


### PR DESCRIPTION
## Problem

`ScheduleEventSource` documents that multiple subscriptions may share one cron expression, and that one underlying job fans ticks out to all of them. `register()` correctly treated a duplicate expression as a no-op for job creation, but `unregister()` stopped and deleted the job on the first call.

If two skills registered `0 9 * * MON` and one later unregistered, the remaining subscription was silently orphaned and never received ticks again.

## Fix

Reference-count each expression:

- `register()` increments the count and creates the job only on the first subscription
- `unregister()` decrements and stops the job only when the last subscriber leaves
- `stop()` still tears everything down and clears the counts

## Tests

- Existing `source/events/sources/schedule.spec.ts` suite still passes
- New regression test `shared expression stays live until the last unregister` covers: one job for two registers, job stays listed after the first unregister, tick still dispatches to both subscribers, last unregister stops the job

```text
8 tests passed
```

`tsc --noEmit` passes.

Fixes #1239
