### PR TITLE
fix(tui): scale the fullscreen chat tail cap to terminal height

### DIFF
--- a/.changeset/bright-turns-settle.md
+++ b/.changeset/bright-turns-settle.md
@@ -1,0 +1,5 @@
+---
+"@nanocollective/nanocoder": patch
+---
+
+Fix fullscreen chat rendering getting progressively slower in long conversations by scaling the mounted transcript tail to terminal height instead of a flat 60-component cap.

--- a/source/app/components/chat-history.spec.tsx
+++ b/source/app/components/chat-history.spec.tsx
@@ -245,3 +245,63 @@ test('fullscreen mode hides welcome banner while liveComponent is active', t => 
 	unmount();
 });
 
+// ============================================================================
+// Fullscreen tail cap: ChatHistory derives ChatQueue's mounted-tail cap from
+// terminal height (computeFullscreenTailCap) instead of a flat 60, so Yoga
+// layout cost stops scaling with total session length (#1274).
+// ============================================================================
+
+test('fullscreen mode mounts fewer than the flat 60-item tail on a short terminal', t => {
+	const originalRows = process.stdout.rows;
+	process.stdout.rows = 24; // computeFullscreenTailCap(24) === 12
+
+	try {
+		const components = Array.from({length: 30}, (_, i) => (
+			<div key={`turn-${i}`}>{`turn-${i}`}</div>
+		));
+		const props = createDefaultProps({
+			fullscreen: true,
+			staticComponents: [<div key="welcome">WELCOME-BANNER</div>],
+			queuedComponents: components,
+		});
+		const {lastFrame, unmount} = renderWithTheme(<ChatHistory {...props} />);
+		const output = lastFrame() ?? '';
+
+		// Only the last 12 turns (18..29) should be mounted; the flat-60 cap
+		// this replaces would have kept all 30.
+		t.notRegex(output, /\bturn-17\b/);
+		t.regex(output, /\bturn-18\b/);
+		t.regex(output, /\bturn-29\b/);
+		unmount();
+	} finally {
+		process.stdout.rows = originalRows;
+	}
+});
+
+test('inline mode is unaffected by terminal height - still keeps the flat 60-item tail', t => {
+	const originalRows = process.stdout.rows;
+	process.stdout.rows = 24;
+
+	try {
+		// isFreshInline (disableStatic without fullscreen) keeps ChatQueue's own
+		// default cap rather than the terminal-derived one - only fullscreen
+		// mode has the render-cost problem #1274 reports.
+		const components = Array.from({length: 30}, (_, i) => (
+			<div key={`turn-${i}`}>{`turn-${i}`}</div>
+		));
+		const props = createDefaultProps({
+			fullscreen: false,
+			staticComponents: [<div key="welcome">WELCOME-BANNER</div>],
+			queuedComponents: components,
+		});
+		const {lastFrame, unmount} = renderWithTheme(<ChatHistory {...props} />);
+		const output = lastFrame() ?? '';
+
+		t.regex(output, /\bturn-0\b/);
+		t.regex(output, /\bturn-29\b/);
+		unmount();
+	} finally {
+		process.stdout.rows = originalRows;
+	}
+});
+

--- a/source/app/components/chat-history.tsx
+++ b/source/app/components/chat-history.tsx
@@ -1,6 +1,6 @@
 import {Box, measureElement, Text, useInput} from 'ink';
 import React from 'react';
-import ChatQueue from '@/components/chat-queue';
+import ChatQueue, {computeFullscreenTailCap} from '@/components/chat-queue';
 import {RenderErrorBoundary} from '@/components/render-error-boundary';
 import {useTerminalRows} from '@/hooks/useTerminalWidth';
 import {useTheme} from '@/hooks/useTheme';
@@ -165,6 +165,13 @@ export const ChatHistory = React.memo(function ChatHistory({
 			renderLastQueuedComponentLive,
 			clearKey,
 			disableStatic: fullscreen || isFreshInline,
+			// Only the fullscreen path pays Yoga layout cost for its whole mounted
+			// tail on every render (see computeFullscreenTailCap) - isFreshInline
+			// is a brief pre-Static state with little content, so it keeps
+			// ChatQueue's flat default.
+			fullscreenTailCap: fullscreen
+				? computeFullscreenTailCap(terminalRows)
+				: undefined,
 		}),
 		[
 			frozenComponents,
@@ -173,6 +180,7 @@ export const ChatHistory = React.memo(function ChatHistory({
 			clearKey,
 			fullscreen,
 			isFreshInline,
+			terminalRows,
 		],
 	);
 

--- a/source/components/chat-queue.spec.tsx
+++ b/source/components/chat-queue.spec.tsx
@@ -2,7 +2,7 @@ import test from 'ava';
 import {Box, Text} from 'ink';
 import {render} from 'ink-testing-library';
 import React from 'react';
-import ChatQueue from './chat-queue';
+import ChatQueue, {computeFullscreenTailCap} from './chat-queue';
 
 test('ChatQueue renders without components', t => {
 	t.notThrows(() => {
@@ -171,6 +171,48 @@ test('disableStatic caps the rendered tail at FULLSCREEN_TAIL_CAP (60) component
 	t.notRegex(output, /\bitem-9\b/);
 	t.regex(output, /\bitem-10\b/);
 	t.regex(output, /\bitem-69\b/);
+});
+
+test('disableStatic honors a custom fullscreenTailCap instead of the flat 60 default', t => {
+	// 20 numbered items with a cap of 8: only the last 8 (indices 12..19) survive.
+	const components = Array.from({length: 20}, (_, i) => (
+		<Box key={`cap-${i}`}>{`cap-${i}`}</Box>
+	));
+
+	const {lastFrame} = render(
+		<ChatQueue
+			staticComponents={components}
+			queuedComponents={[]}
+			disableStatic
+			fullscreenTailCap={8}
+		/>,
+	);
+	const output = lastFrame() ?? '';
+
+	t.notRegex(output, /\bcap-11\b/);
+	t.regex(output, /\bcap-12\b/);
+	t.regex(output, /\bcap-19\b/);
+});
+
+// ============================================================================
+// computeFullscreenTailCap — scales the fullscreen tail to terminal height
+// (source/app/components/chat-history.tsx wires this from useTerminalRows)
+// instead of paying Yoga layout cost for a flat worst-case constant.
+// ============================================================================
+
+test('computeFullscreenTailCap floors at 10 for very short terminals', t => {
+	t.is(computeFullscreenTailCap(1), 10);
+	t.is(computeFullscreenTailCap(10), 10);
+});
+
+test('computeFullscreenTailCap scales roughly to half the terminal height', t => {
+	t.is(computeFullscreenTailCap(24), 12);
+	t.is(computeFullscreenTailCap(40), 20);
+});
+
+test('computeFullscreenTailCap caps at 60 for very tall terminals', t => {
+	t.is(computeFullscreenTailCap(200), 60);
+	t.is(computeFullscreenTailCap(120), 60);
 });
 
 test('disableStatic with fewer than 60 components renders all of them untouched', t => {

--- a/source/components/chat-queue.tsx
+++ b/source/components/chat-queue.tsx
@@ -8,9 +8,27 @@ import type {ChatQueueProps} from '@/types/index';
  * ever be seen (the viewport clips the rest), but Yoga still lays out every
  * mounted component. Cap the rendered tail so layout cost stays bounded in
  * long sessions. 60 components is comfortably more than any terminal is
- * tall.
+ * tall - it's the hard ceiling computeFullscreenTailCap clamps to, and the
+ * default used when no terminal-derived cap is supplied.
  */
 const FULLSCREEN_TAIL_CAP = 60;
+
+/** Floor for computeFullscreenTailCap, below which scrollback would feel unusably shallow. */
+const FULLSCREEN_TAIL_MIN = 10;
+
+/**
+ * Scales the fullscreen tail to terminal height instead of the flat
+ * FULLSCREEN_TAIL_CAP: messages are typically several rows tall, so roughly
+ * half as many mounted components as terminal rows comfortably covers what
+ * can be visible plus a page of scrollback, without paying Yoga layout cost
+ * for components that can never be seen.
+ */
+export function computeFullscreenTailCap(terminalRows: number): number {
+	return Math.min(
+		FULLSCREEN_TAIL_CAP,
+		Math.max(FULLSCREEN_TAIL_MIN, Math.ceil(terminalRows / 2)),
+	);
+}
 
 const componentKey = (component: ReactNode, fallback: string): Key => {
 	if (
@@ -30,6 +48,7 @@ export default memo(function ChatQueue({
 	renderLastQueuedComponentLive = false,
 	clearKey,
 	disableStatic = false,
+	fullscreenTailCap = FULLSCREEN_TAIL_CAP,
 }: ChatQueueProps) {
 	const {staticQueuedComponents, liveQueuedComponents} = useMemo(() => {
 		if (!renderLastQueuedComponentLive) {
@@ -55,8 +74,8 @@ export default memo(function ChatQueue({
 	// the bottom-anchored viewport in ChatHistory can clip it at the top.
 	const flowComponents = useMemo(() => {
 		if (!disableStatic) return [];
-		return allStaticComponents.slice(-FULLSCREEN_TAIL_CAP);
-	}, [disableStatic, allStaticComponents]);
+		return allStaticComponents.slice(-fullscreenTailCap);
+	}, [disableStatic, allStaticComponents, fullscreenTailCap]);
 
 	if (disableStatic) {
 		// Fullscreen (alt-screen): this transcript renders inside the scroll

--- a/source/types/components.ts
+++ b/source/types/components.ts
@@ -34,6 +34,13 @@ export interface ChatQueueProps {
 	 * to print into. Only a bounded tail of components is rendered.
 	 */
 	disableStatic?: boolean;
+	/**
+	 * Overrides the default fullscreen tail cap (see FULLSCREEN_TAIL_CAP in
+	 * chat-queue.tsx). ChatHistory derives this from terminal height via
+	 * computeFullscreenTailCap so the mounted tail tracks what can actually
+	 * be visible instead of a flat worst-case constant.
+	 */
+	fullscreenTailCap?: number;
 }
 
 export type Completion = {name: string; isCustom: boolean};


### PR DESCRIPTION
## Description

Fixes #1274. 
In fullscreen mode, chat rendering gets progressively slower as a conversation grows, 
past ~60 messages, each streaming flush takes over 2x its time budget, felt as stuttering and laggy composer input.

Root cause: `chat-queue.tsx`'s fullscreen path mounts a flat `FULLSCREEN_TAIL_CAP = 60` as a worst-case ceiling instead of something tied to what can actually be visible. Ink's Yoga re-lays-out and serializes every mounted component tree on every render, so cost scales with the cap, not with the viewport.

Fix: added `computeFullscreenTailCap(terminalRows)`, which scales the mounted tail to roughly half the terminal's row count (messages are typically multi-row) clamped to `[10, 60]`. `ChatQueue` takes this as an optional `fullscreenTailCap` prop (defaulting to the old flat 60 elsewhere), and `ChatHistory` derives it from `useTerminalRows()` and passes it through, only for the fullscreen path, since inline mode (Ink's `Static`) never re-lays-out finished turns and isn't affected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset

## Testing

### Automated Tests

- [x] New tests added
- [x] All existing tests pass
- [x] Tests cover both success and error scenarios

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

## Checklist

- [x] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Appropriate logging added using structured logging (see [CONTRIBUTING.md](../CONTRIBUTING.md#logging)) 