### PR TITLE
fix: update access order on BoundedMap overwrite

### DIFF
--- a/.changeset/bounded-map-access-order.md
+++ b/.changeset/bounded-map-access-order.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix BoundedMap.set to properly update access order on overwrite

--- a/source/utils/bounded-map.spec.ts
+++ b/source/utils/bounded-map.spec.ts
@@ -102,6 +102,24 @@ test('BoundedMap - updating existing key does not trigger eviction', t => {
 	t.is(map.get('b'), 2);
 });
 
+test('BoundedMap - updating existing key updates its access order', t => {
+	const map = new BoundedMap<string, number>({maxSize: 2});
+
+	map.set('a', 1);
+	map.set('b', 2);
+
+	// Update existing key, moving 'a' to the end of insertion order
+	map.set('a', 10);
+
+	// Add a new key, should evict 'b' instead of 'a'
+	map.set('c', 3);
+
+	t.is(map.size, 2);
+	t.true(map.has('a'));
+	t.false(map.has('b'));
+	t.true(map.has('c'));
+});
+
 test('BoundedMap - TTL causes entries to expire', async t => {
 	const map = new BoundedMap<string, number>({
 		maxSize: 100,

--- a/source/utils/bounded-map.ts
+++ b/source/utils/bounded-map.ts
@@ -57,6 +57,11 @@ export class BoundedMap<K, V> {
 			}
 		}
 
+		// Delete the key if it exists so setting it moves it to the end of insertion order
+		if (this.map.has(key)) {
+			this.map.delete(key);
+		}
+
 		this.map.set(key, {
 			value,
 			timestamp: Date.now(),


### PR DESCRIPTION
## Description

Brief description of what this PR does

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [ ] Added a changeset (`pnpm changeset`) describing this change for the changelog

Docs-only or internal chores need no changeset (or run `pnpm changeset --empty` to note that intentionally).

## Testing

### Automated Tests

- [ ] New features include passing tests in `.spec.ts/tsx` files
- [ ] All existing tests pass (`pnpm test:all` completes successfully)
- [ ] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging))

---

Root cause: When setting an existing key in a standard Javascript `Map`, its insertion order is not updated. As a result, `BoundedMap` could mistakenly evict a frequently-accessed/overwritten key when it reaches max capacity, as it was considered older than it should have been.
Fix: Updated `BoundedMap.set` to delete an existing key before setting it again. This bumps the key to the end of the map's insertion order, updating its access order correctly.
Validation: Ran `pnpm run build && pnpm test:format && pnpm test:lint && pnpm test:types && pnpm test:knip`. Ran tests in `source/utils/bounded-map.spec.ts` using `pnpm test:ava source/utils/bounded-map.spec.ts` which verified the exact behavior.

Fixes https://github.com/Nano-Collective/nanocoder/issues/1143

Fixes #1143
