### PR TITLE
feat(copy): add terminal support for `/copy code` (#1241)

### DIFF
--- a/.changeset/copy-code-terminal.md
+++ b/.changeset/copy-code-terminal.md
@@ -1,0 +1,7 @@
+---
+'@nanocollective/nanocoder': patch
+---
+
+Add terminal support for `/copy code`.
+
+Running `/copy code` in the terminal previously returned "This functionality isn't supported in the terminal." It now parses fenced code blocks from the last assistant message and copies the most recent block to the system clipboard, matching the VS Code webview behaviour. Returns "No code blocks found in the last response." when the last response contains no fenced blocks.

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -30,7 +30,7 @@ Type `/` in the chat input to see available commands. All commands start with `/
 | `/context-max` | Set maximum context length for the current session, or inspect the resolved context source. Also available as `--context-max` CLI flag |
 | `/exit` | Exit the application (alias: `/quit`) |
 | `/export` | Export current session to markdown file |
-| `/copy` | Copy the last assistant response to the system clipboard |
+| `/copy` | Copy the last assistant response to the system clipboard. Use `/copy code` to copy just the last fenced code block from the last response |
 | `/commit` | Generate a Conventional Commit message from staged Git changes. Add `--copy` (or `-c`) to also copy the message to the system clipboard. A spinner shows while the model is working |
 | `/doctor` | Show environment health report for bug reports |
 | `/update` | Update Nanocoder to the latest version |

--- a/source/commands/copy.spec.tsx
+++ b/source/commands/copy.spec.tsx
@@ -131,7 +131,75 @@ test('copyCommand ignores trailing non-assistant messages', async t => {
 	t.is(lastWritten, 'To get to the other side.');
 });
 
-test('copyCommand code is rejected in the terminal', async t => {
+test('copyCommand code copies the code block body only', async t => {
+	const messages: Message[] = [
+		{
+			role: 'assistant',
+			content: 'Here is a helper:\n```js\nconst x = 1;\n```\nHope that helps!',
+		},
+	];
+
+	const result = await copyCommand.handler(['code'], messages, testMetadata);
+	t.is(lastWritten, 'const x = 1;');
+
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+	t.true(output.includes('Copied code block to clipboard'));
+	t.true(output.includes('1 line'));
+	t.false(output.includes('const x = 1;'));
+});
+
+test('copyCommand code copies the last block when multiple exist', async t => {
+	const messages: Message[] = [
+		{
+			role: 'assistant',
+			content:
+				'First:\n```js\nconst a = 1;\n```\nSecond:\n```py\nprint("b")\nprint("c")\n```',
+		},
+	];
+
+	const result = await copyCommand.handler(['code'], messages, testMetadata);
+	t.is(lastWritten, 'print("b")\nprint("c")');
+
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+	t.true(output.includes('Copied code block to clipboard'));
+	t.true(output.includes('2 lines'));
+});
+
+test('copyCommand CODE works case-insensitively', async t => {
+	const messages: Message[] = [
+		{role: 'assistant', content: '```js\nconst x = 1;\n```'},
+	];
+
+	await copyCommand.handler(['CODE'], messages, testMetadata);
+	t.is(lastWritten, 'const x = 1;');
+});
+
+test('copyCommand code warns when no code blocks exist', async t => {
+	const result = await copyCommand.handler(['code'], baseMessages, testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+
+	t.true(output.includes('No code blocks found in the last response'));
+	t.is(lastWritten, null);
+});
+
+test('copyCommand code warns when no assistant response exists', async t => {
+	const messages: Message[] = [{role: 'user', content: 'Hello?'}];
+
+	const result = await copyCommand.handler(['code'], messages, testMetadata);
+	const {lastFrame} = renderWithTheme(result as React.ReactElement);
+	const output = lastFrame() || '';
+
+	t.true(output.includes('No assistant response to copy yet'));
+	t.is(lastWritten, null);
+});
+
+test('copyCommand code returns an error when clipboard write fails', async t => {
+	writeImpl = async () => {
+		throw new Error('no clipboard tool available');
+	};
 	const messages: Message[] = [
 		{role: 'assistant', content: '```js\nconst x = 1;\n```'},
 	];
@@ -140,19 +208,33 @@ test('copyCommand code is rejected in the terminal', async t => {
 	const {lastFrame} = renderWithTheme(result as React.ReactElement);
 	const output = lastFrame() || '';
 
-	t.true(output.includes("This functionality isn't supported in the terminal."));
-	t.is(lastWritten, null);
+	t.true(output.includes('Failed to copy to clipboard'));
 });
 
-test('copyCommand CODE is rejected case-insensitively', async t => {
-	const result = await copyCommand.handler(
-		['CODE'],
-		baseMessages,
-		testMetadata,
-	);
+test('copyCommand code ignores blockquote fenced code', async t => {
+	const messages: Message[] = [
+		{
+			role: 'assistant',
+			content: '> ```js\n> const x = 1;\n> ```\nNo real blocks here.',
+		},
+	];
+
+	const result = await copyCommand.handler(['code'], messages, testMetadata);
 	const {lastFrame} = renderWithTheme(result as React.ReactElement);
 	const output = lastFrame() || '';
 
-	t.true(output.includes("This functionality isn't supported in the terminal."));
+	t.true(output.includes('No code blocks found in the last response'));
 	t.is(lastWritten, null);
+});
+
+test('copyCommand code handles indented fences inside lists', async t => {
+	const messages: Message[] = [
+		{
+			role: 'assistant',
+			content: '- item\n  ```js\n  const x = 1;\n  ```',
+		},
+	];
+
+	await copyCommand.handler(['code'], messages, testMetadata);
+	t.is(lastWritten, 'const x = 1;');
 });

--- a/source/commands/copy.ts
+++ b/source/commands/copy.ts
@@ -1,7 +1,7 @@
 /**
  * /copy command
  * Copies the last assistant response to the system clipboard.
- * `/copy code` is webview-only; the terminal rejects that argument.
+ * `/copy code` copies just the last fenced code block from that response.
  */
 import clipboard from 'clipboardy';
 import type {Command} from '@/types/commands';
@@ -18,13 +18,72 @@ function findLastAssistantContent(messages: Message[]): string | undefined {
 	return undefined;
 }
 
+/**
+ * Extract raw bodies of fenced code blocks from markdown.
+ *
+ * Mirrors the fence recognition in `source/markdown-parser/index.ts`: both
+ * fences must sit at the start of a line (after optional spaces/tabs only)
+ * so fences nested inside a blockquote (`> ``` `) are not treated as
+ * copyable code. Leading indentation on the opening fence is stripped from
+ * each content line so indented fences (e.g. inside a list item) copy
+ * cleanly. Matches the VS Code webview behaviour of copying the most
+ * recent (last) block — callers pick `blocks[blocks.length - 1]`.
+ */
+function extractCodeBlocks(markdown: string): string[] {
+	const blocks: string[] = [];
+	const pattern =
+		/^([ \t]*)```[a-zA-Z0-9\-+#]*[ \t]*\r?\n([\s\S]*?)^\1```[ \t]*$/gm;
+	let match: RegExpExecArray | null;
+	while ((match = pattern.exec(markdown)) !== null) {
+		const indent = match[1] ?? '';
+		let code = match[2] ?? '';
+		if (indent) {
+			code = code
+				.split('\n')
+				.map(line =>
+					line.startsWith(indent) ? line.slice(indent.length) : line,
+				)
+				.join('\n');
+		}
+		// The capture includes the newline before the closing fence; drop one
+		// trailing newline to match the webview's `textContent.replace(/\n$/, '')`.
+		code = code.replace(/\r?\n$/, '');
+		blocks.push(code);
+	}
+	return blocks;
+}
+
 export const copyCommand: Command = {
 	name: 'copy',
 	description: 'Copy the last assistant response to the clipboard',
 	handler: async (args, messages) => {
 		if (args[0]?.toLowerCase() === 'code') {
-			return warningMsg(
-				"This functionality isn't supported in the terminal.",
+			const content = findLastAssistantContent(messages);
+
+			if (!content) {
+				return warningMsg('No assistant response to copy yet.', 'copy');
+			}
+
+			const blocks = extractCodeBlocks(content);
+
+			if (blocks.length === 0) {
+				return warningMsg('No code blocks found in the last response.', 'copy');
+			}
+
+			// Copy the most recent block, matching the VS Code webview's
+			// `/copy code` (last `pre code` of the last turn).
+			const code = blocks[blocks.length - 1] ?? '';
+
+			try {
+				await clipboard.write(code);
+			} catch (error) {
+				const detail = error instanceof Error ? error.message : String(error);
+				return errorMsg(`Failed to copy to clipboard: ${detail}`, 'copy');
+			}
+
+			const lineCount = code === '' ? 0 : code.split('\n').length;
+			return successMsg(
+				`Copied code block to clipboard (${lineCount} ${lineCount === 1 ? 'line' : 'lines'})`,
 				'copy',
 			);
 		}


### PR DESCRIPTION
## Description

Adds native terminal support for `/copy code` (closes #1241).

Previously, running `/copy code` in the terminal returned `"This functionality isn't supported in the terminal."`, leaving CLI users with only `/copy` (whole response including prose). Now the terminal parses fenced code blocks from the last assistant message and copies the most recent block to the system clipboard via `clipboard.write()` — matching the VS Code webview behavior:

- Success → `Copied code block to clipboard (N line/lines)`
- No fenced blocks → `No code blocks found in the last response.`
- No assistant response yet → `No assistant response to copy yet.`
- Clipboard failure → `Failed to copy to clipboard: <detail>`

Fence recognition mirrors `source/markdown-parser/index.ts` (fences must start the line, `> ```quote` ignored, indented list fences dedented).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changeset

- [x] Added a changeset (`pnpm changeset`) describing this change for the changelog — `.changeset/copy-code-terminal.md` (patch)

## Testing

### Automated Tests

- [x] New features include passing tests in `.spec.ts/tsx` files — `source/commands/copy.spec.tsx`: 15 tests pass (single-block body-only copy, multi-block last-wins + line count, case-insensitive `CODE`, no-blocks / no-response warnings, clipboard-failure error, blockquote ignored, indented-list fences)
- [ ] All existing tests pass (`pnpm test:all` completes successfully) — targeted suites pass (`copy` + `markdown-parser` + `assistant-message`: 135 tests); full serial suite timed out locally after 10 min, left for CI
- [x] Tests cover both success and error scenarios
- [x] `tsc --noEmit` (root + `plugins/vscode`), `biome check`, `biome lint`, `knip` all pass; `pnpm run build` succeeds and the built handler was verified end-to-end

### Manual Testing

- [ ] Tested with Ollama
- [ ] Tested with OpenRouter
- [ ] Tested with OpenAI-compatible API
- [ ] Tested MCP integration (if applicable)

Not applicable — this change touches no LLM/provider path. Verified against built `dist/` output: single/multi-block copy returns the success message, no-code and empty transcripts return the correct warnings.

## Checklist

- [ ] If this was for an open issue, I was assigned to it
- [x] Code follows project style guidelines (Biome format + lint clean)
- [x] Self-review completed
- [x] Documentation updated (if needed) — `docs/features/commands.md` `/copy` row now documents `/copy code`
- [x] No breaking changes (or clearly documented) — `/copy` behavior unchanged; only the previously-rejected `/copy code` arg is now handled
- [ ] Appropriate logging added using structured logging — not applicable, command surfaces status via chat messages per existing pattern