### PR TITLE
fix: parse and format step minutes gracefully in formatCronHuman

### DIFF
--- a/.changeset/fix-cron-step-minutes.md
+++ b/.changeset/fix-cron-step-minutes.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix display of step minutes in cron scheduling

--- a/source/schedule/cron.spec.ts
+++ b/source/schedule/cron.spec.ts
@@ -69,6 +69,11 @@ test('formatCronHuman formats hourly pattern', t => {
 	t.is(formatCronHuman('0 * * * *'), 'every hour at minute 0');
 });
 
+test('formatCronHuman formats step minutes', t => {
+	t.is(formatCronHuman('*/5 * * * *'), 'every 5 minutes');
+	t.is(formatCronHuman('*/10 * * * *'), 'every 10 minutes');
+});
+
 test('formatCronHuman formats daily pattern', t => {
 	t.is(formatCronHuman('0 9 * * *'), 'daily at 9:00');
 	t.is(formatCronHuman('30 14 * * *'), 'daily at 14:30');

--- a/source/schedule/cron.ts
+++ b/source/schedule/cron.ts
@@ -53,6 +53,10 @@ export function formatCronHuman(expression: string): string {
 		month === '*' &&
 		dayOfWeek === '*'
 	) {
+		if (minute.startsWith('*/')) {
+			const step = minute.slice(2);
+			return `every ${step} minutes`;
+		}
 		return `every hour at minute ${minute}`;
 	}
 


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause:
The `formatCronHuman` logic for handling the hourly branch (`minute !== '*'` while others are `*`) fell back to simply printing "every hour at minute {minute}". For step minutes like `*/5`, this resulted in the raw string "every hour at minute */5" instead of formatting it.

Fix:
Intercept the `minute` field inside the hourly branch check. If `minute` begins with `*/`, extract the step numerical string and format it as `"every ${step} minutes"`. Otherwise, fall back to the existing behavior. I also added explicit assertions into `source/schedule/cron.spec.ts` to ensure it parses correctly and catches regressions.

Validation:
Executed the required commands directly locally:
pnpm run build (Success)
pnpm test:format (Success)
pnpm test:lint (Success)
pnpm test:types (Success)
pnpm test:knip (Success)
pnpm test:ava source/schedule/cron.spec.ts (Success, 18 passing tests)
Validated changeset presence with pnpm changeset status.

Fixes https://github.com/Nano-Collective/nanocoder/issues/1132

Fixes #1132
