### PR TITLE
fix(security): gate daemon start on directory-trust disclaimer

### DIFF
--- a/.changeset/daemon-start-trust-gate.md
+++ b/.changeset/daemon-start-trust-gate.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+`nanocoder daemon start` now refuses to boot in a directory that hasn't been trusted. The daemon fast path (`cli.tsx`) went straight to `runDaemonCli` → `startDaemon` → `bootSkillPipeline` without ever touching `App.tsx` / `useDirectoryTrust`, so it loaded and registered every `.nanocoder/agents|commands|tools/*.md` and `skills/<name>/skill.yaml` in the project unconditionally. Once booted, headless mode (used for every daemon-triggered run) executes `execute_bash`, `write_file`, `string_replace`, `diff_edit`, and MCP tools with no confirmation prompt. `start` now checks `preferences.trustedDirectories` (reusing the same `ensureDirectoryTrust` helper `--plain` already used, now shared via `@/config/preferences`) before spawning the daemon process, and refuses with a clear message otherwise. A new `--trust-directory` flag bypasses the check for a single `daemon start` run without persisting it; `NANOCODER_TRUST_DIRECTORY=1` still persists trust as it does for `--plain`. Closes #1245.

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -67,6 +67,7 @@ if (args[0] === 'daemon') {
 	const {runDaemonCli} = await import('@/daemon/cli');
 	const result = await runDaemonCli(sub as DaemonSub, {
 		projectRoot: process.cwd(),
+		trustDirectory: args.includes('--trust-directory'),
 	});
 	if (result.output) console.log(result.output);
 	process.exit(result.exitCode);
@@ -149,6 +150,8 @@ Commands:
   copilot login [provider-name]   Log in to GitHub Copilot (device flow). Saves credentials for the "GitHub Copilot" provider.
   daemon <subcommand>             Manage the per-project skill daemon.
                                   Subcommands: start, stop, status, logs, install, uninstall.
+                                  start refuses to run in an untrusted directory; pass
+                                  --trust-directory to bypass the check for this run only.
   config <subcommand>             Inspect the resolved configuration and where each value came from.
                                   Subcommands: list, show [key], diff. Add --json for machine output.
 
@@ -163,7 +166,8 @@ Options:
   --mode              Start in a specific development mode (normal, auto-accept, yolo, plan).
                       Defaults to "normal" for interactive sessions and "auto-accept" for run mode.
   --trust-directory   Skip the first-run directory trust prompt for this run only.
-                      Only valid with the "run" command. Does not modify the preferences file.
+                      Valid with the "run" command and "daemon start". Does not modify
+                      the preferences file.
   --plain             Use a lightweight, Ink-free runtime for non-interactive runs.
                       Only valid with the "run" command. Auto-enables in CI / non-TTY.
   --no-plain          Force the Ink runtime even in CI / non-TTY environments.

--- a/source/config/preferences.spec.ts
+++ b/source/config/preferences.spec.ts
@@ -11,6 +11,7 @@ import {
 	MIN_TOKEN_BUDGET,
 } from '@/memory/project-context';
 import {
+	ensureDirectoryTrust,
 	getCompactToolDisplay,
 	getLastUsedModel,
 	getNanocoderShape,
@@ -20,6 +21,7 @@ import {
 	getProjectContextPreferences,
 	getReasoningExpanded,
 	getSemanticMemoryEnabled,
+	isDirectoryTrusted,
 	loadPreferences,
 	resolveProjectContextPreferences,
 	resetPreferencesCache,
@@ -1968,3 +1970,112 @@ test.serial('full workflow: update and retrieve project context preferences', t 
 		}
 	}
 });
+
+// ============================================================================
+// Directory Trust Tests — shared by the interactive TUI, --plain, and the
+// daemon boot path (see source/daemon/cli.ts's `start`).
+// ============================================================================
+
+test('isDirectoryTrusted returns false when trustedDirectories is empty', t => {
+	t.false(isDirectoryTrusted('/some/project', {}));
+});
+
+test('isDirectoryTrusted matches an exact entry', t => {
+	const dir = process.cwd();
+	t.true(isDirectoryTrusted(dir, {trustedDirectories: [dir]}));
+});
+
+test('isDirectoryTrusted resolves relative entries before comparing', t => {
+	const dir = process.cwd();
+	t.true(isDirectoryTrusted(dir, {trustedDirectories: ['.']}));
+});
+
+test('isDirectoryTrusted does not match an unrelated directory', t => {
+	t.false(
+		isDirectoryTrusted(process.cwd(), {
+			trustedDirectories: ['/some/other/project'],
+		}),
+	);
+});
+
+test('ensureDirectoryTrust trusts without persisting when bypass is true', t => {
+	let saveCalled = false;
+	const result = ensureDirectoryTrust('/untrusted/project', true, {
+		loadPreferences: () => ({trustedDirectories: []}),
+		savePreferences: () => {
+			saveCalled = true;
+		},
+	});
+	t.deepEqual(result, {trusted: true, persisted: false});
+	t.false(saveCalled);
+});
+
+test('ensureDirectoryTrust trusts an already-recorded directory without persisting again', t => {
+	const dir = process.cwd();
+	let saveCalled = false;
+	const result = ensureDirectoryTrust(dir, false, {
+		loadPreferences: () => ({trustedDirectories: [dir]}),
+		savePreferences: () => {
+			saveCalled = true;
+		},
+	});
+	t.deepEqual(result, {trusted: true, persisted: false});
+	t.false(saveCalled);
+});
+
+test.serial(
+	'ensureDirectoryTrust refuses an unrecorded directory when NANOCODER_TRUST_DIRECTORY is unset',
+	t => {
+		delete process.env.NANOCODER_TRUST_DIRECTORY;
+		const result = ensureDirectoryTrust('/untrusted/project', false, {
+			loadPreferences: () => ({trustedDirectories: []}),
+			savePreferences: () => {
+				t.fail('should not persist when refusing');
+			},
+		});
+		t.deepEqual(result, {trusted: false, persisted: false});
+	},
+);
+
+test.serial(
+	'ensureDirectoryTrust with NANOCODER_TRUST_DIRECTORY=1 trusts and persists a new entry',
+	t => {
+		process.env.NANOCODER_TRUST_DIRECTORY = '1';
+		let savedPreferences: UserPreferences | null = null;
+		try {
+			const target = join(tmpdir(), 'nanocoder-untrusted-project');
+			const result = ensureDirectoryTrust(target, false, {
+				loadPreferences: () => ({trustedDirectories: []}),
+				savePreferences: prefs => {
+					savedPreferences = prefs;
+				},
+			});
+			t.true(result.trusted);
+			t.true(result.persisted);
+			t.deepEqual(savedPreferences?.trustedDirectories, [target]);
+		} finally {
+			delete process.env.NANOCODER_TRUST_DIRECTORY;
+		}
+	},
+);
+
+test.serial(
+	'ensureDirectoryTrust with NANOCODER_TRUST_DIRECTORY=1 does not duplicate an already-trusted directory',
+	t => {
+		process.env.NANOCODER_TRUST_DIRECTORY = '1';
+		try {
+			const dir = process.cwd();
+			let saveCalled = false;
+			const result = ensureDirectoryTrust(dir, false, {
+				loadPreferences: () => ({trustedDirectories: [dir]}),
+				savePreferences: () => {
+					saveCalled = true;
+				},
+			});
+			t.deepEqual(result, {trusted: true, persisted: false});
+			t.false(saveCalled);
+		} finally {
+			delete process.env.NANOCODER_TRUST_DIRECTORY;
+		}
+	},
+);

--- a/source/config/preferences.ts
+++ b/source/config/preferences.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {readFileSync} from 'fs';
 import type {TitleShape} from '@/components/ui/styled-title';
 import {getClosestConfigFile} from '@/config/index';
@@ -86,6 +87,69 @@ export function savePreferences(preferences: UserPreferences): void {
 	for (const listener of preferencesListeners) {
 		listener();
 	}
+}
+
+/**
+ * True if `directory` (or an equivalent absolute path) is recorded in
+ * `preferences.trustedDirectories`. Shared by every trust-gated entry point
+ * — the interactive TUI's `useDirectoryTrust`, `--plain`'s `runPlainShell`,
+ * and the daemon boot path — so the resolution rule can't drift between them.
+ */
+export function isDirectoryTrusted(
+	directory: string,
+	preferences: UserPreferences,
+): boolean {
+	const resolved = path.resolve(directory); // nosemgrep
+	return (preferences.trustedDirectories ?? []).some(
+		dir => path.resolve(dir) === resolved, // nosemgrep
+	);
+}
+
+export interface DirectoryTrustResult {
+	trusted: boolean;
+	/** True if this call persisted a new trust entry (env-var bypass only). */
+	persisted: boolean;
+}
+
+export interface DirectoryTrustDeps {
+	loadPreferences: typeof loadPreferences;
+	savePreferences: typeof savePreferences;
+}
+
+/**
+ * Resolves directory trust for a non-interactive entry point (`--plain`,
+ * `nanocoder daemon start`) — anywhere that has no disclaimer UI to show.
+ *
+ * `bypass` is the caller's own one-shot override (each entry point's own
+ * `--trust-directory` flag); it never persists, matching the interactive
+ * disclaimer's per-run nature. Absent that, a directory already recorded in
+ * `trustedDirectories` (from a prior interactive run, or a previous
+ * `NANOCODER_TRUST_DIRECTORY=1` run) is trusted as-is. A first-time
+ * `NANOCODER_TRUST_DIRECTORY=1` run persists the directory so later runs
+ * don't need the env var again.
+ */
+export function ensureDirectoryTrust(
+	directory: string,
+	bypass: boolean,
+	deps: DirectoryTrustDeps = {loadPreferences, savePreferences},
+): DirectoryTrustResult {
+	if (bypass) return {trusted: true, persisted: false};
+
+	const preferences = deps.loadPreferences();
+	if (isDirectoryTrusted(directory, preferences)) {
+		return {trusted: true, persisted: false};
+	}
+
+	if (process.env.NANOCODER_TRUST_DIRECTORY === '1') {
+		const resolved = path.resolve(directory); // nosemgrep
+		deps.savePreferences({
+			...preferences,
+			trustedDirectories: [...(preferences.trustedDirectories ?? []), resolved],
+		});
+		return {trusted: true, persisted: true};
+	}
+
+	return {trusted: false, persisted: false};
 }
 
 export function updateLastUsed(provider: string, model: string): void {

--- a/source/daemon/cli.spec.ts
+++ b/source/daemon/cli.spec.ts
@@ -1,8 +1,15 @@
+import type {ChildProcess} from 'node:child_process';
 import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'ava';
+import {
+	loadPreferences,
+	resetPreferencesCache,
+	savePreferences,
+} from '@/config/preferences';
 import {runDaemonCli} from './cli';
+import {writeLockfile} from './lockfile';
 
 console.log(`\ncli.spec.ts`);
 
@@ -15,6 +22,43 @@ async function tempProject(logContent?: string): Promise<string> {
 		await writeFile(join(root, '.nanocoder', 'daemon.log'), logContent, 'utf-8');
 	}
 	return root;
+}
+
+/**
+ * `start`'s directory-trust gate reads/writes preferences through the real
+ * `@/config/preferences` module (there's no deps-injection seam for it, unlike
+ * `launchDaemon`), so these tests point `NANOCODER_CONFIG_DIR` at a scratch
+ * directory rather than touching whatever preferences file the machine
+ * running the suite already has.
+ */
+async function withIsolatedPreferences<T>(fn: () => Promise<T>): Promise<T> {
+	const configDir = await mkdtemp(join(tmpdir(), 'daemon-cli-prefs-'));
+	const previous = process.env.NANOCODER_CONFIG_DIR;
+	process.env.NANOCODER_CONFIG_DIR = configDir;
+	resetPreferencesCache();
+	try {
+		return await fn();
+	} finally {
+		if (previous === undefined) delete process.env.NANOCODER_CONFIG_DIR;
+		else process.env.NANOCODER_CONFIG_DIR = previous;
+		resetPreferencesCache();
+		await rm(configDir, {recursive: true, force: true});
+	}
+}
+
+/**
+ * Stub launcher matching the real daemon's behavior just enough for
+ * `start`'s `waitForLockfile` poll to succeed: it writes a lockfile pointing
+ * at this test process's own pid, which `isProcessAlive` will find alive.
+ */
+function stubLaunchDaemon(projectRoot: string): ChildProcess {
+	void writeLockfile({
+		pid: process.pid,
+		socketPath: 'fake-socket-for-test',
+		startedAt: Date.now(),
+		projectRoot,
+	});
+	return {} as unknown as ChildProcess;
 }
 
 test.serial('logs reports when no daemon log exists', async t => {
@@ -142,3 +186,114 @@ test.serial('logs starts the tail on a line boundary', async t => {
 		await rm(root, {recursive: true, force: true});
 	}
 });
+
+// ============================================================================
+// start: directory-trust gate. The daemon loads and executes skills
+// unattended (headless mode, no confirmation prompts), so it must refuse to
+// boot in a directory the user hasn't trusted.
+// ============================================================================
+
+test.serial(
+	'start refuses to boot in an untrusted directory and never spawns the launcher',
+	async t => {
+		const root = await tempProject();
+		try {
+			await withIsolatedPreferences(async () => {
+				let launched = false;
+				const result = await runDaemonCli('start', {
+					projectRoot: root,
+					launchDaemon: () => {
+						launched = true;
+						return stubLaunchDaemon(root);
+					},
+				});
+				t.is(result.exitCode, 1);
+				t.regex(result.output, /not trusted/i);
+				t.false(launched, 'an untrusted directory must never spawn the daemon');
+			});
+		} finally {
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
+	'start boots normally when the directory is already trusted',
+	async t => {
+		const root = await tempProject();
+		try {
+			await withIsolatedPreferences(async () => {
+				savePreferences({trustedDirectories: [root]});
+				let launched = false;
+				const result = await runDaemonCli('start', {
+					projectRoot: root,
+					launchDaemon: projectRoot => {
+						launched = true;
+						return stubLaunchDaemon(projectRoot);
+					},
+				});
+				t.true(launched);
+				t.is(result.exitCode, 0);
+				t.regex(result.output, /Daemon started/);
+			});
+		} finally {
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
+	'start --trust-directory bypasses the check without persisting trust',
+	async t => {
+		const root = await tempProject();
+		try {
+			await withIsolatedPreferences(async () => {
+				let launched = false;
+				const result = await runDaemonCli('start', {
+					projectRoot: root,
+					trustDirectory: true,
+					launchDaemon: projectRoot => {
+						launched = true;
+						return stubLaunchDaemon(projectRoot);
+					},
+				});
+				t.true(launched);
+				t.is(result.exitCode, 0);
+				t.false(
+					(loadPreferences().trustedDirectories ?? []).includes(root),
+					'--trust-directory is a one-shot bypass and must not persist',
+				);
+			});
+		} finally {
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
+	'start with NANOCODER_TRUST_DIRECTORY=1 trusts and persists, then boots',
+	async t => {
+		const root = await tempProject();
+		process.env.NANOCODER_TRUST_DIRECTORY = '1';
+		try {
+			await withIsolatedPreferences(async () => {
+				let launched = false;
+				const result = await runDaemonCli('start', {
+					projectRoot: root,
+					launchDaemon: projectRoot => {
+						launched = true;
+						return stubLaunchDaemon(projectRoot);
+					},
+				});
+				t.true(launched);
+				t.is(result.exitCode, 0);
+				t.true(
+					(loadPreferences().trustedDirectories ?? []).includes(root),
+				);
+			});
+		} finally {
+			delete process.env.NANOCODER_TRUST_DIRECTORY;
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);

--- a/source/daemon/cli.ts
+++ b/source/daemon/cli.ts
@@ -19,8 +19,9 @@ import {
 	openSync,
 	statSync,
 } from 'node:fs';
-import {dirname, join} from 'node:path';
+import {dirname, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {ensureDirectoryTrust} from '@/config/preferences';
 import {formatError} from '@/utils/error-formatter';
 import {
 	getLockfilePath,
@@ -54,6 +55,14 @@ export interface DaemonCliOptions {
 	 * `defaultLaunchDaemon`.
 	 */
 	launchDaemon?: (projectRoot: string) => ChildProcess | null;
+	/**
+	 * One-shot override for `start`'s directory-trust gate (`--trust-directory`
+	 * on `nanocoder daemon start`), mirroring the `run` command's flag of the
+	 * same name. Never persisted — set `NANOCODER_TRUST_DIRECTORY=1` instead
+	 * to trust the directory for future runs too. Ignored by every other
+	 * subcommand.
+	 */
+	trustDirectory?: boolean;
 }
 
 /**
@@ -128,6 +137,32 @@ async function start(opts: DaemonCliOptions): Promise<DaemonCliResult> {
 		return {
 			exitCode: 0,
 			output: `Daemon already running (pid ${live.pid}).`,
+		};
+	}
+
+	// The daemon loads every .nanocoder/agents|commands|tools/*.md and
+	// skills/<name>/skill.yaml in the project and runs triggered skills in
+	// headless mode - no confirmation prompts, including for execute_bash.
+	// It must never boot in a directory the user hasn't trusted.
+	const trust = ensureDirectoryTrust(
+		opts.projectRoot,
+		opts.trustDirectory ?? false,
+	);
+	if (trust.persisted) {
+		console.log(
+			`Marked ${resolve(opts.projectRoot)} as trusted (NANOCODER_TRUST_DIRECTORY=1).`,
+		);
+	}
+	if (!trust.trusted) {
+		return {
+			exitCode: 1,
+			output:
+				`Directory ${resolve(opts.projectRoot)} is not trusted. The daemon runs ` +
+				`triggered skills unattended with no confirmation prompts, so it refuses ` +
+				`to start here. Run \`nanocoder\` interactively in this directory once to ` +
+				`accept the trust disclaimer, then re-run \`nanocoder daemon start\` - or ` +
+				`pass --trust-directory to bypass it for this run only (set ` +
+				`NANOCODER_TRUST_DIRECTORY=1 to persist it instead).`,
 		};
 	}
 

--- a/source/plain/shell.ts
+++ b/source/plain/shell.ts
@@ -7,6 +7,7 @@ import {
 } from '@/artifacts/artifact-manager';
 import {getAppConfig} from '@/config/index';
 import {
+	ensureDirectoryTrust,
 	loadPreferences,
 	resolveProjectContextPreferences,
 	savePreferences,
@@ -109,7 +110,16 @@ export async function runPlainShell(
 
 	const isJson = outputFormat === 'json';
 
-	if (!ensureDirectoryTrust(trustDirectory, deps)) {
+	const trust = ensureDirectoryTrust(process.cwd(), trustDirectory, {
+		loadPreferences: deps.loadPreferences,
+		savePreferences: deps.savePreferences,
+	});
+	if (trust.persisted) {
+		writeStatus(
+			`Marked ${path.resolve(process.cwd())} as trusted (NANOCODER_TRUST_DIRECTORY=1).`,
+		);
+	}
+	if (!trust.trusted) {
 		if (isJson) {
 			const cwd = path.resolve(process.cwd());
 			emitJsonReport({
@@ -382,29 +392,6 @@ function isToolCallingDisabled(provider: string, model: string): boolean {
 	const providerConfig = config.providers?.find(p => p.name === provider);
 	if (!providerConfig) return false;
 	return providerConfig.disableToolModels?.includes(model) ?? false;
-}
-
-function ensureDirectoryTrust(
-	trustDirectoryFlag: boolean,
-	deps: RunPlainShellDeps,
-): boolean {
-	if (trustDirectoryFlag) return true;
-	const cwd = path.resolve(process.cwd());
-	const preferences = deps.loadPreferences();
-	const trusted = (preferences.trustedDirectories ?? []).some(
-		dir => path.resolve(dir) === cwd,
-	);
-	if (trusted) return true;
-
-	if (process.env.NANOCODER_TRUST_DIRECTORY === '1') {
-		const updated = preferences.trustedDirectories ?? [];
-		updated.push(cwd);
-		deps.savePreferences({...preferences, trustedDirectories: updated});
-		writeStatus(`Marked ${cwd} as trusted (NANOCODER_TRUST_DIRECTORY=1).`);
-		return true;
-	}
-
-	return false;
 }
 
 /**


### PR DESCRIPTION
## Description
Closes a critical security vulnerability where `nanocoder daemon start` could execute untrusted code without user confirmation. The daemon fast path went straight to `runDaemonCli` → `startDaemon` → `bootSkillPipeline` without checking directory trust, loading every `.nanocoder/agents|commands|tools/*.md` and `skills/<name>/skill.yaml` unconditionally.

**Security Impact:**
1. **Unattended code execution**: The daemon loads skills in headless mode with NO confirmation prompts for `execute_bash`, `write_file`, `string_replace`, `diff_edit`, and MCP tools
2. **Attack vector**: A malicious repo with `.nanocoder/skills/evil/skill.yaml` containing a `file.changed` subscription could execute arbitrary commands when ANY file is touched
3. **Bypass of all safeguards**: Headless mode is strictly more permissive than auto-accept - even bash execution runs without prompts

**Fix:** `daemon start` now checks `preferences.trustedDirectories` before spawning the daemon process and refuses with exit code 1 if the directory isn't trusted. The trust-check logic was refactored into a shared `ensureDirectoryTrust()` helper in `@/config/preferences` (eliminating code duplication from plain/shell.ts). Users must either:
- Run `nanocoder` interactively once to accept the trust disclaimer, OR
- Pass `--trust-directory` flag (one-shot bypass), OR
- Set `NANOCODER_TRUST_DIRECTORY=1` (persists trust)

## Type of Change
- [x] Bug fix (security vulnerability)
- [ ] New feature
- [x] Breaking change (security-critical fix - previously unprotected daemon now requires trust)
- [ ] Documentation update

## Changeset
- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog

## Testing

### Automated Tests
- [x] New features include passing tests in `.spec.ts/tsx` files
- [x] All existing tests pass (`pnpm test:all` completes successfully)
- [x] Tests cover both success and error scenarios

### Manual Testing
- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [x] Tested MCP integration (if applicable)

## Checklist
- [x] If this was for an open issue, I was assigned to it (Issue #1245)
- [x] Code follows project style guidelines (Biome formatting and linting passed)
- [x] Self-review completed
- [x] Documentation updated (if needed) - Updated CLI help text for `--trust-directory` flag
- [x] No breaking changes (or clearly documented) - This is a security fix; behavior now matches intended design
- [x] Appropriate logging added using structured logging