### PR TITLE
fix: prevent custom commands scan abort on permission error

### DIFF
--- a/.changeset/custom-commands-scan-fix.md
+++ b/.changeset/custom-commands-scan-fix.md
@@ -1,0 +1,5 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+Fix: custom commands scan no longer aborts on permission errors in sub-directories

--- a/source/custom-commands/loader.spec.ts
+++ b/source/custom-commands/loader.spec.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, rmSync, existsSync, mkdirSync } from 'fs';
+import { writeFileSync, rmSync, existsSync, mkdirSync, chmodSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import test from 'ava';
@@ -294,6 +294,33 @@ test('CustomCommandLoader - ignores non-markdown files', t => {
 
 	// Should only load the .md file
 	t.is(loader.getAllCommands().length, 1);
+});
+
+test('CustomCommandLoader - handles unreadable directories gracefully', t => {
+	const testDir = createTestDir('unreadable-dir');
+	const commandsDir = join(testDir, '.nanocoder', 'commands');
+	const unreadableDir = join(commandsDir, 'unreadable');
+
+	t.teardown(() => {
+		if (existsSync(unreadableDir)) {
+			try { chmodSync(unreadableDir, 0o777); } catch {}
+		}
+		cleanupTestDir(testDir);
+	});
+
+	mkdirSync(commandsDir, {recursive: true});
+	createCommandFile(join(commandsDir, 'test.md'), 'Test command');
+
+	mkdirSync(unreadableDir);
+	chmodSync(unreadableDir, 0o000);
+
+	const loader = new CustomCommandLoader(testDir);
+
+	t.notThrows(() => loader.loadCommands());
+
+	const commands = loader.getAllCommands();
+	t.is(commands.length, 1);
+	t.is(commands[0].name, 'test');
 });
 
 test('CustomCommandLoader - loadCommands clears aliases on reload', t => {

--- a/source/custom-commands/loader.ts
+++ b/source/custom-commands/loader.ts
@@ -3,7 +3,7 @@ import {basename, join} from 'path';
 import {getConfigPath} from '@/config/paths';
 import {parseCommandFile} from '@/custom-commands/parser';
 import type {CommandResource, CustomCommand} from '@/types/index';
-import {logError} from '@/utils/message-queue';
+import {logError, logWarning} from '@/utils/message-queue';
 
 const RESOURCES_DIR = 'resources';
 const RELEVANCE_THRESHOLD = 5;
@@ -59,7 +59,13 @@ export class CustomCommandLoader {
 		namespace?: string,
 		source?: 'personal' | 'project',
 	): void {
-		const entries = readdirSync(dir);
+		let entries: string[];
+		try {
+			entries = readdirSync(dir);
+		} catch (error) {
+			logWarning(`Failed to read directory ${dir}: ${String(error)}`);
+			return;
+		}
 
 		for (const entry of entries) {
 			if (!isSafeEntry(entry)) continue;


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause: `scanDirectory` in `CustomCommandLoader` used `readdirSync` without a try-catch block, causing the entire custom commands scan to abort when it encountered an unreadable directory due to an `EACCES` permission error.

Fix: Wrapped the `readdirSync(dir)` call in a try-catch block inside `scanDirectory`. If an error occurs, it now logs a warning using `logWarning` and returns early for that specific directory, allowing the scan to continue for other valid directories and files. Added a test case in `loader.spec.ts` to ensure unreadable directories are handled gracefully and correctly. Also added a changeset.

Validation: 
```bash
pnpm run build
pnpm test:format
pnpm test:lint
pnpm test:types
pnpm test:knip
pnpm test:ava source/custom-commands/loader.spec.ts
```
Results were all successful. Note that full suite `pnpm test:ava` timed out in container, but tests are isolated.

Fixes https://github.com/Nano-Collective/nanocoder/issues/1142

Fixes #1142
