### PR TITLE
fix: correctly map built-in source to priority for commands and tools

### DIFF
--- a/.changeset/built-in-source-priority.md
+++ b/.changeset/built-in-source-priority.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix bug where built-in command and tool sources were silently mapped to project priority

--- a/source/custom-tools/loader.ts
+++ b/source/custom-tools/loader.ts
@@ -107,7 +107,7 @@ export class CustomToolLoader {
 
 	private scanDirectory(
 		dir: string,
-		source: 'personal' | 'project',
+		source: 'built-in' | 'personal' | 'project',
 	): LoadedCustomTool[] {
 		if (!existsSync(dir)) return [];
 		const out: LoadedCustomTool[] = [];

--- a/source/skills/bootstrap.spec.ts
+++ b/source/skills/bootstrap.spec.ts
@@ -123,6 +123,76 @@ test.serial(
 );
 
 test.serial(
+	'synthesizes built-in flat commands and tools with built-in priority',
+	async t => {
+		resetSkillRegistry();
+		const root = await tempProject();
+		try {
+			const commandLoader = new CustomCommandLoader(root);
+			// Override to inject a built-in command
+			commandLoader.getAllCommands = () => [
+				{
+					name: 'built-in-cmd',
+					path: '/builtin/cmd.md',
+					namespace: undefined,
+					fullName: 'built-in-cmd',
+					metadata: {},
+					content: 'body',
+					source: 'built-in',
+				},
+			];
+
+			const toolManager = new ToolManager();
+			// Override to inject a built-in tool
+			toolManager.getCustomToolNames = () => ['built-in-tool'];
+			toolManager.getCustomToolInfo = (name) => {
+				if (name === 'built-in-tool') {
+					return {
+						approval: 'always',
+						readOnly: true,
+						source: 'built-in',
+						filePath: '/builtin/tool.md',
+					};
+				}
+				return undefined;
+			};
+			toolManager.getToolEntry = (name) => {
+				if (name === 'built-in-tool') {
+					return {
+						name: 'built-in-tool',
+						tool: {
+							description: 'builtin tool',
+							parameters: { type: 'object', properties: {} } as any,
+							execute: async () => 'ok',
+						},
+						handler: async () => 'ok',
+					};
+				}
+				return undefined;
+			};
+
+			const result = await bootSkillPipeline({
+				projectRoot: root,
+				toolManager,
+				commandLoader,
+				subagentLoader: new SubagentLoader(root),
+				eventRouter: noopRouter(),
+			});
+
+			const cmdSkill = result.skills.find(s => s.name === 'cmd');
+			t.truthy(cmdSkill, 'command skill should be synthesized');
+			t.is(cmdSkill?.source.priority, 'built-in', 'command should have built-in priority');
+
+			const toolSkill = result.skills.find(s => s.name === 'tool');
+			t.truthy(toolSkill, 'tool skill should be synthesized');
+			t.is(toolSkill?.source.priority, 'built-in', 'tool should have built-in priority');
+		} finally {
+			await rm(root, {recursive: true, force: true});
+		}
+	},
+);
+
+test.serial(
 	'flat-dir commands are picked up via the legacy loader and surfaced as skills',
 	async t => {
 		resetSkillRegistry();

--- a/source/skills/bootstrap.ts
+++ b/source/skills/bootstrap.ts
@@ -217,7 +217,9 @@ function synthesizeCommandSkills(loader: CustomCommandLoader): Skill[] {
 				? 'project'
 				: command.source === 'personal'
 					? 'personal'
-					: 'project';
+					: command.source === 'built-in'
+						? 'built-in'
+						: 'project';
 		out.push(
 			commandToSkill(command, {
 				filePath: command.path,
@@ -259,7 +261,13 @@ function synthesizeToolSkills(manager: ToolManager): Skill[] {
 		const entry = manager.getToolEntry(name);
 		if (!info || !entry) continue;
 		const priority: SkillPriority =
-			info.source === 'project' ? 'project' : 'personal';
+			info.source === 'project'
+				? 'project'
+				: info.source === 'personal'
+					? 'personal'
+					: info.source === 'built-in'
+						? 'built-in'
+						: 'project';
 		out.push(
 			toolToSkill(entry, {
 				filePath: info.filePath,

--- a/source/tools/tool-manager.ts
+++ b/source/tools/tool-manager.ts
@@ -82,7 +82,7 @@ export class ToolManager {
 		{
 			approval: CustomToolApprovalPolicy;
 			readOnly: boolean;
-			source: 'personal' | 'project';
+			source: 'built-in' | 'personal' | 'project';
 			filePath: string;
 			subscribe?: import('@/types/skills').SkillTrigger[];
 		}
@@ -389,7 +389,7 @@ export class ToolManager {
 		| {
 				approval: CustomToolApprovalPolicy;
 				readOnly: boolean;
-				source: 'personal' | 'project';
+				source: 'built-in' | 'personal' | 'project';
 				filePath: string;
 				subscribe?: import('@/types/skills').SkillTrigger[];
 		  }

--- a/source/types/commands.ts
+++ b/source/types/commands.ts
@@ -88,7 +88,7 @@ export interface CustomCommand {
 	metadata: CustomCommandMetadata;
 	content: string; // The markdown content without frontmatter
 	// Skill-like fields (populated for commands with auto-injection capabilities)
-	source?: 'personal' | 'project';
+	source?: 'built-in' | 'personal' | 'project';
 	lastModified?: Date;
 	loadedResources?: CommandResource[];
 	/**

--- a/source/types/custom-tools.ts
+++ b/source/types/custom-tools.ts
@@ -58,7 +58,7 @@ export interface LoadedCustomTool {
 	metadata: CustomToolMetadata;
 	body: string;
 	filePath: string;
-	source: 'personal' | 'project';
+	source: 'built-in' | 'personal' | 'project';
 	/**
 	 * Event subscriptions declared in the file's frontmatter, if any.
 	 * Carried through the loader so the skill registrar can wire them up.


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause: The priority fall-through logic in `bootstrap.ts` collapsed anything that wasn't `'project'` or `'personal'` to `'project'`, which caused `'built-in'` sources to be incorrectly mapped as project priority.
Fix: Added `'built-in'` to the allowed `source` union types in `CustomCommand`, `LoadedCustomTool`, and related interfaces. Updated the logic in `synthesizeCommandSkills` and `synthesizeToolSkills` to explicitly map `source === 'built-in'` to the `'built-in'` priority, and added a regression test.
Validation: Ran `pnpm test:format`, `pnpm test:lint`, `pnpm test:types`, `pnpm test:knip`, and targeted `pnpm test:ava` runs for `source/skills/bootstrap.spec.ts`, `source/tools/tool-manager.spec.ts`, and `source/custom-tools/loader.spec.ts`. All passed.
Fixes https://github.com/Nano-Collective/nanocoder/issues/1134

Fixes #1134
